### PR TITLE
Fixes the failing build command

### DIFF
--- a/cmd/easi/serve.go
+++ b/cmd/easi/serve.go
@@ -1,4 +1,3 @@
-// Package main is the entrypoint for command line execution of the easi tool
 package main
 
 import (

--- a/cmd/easi/test.go
+++ b/cmd/easi/test.go
@@ -1,4 +1,3 @@
-// Package main is the entrypoint for command line execution of the easi tool
 package main
 
 import (
@@ -16,7 +15,7 @@ var testCmd = &cobra.Command{
 			test.All()
 		} else if pretest {
 			test.Pretest()
-		} else if testServer {
+		} else if serverTest {
 			test.Server()
 		} else {
 			test.All()
@@ -26,10 +25,10 @@ var testCmd = &cobra.Command{
 
 var all bool
 var pretest bool
-var testServer bool
+var serverTest bool
 
 func init() {
 	testCmd.Flags().BoolVarP(&all, "all", "a", false, "Run all tests")
 	testCmd.Flags().BoolVarP(&pretest, "pretest", "p", false, "Run pretests (such as linters)")
-	testCmd.Flags().BoolVarP(&testServer, "server", "s", false, "Run server tests")
+	testCmd.Flags().BoolVarP(&serverTest, "server", "s", false, "Run server tests")
 }


### PR DESCRIPTION
```
Elizabeths-MBP:easi-app eeeady$ go build -o bin/easi ./cmd/easi
# github.com/cmsgov/easi-app/cmd/easi
cmd/easi/serve.go:6:2: server redeclared in this block
	previous declaration at cmd/easi/test.go:28:5

This PR changing server -> testServer in the test.go file to make it unique. Also had to add in comments above the `package main` declaration in cmd/easi/serve.go and cmd/easi/test.go
