### PR TITLE
Add Public Sans

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <!-- TODO: This font should be imported through USWDS and not Google Fonts -->
+    <link
+      href="https://fonts.googleapis.com/css?family=Public+Sans:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i,800,800i,900,900i&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,27 @@
-@import './stylesheets/settings.scss';
+// .scss settings
+@import './stylesheets/_settings.scss';
+
+// TODO: The commented lines are attempts to require Public Sans
+// through USWDS instead of using Google Fronts. Work in progress
+// @import '~uswds/src/stylesheets/settings/_settings-color.scss';
+// @import '~uswds/src/stylesheets/settings/_settings-components.scss';
+// @import '~uswds/src/stylesheets/settings/_settings-general.scss';
+// @import '~uswds/src/stylesheets/settings/_settings-spacing.scss';
+// @import '~uswds/src/stylesheets/settings/_settings-typography.scss';
+// @import '~uswds/src/stylesheets/settings/_settings-utilities.scss';
+
+// @import '~uswds/src/stylesheets/core/_functions.scss';
+// @import '~uswds/src/stylesheets/core/_system-tokens.scss';
+// @import '~uswds/src/stylesheets/core/_variables.scss';
+// @import '~uswds/src/stylesheets/core/_properties.scss';
+// @import '~uswds/src/stylesheets/core/mixins/_all.scss';
+
+// @import '~uswds/src/stylesheets/global/_font-face.scss';
+// @import '~uswds/src/stylesheets/lib/_normalize.scss';
+
+// @import '~uswds/src/stylesheets/utilities/palettes/_all.scss';
+// @import '~uswds/src/stylesheets/utilities/rules/_all.scss';
+// @import '~uswds/src/stylesheets/utilities/rules/_package.scss';
 
 // Vendor Styles
 @import '~font-awesome/css/font-awesome.min.css';
@@ -6,10 +29,9 @@
 @import 'uswds';
 
 body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Public Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    'Roboto', 'Oxygen', -'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', -sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -29,9 +29,10 @@
 @import 'uswds';
 
 body {
+  margin: 0;
   font-family: 'Public Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    'Roboto', 'Oxygen', -'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
-    'Helvetica Neue', -sans-serif;
+    'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
This PR adds the font family Public Sans via Google Fonts. This will allow the frontend to use the correct font so that the UI looks more like the mockups Design provides.

I have left comments noting that this is not the end state of the implementation. Ideally, we should be getting Public Sans from USWDS (see `uswds/src/fonts`), but for some reason the font family isn't getting required.

Using Google Fronts isn't the worst thing in the world, but we should not need to use it because the font is packaged up with USWDS.