### PR TITLE
Update serialize-javascript package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "redux-devtools-extension": "^2.13.8",
     "redux-saga": "^1.1.1",
     "reselect": "^4.0.0",
+    "serialize-javascript": "^2.1.2",
     "typescript": "3.6.4",
     "uswds": "^2.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10420,6 +10420,11 @@ serialize-javascript@^1.7.0:
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
   integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
 
+serialize-javascript@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
 serve-index@^1.7.2:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"


### PR DESCRIPTION
This PR fixes the security risk reported by GitHub. This security risk would not affect the application code because the compromised library is only used at build time. However, the error should be resolved for peace of mind.