### PR TITLE
Add app tests, docker build & push to ECR process in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
     docker:
       - image: trussworks/circleci-docker-primary:tf12-5ee2cb35bc081dbc91da46afc3904ef0e1c111fb
     steps:
+      - checkout
       - run:
           name: Build the thing in docker, tag, and push to ECR
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
       - image: trussworks/circleci-docker-primary:tf12-5ee2cb35bc081dbc91da46afc3904ef0e1c111fb
     steps:
       - checkout
+      - setup_remote_docker
       - run:
           name: Build the thing in docker, tag, and push to ECR
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           name: Build the thing in docker, tag, and push to ECR
           command: |
             bash -x -c 'docker build --no-cache --tag "easi:$CIRCLE_SHA1" .'
-            bash -x -c "$(aws ecr get-login --no-include-email --region "us-west-2")"
+            bash -c "$(aws ecr get-login --no-include-email --region "us-west-2" --registry-ids "${AWS_ACCOUNT_ID}")"
             bash -x -c 'docker tag "easi:$CIRCLE_SHA1" "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
             bash -x -c 'docker push "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,6 @@ jobs:
       - run:
           name: Run easi app tests
           command: |
-            bash -c 'curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.21.0'
-            bash -c 'golangci-lint --version'
             go build -a -o bin/easi ./cmd/easi
             ./bin/easi test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,6 @@ jobs:
           key: yarn-deps-cache-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
-      - app_tests:
-          name: Run golang app tests
-          command: true  # TODO
 
   build_tag_push:
     docker:
@@ -41,9 +38,9 @@ jobs:
           name: Build the thing in docker, tag, and push to ECR
           command: |
             docker build --no-cache --tag "easi:$CIRCLE_SHA1" .
-            bash -c "$(aws ecr get-login --no-include-email --region "$AWS_DEFAULT_REGION")"
-            docker tag <AWS_ACCOUNT_ID>dkr.ecr.us-west-2.amazonaws.com:git-"$CIRCLE_SHA1"  # TODO
-            docker push <AWS_ACCOUNT_ID>dkr.ecr.us-west-2.amazonaws.com:git-"$CIRCLE_SHA1"  # TODO
+            bash -c "$(aws ecr get-login --no-include-email --region "us-west-2")"
+            docker tag "easi:$CIRCLE_SHA1" "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"  # TODO
+            docker push "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"  # TODO
 
   test:
     docker:
@@ -52,7 +49,7 @@ jobs:
       - run:
           name: Test the built thing in docker
           command: |
-            docker pull <AWS_ACCOUNT_ID>dkr.ecr.us-west-2.amazonaws.com:git-"$CIRCLE_SHA1"  # TODO
+            docker pull "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"  # TODO
             # TODO run_tests_on_container
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
       - run:
           name: Test the built thing in docker
           command: |
+            - setup_remote_docker
             bash -x -c 'docker pull "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
             # TODO run_tests_on_container
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           name: Run easi app tests
           command: |
             go build -a -o bin/easi ./cmd/easi
-            ./cmd/easi test
+            ./bin/easi test
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,13 +48,12 @@ jobs:
     docker:
       - image: trussworks/circleci-docker-primary:tf12-5ee2cb35bc081dbc91da46afc3904ef0e1c111fb
     steps:
-      - setup_remote_docker
+      - checkout
       - run:
-          name: Test the built thing in docker
+          name: Run easi app tests
           command: |
-            bash -c "$(aws ecr get-login --no-include-email --region "us-west-2" --registry-ids "${AWS_ACCOUNT_ID}")"
-            bash -x -c 'docker pull "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_BRANCH-$CIRCLE_SHA1"'
-            # TODO run_tests_on_container
+            go build -a -o bin/easi ./cmd/easi
+            ./cmd/easi test
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,10 @@ jobs:
       - run:
           name: Build the thing in docker, tag, and push to ECR
           command: |
-            docker build --no-cache --tag "easi:$CIRCLE_SHA1" .
-            bash -c "$(aws ecr get-login --no-include-email --region "us-west-2")"
-            docker tag "easi:$CIRCLE_SHA1" "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"  # TODO
-            docker push "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"  # TODO
+            bash -x -c 'docker build --no-cache --tag "easi:$CIRCLE_SHA1" .'
+            bash -x -c "$(aws ecr get-login --no-include-email --region "us-west-2")"
+            bash -x -c 'docker tag "easi:$CIRCLE_SHA1" "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
+            bash -x -c 'docker push "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
 
   test:
     docker:
@@ -51,7 +51,7 @@ jobs:
       - run:
           name: Test the built thing in docker
           command: |
-            docker pull "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"  # TODO
+            bash -x -c 'docker pull "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
             # TODO run_tests_on_container
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
       - run:
           name: Test the built thing in docker
           command: |
+            bash -c "$(aws ecr get-login --no-include-email --region "us-west-2" --registry-ids "${AWS_ACCOUNT_ID}")"
             bash -x -c 'docker pull "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
             # TODO run_tests_on_container
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,8 @@ jobs:
       - run:
           name: Run easi app tests
           command: |
+            bash -c 'curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.21.0'
+            bash -c 'golangci-lint --version'
             go build -a -o bin/easi ./cmd/easi
             ./bin/easi test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
+---
 version: 2
 jobs:
-  validate:
+  pre_test:
     docker:
       - image: trussworks/circleci-docker-primary:tf12-5ee2cb35bc081dbc91da46afc3904ef0e1c111fb
     steps:
@@ -11,9 +12,6 @@ jobs:
       - restore_cache:
           keys:
             - yarn-deps-cache-{{ checksum "yarn.lock" }}
-      - run:
-          name: Update pre-commit deps
-          command: pre-commit autoupdate
       - run:
           name: Install dependencies for pre-commit in yarn (temporary?)
           command: yarn install
@@ -31,9 +29,39 @@ jobs:
           key: yarn-deps-cache-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
+      - app_tests:
+          name: Run golang app tests
+          command: true  # TODO
+
+  build_tag_push:
+    docker:
+      - image: trussworks/circleci-docker-primary:tf12-5ee2cb35bc081dbc91da46afc3904ef0e1c111fb
+    steps:
+      - run:
+          name: Build the thing in docker, tag, and push to ECR
+          command: |
+            docker build --no-cache --tag "easi:$CIRCLE_SHA1" .
+            bash -c "$(aws ecr get-login --no-include-email --region "$AWS_DEFAULT_REGION")"
+            docker tag <AWS_ACCOUNT_ID>dkr.ecr.us-west-2.amazonaws.com:git-"$CIRCLE_SHA1"  # TODO
+            docker push <AWS_ACCOUNT_ID>dkr.ecr.us-west-2.amazonaws.com:git-"$CIRCLE_SHA1"  # TODO
+
+  test:
+    docker:
+      - image: trussworks/circleci-docker-primary:tf12-5ee2cb35bc081dbc91da46afc3904ef0e1c111fb
+    steps:
+      - run:
+          name: Test the built thing in docker
+          command: |
+            docker pull <AWS_ACCOUNT_ID>dkr.ecr.us-west-2.amazonaws.com:git-"$CIRCLE_SHA1"  # TODO
+            # TODO run_tests_on_container
 
 workflows:
   version: 2
-  validate:
+  compile:
     jobs:
-      - validate
+      - pre_test
+      - build_tag_push
+      - test:
+          requires:
+            - pre_test
+            - build_tag_push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,10 @@ jobs:
     docker:
       - image: trussworks/circleci-docker-primary:tf12-5ee2cb35bc081dbc91da46afc3904ef0e1c111fb
     steps:
+      - setup_remote_docker
       - run:
           name: Test the built thing in docker
           command: |
-            - setup_remote_docker
             bash -x -c 'docker pull "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
             # TODO run_tests_on_container
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,10 @@ jobs:
       - run:
           name: Build the thing in docker, tag, and push to ECR
           command: |
-            bash -x -c 'docker build --no-cache --tag "easi:$CIRCLE_SHA1" .'
+            bash -x -c 'docker build --no-cache --tag "easi:$CIRCLE_BRANCH-$CIRCLE_SHA1" .'
             bash -c "$(aws ecr get-login --no-include-email --region "us-west-2" --registry-ids "${AWS_ACCOUNT_ID}")"
-            bash -x -c 'docker tag "easi:$CIRCLE_SHA1" "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
-            bash -x -c 'docker push "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
+            bash -x -c 'docker tag "easi:$CIRCLE_BRANCH-$CIRCLE_SHA1" "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_BRANCH-$CIRCLE_SHA1"'
+            bash -x -c 'docker push "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_BRANCH-$CIRCLE_SHA1"'
 
   test:
     docker:
@@ -53,7 +53,7 @@ jobs:
           name: Test the built thing in docker
           command: |
             bash -c "$(aws ecr get-login --no-include-email --region "us-west-2" --registry-ids "${AWS_ACCOUNT_ID}")"
-            bash -x -c 'docker pull "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
+            bash -x -c 'docker pull "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_BRANCH-$CIRCLE_SHA1"'
             # TODO run_tests_on_container
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,8 @@ workflows:
   compile:
     jobs:
       - pre_test
-      - build_tag_push
-      - test:
+      - test
+      - build_tag_push:
           requires:
             - pre_test
-            - build_tag_push
+            - test

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+# [Jira story](<URL>)
+
+<!--
+    If applicable, insert the Jira story URL in the markdown link above
+--->
+
+Changes proposed in this pull request:
+
+- Change 1
+- Change 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
             vendor/|
             docs/adr/index.md
           )$
+      - id: circleci-validate
 
   - repo: git://github.com/golangci/golangci-lint
     rev: v1.21.0

--- a/.spelling
+++ b/.spelling
@@ -62,3 +62,4 @@ autoscaling
 s3
 trailblaze
 Cloudfront
+Jira

--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ you are about to commit to the repository.
 Next install the pre-commit hook libraries
 with `pre-commit install-hooks`.
 
+### Setup: CircleCI (optional)
+
+If you want to make changes to the CircleCI configuration, you will need to
+install the `circleci` cli tool so that the changes can be validated by
+pre-commit: `brew install circleci`
+
 ### Setup: Docker
 
 To set up docker on your local machine:

--- a/cmd/easi/test.go
+++ b/cmd/easi/test.go
@@ -13,8 +13,6 @@ var testCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if all {
 			test.All()
-		} else if pretest {
-			test.Pretest()
 		} else if serverTest {
 			test.Server()
 		} else {
@@ -24,11 +22,9 @@ var testCmd = &cobra.Command{
 }
 
 var all bool
-var pretest bool
 var serverTest bool
 
 func init() {
 	testCmd.Flags().BoolVarP(&all, "all", "a", false, "Run all tests")
-	testCmd.Flags().BoolVarP(&pretest, "pretest", "p", false, "Run pretests (such as linters)")
 	testCmd.Flags().BoolVarP(&serverTest, "server", "s", false, "Run server tests")
 }

--- a/cmd/easi/test/test.go
+++ b/cmd/easi/test/test.go
@@ -9,7 +9,6 @@ import (
 
 // All runs the full test suite
 func All() {
-	Pretest()
 	Server()
 }
 
@@ -29,25 +28,5 @@ func Server() {
 	err := c.Run()
 	if err != nil {
 		log.Fatalf("Fail %v", err)
-	}
-}
-
-// Pretest runs tests that analyze code,
-// like linters
-func Pretest() {
-	golangCILint()
-}
-
-func golangCILint() {
-	c := exec.Command(
-		"golangci-lint",
-		"run",
-		"./pkg/...")
-	// Replace with some sort of configured writer
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-	err := c.Run()
-	if err != nil {
-		log.Fatalf("Failed to execute golangci-lint: %v", err)
 	}
 }


### PR DESCRIPTION
# [EASI-90](https://jiraent.cms.gov/browse/EASI-90)

Changes proposed in this pull request:

- Add a CI job for running app tests.
- Add a CI job for building the app in docker & pushing the built image to our ECR repository.
- Define a CI workflow to verify that pre-commit & app tests pass before the docker build job is performed.
- Remove `easi` code that executed `golangci-lint`.
  * This is now being performed by pre-commit in CI.
- Remove `pre-commit autoupdate` from the circleci config.
  * This will cause pre-commit to run different versions of the hooks in CI than are being checked out locally, which will cause unexpected build failures.
  * We can run this command periodically or as needed, but changes to the pre-commit config should be code reviewed & committed to this repo.
- Add circleci-validate pre-commit hook.
- Add a pull request template.