### PR TITLE
Remove git branch name from image tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,10 @@ jobs:
       - run:
           name: Build the thing in docker, tag, and push to ECR
           command: |
-            bash -x -c 'docker build --no-cache --tag "easi:$CIRCLE_BRANCH-$CIRCLE_SHA1" .'
+            bash -x -c 'docker build --no-cache --tag "easi:$CIRCLE_SHA1" .'
             bash -c "$(aws ecr get-login --no-include-email --region "us-west-2" --registry-ids "${AWS_ACCOUNT_ID}")"
-            bash -x -c 'docker tag "easi:$CIRCLE_BRANCH-$CIRCLE_SHA1" "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_BRANCH-$CIRCLE_SHA1"'
-            bash -x -c 'docker push "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_BRANCH-$CIRCLE_SHA1"'
+            bash -x -c 'docker tag "easi:$CIRCLE_SHA1" "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
+            bash -x -c 'docker push "${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-backend:$CIRCLE_SHA1"'
 
   test:
     docker:


### PR DESCRIPTION
# [EASI-97](https://jiraent.cms.gov/browse/EASI-97)

Changes proposed in this pull request:

- Remove `$CIRCLE_BRANCH` from the docker image tag.

Originally we were tagging images with the git branch name followed by the commit hash. Unfortunately git is more permissive about what can go in a branch name than docker is about what can go in a tag, which leads to unexpected build failures.

This PR unblocks branch protection on master. We may revisit the tagging scheme later on.