### PR TITLE
EASI-259: Add APPLICATION_VERSION variable at build-time 

### DIFF
--- a/scripts/build_docker_image
+++ b/scripts/build_docker_image
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# build `easi` in docker and release to ECS
+# build `easi` in docker and push to ECR
 #
 
 # log in to ECR

--- a/scripts/build_docker_image
+++ b/scripts/build_docker_image
@@ -11,7 +11,7 @@ if bash +x -o nounset -c "$(aws ecr get-login --no-include-email --region "us-we
 
   builddir="$(git rev-parse --show-toplevel)"
 
-  if (set -x ; docker build --no-cache --tag "easi" "$builddir") ; then
+  if (set -x ; docker build --no-cache --tag "easi" --build-arg APPLICATION_VERSION="$(date +%F)_${sha}" "$builddir") ; then
     ( set -x -u
       docker tag "easi:latest" "${target}:${sha}" && docker push "${target}:${sha}" || exit
       docker tag "easi:latest" "${target}:latest" && docker push "${target}:latest" || exit


### PR DESCRIPTION
# EASI-259

Changes proposed in this pull request:

- Adds an `APPLICATION_VERSION` variable as a docker [build-arg](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg)