### PR TITLE
Add request logging

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,0 +1,38 @@
+package context
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+type contextKey int
+
+const (
+	loggerKey contextKey = iota
+	traceKey
+)
+
+// WithLogger returns a context with the given logger
+func WithLogger(ctx context.Context, logger *zap.Logger) context.Context {
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+// Logger returns the context's logger
+func Logger(ctx context.Context) (*zap.Logger, bool) {
+	logger, ok := ctx.Value(loggerKey).(*zap.Logger)
+	return logger, ok
+}
+
+// WithTrace returns a context with request trace
+func WithTrace(ctx context.Context) context.Context {
+	traceID := uuid.New()
+	return context.WithValue(ctx, traceKey, traceID)
+}
+
+// Trace returns the context's trace UUID
+func Trace(ctx context.Context) (uuid.UUID, bool) {
+	traceID, ok := ctx.Value(traceKey).(uuid.UUID)
+	return traceID, ok
+}

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -1,0 +1,64 @@
+package context
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+)
+
+type ContextTestSuite struct {
+	suite.Suite
+	logger *zap.Logger
+}
+
+func TestContextTestSuite(t *testing.T) {
+	contextTestSuite := &ContextTestSuite{
+		Suite:  suite.Suite{},
+		logger: zap.NewNop(),
+	}
+	suite.Run(t, contextTestSuite)
+}
+
+func (s ContextTestSuite) TestWithLogger() {
+	ctx := context.Background()
+	expectedLogger := zap.NewNop()
+
+	ctx = WithLogger(ctx, expectedLogger)
+	logger := ctx.Value(loggerKey).(*zap.Logger)
+
+	s.Equal(expectedLogger, logger)
+}
+
+func (s ContextTestSuite) TestLogger() {
+	ctx := context.Background()
+	expectedLogger := zap.NewNop()
+	ctx = context.WithValue(ctx, loggerKey, expectedLogger)
+
+	logger, ok := Logger(ctx)
+
+	s.True(ok)
+	s.Equal(expectedLogger, logger)
+}
+
+func (s ContextTestSuite) TestWithTrace() {
+	ctx := context.Background()
+
+	ctx = WithTrace(ctx)
+	traceID := ctx.Value(traceKey).(uuid.UUID)
+
+	s.NotEqual(uuid.UUID{}, traceID)
+}
+
+func (s ContextTestSuite) TestTrace() {
+	ctx := context.Background()
+	expectedID := uuid.New()
+	ctx = context.WithValue(ctx, traceKey, expectedID)
+
+	traceID, ok := Trace(ctx)
+
+	s.True(ok)
+	s.NotEqual(expectedID, traceID)
+}

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -60,5 +60,5 @@ func (s ContextTestSuite) TestTrace() {
 	traceID, ok := Trace(ctx)
 
 	s.True(ok)
-	s.NotEqual(expectedID, traceID)
+	s.Equal(expectedID, traceID)
 }

--- a/pkg/handlers/systems.go
+++ b/pkg/handlers/systems.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/cmsgov/easi-app/pkg/context"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -22,16 +23,22 @@ type SystemsListHandler struct {
 // Handle handles a web request and returns a list of systems
 func (h SystemsListHandler) Handle() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		logger, ok := context.Logger(r.Context())
+		if !ok {
+			h.Logger.Error("Failed to logger from context in systems list handler")
+			logger = h.Logger
+		}
+
 		systems, err := h.FetchSystems()
 		if err != nil {
-			h.Logger.Error(fmt.Sprintf("Failed to fetch system: %v", err))
+			logger.Error(fmt.Sprintf("Failed to fetch system: %v", err))
 			http.Error(w, "failed to fetch systems", http.StatusInternalServerError)
 			return
 		}
 
 		js, err := h.Marshal(systems)
 		if err != nil {
-			h.Logger.Error(fmt.Sprintf("Failed to marshal system: %v", err))
+			logger.Error(fmt.Sprintf("Failed to marshal system: %v", err))
 			http.Error(w, "failed to fetch systems", http.StatusInternalServerError)
 			return
 		}
@@ -40,7 +47,7 @@ func (h SystemsListHandler) Handle() http.HandlerFunc {
 
 		_, err = w.Write(js)
 		if err != nil {
-			h.Logger.Error(fmt.Sprintf("Failed to write systems response: %v", err))
+			logger.Error(fmt.Sprintf("Failed to write systems response: %v", err))
 			http.Error(w, "failed to fetch systems", http.StatusInternalServerError)
 			return
 		}

--- a/pkg/handlers/systems_test.go
+++ b/pkg/handlers/systems_test.go
@@ -17,16 +17,18 @@ func (s HandlerTestSuite) TestSystemsHandler() {
 
 	s.Run("golden path passes", func() {
 		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/systems/", nil)
+		s.NoError(err)
 		SystemsListHandler{
 			FetchSystems: makeFakeSystemShorts,
 			Marshal:      json.Marshal,
 			Logger:       s.logger,
-		}.Handle()(rr, nil)
+		}.Handle()(rr, req)
 
 		s.Equal(http.StatusOK, rr.Code)
 
 		var systems models.SystemShorts
-		err := json.Unmarshal(rr.Body.Bytes(), &systems)
+		err = json.Unmarshal(rr.Body.Bytes(), &systems)
 
 		s.NoError(err)
 		s.Len(systems, 3)
@@ -35,11 +37,13 @@ func (s HandlerTestSuite) TestSystemsHandler() {
 
 	s.Run("marshalling fails, returns 500", func() {
 		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/systems/", nil)
+		s.NoError(err)
 		SystemsListHandler{
 			FetchSystems: makeFakeSystemShorts,
 			Marshal:      failMarshal,
 			Logger:       s.logger,
-		}.Handle()(rr, nil)
+		}.Handle()(rr, req)
 
 		s.Equal(http.StatusInternalServerError, rr.Code)
 		s.Equal("failed to fetch systems\n", rr.Body.String())

--- a/pkg/server/logger.go
+++ b/pkg/server/logger.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+
+	requestcontext "github.com/cmsgov/easi-app/pkg/context"
+)
+
+const traceField string = "traceID"
+
+func loggerMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		traceID, ok := requestcontext.Trace(ctx)
+		if ok {
+			ctx = requestcontext.WithLogger(ctx, logger.With(zap.String(traceField, traceID.String())))
+		} else {
+			ctx = requestcontext.WithLogger(ctx, logger)
+			logger.Error("Failed to get trace ID from context")
+		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// NewLoggerMiddleware returns a handler with a request based logger
+func NewLoggerMiddleware(logger *zap.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return loggerMiddleware(logger, next)
+	}
+}

--- a/pkg/server/logger.go
+++ b/pkg/server/logger.go
@@ -15,11 +15,25 @@ func loggerMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
 		ctx := r.Context()
 		traceID, ok := requestcontext.Trace(ctx)
 		if ok {
-			ctx = requestcontext.WithLogger(ctx, logger.With(zap.String(traceField, traceID.String())))
+			logger = logger.With(zap.String(traceField, traceID.String()))
 		} else {
-			ctx = requestcontext.WithLogger(ctx, logger)
 			logger.Error("Failed to get trace ID from context")
 		}
+		ctx = requestcontext.WithLogger(ctx, logger)
+
+		fields := []zap.Field{
+			zap.String("accepted-language", r.Header.Get("accepted-language")),
+			zap.Int64("content-length", r.ContentLength),
+			zap.String("host", r.Host),
+			zap.String("method", r.Method),
+			zap.String("protocol-version", r.Proto),
+			zap.String("referer", r.Header.Get("referer")),
+			zap.String("source", r.RemoteAddr),
+			zap.String("url", r.URL.String()),
+			zap.String("user-agent", r.UserAgent()),
+		}
+		logger.Info("Request", fields...)
+
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/server/logger_test.go
+++ b/pkg/server/logger_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"go.uber.org/zap"
+
+	requestcontext "github.com/cmsgov/easi-app/pkg/context"
+)
+
+func (s ServerTestSuite) TestLoggerMiddleware() {
+	s.Run("get a new logger with trace ID", func() {
+
+		req := httptest.NewRequest("GET", "/systems/", nil)
+		rr := httptest.NewRecorder()
+		traceMiddleware := NewTraceMiddleware(s.logger)
+		prodLogger, err := zap.NewProduction()
+		s.NoError(err)
+		loggerMiddleware := NewLoggerMiddleware(prodLogger)
+
+		// this is the actual test, since the context is cancelled post request
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			logger, ok := requestcontext.Logger(r.Context())
+
+			s.True(ok)
+			s.NotEqual(prodLogger, logger)
+		})
+
+		traceMiddleware(loggerMiddleware(testHandler)).ServeHTTP(rr, req)
+	})
+
+	s.Run("get the same logger with no trace ID", func() {
+
+		req := httptest.NewRequest("GET", "/systems/", nil)
+		rr := httptest.NewRecorder()
+		// need a new logger, because no-op won't use options
+		prodLogger, err := zap.NewProduction()
+		s.NoError(err)
+		loggerMiddleware := NewLoggerMiddleware(prodLogger)
+
+		// this is the actual test, since the context is cancelled post request
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			logger, ok := requestcontext.Logger(r.Context())
+
+			s.True(ok)
+			s.Equal(prodLogger, logger)
+		})
+
+		loggerMiddleware(testHandler).ServeHTTP(rr, req)
+	})
+}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -23,7 +23,7 @@ func (s *server) routes(
 	// add a request based logger
 	s.router.Use(loggerMiddleware)
 
-  // health check goes directly on the main router to avoid auth
+	// health check goes directly on the main router to avoid auth
 	healthCheckHandler := handlers.HealthCheckHandler{
 		Config: s.Config,
 	}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -10,10 +10,18 @@ import (
 
 func (s *server) routes(
 	authorizationMiddleware func(handler http.Handler) http.Handler,
-	corsMiddleware func(handler http.Handler) http.Handler) {
+	corsMiddleware func(handler http.Handler) http.Handler,
+	traceMiddleware func(handler http.Handler) http.Handler,
+	loggerMiddleware func(handler http.Handler) http.Handler) {
 
 	// set to standard library marshaller
 	marshalFunc := json.Marshal
+
+	// trace all requests with an ID
+	s.router.Use(traceMiddleware)
+
+	// add a request based logger
+	s.router.Use(loggerMiddleware)
 
 	// health check goes directly on the main router to avoid auth
 	s.router.HandleFunc("/api/v1/healthcheck", handlers.HealthCheckHandler{}.Handle())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -58,7 +58,11 @@ func Serve(config *viper.Viper) {
 	}
 
 	// set up routes
-	s.routes(authMiddleware, newCORSMiddleware(clientAddress))
+	s.routes(
+		authMiddleware,
+		newCORSMiddleware(clientAddress),
+		NewTraceMiddleware(zapLogger),
+		NewLoggerMiddleware(zapLogger))
 
 	// start the server
 	zapLogger.Info("Serving application on localhost:8080")

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,1 +1,21 @@
 package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+)
+
+type ServerTestSuite struct {
+	suite.Suite
+	logger *zap.Logger
+}
+
+func TestServerTestSuite(t *testing.T) {
+	serverTestSuite := &ServerTestSuite{
+		Suite:  suite.Suite{},
+		logger: zap.NewNop(),
+	}
+	suite.Run(t, serverTestSuite)
+}

--- a/pkg/server/trace.go
+++ b/pkg/server/trace.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+
+	requestcontext "github.com/cmsgov/easi-app/pkg/context"
+)
+
+func traceMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		next.ServeHTTP(w, r.WithContext(requestcontext.WithTrace(ctx)))
+	})
+}
+
+// NewTraceMiddleware returns a handler with a trace ID in context
+func NewTraceMiddleware(logger *zap.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return traceMiddleware(logger, next)
+	}
+}

--- a/pkg/server/trace_test.go
+++ b/pkg/server/trace_test.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/google/uuid"
+
+	requestcontext "github.com/cmsgov/easi-app/pkg/context"
+)
+
+func (s ServerTestSuite) TestTraceMiddleware() {
+	// this is the actual test, since the context is cancelled post request
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		traceID, ok := requestcontext.Trace(r.Context())
+
+		s.True(ok)
+		s.NotEqual(uuid.UUID{}, traceID)
+	})
+
+	req := httptest.NewRequest("GET", "/systems/", nil)
+	rr := httptest.NewRecorder()
+	middleware := NewTraceMiddleware(s.logger)
+
+	middleware(testHandler).ServeHTTP(rr, req)
+}


### PR DESCRIPTION
# EASI-37

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Adds a trace ID to every request
- Creates a child logger with the trace ID so all logs are traceable to the original request
- Puts them in middleware and sets it up in routes
