### PR TITLE
Add CI deployment workflow for IMPL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,5 +128,9 @@ workflows:
           requires:
             - build_tag_push
       - deploy_impl:
+          filters:
+            branches:
+              only:
+                - master
           requires:
             - deploy_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,6 @@ workflows:
       - deploy_dev:
           requires:
             - build_tag_push
-      # - deploy_impl:
-      #     requires:
-      #       - deploy_dev
+      - deploy_impl:
+          requires:
+            - deploy_dev

--- a/scripts/build_docker_image
+++ b/scripts/build_docker_image
@@ -17,7 +17,7 @@ if bash +x -o nounset -c "$(aws ecr get-login --no-include-email --region "us-we
         docker tag "easi:latest" "${target}:latest" && docker push "${target}:latest" || exit
 
         if [[ "$CIRCLE_BRANCH" = "master" ]]; then
-          docker tag "easi:latest" "${target}:impl" || exit
+          docker tag "easi:latest" "${target}:impl" && docker push "${target}:impl" || exit
         else
           docker tag "easi:latest" "${target}:dev" && docker push "${target}:dev" || exit
         fi

--- a/scripts/build_docker_image
+++ b/scripts/build_docker_image
@@ -16,6 +16,11 @@ if bash +x -o nounset -c "$(aws ecr get-login --no-include-email --region "us-we
       docker tag "easi:latest" "${target}:${sha}" && docker push "${target}:${sha}" || exit
       docker tag "easi:latest" "${target}:latest" && docker push "${target}:latest" || exit
     )
+    if [[ "$CIRCLE_BRANCH" = "master" ]]; then
+      (set -x -u ; docker tag "easi:latest" "${target}:impl" || exit)
+    else
+      (set -x -u ; docker tag "easi:latest" "${target}:dev" && docker push "${target}:dev" || exit)
+    fi
   else
     exit
   fi

--- a/scripts/build_docker_image
+++ b/scripts/build_docker_image
@@ -11,19 +11,20 @@ if bash +x -o nounset -c "$(aws ecr get-login --no-include-email --region "us-we
 
   builddir="$(git rev-parse --show-toplevel)"
 
-  if (set -x ; docker build --no-cache --tag "easi" "$builddir") ; then
-    ( set -x -u
-      docker tag "easi:latest" "${target}:${sha}" && docker push "${target}:${sha}" || exit
-      docker tag "easi:latest" "${target}:latest" && docker push "${target}:latest" || exit
-    )
-    if [[ "$CIRCLE_BRANCH" = "master" ]]; then
-      (set -x -u ; docker tag "easi:latest" "${target}:impl" || exit)
+  ( set -x
+    if docker build --no-cache --tag "easi" "$builddir" ; then
+        docker tag "easi:latest" "${target}:${sha}" && docker push "${target}:${sha}" || exit
+        docker tag "easi:latest" "${target}:latest" && docker push "${target}:latest" || exit
+
+        if [[ "$CIRCLE_BRANCH" = "master" ]]; then
+          docker tag "easi:latest" "${target}:impl" || exit
+        else
+          docker tag "easi:latest" "${target}:dev" && docker push "${target}:dev" || exit
+        fi
     else
-      (set -x -u ; docker tag "easi:latest" "${target}:dev" && docker push "${target}:dev" || exit)
+      exit
     fi
-  else
-    exit
-  fi
+  )
 else
   status=$?
   echo "FATAL: ECR login failed" 1>&2

--- a/scripts/build_docker_image
+++ b/scripts/build_docker_image
@@ -11,7 +11,7 @@ if bash +x -o nounset -c "$(aws ecr get-login --no-include-email --region "us-we
 
   builddir="$(git rev-parse --show-toplevel)"
 
-  ( set -x
+  ( set -x -u
     if docker build --no-cache --tag "easi" "$builddir" ; then
         docker tag "easi:latest" "${target}:${sha}" && docker push "${target}:${sha}" || exit
         docker tag "easi:latest" "${target}:latest" && docker push "${target}:latest" || exit


### PR DESCRIPTION
# EASI-267 and EASI-266

Changes proposed in this pull request:

- When building from master, tag image with `easi:impl` and restart IMPL fargate service
- When building from others, tag image with `easi:dev` and restart DEV fargate service