### PR TITLE
Always tag :dev image on every build

### DIFF
--- a/scripts/build_docker_image
+++ b/scripts/build_docker_image
@@ -15,11 +15,10 @@ if bash +x -o nounset -c "$(aws ecr get-login --no-include-email --region "us-we
     if docker build --no-cache --tag "easi" "$builddir" ; then
         docker tag "easi:latest" "${target}:${sha}" && docker push "${target}:${sha}" || exit
         docker tag "easi:latest" "${target}:latest" && docker push "${target}:latest" || exit
+        docker tag "easi:latest" "${target}:dev" && docker push "${target}:dev" || exit
 
         if [[ "$CIRCLE_BRANCH" = "master" ]]; then
           docker tag "easi:latest" "${target}:impl" && docker push "${target}:impl" || exit
-        else
-          docker tag "easi:latest" "${target}:dev" && docker push "${target}:dev" || exit
         fi
     else
       exit


### PR DESCRIPTION
# EASI-267 and EASI-266

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Every build will now be tagged `:dev`. Before this change, the DEV fargate service would be restarted without a corresponding image tag being pushed