### PR TITLE
Run db migrations in DEV

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,11 @@ jobs:
             echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
             echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
       - run:
+          name: Run db migrations
+          command: |
+             aws ecs update-service --cluster dev-easi-app --service easi-app-db-clean --force-new-deployment
+             aws ecs update-service --cluster dev-easi-app --service easi-app-db-migrate --force-new-deployment
+      - run:
           name: Restart ECS service
           command: |
             ./scripts/restart_ecs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,12 +87,12 @@ jobs:
       - run:
           name: Run db migrations
           command: |
-             aws ecs update-service --cluster dev-easi-app --service easi-app-db-clean --force-new-deployment
-             aws ecs update-service --cluster dev-easi-app --service easi-app-db-migrate --force-new-deployment
+            ./scripts/restart_ecs "easi-db-clean"
+            ./scripts/restart_ecs "easi-db-migrate"
       - run:
           name: Restart ECS service
           command: |
-            ./scripts/restart_ecs
+            ./scripts/restart_ecs "easi-app"
       - run:
           name: Build static assets and release to S3
           command: |
@@ -126,7 +126,7 @@ jobs:
       - run:
           name: Restart ECS service
           command: |
-            ./scripts/restart_ecs
+            ./scripts/restart_ecs "easi-app"
       - run:
           name: Build static assets and release to S3
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,8 @@ jobs:
       - run:
           name: Run db migrations
           command: |
-            ./scripts/restart_ecs "easi-db-clean"
-            ./scripts/restart_ecs "easi-db-migrate"
+            ./scripts/restart_ecs "easi-app-db-clean"
+            ./scripts/restart_ecs "easi-app-db-migrate"
       - run:
           name: Restart ECS service
           command: |

--- a/scripts/restart_ecs
+++ b/scripts/restart_ecs
@@ -4,5 +4,5 @@
 #
 
 cluster_name="${APP_ENV}-easi-app"
-service_name="easi-app"
+service_name="$1"
 ( set -x ; aws ecs update-service --cluster "$cluster_name" --service "$service_name" --force-new-deployment )


### PR DESCRIPTION
# EASI-205

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Refactor `restart_ecs` script to take the service name as an argument
- Add a step to the deploy_dev job that restarts ECS services for cleaning & migrating the database
