### PR TITLE
Add Lock for Okta Access Token in Tests

### DIFF
--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -33,8 +33,7 @@ type IntegrationTestSuite struct {
 }
 
 func TestIntegrationTestSuite(t *testing.T) {
-	config := viper.New()
-	config.AutomaticEnv()
+	config := testhelpers.NewConfig()
 
 	if !testing.Short() && config.Get("ENVIRONMENT") == "local" {
 		easiServer := server.NewServer(config)

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -40,23 +40,7 @@ func TestIntegrationTestSuite(t *testing.T) {
 		testServer := httptest.NewServer(easiServer)
 		defer testServer.Close()
 
-		oktaDomain := config.GetString("OKTA_DOMAIN")
-		oktaIssuer := config.GetString("OKTA_ISSUER")
-		oktaClientID := config.GetString("OKTA_CLIENT_ID")
-		oktaRedirectURL := config.GetString("OKTA_REDIRECT_URI")
-		username := config.GetString("OKTA_TEST_USERNAME")
-		password := config.GetString("OKTA_TEST_PASSWORD")
-		secret := config.GetString("OKTA_TEST_SECRET")
-
-		accessToken, err := testhelpers.OktaAccessToken(
-			oktaDomain,
-			oktaIssuer,
-			oktaClientID,
-			oktaRedirectURL,
-			username,
-			password,
-			secret,
-		)
+		accessToken, err := testhelpers.OktaAccessToken(config)
 		if err != nil {
 			fmt.Println("Failed to get access token for integration testing")
 			t.Fail()
@@ -68,7 +52,7 @@ func TestIntegrationTestSuite(t *testing.T) {
 			logger:      zap.NewNop(),
 			config:      config,
 			server:      testServer,
-			user:        user{euaID: username, accessToken: accessToken},
+			user:        user{euaID: config.GetString("OKTA_TEST_USERNAME"), accessToken: accessToken},
 		}
 
 		suite.Run(t, testSuite)

--- a/pkg/okta/okta_test.go
+++ b/pkg/okta/okta_test.go
@@ -21,8 +21,7 @@ type OktaTestSuite struct {
 }
 
 func TestOktaTestSuite(t *testing.T) {
-	config := viper.New()
-	config.AutomaticEnv()
+	config := testhelpers.NewConfig()
 
 	testSuite := &OktaTestSuite{
 		Suite:  suite.Suite{},

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -65,24 +65,24 @@ func (s *Server) routes(
 	}
 	api.Handle("/systems", systemHandler.Handle())
 
-	systemIntakeHandler := handlers.SystemIntakeHandler{
-		Logger: s.logger,
-		SaveSystemIntake: services.NewSaveSystemIntake(
-			store.SaveSystemIntake,
-			store.FetchSystemIntakeByID,
-			services.NewAuthorizeSaveSystemIntake(s.logger),
-			s.logger,
-		),
-		FetchSystemIntakeByID: services.NewFetchSystemIntakeByID(
-			store.FetchSystemIntakeByID,
-			s.logger,
-		),
-	}
-
-	api.Handle("/system_intake/{intake_id}", systemIntakeHandler.Handle())
-	api.Handle("/system_intake", systemIntakeHandler.Handle())
-
 	if s.Config.GetString("ENVIRONMENT") == "LOCAL" {
+		systemIntakeHandler := handlers.SystemIntakeHandler{
+			Logger: s.logger,
+			SaveSystemIntake: services.NewSaveSystemIntake(
+				store.SaveSystemIntake,
+				store.FetchSystemIntakeByID,
+				services.NewAuthorizeSaveSystemIntake(s.logger),
+				s.logger,
+			),
+			FetchSystemIntakeByID: services.NewFetchSystemIntakeByID(
+				store.FetchSystemIntakeByID,
+				s.logger,
+			),
+		}
+
+		api.Handle("/system_intake/{intake_id}", systemIntakeHandler.Handle())
+		api.Handle("/system_intake", systemIntakeHandler.Handle())
+
 		systemIntakesHandler := handlers.SystemIntakesHandler{
 			Logger:             s.logger,
 			FetchSystemIntakes: services.FetchSystemIntakesByEuaID,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	_ "github.com/lib/pq" // pq is needed for the postgres driver
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -14,10 +14,9 @@ import (
 
 type StoreTestSuite struct {
 	suite.Suite
-	db          *sqlx.DB
-	logger      *zap.Logger
-	store       *Store
-	environment string
+	db     *sqlx.DB
+	logger *zap.Logger
+	store  *Store
 }
 
 func TestStoreTestSuite(t *testing.T) {
@@ -34,11 +33,12 @@ func TestStoreTestSuite(t *testing.T) {
 	store := NewStore(db, logger)
 
 	storeTestSuite := &StoreTestSuite{
-		Suite:       suite.Suite{},
-		db:          db,
-		logger:      logger,
-		store:       store,
-		environment: config.GetString("ENVIRONMENT"),
+		Suite:  suite.Suite{},
+		db:     db,
+		logger: logger,
+		store:  store,
 	}
-	suite.Run(t, storeTestSuite)
+	if config.GetString("ENVIRONMENT") == "local" {
+		suite.Run(t, storeTestSuite)
+	}
 }

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq" // required for postgres driver in sqlx
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/testhelpers"
 )
 
 type StoreTestSuite struct {
@@ -20,8 +21,7 @@ type StoreTestSuite struct {
 }
 
 func TestStoreTestSuite(t *testing.T) {
-	config := viper.New()
-	config.AutomaticEnv()
+	config := testhelpers.NewConfig()
 
 	dbUser := config.Get("PGUSER")
 	sslMode := config.GetString("PG_SSL_MODE")

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -36,11 +36,6 @@ func NewSystemIntake() models.SystemIntake {
 }
 
 func (s StoreTestSuite) TestSaveSystemIntake() {
-	if s.environment != "local" {
-		// TODO: When DB is hooked up in CircleCI, remove this check
-		return
-	}
-
 	s.Run("save a new system intake", func() {
 		intake := NewSystemIntake()
 
@@ -121,11 +116,6 @@ func (s StoreTestSuite) TestSaveSystemIntake() {
 }
 
 func (s StoreTestSuite) TestFetchSystemIntakeByID() {
-	if s.environment != "local" {
-		// TODO: When DB is hooked up in CircleCI, remove this check
-		return
-	}
-
 	s.Run("golden path to fetch a system intake", func() {
 		intake := NewSystemIntake()
 		id := intake.ID

--- a/pkg/testhelpers/config.go
+++ b/pkg/testhelpers/config.go
@@ -6,16 +6,15 @@ import (
 	"github.com/spf13/viper"
 )
 
-var lock = &sync.Mutex{}
+var configLock = &sync.Mutex{}
 
 // global config for testing
 var viperConfig *viper.Viper
 
 // NewConfig returns a global viper config for testing
 func NewConfig() *viper.Viper {
-
-	lock.Lock()
-	defer lock.Unlock()
+	configLock.Lock()
+	defer configLock.Unlock()
 
 	if viperConfig == nil {
 		viperConfig = viper.New()

--- a/pkg/testhelpers/config.go
+++ b/pkg/testhelpers/config.go
@@ -1,0 +1,26 @@
+package testhelpers
+
+import (
+	"sync"
+
+	"github.com/spf13/viper"
+)
+
+var lock = &sync.Mutex{}
+
+// global config for testing
+var viperConfig *viper.Viper
+
+// NewConfig returns a global viper config for testing
+func NewConfig() *viper.Viper {
+
+	lock.Lock()
+	defer lock.Unlock()
+
+	if viperConfig == nil {
+		viperConfig = viper.New()
+		viperConfig.AutomaticEnv()
+	}
+
+	return viperConfig
+}


### PR DESCRIPTION
# Add Lock for Okta Access Token in Tests

Changes proposed in this pull request:

- Uses a shared config across tests
- Locks access token so only one will be retrieved
