### PR TITLE
Switch Local to local everywhere

### DIFF
--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -65,7 +65,7 @@ func (s *Server) routes(
 	}
 	api.Handle("/systems", systemHandler.Handle())
 
-	if s.Config.GetString("ENVIRONMENT") == "LOCAL" {
+	if s.Config.GetString("ENVIRONMENT") == "local" {
 		systemIntakeHandler := handlers.SystemIntakeHandler{
 			Logger: s.logger,
 			SaveSystemIntake: services.NewSaveSystemIntake(

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s ServicesTestSuite) TestSystemIntakesByUserFetcher() {
-	if viper.Get("ENVIRONMENT") == "LOCAL" {
+	if viper.Get("ENVIRONMENT") == "local" {
 		s.Run("successfully fetches System Intakes", func() {
 			tx := s.db.MustBegin()
 			// Todo is this the best way to generate a random string?


### PR DESCRIPTION
# EASI-000

Changes proposed in this pull request:

- Use "local" instead of "LOCAL" since they are not considered the same value for env vars
