### PR TITLE
Purge old static assets from S3 during deploy

### DIFF
--- a/scripts/release_static
+++ b/scripts/release_static
@@ -10,7 +10,7 @@ if [[ -z "$s3_err" ]] ; then
   ( set -x -u ;
     yarn install
     yarn run build || exit
-    aws s3 sync --no-progress build/ s3://"$STATIC_S3_BUCKET"/
+    aws s3 sync --no-progress --delete build/ s3://"$STATIC_S3_BUCKET"/
   )
 else
   echo "+ aws s3 ls $STATIC_S3_BUCKET"


### PR DESCRIPTION
# EASI-125

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Adds the `--delete` switch to the aws s3 sync operation that releases new static assets

This removes files in the destination that are not present in the source.