### PR TITLE
Add db migrations execution step in IMPL deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,10 @@ jobs:
             echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
             echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
       - run:
+          name: Run migrations
+          command: |
+            ./scripts/db_lambda_invoke easi-app-db-migrate
+      - run:
           name: Restart ECS service
           command: |
             ./scripts/restart_ecs


### PR DESCRIPTION
# EASI-361

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Update the circleci configuration to execute database migrations during a deployment in IMPL

Notes:

- We do not clean the database in IMPL before running migrations because we do not roll back migrations in PROD: this should keep the IMPL db in a state as close to production as possible for now.