### PR TITLE
Remove db_clean service from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,16 +5,6 @@ services:
     image: postgres:11.6
     ports:
       - 5432:5432
-  db_clean:
-    build:
-      context: .
-      dockerfile: Dockerfile.db_clean
-    environment:
-      - FLYWAY_USER=postgres
-      - FLYWAY_PASSWORD=
-      - FLYWAY_URL=jdbc:postgresql://db/postgres
-    depends_on:
-      - db
   db_migrate:
     build:
       context: .
@@ -26,7 +16,7 @@ services:
     volumes:
       - ./migrations:/flyway/sql
     depends_on:
-      - db_clean
+      - db
   easi:
     build:
       context: .


### PR DESCRIPTION


# EASI-340

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Remove db_clean container from docker-compose.yml

A race condition between the migration containers was causing the database to sometimes get cleaned after migrations had been run. Rather than hack together scripts to track this state I'm simply removing the clean service from the docker-compose configuration. 

See also:
  * https://docs.docker.com/compose/startup-order/
  * https://github.com/docker/compose/issues/374

Note: After pulling this change locally, start once with `docker-compose up --remove-orphans` to clear out the orphaned db_clean image. After that, the services can be started normally with just `docker-compose up`.