### PR TITLE
add air for go hot reloading

### DIFF
--- a/.air.conf
+++ b/.air.conf
@@ -1,0 +1,48 @@
+# Config file for [Air](https://github.com/cosmtrek/air) in TOML format
+
+# Working directory
+# . or absolute path, please note that the directories following must be under root.
+root = "."
+tmp_dir = "tmp/air"
+
+[build]
+# Just plain old shell command. You could use `make` as well.
+cmd = "go build -o bin/easi ./cmd/easi"
+# Binary file yields from `cmd`.
+bin = "bin/easi"
+# Customize binary.
+full_bin = "bin/easi serve"
+# Watch these filename extensions.
+include_ext = ["go"]
+# Ignore these filename extensions or directories.
+# exclude_dir = ["assets", "tmp", "vendor", "frontend/node_modules"]
+# Watch these directories if you specified.
+include_dir = ["cmd", "pkg"]
+# Exclude files.
+# exclude_file = []
+# This log file places in your tmp_dir.
+log = "air.log"
+# It's not necessary to trigger build each time file changes if it's too frequent.
+delay = 1000 # ms
+# Stop running old binary when build errors occur.
+stop_on_error = true
+# Send Interrupt signal before killing process (windows does not support this feature)
+send_interrupt = false
+# Delay after sending Interrupt signal
+kill_delay = 500 # ms
+
+[log]
+# Show log time
+time = false
+
+[color]
+# Customize each part's color. If no color found, use the raw app log.
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,7 @@ services:
     depends_on:
       - db
   easi:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: cosmtrek/air:v1.12.1
     environment:
       - APPLICATION_VERSION=APPLICATION_VERSION
       - APPLICATION_DATETIME=APPLICATION_DATETIME
@@ -38,7 +36,16 @@ services:
       - REACT_APP_OKTA_ISSUER=$REACT_APP_OKTA_DOMAIN/oauth2/$REACT_APP_OKTA_SERVER_ID
       - OKTA_ISSUER=$REACT_APP_OKTA_ISSUER
       - REACT_APP_OKTA_REDIRECT_URI=http://localhost:3000/implicit/callback
-    entrypoint: ["/easi/easi", "serve"]
+      - PGHOST=db
+      - PGPORT=$PGPORT
+      - PGDATABASE=$PGDATABASE
+      - PGUSER=$PGUSER
+      - PGPASS=$PGPASS
+      - PGSSLMODE=$PGSSLMODE
+    volumes:
+      - ./:/easi
+    working_dir: /easi
+    entrypoint: ["/go/bin/air"]
     ports:
       - 8080:8080
     depends_on:


### PR DESCRIPTION
# Add air for Go hot reloading

All you should have to do is run `docker-compose up` to serve the application locally. It will now hotload when files are changed locally. I'd love if some folks could try this out.

Changes proposed in this pull request:

- Adds the air docker image to docker-compose
- Sets entrypoint to air binary
- Shares current directory
- Updates postgres env vars


Other notes:
I looked at a few packages, but this seemed to be the only one that's maintained. https://github.com/codegangsta/gin and https://github.com/gravityblast/fresh were the two others, but are not active. This was quick and easy since there was a docker image. Easy to change back if this doesn't work out.