### PR TITLE
Add healthcheck waiter in restart_ecs script

### DIFF
--- a/scripts/restart_ecs
+++ b/scripts/restart_ecs
@@ -12,7 +12,9 @@ healthcheck_timeout="180"
 
 cluster_name="${APP_ENV}-easi-app"
 service_name="easi-app"
-( set -x ; aws ecs update-service --cluster "$cluster_name" --service "$service_name" --force-new-deployment ) | jq '.service.events = ["REDACTED"]'
+
+# we remove the list of service events since it is verbose and rarely needed when reviewing logs in CI
+( set -x ; aws ecs update-service --cluster "$cluster_name" --service "$service_name" --force-new-deployment ) | jq '.service.events = ["REMOVED"]'
 
 # wait for the new service to come up
 echo -n "Waiting for health check version to match new deployment on ${healthcheck_url}" 1>&2

--- a/scripts/restart_ecs
+++ b/scripts/restart_ecs
@@ -3,6 +3,24 @@
 # Restart ECS service
 #
 
+healthcheck_url="https://${APP_ENV}.easi.cms.gov/api/v1/healthcheck"
+healthcheck_timeout="180"
+
 cluster_name="${APP_ENV}-easi-app"
 service_name="easi-app"
 ( set -x ; aws ecs update-service --cluster "$cluster_name" --service "$service_name" --force-new-deployment )
+
+# wait for the new service to come up
+echo -n "Waiting for health check version to match new deployment." 1>&2
+until [[ "$(jq --raw-output --monochrome-output .version < <(curl --silent --show-error --location "$healthcheck_url"))" == "$CIRCLE_SHA1" ]] ; do
+  if ((++time > healthcheck_timeout)) ; then
+    # we timed out
+    echo ""
+    echo "FATAL: Timed out waiting." 1>&2
+    exit 1
+  else
+    [[ $((time % 10)) -eq 0 ]] && echo -n "."
+    sleep 1
+  fi
+done
+echo ""

--- a/scripts/restart_ecs
+++ b/scripts/restart_ecs
@@ -3,7 +3,11 @@
 # Restart ECS service
 #
 
-healthcheck_url="https://${APP_ENV}.easi.cms.gov/api/v1/healthcheck"
+if [[ "$APP_ENV" != "prod" ]] ; then
+  url_prefix="${APP_ENV}."
+fi
+
+healthcheck_url="https://${url_prefix}easi.cms.gov/api/v1/healthcheck"
 healthcheck_timeout="180"
 
 cluster_name="${APP_ENV}-easi-app"

--- a/scripts/restart_ecs
+++ b/scripts/restart_ecs
@@ -12,7 +12,7 @@ healthcheck_timeout="180"
 
 cluster_name="${APP_ENV}-easi-app"
 service_name="easi-app"
-( set -x ; aws ecs update-service --cluster "$cluster_name" --service "$service_name" --force-new-deployment )
+( set -x ; aws ecs update-service --cluster "$cluster_name" --service "$service_name" --force-new-deployment ) | jq '.service.events = ["REDACTED"]'
 
 # wait for the new service to come up
 echo -n "Waiting for health check version to match new deployment on ${healthcheck_url}" 1>&2

--- a/scripts/restart_ecs
+++ b/scripts/restart_ecs
@@ -15,7 +15,7 @@ service_name="easi-app"
 ( set -x ; aws ecs update-service --cluster "$cluster_name" --service "$service_name" --force-new-deployment )
 
 # wait for the new service to come up
-echo -n "Waiting for health check version to match new deployment." 1>&2
+echo -n "Waiting for health check version to match new deployment on ${healthcheck_url}" 1>&2
 until [[ "$(jq --raw-output --monochrome-output .version < <(curl --silent --show-error --location "$healthcheck_url"))" == "$CIRCLE_SHA1" ]] ; do
   if ((++time > healthcheck_timeout)) ; then
     # we timed out


### PR DESCRIPTION
# EASI-367

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add a 3-minute waiting period to the ECS deployment process to verify the correct version of the application is deployed