### PR TITLE
Okta test helper fails if no session token received from OTP challenge

### DIFF
--- a/pkg/testhelpers/okta.go
+++ b/pkg/testhelpers/okta.go
@@ -5,6 +5,7 @@ package testhelpers
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -121,6 +122,11 @@ func fetchOktaAccessToken(
 	if err != nil {
 		fmt.Println("could not marshall mfa response")
 		return "", err
+	}
+
+	if authn.SessionToken == "" {
+		fmt.Println("did not receive session token")
+		return "", errors.New("did not receive session token from OTP challenge response")
 	}
 
 	// Issue get request with session token to get id/access tokens

--- a/pkg/testhelpers/okta.go
+++ b/pkg/testhelpers/okta.go
@@ -5,7 +5,6 @@ package testhelpers
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -125,9 +124,9 @@ func fetchOktaAccessToken(
 	}
 
 	// Request can return 200 even if session token unset.
-	if authn.SessionToken == "" {
-		fmt.Println("did not receive session token")
-		return "", errors.New("did not receive session token from OTP challenge response")
+	if authn.Status != "SUCCESS" {
+		fmt.Println("did not succeed MFA challenge")
+		return "", fmt.Errorf("bad status in response from MFA request: %s", authn.Status)
 	}
 
 	// Issue get request with session token to get id/access tokens

--- a/pkg/testhelpers/okta.go
+++ b/pkg/testhelpers/okta.go
@@ -124,6 +124,7 @@ func fetchOktaAccessToken(
 		return "", err
 	}
 
+	// Request can return 200 even if session token unset.
 	if authn.SessionToken == "" {
 		fmt.Println("did not receive session token")
 		return "", errors.New("did not receive session token from OTP challenge response")


### PR DESCRIPTION
# EASI-000

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Returns a helpful error message if no session token is received. 
