### PR TITLE
Fix header username button

### DIFF
--- a/src/components/Header/UserActionList/index.scss
+++ b/src/components/Header/UserActionList/index.scss
@@ -24,8 +24,11 @@
 
     &:hover {
       background-color: #005ea2;
-      color: #fff;
-      cursor: pointer;
+
+      button {
+        color: #fff;
+        cursor: pointer;
+      }
     }
   }
 }

--- a/src/components/Header/UserActionList/index.tsx
+++ b/src/components/Header/UserActionList/index.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import './index.scss';
 
 type UserActionListProps = {
+  id: string;
   className?: string;
   children: React.ReactNodeArray;
 };
@@ -14,11 +15,16 @@ type UserActionProps = {
 };
 
 export const UserActionList = ({
+  id,
   className,
   children
 }: UserActionListProps) => {
   const classNames = classnames('user-actions-dropdown', className);
-  return <ul className={classNames}>{children}</ul>;
+  return (
+    <ul id={id} className={classNames}>
+      {children}
+    </ul>
+  );
 };
 
 export const UserAction = ({ onClick, link, children }: UserActionProps) => {

--- a/src/components/Header/index.scss
+++ b/src/components/Header/index.scss
@@ -8,6 +8,7 @@
   }
 
   &__username {
+    padding: 0;
     border: none;
     background-color: transparent;
     cursor: pointer;
@@ -61,6 +62,7 @@
   }
 
   &__caret {
+    margin-left: 5px;
     border: none;
     transform: rotate(0deg);
     cursor: pointer;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -72,29 +72,25 @@ export const Header = ({ auth, children, name }: HeaderProps) => {
           <span className="fa fa-bars" />
         </button>
         <div className="navbar--container">
-          {user && user.name && (
-            <button
-              className="easi-header__username"
-              type="button"
-              onClick={() => {
-                setDisplayDropdown(!displayDropdown);
-              }}
-            >
-              {user.name}
-            </button>
-          )}
           {isAuthenticated ? (
             <div className="easi-header__dropdown-wrapper" ref={dropdownNode}>
               <button
-                aria-label="Expand"
+                aria-label={
+                  displayDropdown ? 'Collapse User Menu' : 'Expand User Menu'
+                }
+                aria-expanded={displayDropdown}
+                aria-controls="Header-UserActionsList"
                 type="button"
-                className={arrowClassname}
+                className="easi-header__username"
                 onClick={() => {
                   setDisplayDropdown(!displayDropdown);
                 }}
-              />
+              >
+                {user && user.name ? user.name : ''}
+                <i className={arrowClassname} />
+              </button>
               {displayDropdown && (
-                <UserActionList>
+                <UserActionList id="Header-UserActionsList">
                   <UserAction link="/system/new">Add New System</UserAction>
                   <UserAction onClick={handleLogout}>Log Out</UserAction>
                 </UserActionList>


### PR DESCRIPTION
This PR fixes some header username mistakes.

1. The username and caret are now one single button. The focus wraps around the whole thing and the actions menu opens/closes as expected.
![Screen Shot 2020-04-13 at 9 55 33 PM](https://user-images.githubusercontent.com/8367504/79187591-90406e80-7dd1-11ea-874e-001e165ca365.png)

2. The actions menu hover text color is white.
![Screen Shot 2020-04-13 at 9 55 42 PM](https://user-images.githubusercontent.com/8367504/79187580-874f9d00-7dd1-11ea-9231-a81a2e9113c8.png)

Additionally, I added some accessibility fixes to the username/caret and actions menu. I'll leave comments inline.


