### PR TITLE
Add explicit logging of db lambda response

### DIFF
--- a/scripts/db_lambda_invoke
+++ b/scripts/db_lambda_invoke
@@ -6,7 +6,7 @@ payload='{ "command": "" }'
 cli_read_timeout=240
 
 if (set -x ; aws lambda invoke --cli-read-timeout "$cli_read_timeout" --function "$function_name" --payload "$payload" lambda_response.json) ; then
-  (set -x ; cat < lambda_response.json)
+  jq < lambda_response.json
   exitCode="$(jq '.data.response.taskStatus.exitCode' < lambda_response.json)"
   if [[ "$exitCode" != 0 ]] ; then
     echo ": task exited non-zero or exit status could not be parsed" 1>&2

--- a/scripts/db_lambda_invoke
+++ b/scripts/db_lambda_invoke
@@ -6,6 +6,7 @@ payload='{ "command": "" }'
 cli_read_timeout=240
 
 if (set -x ; aws lambda invoke --cli-read-timeout "$cli_read_timeout" --function "$function_name" --payload "$payload" lambda_response.json) ; then
+  (set -x ; cat < lambda_response.json)
   exitCode="$(jq '.data.response.taskStatus.exitCode' < lambda_response.json)"
   if [[ "$exitCode" != 0 ]] ; then
     echo ": task exited non-zero or exit status could not be parsed" 1>&2


### PR DESCRIPTION
# EASI-365
<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add a step to CI that pretty-prints the response from the lambda using jq
