### PR TITLE
Refactor environment variables for static asset build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,14 +109,6 @@ jobs:
         environment:
           AWS_DEFAULT_REGION: us-west-2
           APP_ENV: dev
-          OKTA_CLIENT_ID: 0oa2e913coDQeG19S297
-          REACT_APP_OKTA_CLIENT_ID: 0oa2e913coDQeG19S297
-          REACT_APP_OKTA_DOMAIN: https://test.idp.idm.cms.gov
-          REACT_APP_OKTA_SERVER_ID: aus2e96etlbFPnBHt297
-          REACT_APP_OKTA_ISSUER: https://test.idp.idm.cms.gov/oauth2/aus2e96etlbFPnBHt297
-          OKTA_ISSUER: https://test.idp.idm.cms.gov/oauth2/aus2e96etlbFPnBHt297
-          REACT_APP_OKTA_REDIRECT_URI: https://dev.easi.cms.gov/implicit/callback
-          REACT_APP_API_ADDRESS: https://dev.easi.cms.gov/api/v1
     steps:
       - checkout
       - run:
@@ -143,7 +135,7 @@ jobs:
       - run:
           name: Build static assets and release to S3
           command: |
-            ./scripts/release_static $STATIC_S3_BUCKET_DEV
+            ./scripts/release_static
 
   deploy_impl:
     docker:
@@ -151,14 +143,6 @@ jobs:
         environment:
           AWS_DEFAULT_REGION: us-west-2
           APP_ENV: impl
-          OKTA_CLIENT_ID: 0oa2sjdaxkwy3TrW1297
-          REACT_APP_OKTA_CLIENT_ID: 0oa2sjdaxkwy3TrW1297
-          REACT_APP_OKTA_DOMAIN: https://impl.idp.idm.cms.gov
-          REACT_APP_OKTA_SERVER_ID: aus2sjf5g6mzGsnSZ297
-          REACT_APP_OKTA_ISSUER: https://impl.idp.idm.cms.gov/oauth2/aus2sjf5g6mzGsnSZ297
-          OKTA_ISSUER: https://impl.idp.idm.cms.gov/oauth2/aus2sjf5g6mzGsnSZ297
-          REACT_APP_OKTA_REDIRECT_URI: https://impl.easi.cms.gov/implicit/callback
-          REACT_APP_API_ADDRESS: https://impl.easi.cms.gov/api/v1
     steps:
       - checkout
       - run:
@@ -181,7 +165,7 @@ jobs:
       - run:
           name: Build static assets and release to S3
           command: |
-            ./scripts/release_static "$STATIC_S3_BUCKET_IMPL"
+            ./scripts/release_static
 
 workflows:
   version: 2

--- a/scripts/release_static
+++ b/scripts/release_static
@@ -1,7 +1,36 @@
 #!/usr/bin/env bash
 #
 
-STATIC_S3_BUCKET=$1
+set -eu -o pipefail
+
+case "$APP_ENV" in
+  "dev")
+    STATIC_S3_BUCKET="$STATIC_S3_BUCKET_DEV"
+    EASI_URL="https://dev.easi.cms.gov"
+    export REACT_APP_OKTA_DOMAIN="https://test.idp.idm.cms.gov"
+    export REACT_APP_OKTA_CLIENT_ID="$OKTA_CLIENT_ID_DEV"
+    export REACT_APP_OKTA_SERVER_ID="$OKTA_SERVER_ID_DEV"
+    ;;
+  "impl")
+    STATIC_S3_BUCKET="$STATIC_S3_BUCKET_IMPL"
+    EASI_URL="https://impl.easi.cms.gov"
+    export REACT_APP_OKTA_DOMAIN="https://impl.idp.idm.cms.gov"
+    export REACT_APP_OKTA_CLIENT_ID="$OKTA_CLIENT_ID_IMPL"
+    export REACT_APP_OKTA_SERVER_ID="$OKTA_SERVER_ID_IMPL"
+    ;;
+  "prod")
+    STATIC_S3_BUCKET="$STATIC_S3_BUCKET_PROD"
+    EASI_URL="https://easi.cms.gov"
+    export REACT_APP_OKTA_DOMAIN="https://idm.cms.gov"
+    export REACT_APP_OKTA_CLIENT_ID="$OKTA_CLIENT_ID_PROD"
+    export REACT_APP_OKTA_SERVER_ID="$OKTA_SERVER_ID_PROD"
+    ;;
+  *)
+esac
+
+export REACT_APP_OKTA_ISSUER="${REACT_APP_OKTA_DOMAIN}/oauth2/${REACT_APP_OKTA_SERVER_ID}"
+export REACT_APP_OKTA_REDIRECT_URI="${EASI_URL}/implicit/callback"
+export REACT_APP_API_ADDRESS="${EASI_URL}/api/v1"
 
 # Check if we have any access to the s3 bucket
 # Since `s3 ls` returns zero even if the command failed, we assume failure if this command prints anything to stderr

--- a/scripts/release_static
+++ b/scripts/release_static
@@ -26,6 +26,10 @@ case "$APP_ENV" in
     export REACT_APP_OKTA_SERVER_ID="$OKTA_SERVER_ID_PROD"
     ;;
   *)
+    echo "APP_ENV value not recognized: ${APP_ENV:-unset}"
+    echo "Allowed values: 'dev', 'impl', 'prod'"
+    exit 1
+    ;;
 esac
 
 export REACT_APP_OKTA_ISSUER="${REACT_APP_OKTA_DOMAIN}/oauth2/${REACT_APP_OKTA_SERVER_ID}"


### PR DESCRIPTION
# EASI-315

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Move the Okta and other React environment variables from `.circleci/config.yml` to `scripts/release_static`. This way, we can reserve the `environment:` section for environment variables that are needed in multiple steps within a job.
- Remove unneeded environment variables and refactor how the others are composed
