### PR TITLE
Fix saving intake with new id

### DIFF
--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -60,13 +60,13 @@ func NewSaveSystemIntake(
 	logger *zap.Logger,
 ) func(context context.Context, intake *models.SystemIntake) error {
 	return func(ctx context.Context, intake *models.SystemIntake) error {
-		existingIntake, err := fetch(intake.ID)
+		existingIntake, fetchErr := fetch(intake.ID)
 		// TODO: Replace with a method that intentionally decides no result
-		if err != nil && err.Error() == "sql: no rows in result set" {
+		if fetchErr != nil && fetchErr.Error() == "sql: no rows in result set" {
 			existingIntake = nil
-		} else if err != nil {
+		} else if fetchErr != nil {
 			return &apperrors.QueryError{
-				Err:       err,
+				Err:       fetchErr,
 				Operation: apperrors.QueryFetch,
 				Model:     "SystemIntake",
 			}

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -113,6 +113,18 @@ func (s ServicesTestSuite) TestNewSaveSystemIntake() {
 		s.IsType(&apperrors.QueryError{}, err)
 	})
 
+	s.Run("saves when fetch existing fails with no results", func() {
+		ctx := context.Background()
+		failFetch := func(uuid uuid.UUID) (*models.SystemIntake, error) {
+			return nil, errors.New("sql: no rows in result set")
+		}
+		saveSystemIntake := NewSaveSystemIntake(save, failFetch, authorize, logger)
+
+		err := saveSystemIntake(ctx, &models.SystemIntake{})
+
+		s.NoError(err)
+	})
+
 	s.Run("returns error when authorization errors", func() {
 		ctx := context.Background()
 		err := errors.New("authorization failed")


### PR DESCRIPTION
# EASI-000

Changes proposed in this pull request:

- Fetch for existing error shouldn't affect saving a brand new intake
