### PR TITLE
Move "Save & Exit" from header to main content area

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -13,25 +13,10 @@ type HeaderProps = {
   name: string;
 };
 
-const easiLogo = (
-  <Link to="/" title="Home" aria-label="EASi home">
-    EASi
-  </Link>
-);
-
-const intakeLogo = <span aria-label="EASi home">CMS System Intake</span>;
-
 export const Header = ({ auth, children, name }: HeaderProps) => {
   const [isAuthenticated, user = {}, handleLogout] = useAuth(auth);
   const [displayDropdown, setDisplayDropdown] = useState(false);
   const dropdownNode = useRef<any>();
-
-  let logo;
-  if (name === 'INTAKE') {
-    logo = intakeLogo;
-  } else {
-    logo = easiLogo;
-  }
 
   const handleClick = (e: Event) => {
     if (
@@ -66,7 +51,7 @@ export const Header = ({ auth, children, name }: HeaderProps) => {
       <UsGovBanner />
       <div className="grid-container easi-header__basic">
         <div className="usa-logo site-logo" id="logo">
-          <em className="usa-logo__text">{logo}</em>
+          <em className="usa-logo__text">{name || 'EASi'}</em>
         </div>
         <button type="button" className="usa-menu-btn">
           <span className="fa fa-bars" />

--- a/src/views/BusinessCase/index.tsx
+++ b/src/views/BusinessCase/index.tsx
@@ -131,15 +131,7 @@ export const BusinessCase = () => {
 
   return (
     <div className="business-case">
-      <Header name="BUSINESS">
-        <div className="margin-bottom-3">
-          {pageObj.type === 'FORM' && (
-            <button type="button" className="easi-button__save usa-button">
-              <span>Save & Exit</span>
-            </button>
-          )}
-        </div>
-      </Header>
+      <Header name="BUSINESS" />
       <main role="main">
         <Formik
           initialValues={businessCaseInitalData}
@@ -235,6 +227,22 @@ export const BusinessCase = () => {
                       >
                         Send to Review Team
                       </Button>
+                    )}
+
+                    {pageObj.type === 'FORM' && (
+                      <div className="margin-y-3">
+                        <Button
+                          type="button"
+                          unstyled
+                          onClick={() => {
+                            // dispatch save and exit function
+                          }}
+                        >
+                          <span>
+                            <i className="fa fa-angle-left" /> Save & Exit
+                          </span>
+                        </Button>
+                      </div>
                     )}
                   </div>
                 </Form>

--- a/src/views/BusinessCase/index.tsx
+++ b/src/views/BusinessCase/index.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { withRouter } from 'react-router-dom';
 import { Formik, Form, FormikProps } from 'formik';
-
 import Header from 'components/Header';
 import Button from 'components/shared/Button';
 import PageNumber from 'components/PageNumber';
@@ -131,7 +129,7 @@ export const BusinessCase = () => {
 
   return (
     <div className="business-case">
-      <Header name="BUSINESS" />
+      <Header name="CMS Business Case" />
       <main role="main">
         <Formik
           initialValues={businessCaseInitalData}
@@ -263,4 +261,4 @@ export const BusinessCase = () => {
   );
 };
 
-export default withRouter(BusinessCase);
+export default BusinessCase;

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { useHistory, withRouter, RouteComponentProps } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { Formik, Form, FormikProps } from 'formik';
 import { v4 as uuidv4 } from 'uuid';
 import Header from 'components/Header';
@@ -12,18 +12,13 @@ import { SystemIntakeForm } from 'types/systemIntake';
 import SystemIntakeValidationSchema from 'validations/systemIntakeSchema';
 import flattenErrors from 'utils/flattenErrors';
 import AutoSave from 'components/shared/AutoSave';
+import { initialSystemIntakeForm } from 'data/systemIntake';
 import ContactDetails from './ContactDetails';
 import RequestDetails from './RequestDetails';
 import Review from './Review';
 import './index.scss';
-import { initialSystemIntakeForm } from '../../data/systemIntake';
 
-export type SystemIntakeRouterProps = {
-  profileId: string;
-};
-type SystemIntakeProps = RouteComponentProps<SystemIntakeRouterProps> & {};
-
-export const SystemIntake = ({ match }: SystemIntakeProps) => {
+export const SystemIntake = () => {
   const pages = [
     {
       type: 'FORM',
@@ -73,7 +68,7 @@ export const SystemIntake = ({ match }: SystemIntakeProps) => {
 
   return (
     <div className="system-intake">
-      <Header activeNavListItem={match.params.profileId} name="INTAKE" />
+      <Header name="CMS System Intake" />
       <main className="grid-container" role="main">
         <Formik
           initialValues={initialData}
@@ -206,4 +201,4 @@ export const SystemIntake = ({ match }: SystemIntakeProps) => {
   );
 };
 
-export default withRouter(SystemIntake);
+export default SystemIntake;

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -73,23 +73,7 @@ export const SystemIntake = ({ match }: SystemIntakeProps) => {
 
   return (
     <div className="system-intake">
-      <Header activeNavListItem={match.params.profileId} name="INTAKE">
-        {pageObj.type === 'FORM' && (
-          <div className="margin-bottom-3">
-            <button
-              type="button"
-              className="easi-header__save-button usa-button"
-              id="save-button"
-              onClick={() => {
-                dispatch(saveSystemIntake(id, formikRef.current.values));
-                history.push('/system/all');
-              }}
-            >
-              <span>Save & Exit</span>
-            </button>
-          </div>
-        )}
-      </Header>
+      <Header activeNavListItem={match.params.profileId} name="INTAKE" />
       <main className="grid-container" role="main">
         <Formik
           initialValues={initialData}
@@ -183,6 +167,24 @@ export const SystemIntake = ({ match }: SystemIntakeProps) => {
                       Send to GRT
                     </Button>
                   )}
+
+                  {pageObj.type === 'FORM' && (
+                    <div className="margin-y-3">
+                      <Button
+                        type="button"
+                        unstyled
+                        onClick={() => {
+                          dispatch(saveSystemIntake(id, values));
+                          history.push('/system/all');
+                        }}
+                      >
+                        <span>
+                          <i className="fa fa-angle-left" /> Save & Exit
+                        </span>
+                      </Button>
+                    </div>
+                  )}
+
                   <AutoSave
                     values={values}
                     onSave={dispatchSave}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1836,10 +1836,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
-"@types/lodash@":
-  version "4.14.149"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
-  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+"@types/lodash@^4.14.149":
+  version "4.14.150"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.150.tgz#649fe44684c3f1fcb6164d943c5a61977e8cf0bd"
+  integrity sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==
 
 "@types/luxon@^1.21.0":
   version "1.22.0"


### PR DESCRIPTION
# [EASI-300](https://jiraent.cms.gov/browse/EASI-300)

Due to accessibility constraints, this PR moves the "Save & Exit button from the header to below the "back" and "next" buttons in the main content area.

Along with this change, I also included some small clean up work:
- Move logic for header name into the view rather than managing it from the Header component
- Remove unnecessary dependencies
