### PR TITLE
Remove system profile page

### DIFF
--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -6,7 +6,7 @@ import Home from 'views/Home';
 import Login from 'views/Login';
 import BusinessCase from 'views/BusinessCase';
 import GRTSystemIntakeReview from 'views/GRTSystemIntakeReview';
-import SystemProfile from 'views/SystemProfile';
+// import SystemProfile from 'views/SystemProfile';
 import SystemProfiles from 'views/SystemProfiles';
 import SystemIntake from 'views/SystemIntake';
 import Sandbox from 'views/Sandbox';
@@ -39,10 +39,10 @@ class App extends React.Component<MainProps, MainState> {
                 path="/system/:systemId/grt-review"
                 component={GRTSystemIntakeReview}
               />
-              <SecureRoute
+              {/* <SecureRoute
                 path="/system/:profileId"
                 component={SystemProfile}
-              />
+              /> */}
               <SecureRoute path="/business/new" component={BusinessCase} />
               <Route path="/implicit/callback" component={ImplicitCallback} />
             </Switch>

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -6,7 +6,6 @@ import Home from 'views/Home';
 import Login from 'views/Login';
 import BusinessCase from 'views/BusinessCase';
 import GRTSystemIntakeReview from 'views/GRTSystemIntakeReview';
-// import SystemProfile from 'views/SystemProfile';
 import SystemProfiles from 'views/SystemProfiles';
 import SystemIntake from 'views/SystemIntake';
 import Sandbox from 'views/Sandbox';

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -170,7 +170,7 @@ export const SystemIntake = () => {
                         unstyled
                         onClick={() => {
                           dispatch(saveSystemIntake(id, values));
-                          history.push('/system/all');
+                          history.push('/');
                         }}
                       >
                         <span>


### PR DESCRIPTION
# EASI-442

- Removes the `/system/:systemId` route so users can't access the system profile page since it's not in scope
- After Save & Exit, users are redirected to the home page.