### PR TITLE
Add link to jira ticket in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-# EASI-000
+# [EASI-000](https://jiraent.cms.gov/browse/EASI-000)
 
 <!--
     If applicable, insert the Jira story number in the markdown header above


### PR DESCRIPTION
This PR provides an easy for for engineers to link to the JIRA tickets. `000` can be swapped out with the ticket number and it will make it easier for reviewers to find the ticket for acceptance criteria.