### PR TITLE
Fix flashing that occurs after autosave on system intake

### DIFF
--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -68,12 +68,13 @@ export const SystemIntake = ({ match }: SystemIntakeProps) => {
   };
 
   const dispatchSave = () => {
-    const { current } = formikRef;
-    if (current.dirty) {
-      dispatch(saveSystemIntake(current.values));
-      current.dirty = false;
+    const currentRef = formikRef.current as FormikProps<SystemIntakeForm>;
+    if (currentRef.dirty) {
+      dispatch(saveSystemIntake(currentRef.values));
+      // Set initial values to those just saved so ref.dirty is compared against last saved values.
+      currentRef.resetForm({ values: currentRef.values });
       if (!match.params.systemId) {
-        history.replace(`/system/${current.values.id}`);
+        history.replace(`/system/${currentRef.values.id}`);
       }
     }
   };
@@ -84,7 +85,9 @@ export const SystemIntake = ({ match }: SystemIntakeProps) => {
     } else {
       dispatch(storeSystemIntakeId(uuidv4()));
     }
-  }, [dispatch, match.params.systemId]);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="system-intake">
@@ -101,7 +104,6 @@ export const SystemIntake = ({ match }: SystemIntakeProps) => {
             validateOnChange={false}
             validateOnMount={false}
             innerRef={formikRef}
-            enableReinitialize
           >
             {(formikProps: FormikProps<SystemIntakeForm>) => {
               const {

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -68,13 +68,12 @@ export const SystemIntake = ({ match }: SystemIntakeProps) => {
   };
 
   const dispatchSave = () => {
-    const currentRef = formikRef.current as FormikProps<SystemIntakeForm>;
-    if (currentRef.dirty) {
-      dispatch(saveSystemIntake(currentRef.values));
-      // Set initial values to those just saved so ref.dirty is compared against last saved values.
-      currentRef.resetForm({ values: currentRef.values });
+    const { current } = formikRef;
+    if (current.dirty) {
+      dispatch(saveSystemIntake(current.values));
+      current.dirty = false;
       if (!match.params.systemId) {
-        history.replace(`/system/${currentRef.values.id}`);
+        history.replace(`/system/${current.values.id}`);
       }
     }
   };
@@ -102,6 +101,7 @@ export const SystemIntake = ({ match }: SystemIntakeProps) => {
             validateOnChange={false}
             validateOnMount={false}
             innerRef={formikRef}
+            enableReinitialize
           >
             {(formikProps: FormikProps<SystemIntakeForm>) => {
               const {


### PR DESCRIPTION
How to produce the bug?
1. Checkout to `master`
2. Navigate to `/system/new`
3. Type in something for the Requester's name

Notice there's a flash that makes it appear that the page refreshed. The URL changes (as it should). Because the URL changes, `match.params.systemId` changes as well. The `useEffect` hook executes and attempts to fetch that system intake by its `id`.

In this situation with the give acceptance criteria, we only need to fetch the data when the page mounts. This way, when the app autosaves and updates the URL, the app doesn't try to fetch the data again.