### PR TITLE
Create RDS snapshot before running database migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,10 @@ jobs:
             echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
             echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
       - run:
+          name: Backup the database
+          command: |
+            ./scripts/rds-snapshot-app-db
+      - run:
           name: Nuke the database
           command: |
             ./scripts/db_lambda_invoke easi-app-db-clean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,10 +125,6 @@ jobs:
             echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
             echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
       - run:
-          name: Backup the database
-          command: |
-            ./scripts/rds-snapshot-app-db
-      - run:
           name: Nuke the database
           command: |
             ./scripts/db_lambda_invoke easi-app-db-clean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,10 @@ jobs:
             echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
             echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
       - run:
+          name: Backup the database
+          command: |
+            ./scripts/rds-snapshot-app-db
+      - run:
           name: Run migrations
           command: |
             ./scripts/db_lambda_invoke easi-app-db-migrate

--- a/scripts/rds-snapshot-app-db
+++ b/scripts/rds-snapshot-app-db
@@ -1,0 +1,34 @@
+#! /usr/bin/env bash
+#
+#   Creates a snapshot of the app database for the given environment.
+#
+set -eu -o pipefail
+
+readonly environment="$APP_ENV"
+
+readonly db_instance_identifier=easi$environment
+readonly db_snapshot_identifier=$db_instance_identifier-$(date +%s)
+readonly tags=("Key=Environment,Value=$environment" "Key=Tool,Value=$(basename "$0")")
+
+echo
+echo "Wait for concurrent database snapshots for ${db_instance_identifier} to complete before continuing ..."
+time aws rds wait db-snapshot-completed --db-instance-identifier "$db_instance_identifier"
+
+echo
+echo "Create database snapshot for ${db_instance_identifier} with identifier ${db_snapshot_identifier}"
+aws rds create-db-snapshot --db-instance-identifier "$db_instance_identifier" --db-snapshot-identifier "$db_snapshot_identifier" --tags "${tags[@]}"
+
+echo
+echo "Wait for current database snapshot ${db_snapshot_identifier} to complete before continuing ..."
+time aws rds wait db-snapshot-completed --db-snapshot-identifier "$db_snapshot_identifier"
+
+echo
+echo "Describe the database snapshot ${db_snapshot_identifier}"
+db_description=$(aws rds describe-db-snapshots --db-snapshot-identifier "$db_snapshot_identifier")
+echo "${db_description}"
+db_status=$(echo "${db_description}" | jq -r ".DBSnapshots[].Status")
+if [[ "${db_status}" != "available" ]]; then
+  echo
+  echo "DB Status is '${db_status}', expected 'available'"
+  exit 1
+fi


### PR DESCRIPTION
# EASI-355

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add a script to snapshot the RDS instance before running database migrations

For initial testing, the script is backing up the dev RDS instance. Once the PR passes initial code review, I can remove the backup step in dev. 
