### PR TITLE
Add browser back/next to system intake form

### DIFF
--- a/src/components/shared/AutoSave/index.tsx
+++ b/src/components/shared/AutoSave/index.tsx
@@ -9,7 +9,8 @@ type AutoSaveProps = {
 
 const AutoSave = ({ values, onSave, debounceDelay }: AutoSaveProps) => {
   const debounceSave = useCallback(debounce(onSave, debounceDelay), [
-    debounceDelay
+    debounceDelay,
+    onSave
   ]);
   useEffect(debounceSave, [debounceSave, values]);
   return null;

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -117,13 +117,19 @@ export const prepareSystemIntakeForApp = (systemIntake: any) => {
       teams: governanceTeams() || []
     },
     fundingSource: {
-      isFunded: systemIntake.existingFunding || null,
+      isFunded:
+        systemIntake.existingFunding === null
+          ? null
+          : systemIntake.existingFunding,
       fundingNumber: systemIntake.fundingSource || ''
     },
     businessNeed: systemIntake.businessNeed || '',
     businessSolution: systemIntake.solution || '',
     currentStage: systemIntake.processStatus || '',
-    needsEaSupport: systemIntake.eaSupportRequest || null,
+    needsEaSupport:
+      systemIntake.eaSupportRequest === null
+        ? null
+        : systemIntake.eaSupportRequest,
     hasContract: systemIntake.existingContract || ''
   };
 };

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Switch, Route } from 'react-router-dom';
+import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom';
 import { SecureRoute, ImplicitCallback } from '@okta/okta-react';
 import AuthenticationWrapper from 'views/AuthenticationWrapper';
 import Home from 'views/Home';
@@ -27,11 +27,19 @@ class App extends React.Component<MainProps, MainState> {
               <Route path="/" exact component={Home} />
               <Route path="/login" exact component={Login} />
               <Route path="/sandbox" exact component={Sandbox} />
-              <SecureRoute path="/system/new" exact component={SystemIntake} />
-              <SecureRoute path="/system/:systemId" component={SystemIntake} />
               <SecureRoute
+                exact
                 path="/system/:systemId/grt-review"
                 component={GRTSystemIntakeReview}
+              />
+              <Redirect
+                exact
+                from="/system/:systemId"
+                to="/system/:systemId/contact-details"
+              />
+              <SecureRoute
+                path="/system/:systemId/:formPage"
+                component={SystemIntake}
               />
               {/* <SecureRoute
                 path="/system/all"

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -58,7 +58,7 @@ const Home = ({ auth, history }: HomeProps) => {
   return (
     <div>
       <Header />
-      <div role="main" className="grid-container margin-top-6">
+      <div role="main" className="grid-container margin-y-6">
         {getSystemIntakeBanners()}
         <div className="tablet:grid-col-9">
           <h1 className="margin-top-6">Welcome to EASi</h1>

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -75,8 +75,14 @@ export const SystemIntake = () => {
   }, []);
 
   useEffect(() => {
-    const pageSlugs = pages.map(p => p.slug);
-    setPage(pageSlugs.indexOf(formPage || ''));
+    const pageSlugs: any[] = pages.map(p => p.slug);
+    if (pageSlugs.includes(formPage)) {
+      setPage(pageSlugs.indexOf(formPage));
+    } else {
+      history.replace(`/system/${systemId}/contact-details`);
+      setPage(0);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pages, formPage]);
 
   return (

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -59,6 +59,7 @@ export const SystemIntake = () => {
     const currentRef = formikRef.current as FormikProps<SystemIntakeForm>;
     if (currentRef.dirty) {
       dispatch(saveSystemIntake(currentRef.values));
+      currentRef.resetForm({ values: currentRef.values });
       if (systemId === 'new') {
         history.replace(`/system/${currentRef.values.id}/${pageObj.slug}`);
       }

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -43,10 +43,10 @@ export const SystemIntake = () => {
 
   const history = useHistory();
   const { systemId, formPage } = useParams();
-  const [page, setPage] = useState(0);
+  const [pageIndex, setPageIndex] = useState(0);
   const dispatch = useDispatch();
   const formikRef: any = useRef();
-  const pageObj = pages[page];
+  const pageObj = pages[pageIndex];
 
   const systemIntake = useSelector(
     (state: AppState) => state.systemIntake.systemIntake
@@ -77,10 +77,10 @@ export const SystemIntake = () => {
   useEffect(() => {
     const pageSlugs: any[] = pages.map(p => p.slug);
     if (pageSlugs.includes(formPage)) {
-      setPage(pageSlugs.indexOf(formPage));
+      setPageIndex(pageSlugs.indexOf(formPage));
     } else {
       history.replace(`/system/${systemId}/contact-details`);
-      setPage(0);
+      setPageIndex(0);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pages, systemId, formPage]);
@@ -153,13 +153,13 @@ export const SystemIntake = () => {
                       render={() => <Review formikProps={formikProps} />}
                     />
 
-                    {page > 0 && (
+                    {pageIndex > 0 && (
                       <Button
                         type="button"
                         outline
                         onClick={() => {
                           setErrors({});
-                          const newUrl = pages[page - 1].slug;
+                          const newUrl = pages[pageIndex - 1].slug;
                           history.push(newUrl);
                           window.scrollTo(0, 0);
                         }}
@@ -167,14 +167,14 @@ export const SystemIntake = () => {
                         Back
                       </Button>
                     )}
-                    {page < pages.length - 1 && (
+                    {pageIndex < pages.length - 1 && (
                       <Button
                         type="button"
                         onClick={() => {
                           if (pageObj.validation) {
                             validateForm().then(err => {
                               if (Object.keys(err).length === 0) {
-                                const newUrl = pages[page + 1].slug;
+                                const newUrl = pages[pageIndex + 1].slug;
                                 history.push(newUrl);
                               }
                               window.scrollTo(0, 0);
@@ -185,7 +185,7 @@ export const SystemIntake = () => {
                         Next
                       </Button>
                     )}
-                    {page === pages.length - 1 && (
+                    {pageIndex === pages.length - 1 && (
                       <Button
                         type="submit"
                         disabled={isSubmitting}
@@ -227,7 +227,7 @@ export const SystemIntake = () => {
         )}
         {pageObj.type === 'FORM' && (
           <PageNumber
-            currentPage={page + 1}
+            currentPage={pageIndex + 1}
             totalPages={pages.filter(p => p.type === 'FORM').length}
           />
         )}

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -83,7 +83,7 @@ export const SystemIntake = () => {
       setPage(0);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pages, formPage]);
+  }, [pages, systemId, formPage]);
 
   return (
     <div className="system-intake">


### PR DESCRIPTION
# EASI-282

This PR adds browser back/next functionality to the System Intake form **only**. The business case will need to be tackled separately.

```
/system/new/contact-details
/system/new/request-details
/system/:systemId/contact-details
/system/:systemId/request-details
```

- If users try to visit an unknown/invalid page that isn't a part of the form, they will be redirected to `contact-details`, the first page.
- At this time, users are able to manually enter the URL to get to `request-details` and bypass `contact-details`. This is a known issue and in future work we will add checks to run validations so that a user is bounced to the right page.
- Integration test are in a holding pattern. If we can get this merged in, I can begin adding additional integration test cases in #175 