### PR TITLE
put grt-review subpath before system view in routes

### DIFF
--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -28,11 +28,11 @@ class App extends React.Component<MainProps, MainState> {
               <Route path="/login" exact component={Login} />
               <Route path="/sandbox" exact component={Sandbox} />
               <SecureRoute path="/system/new" exact component={SystemIntake} />
-              <SecureRoute path="/system/:systemId" component={SystemIntake} />
               <SecureRoute
                 path="/system/:systemId/grt-review"
                 component={GRTSystemIntakeReview}
               />
+              <SecureRoute path="/system/:systemId" component={SystemIntake} />
               {/* <SecureRoute
                 path="/system/all"
                 exact

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -27,6 +27,8 @@ class App extends React.Component<MainProps, MainState> {
               <Route path="/" exact component={Home} />
               <Route path="/login" exact component={Login} />
               <Route path="/sandbox" exact component={Sandbox} />
+              /* Subroutes should precede any parent routes or they will not be
+              callable */
               <SecureRoute path="/system/new" exact component={SystemIntake} />
               <SecureRoute
                 path="/system/:systemId/grt-review"


### PR DESCRIPTION
The intake view route is above the grt-review, which will get hit even if there is a subpath afterwards. This changes the order
