### PR TITLE
Pin depolyed images to git commit digests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,15 +127,15 @@ jobs:
       - run:
           name: Nuke the database
           command: |
-            ./scripts/db_lambda_invoke easi-app-db-clean
+            ./scripts/deploy_service "easi-app-db-clean"
       - run:
           name: Run migrations
           command: |
-            ./scripts/db_lambda_invoke easi-app-db-migrate
+            ./scripts/deploy_service "easi-app-db-migrate" "easi-db-migrate"
       - run:
-          name: Restart ECS service
+          name: Deploy ECS service
           command: |
-            ./scripts/restart_ecs
+            ./scripts/deploy_service "easi-app" "easi-backend"
             ./scripts/healthcheck
       - run:
           name: Build static assets and release to S3
@@ -166,11 +166,11 @@ jobs:
       - run:
           name: Run migrations
           command: |
-            ./scripts/db_lambda_invoke easi-app-db-migrate
+            ./scripts/deploy_service "easi-app-db-migrate" "easi-db-migrate"
       - run:
-          name: Restart ECS service
+          name: Deploy ECS service
           command: |
-            ./scripts/restart_ecs
+            ./scripts/deploy_service "easi-app" "easi-backend"
             ./scripts/healthcheck
       - run:
           name: Build static assets and release to S3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ jobs:
           name: Restart ECS service
           command: |
             ./scripts/restart_ecs
+            ./scripts/healthcheck
       - run:
           name: Build static assets and release to S3
           command: |
@@ -170,6 +171,7 @@ jobs:
           name: Restart ECS service
           command: |
             ./scripts/restart_ecs
+            ./scripts/healthcheck
       - run:
           name: Build static assets and release to S3
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
       - run:
           name: Nuke the database
           command: |
-            ./scripts/deploy_service "easi-app-db-clean"
+            ./scripts/db_lambda_invoke "easi-app-db-clean"
       - run:
           name: Run migrations
           command: |

--- a/scripts/deploy_service
+++ b/scripts/deploy_service
@@ -38,7 +38,7 @@ time (set -x ; aws lambda invoke --function-name "$function_name" --qualifier "$
 jq < output.json
 
 status="$(jq '.data.response.ResponseMetadata.HTTPStatusCode' < output.json)"
-if [[ "$status" -ne 200 ]]; then
+if [[ "$status" != 200 ]]; then
   echo ": FATAL HTTPStatusCode is not 200"
   exit 1
 fi

--- a/scripts/deploy_service
+++ b/scripts/deploy_service
@@ -33,6 +33,6 @@ _payload "${image_tag:-}" > payload.json
 jq < payload.json
 
 echo ": Invoking the $function_name lambda..."
-time aws lambda invoke --function-name "$function_name" --qualifier "$function_qualifier" --payload "$(base64 < payload.json)" output.json || exit
+time (set -x ; aws lambda invoke --function-name "$function_name" --qualifier "$function_qualifier" --payload file://./payload.json output.json) || exit
 
 jq < output.json

--- a/scripts/deploy_service
+++ b/scripts/deploy_service
@@ -36,3 +36,9 @@ echo ": Invoking the $function_name lambda..."
 time (set -x ; aws lambda invoke --function-name "$function_name" --qualifier "$function_qualifier" --payload file://./payload.json output.json) || exit
 
 jq < output.json
+
+status="$(jq '.data.response.ResponseMetadata.HTTPStatusCode' < output.json)"
+if [[ "$status" -ne 200 ]]; then
+  echo ": FATAL HTTPStatusCode is not 200"
+  exit 1
+fi

--- a/scripts/deploy_service
+++ b/scripts/deploy_service
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# deploy containers to our ecs services tagged with the git digest of the current build
+
+set -u
+
+service_id="$1"
+image="${2:-}"
+
+function_name="$APP_ENV-ecs-manager"
+function_qualifier="master"
+ecr_backend="${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com"
+
+if [[ -n "$image" ]]; then
+  image_tag="$ecr_backend/$image:${CIRCLE_SHA1-$(git rev-parse HEAD)}"
+fi
+
+_payload() {
+  local image_tag="${1:-}"
+  local cluster_id="${3:-$APP_ENV-easi-app}"
+
+  result=$(jq --null-input '.command = "deploy" | .body.cluster_id = "'"$cluster_id"'" | .body.service_ids = ["'"$service_id"'"]') || return
+
+  if [[ -n "$image_tag" ]]; then
+    result=$(jq '.body.image = "'"$image_tag"'"' <<< "$result") || return
+  fi
+
+  echo "$result"
+}
+
+_payload "${image_tag:-}" > payload.json
+
+jq < payload.json
+
+echo ": Invoking the $function_name lambda..."
+time aws lambda invoke --function-name "$function_name" --qualifier "$function_qualifier" --payload "$(base64 < payload.json)" output.json || exit
+
+jq < output.json

--- a/scripts/deploy_service
+++ b/scripts/deploy_service
@@ -28,7 +28,7 @@ _payload() {
   echo "$result"
 }
 
-_payload "${image_tag:-}" > payload.json
+_payload "${image_tag:-}" > payload.json || exit
 
 jq < payload.json
 

--- a/scripts/healthcheck
+++ b/scripts/healthcheck
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# wait some time for the easi health check http endpoint to return the expected version
+
+if [[ "$APP_ENV" != "prod" ]] ; then
+  url_prefix="${APP_ENV}."
+fi
+
+healthcheck_url="https://${url_prefix}easi.cms.gov/api/v1/healthcheck"
+healthcheck_timeout="180"
+
+# wait for the new service to come up
+echo -n "Waiting for health check version to match new deployment on ${healthcheck_url}" 1>&2
+until [[ "$(jq --raw-output --monochrome-output .version < <(curl --silent --show-error --location "$healthcheck_url"))" == "$CIRCLE_SHA1" ]] ; do
+  if ((++time > healthcheck_timeout)) ; then
+    # we timed out
+    echo ""
+    echo "FATAL: Timed out waiting." 1>&2
+    exit 1
+  else
+    [[ $((time % 10)) -eq 0 ]] && echo -n "."
+    sleep 1
+  fi
+done
+echo ""

--- a/scripts/restart_ecs
+++ b/scripts/restart_ecs
@@ -3,30 +3,8 @@
 # Restart ECS service
 #
 
-if [[ "$APP_ENV" != "prod" ]] ; then
-  url_prefix="${APP_ENV}."
-fi
-
-healthcheck_url="https://${url_prefix}easi.cms.gov/api/v1/healthcheck"
-healthcheck_timeout="180"
-
 cluster_name="${APP_ENV}-easi-app"
 service_name="easi-app"
 
 # we remove the list of service events since it is verbose and rarely needed when reviewing logs in CI
 ( set -x ; aws ecs update-service --cluster "$cluster_name" --service "$service_name" --force-new-deployment ) | jq '.service.events = ["REMOVED"]'
-
-# wait for the new service to come up
-echo -n "Waiting for health check version to match new deployment on ${healthcheck_url}" 1>&2
-until [[ "$(jq --raw-output --monochrome-output .version < <(curl --silent --show-error --location "$healthcheck_url"))" == "$CIRCLE_SHA1" ]] ; do
-  if ((++time > healthcheck_timeout)) ; then
-    # we timed out
-    echo ""
-    echo "FATAL: Timed out waiting." 1>&2
-    exit 1
-  else
-    [[ $((time % 10)) -eq 0 ]] && echo -n "."
-    sleep 1
-  fi
-done
-echo ""


### PR DESCRIPTION
# EASI-466

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Set circleci deployment workflow to use ecs-manager lambda for deploying images to the db-migrate and easi-app services
- Container definitions in those services now pull images named from the git digest of the current build

Notably, this PR does not change the process for cleaning the database in dev. Since the image running in that service is not being rebuilt for each deployment it is unnecessary to pin it to the same version as the others. For more, see the commit message to 6bd5a83.