### PR TITLE
Increase healthcheck timeout

### DIFF
--- a/scripts/healthcheck
+++ b/scripts/healthcheck
@@ -7,7 +7,7 @@ if [[ "$APP_ENV" != "prod" ]] ; then
 fi
 
 healthcheck_url="https://${url_prefix}easi.cms.gov/api/v1/healthcheck"
-healthcheck_timeout="180"
+healthcheck_timeout="300"
 
 # wait for the new service to come up
 echo -n "Waiting for health check version to match new deployment on ${healthcheck_url}" 1>&2

--- a/scripts/healthcheck
+++ b/scripts/healthcheck
@@ -11,7 +11,7 @@ healthcheck_timeout="300"
 
 # wait for the new service to come up
 echo -n "Waiting for health check version to match new deployment on ${healthcheck_url}" 1>&2
-until [[ "$(jq --raw-output --monochrome-output .version < <(curl --silent --show-error --location "$healthcheck_url"))" == "$CIRCLE_SHA1" ]] ; do
+until [[ "$(jq --raw-output --monochrome-output .version < <(curl --silent --show-error --max-time 2 --location "$healthcheck_url"))" == "$CIRCLE_SHA1" ]] ; do
   if ((++time > healthcheck_timeout)) ; then
     # we timed out
     echo ""


### PR DESCRIPTION
# EASI-473

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Increase the healthcheck timeout from 3 minutes to 5 minutes
- Add a max duration for each `curl` call to limit artificially extending the timeout in cases where the endpoint is unresponsive
