### PR TITLE
Run db_lambda_invoke after deploying migrations image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,7 @@ jobs:
           name: Run migrations
           command: |
             ./scripts/deploy_service "easi-app-db-migrate" "easi-db-migrate"
+            ./scripts/db_lambda_invoke "easi-app-db-migrate"
       - run:
           name: Deploy ECS service
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ jobs:
           name: Run migrations
           command: |
             ./scripts/deploy_service "easi-app-db-migrate" "easi-db-migrate"
+            ./scripts/db_lambda_invoke "easi-app-db-migrate"
       - run:
           name: Deploy ECS service
           command: |


### PR DESCRIPTION
# EASI-477

The update service operation does not start a task if the desiredCount is 0, as in the flyway services. An explicit run task command is required.

Therefore this PR restores the migrations lambda invocation after deploying the new image.

Changes proposed in this pull request:

- Invoke db migrations lambda after deploying migrations image