### PR TITLE
Send Slack notification on master branch failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ jobs:
           name: Build the flyway migrations for testing
           command: |
             ./scripts/build_db_image "Dockerfile.db_migrations" "easi-db-migrate"
+      - run:
+          name: Announce failure
+          command: |
+            ./scripts/circleci-announce-broken-branch
+          when: on_fail
 
   test:
     docker:
@@ -54,6 +59,11 @@ jobs:
           command: |
             ./scripts/build_app
             ./scripts/testsuite
+      - run:
+          name: Announce failure
+          command: |
+            ./scripts/circleci-announce-broken-branch
+          when: on_fail
 
   lint:
     docker:
@@ -83,6 +93,11 @@ jobs:
           key: yarn-deps-cache-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
+      - run:
+          name: Announce failure
+          command: |
+            ./scripts/circleci-announce-broken-branch
+          when: on_fail
 
   build_db_clean_image:
     docker:
@@ -96,6 +111,11 @@ jobs:
           name: Build the db cleaner image and push to ECR
           command: |
             ./scripts/build_db_image "Dockerfile.db_clean" "easi-db-clean" "latest"
+      - run:
+          name: Announce failure
+          command: |
+            ./scripts/circleci-announce-broken-branch
+          when: on_fail
 
   build_tag_push:
     docker:
@@ -113,6 +133,11 @@ jobs:
           name: Check for vulnerability scan findings
           command: |
             ./scripts/check_ecr_findings "easi-backend" "$CIRCLE_SHA1"
+      - run:
+          name: Announce failure
+          command: |
+            ./scripts/circleci-announce-broken-branch
+          when: on_fail
 
   deploy_dev:
     docker:
@@ -149,6 +174,11 @@ jobs:
           name: Build static assets and release to S3
           command: |
             ./scripts/release_static
+      - run:
+          name: Announce failure
+          command: |
+            ./scripts/circleci-announce-broken-branch
+          when: on_fail
 
   deploy_impl:
     docker:
@@ -185,6 +215,11 @@ jobs:
           name: Build static assets and release to S3
           command: |
             ./scripts/release_static
+      - run:
+          name: Announce failure
+          command: |
+            ./scripts/circleci-announce-broken-branch
+          when: on_fail
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
+          name: Simulate failure
+          command: |
+            exit 1
+      - run:
           name: Build the flyway migrations for testing
           command: |
             ./scripts/build_db_image "Dockerfile.db_migrations" "easi-db-migrate"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,6 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Simulate failure
-          command: |
-            exit 1
-      - run:
           name: Build the flyway migrations for testing
           command: |
             ./scripts/build_db_image "Dockerfile.db_migrations" "easi-db-migrate"

--- a/scripts/circleci-announce-broken-branch
+++ b/scripts/circleci-announce-broken-branch
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#####
+## Only alert on master branch
+#####
+[[ $CIRCLE_BRANCH = master ]] || exit 0
+
+NOW=$(date '+%s')
+
+pretext="CircleCI $CIRCLE_BRANCH branch failure!"
+title="CircleCI build #$CIRCLE_BUILD_NUM failed on job $CIRCLE_JOB"
+message="The $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH branch broke on job $CIRCLE_JOB! Contact $CIRCLE_USERNAME for more information."
+
+#####
+## Announce in Slack channel
+#####
+# 'color' can be any hex code or the key words 'good', 'warning', or 'danger'
+color="warning"
+if [[ $CIRCLE_JOB == *"deploy"* ]]; then
+  color="danger"
+fi
+
+slack_payload=$(
+cat <<EOM
+{
+    "channel": "#oit-easi-alerts",
+    "attachments": [
+        {
+            "fallback": "$message $CIRCLE_BUILD_URL",
+            "color": "$color",
+            "pretext": "$pretext",
+            "author_name": "$CIRCLE_USERNAME",
+            "title": "$title",
+            "title_link": "$CIRCLE_BUILD_URL",
+            "text": "$message",
+            "ts": $NOW
+        }
+    ]
+}
+EOM
+)
+
+echo
+echo "Slack Payload:"
+echo "$slack_payload"
+echo
+
+curl -X POST --data-urlencode payload="$slack_payload" "$SLACK_WEBHOOK_URL"

--- a/scripts/circleci-announce-broken-branch
+++ b/scripts/circleci-announce-broken-branch
@@ -4,7 +4,7 @@ set -euo pipefail
 #####
 ## Only alert on master branch
 #####
-# [[ $CIRCLE_BRANCH = master ]] || exit 0
+[[ $CIRCLE_BRANCH = master ]] || exit 0
 
 NOW=$(date '+%s')
 

--- a/scripts/circleci-announce-broken-branch
+++ b/scripts/circleci-announce-broken-branch
@@ -17,7 +17,7 @@ message="The $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME $CIRCLE_BRANCH br
 #####
 # 'color' can be any hex code or the key words 'good', 'warning', or 'danger'
 color="warning"
-if [[ $CIRCLE_JOB == *"deploy"* ]]; then
+if [[ $CIRCLE_JOB = *"deploy"* ]]; then
   color="danger"
 fi
 

--- a/scripts/circleci-announce-broken-branch
+++ b/scripts/circleci-announce-broken-branch
@@ -4,7 +4,7 @@ set -euo pipefail
 #####
 ## Only alert on master branch
 #####
-[[ $CIRCLE_BRANCH = master ]] || exit 0
+# [[ $CIRCLE_BRANCH = master ]] || exit 0
 
 NOW=$(date '+%s')
 


### PR DESCRIPTION
# EASI-409

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Send a Slack notification when a job on the master branch fails

To test, I added a temporary step to simulate failure (https://github.com/CMSgov/easi-app/pull/207/commits/5b121d0564a6c4d006469b141e037ca130200a55) and confirmed it didn't send a slack notification on my branch build. I then commented out the part that checks which branch we're on (https://github.com/CMSgov/easi-app/pull/207/commits/9d1fdccaef00d667610d45462a64a7eb82705f9b) and confirmed the failure message was sent to Slack.
