### PR TITLE
Add Created At to Models

### DIFF
--- a/migrations/V10__Add_Created_At.sql
+++ b/migrations/V10__Add_Created_At.sql
@@ -1,0 +1,4 @@
+ALTER TABLE system_intake ADD COLUMN created_at timestamp with time zone;
+ALTER TABLE business_case ADD COLUMN created_at timestamp with time zone;
+ALTER TABLE business_case ADD COLUMN updated_at timestamp with time zone;
+

--- a/pkg/models/business_case.go
+++ b/pkg/models/business_case.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/guregu/null"
@@ -101,6 +102,8 @@ type BusinessCase struct {
 	AlternativeBCons                null.String             `json:"alternativeBCons" db:"alternative_b_cons"`
 	AlternativeBCostSavings         null.String             `json:"alternativeBCostSavings" db:"alternative_b_cost_savings"`
 	LifecycleCostLines              EstimatedLifecycleCosts `json:"lifecycleCostLines" db:"lifecycle_cost_lines"`
+	CreatedAt                       *time.Time              `json:"createdAt" db:"created_at"`
+	UpdatedAt                       *time.Time              `json:"updatedAt" db:"updated_at"`
 }
 
 // BusinessCases is the model for a list of business cases

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -44,6 +44,7 @@ type SystemIntake struct {
 	ProcessStatus           null.String        `json:"processStatus" db:"process_status"`
 	EASupportRequest        null.Bool          `json:"eaSupportRequest" db:"ea_support_request"`
 	ExistingContract        null.String        `json:"existingContract" db:"existing_contract"`
+	CreatedAt               *time.Time         `json:"createdAt" db:"created_at"`
 	UpdatedAt               *time.Time         `json:"updatedAt" db:"updated_at"`
 	SubmittedAt             *time.Time         `json:"submittedAt" db:"submitted_at"`
 	AlfabetID               null.String        `json:"alfabetID" db:"alfabet_id"`

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -118,6 +118,7 @@ func (s *Server) routes(
 			services.NewAuthorizeCreateBusinessCase(s.logger),
 			store.CreateBusinessCase,
 			s.logger,
+			saveClock,
 		),
 		FetchBusinessCaseByID: services.NewFetchBusinessCaseByID(
 			store.FetchBusinessCaseByID,

--- a/pkg/services/business_case.go
+++ b/pkg/services/business_case.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/facebookgo/clock"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
@@ -74,6 +75,7 @@ func NewCreateBusinessCase(
 	authorize func(context context.Context, intake *models.SystemIntake) (bool, error),
 	create func(businessCase *models.BusinessCase) (*models.BusinessCase, error),
 	logger *zap.Logger,
+	clock clock.Clock,
 ) func(context context.Context, businessCase *models.BusinessCase) (*models.BusinessCase, error) {
 	return func(context context.Context, businessCase *models.BusinessCase) (*models.BusinessCase, error) {
 		intake, err := fetchIntake(businessCase.SystemIntakeID)
@@ -96,6 +98,9 @@ func NewCreateBusinessCase(
 		if err != nil {
 			return &models.BusinessCase{}, err
 		}
+		createAt := clock.Now()
+		businessCase.CreatedAt = &createAt
+		businessCase.UpdatedAt = &createAt
 		businessCase, err = create(businessCase)
 		if err != nil {
 			logger.Error("failed to create a business case")

--- a/pkg/services/business_case_test.go
+++ b/pkg/services/business_case_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/facebookgo/clock"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
@@ -115,6 +116,7 @@ func (s ServicesTestSuite) TestAuthorizeCreateBusinessCase() {
 
 func (s ServicesTestSuite) TestBusinessCaseCreator() {
 	logger := zap.NewNop()
+	mockClock := clock.NewMock()
 	euaID := testhelpers.RandomEUAID()
 	intakeID := uuid.New()
 	intake := models.SystemIntake{
@@ -143,7 +145,7 @@ func (s ServicesTestSuite) TestBusinessCaseCreator() {
 	ctx := context.Background()
 
 	s.Run("successfully creates a Business Case without an error", func() {
-		createBusinessCase := NewCreateBusinessCase(fetch, authorize, create, logger)
+		createBusinessCase := NewCreateBusinessCase(fetch, authorize, create, logger, mockClock)
 		businessCase, err := createBusinessCase(ctx, &input)
 		s.NoError(err)
 
@@ -154,7 +156,7 @@ func (s ServicesTestSuite) TestBusinessCaseCreator() {
 		create = func(businessCase *models.BusinessCase) (*models.BusinessCase, error) {
 			return &models.BusinessCase{}, errors.New("creation failed")
 		}
-		createBusinessCase := NewCreateBusinessCase(fetch, authorize, create, logger)
+		createBusinessCase := NewCreateBusinessCase(fetch, authorize, create, logger, mockClock)
 		businessCase, err := createBusinessCase(ctx, &input)
 
 		s.IsType(&apperrors.QueryError{}, err)
@@ -166,7 +168,7 @@ func (s ServicesTestSuite) TestBusinessCaseCreator() {
 			testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{}),
 			testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{}),
 		}
-		createBusinessCase := NewCreateBusinessCase(fetch, authorize, create, logger)
+		createBusinessCase := NewCreateBusinessCase(fetch, authorize, create, logger, mockClock)
 		businessCase, err := createBusinessCase(ctx, &input)
 
 		s.IsType(&apperrors.ValidationError{}, err)

--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -94,6 +94,9 @@ func NewSaveSystemIntake(
 		}
 		updatedTime := clock.Now().UTC()
 		intake.UpdatedAt = &updatedTime
+		if existingIntake == nil {
+			intake.CreatedAt = &updatedTime
+		}
 
 		if intake.Status == models.SystemIntakeStatusSUBMITTED {
 			if intake.AlfabetID.Valid {

--- a/pkg/storage/business_case.go
+++ b/pkg/storage/business_case.go
@@ -117,7 +117,9 @@ func (s *Store) CreateBusinessCase(businessCase *models.BusinessCase) (*models.B
 			alternative_b_acquisition_approach,
 			alternative_b_pros,
 			alternative_b_cons,
-			alternative_b_cost_savings
+			alternative_b_cost_savings,
+		    created_at,
+			updated_at
 		)
 		VALUES (
 			:id,
@@ -153,7 +155,9 @@ func (s *Store) CreateBusinessCase(businessCase *models.BusinessCase) (*models.B
 			:alternative_b_acquisition_approach,
 			:alternative_b_pros,
 			:alternative_b_cons,
-			:alternative_b_cost_savings
+			:alternative_b_cost_savings,
+		    :created_at,
+		    :updated_at
 		)`
 	tx := s.DB.MustBegin()
 	//Rollback only happens if transaction isn't committed

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -34,6 +34,7 @@ func (s *Store) SaveSystemIntake(intake *models.SystemIntake) error {
 			process_status,
 			ea_support_request,
 			existing_contract,
+			created_at,
 			updated_at,
 		    submitted_at,
 		    alfabet_id
@@ -60,6 +61,7 @@ func (s *Store) SaveSystemIntake(intake *models.SystemIntake) error {
 			:process_status,
 			:ea_support_request,
 			:existing_contract,
+		    :created_at,
 		    :updated_at,
 		    :submitted_at,
 		    :alfabet_id
@@ -84,6 +86,7 @@ func (s *Store) SaveSystemIntake(intake *models.SystemIntake) error {
 			process_status=:process_status,
 			ea_support_request=:ea_support_request,
 			existing_contract=:existing_contract,
+		    created_at=:created_at,
 			updated_at=:updated_at,
 			submitted_at=:submitted_at,
 		    alfabet_id=:alfabet_id


### PR DESCRIPTION
# EASI-488

We should log "created at" on our models in general, but also this is needed for metrics.

Changes proposed in this pull request:

- Add "created at" to system and business case
- Add "updated" at to business case
