### PR TITLE
Add metrics digest query

### DIFF
--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -55,9 +55,10 @@ type SystemIntakes []SystemIntake
 
 // SystemIntakeMetrics is a model for storing metrics related to system intake
 type SystemIntakeMetrics struct {
-	StartTime         *time.Time `json:"startTime"`
-	EndTime           *time.Time `json:"endTime"`
-	StartedRequests   int        `json:"startedRequests"`
-	CompletedRequests int        `json:"completedRequests"`
-	FundedRequests    int        `json:"fundedRequests"`
+	StartTime          *time.Time `json:"startTime"`
+	EndTime            *time.Time `json:"endTime"`
+	Started            int        `json:"started"`
+	CompletedOfStarted int        `json:"completedOfStarted"`
+	Completed          int        `json:"completed"`
+	Funded             int        `json:"funded"`
 }

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -51,3 +51,12 @@ type SystemIntake struct {
 
 // SystemIntakes is a list of System Intakes
 type SystemIntakes []SystemIntake
+
+// SystemIntakeMetrics is a model for storing metrics related to system intake
+type SystemIntakeMetrics struct {
+	StartTime         *time.Time `json:"startTime"`
+	EndTime           *time.Time `json:"endTime"`
+	StartedRequests   int        `json:"startedRequests"`
+	CompletedRequests int        `json:"completedRequests"`
+	FundedRequests    int        `json:"fundedRequests"`
+}

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -139,6 +139,9 @@ func (s *Store) GetSystemIntakeMetrics(startTime time.Time, endTime time.Time) (
 	const startedCountSQL = `
 		SELECT count(*) FROM system_intake WHERE created_at >=  $1 and created_at < $2
 	`
+	const completedCountSQL = `
+		SELECT count(*) FROM system_intake WHERE submitted_at >=  $1 and submitted_at < $2
+	`
 	metrics := models.SystemIntakeMetrics{}
 	var startedRequests int
 	err := s.DB.Get(
@@ -151,5 +154,17 @@ func (s *Store) GetSystemIntakeMetrics(startTime time.Time, endTime time.Time) (
 		return metrics, err
 	}
 	metrics.StartedRequests = startedRequests
+
+	var completedRequests int
+	err = s.DB.Get(
+		&completedRequests,
+		completedCountSQL,
+		&startTime,
+		&endTime,
+	)
+	if err != nil {
+		return metrics, err
+	}
+	metrics.CompletedRequests = completedRequests
 	return metrics, nil
 }

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -143,8 +143,14 @@ func (s *Store) GetSystemIntakeMetrics(startTime time.Time, endTime time.Time) (
 		  and created_at < $2
 	`
 	const completedCountSQL = `
+		WITH "started_intakes" as (
+		    SELECT * 
+		    FROM system_intake 
+		    WHERE created_at >=  $1 
+		      and created_at < $2
+		)
 		SELECT count(*) 
-		FROM system_intake 
+		from started_intakes
 		WHERE submitted_at >=  $1 
 		  and submitted_at < $2
 	`

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -136,17 +136,20 @@ func (s *Store) FetchSystemIntakesByEuaID(euaID string) (models.SystemIntakes, e
 
 // GetSystemIntakeMetrics gets a metrics digest for system intake
 func (s *Store) GetSystemIntakeMetrics(startTime time.Time, endTime time.Time) (models.SystemIntakeMetrics, error) {
-	const SystemIntakesMetricsSQL = `
-		SELECT count(*) 
-		FROM system_intake;
+	const startedCountSQL = `
+		SELECT count(*) FROM system_intake WHERE created_at >=  $1 and created_at < $2
 	`
-	var metrics models.SystemIntakeMetrics
-	_, err := s.DB.NamedExec(
-		SystemIntakesMetricsSQL,
-		&metrics,
+	metrics := models.SystemIntakeMetrics{}
+	var startedRequests int
+	err := s.DB.Get(
+		&startedRequests,
+		startedCountSQL,
+		&startTime,
+		&endTime,
 	)
 	if err != nil {
 		return metrics, err
 	}
+	metrics.StartedRequests = startedRequests
 	return metrics, nil
 }

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -137,10 +137,23 @@ func (s *Store) FetchSystemIntakesByEuaID(euaID string) (models.SystemIntakes, e
 // GetSystemIntakeMetrics gets a metrics digest for system intake
 func (s *Store) GetSystemIntakeMetrics(startTime time.Time, endTime time.Time) (models.SystemIntakeMetrics, error) {
 	const startedCountSQL = `
-		SELECT count(*) FROM system_intake WHERE created_at >=  $1 and created_at < $2
+		SELECT count(*) 
+		FROM system_intake 
+		WHERE created_at >=  $1 
+		  and created_at < $2
 	`
 	const completedCountSQL = `
-		SELECT count(*) FROM system_intake WHERE submitted_at >=  $1 and submitted_at < $2
+		SELECT count(*) 
+		FROM system_intake 
+		WHERE submitted_at >=  $1 
+		  and submitted_at < $2
+	`
+	const fundedCountSQL = `
+		SELECT count(*) 
+		FROM system_intake 
+		WHERE submitted_at >=  $1 
+		  and submitted_at < $2
+		  and existing_funding = true
 	`
 	metrics := models.SystemIntakeMetrics{}
 	var startedRequests int
@@ -166,5 +179,17 @@ func (s *Store) GetSystemIntakeMetrics(startTime time.Time, endTime time.Time) (
 		return metrics, err
 	}
 	metrics.CompletedRequests = completedRequests
+
+	var fundedRequests int
+	err = s.DB.Get(
+		&fundedRequests,
+		fundedCountSQL,
+		&startTime,
+		&endTime,
+	)
+	if err != nil {
+		return metrics, err
+	}
+	metrics.FundedRequests = fundedRequests
 	return metrics, nil
 }

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -128,4 +129,21 @@ func (s *Store) FetchSystemIntakesByEuaID(euaID string) (models.SystemIntakes, e
 		return models.SystemIntakes{}, err
 	}
 	return intakes, nil
+}
+
+// GetSystemIntakeMetrics gets a metrics digest for system intake
+func (s *Store) GetSystemIntakeMetrics(startTime time.Time, endTime time.Time) (models.SystemIntakeMetrics, error) {
+	const SystemIntakesMetricsSQL = `
+		SELECT count(*) 
+		FROM system_intake;
+	`
+	var metrics models.SystemIntakeMetrics
+	_, err := s.DB.NamedExec(
+		SystemIntakesMetricsSQL,
+		&metrics,
+	)
+	if err != nil {
+		return metrics, err
+	}
+	return metrics, nil
 }

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -193,7 +193,7 @@ func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
 		fmt.Printf(string(responseBody))
 	})
 
-	s.Run("gets proper number of completed intakes", func() {
+	s.Run("gets proper number of completed and funded intakes", func() {
 		// create a random year to avoid test collisions
 		// uses postgres max year minus 1000000
 		rand.Seed(time.Now().UnixNano())
@@ -202,6 +202,7 @@ func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
 		startDate := endDate.AddDate(0, -1, 0)
 		intake := testhelpers.NewSystemIntake()
 		intake.SubmittedAt = &startDate
+		intake.ExistingFunding = null.BoolFrom(false)
 		err := s.store.SaveSystemIntake(&intake)
 		s.NoError(err)
 		intake2 := testhelpers.NewSystemIntake()
@@ -213,6 +214,7 @@ func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
 		intake3.ID = uuid.New()
 		intake3Date := startDate.AddDate(0, 0, 1)
 		intake3.SubmittedAt = &intake3Date
+		intake3.ExistingFunding = null.BoolFrom(true)
 		err = s.store.SaveSystemIntake(&intake3)
 		s.NoError(err)
 
@@ -220,6 +222,7 @@ func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
 
 		s.NoError(err)
 		s.Equal(2, metrics.CompletedRequests)
+		s.Equal(1, metrics.FundedRequests)
 		responseBody, err := json.Marshal(metrics)
 		s.NoError(err)
 		fmt.Printf(string(responseBody))

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -187,7 +187,7 @@ func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
 			metrics, err := s.store.GetSystemIntakeMetrics(startDate, endDate)
 
 			s.NoError(err)
-			s.Equal(tt.expectedCount, metrics.StartedRequests)
+			s.Equal(tt.expectedCount, metrics.Started)
 		})
 	}
 
@@ -227,7 +227,7 @@ func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
 			metrics, err := s.store.GetSystemIntakeMetrics(startDate, endDate)
 
 			s.NoError(err)
-			s.Equal(tt.expectedCount, metrics.CompletedRequests)
+			s.Equal(tt.expectedCount, metrics.CompletedOfStarted)
 		})
 	}
 }

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -191,6 +191,9 @@ func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
 		})
 	}
 
+	endYear = rand.Intn(294276)
+	endDate = time.Date(endYear, 0, 0, 0, 0, 0, 0, time.UTC)
+	startDate = endDate.AddDate(0, -1, 0)
 	var completedTests = []struct {
 		name          string
 		createdAt     time.Time
@@ -231,6 +234,9 @@ func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
 		})
 	}
 
+	endYear = rand.Intn(294276)
+	endDate = time.Date(endYear, 0, 0, 0, 0, 0, 0, time.UTC)
+	startDate = endDate.AddDate(0, -1, 0)
 	var fundedTests = []struct {
 		name           string
 		submittedAt    time.Time

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -1,7 +1,9 @@
 package storage
 
 import (
+	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/guregu/null"
@@ -154,5 +156,18 @@ func (s StoreTestSuite) TestFetchSystemIntakesByEuaID() {
 		s.NoError(err)
 		s.Len(fetched, 0)
 		s.Equal(models.SystemIntakes{}, fetched)
+	})
+}
+
+func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
+	startDate := time.Now()
+	endDate := time.Now().AddDate(0, 1, 0)
+
+	s.Run("gets metrics successfully", func() {
+		metrics, err := s.store.GetSystemIntakeMetrics(startDate, endDate)
+		s.NoError(err)
+		responseBody, err := json.Marshal(metrics)
+		s.NoError(err)
+		fmt.Printf(string(responseBody))
 	})
 }


### PR DESCRIPTION
# EASI-488

This adds the query for the metrics we want to check in golive

Changes proposed in this pull request:

- Add a model for returning metrics
- Add queries to obtain metrics

Not included:
- a way to trigger these via API
- a way to return them/send them
