### PR TITLE
Wrap radio buttons in a RadioGroup and have them wrap

### DIFF
--- a/src/components/EstimatedLifecycleCost/index.scss
+++ b/src/components/EstimatedLifecycleCost/index.scss
@@ -103,11 +103,6 @@
     border-bottom: 1px solid rgba(0, 0, 0, 0.3);
   }
 
-  &__radio-row {
-    display: flex;
-    flex-direction: row;
-  }
-
   &__help-box {
     border: 3px solid #171717;
     padding: 1rem;

--- a/src/components/EstimatedLifecycleCost/index.tsx
+++ b/src/components/EstimatedLifecycleCost/index.tsx
@@ -5,7 +5,7 @@ import Label from 'components/shared/Label';
 import FieldGroup from 'components/shared/FieldGroup';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import TextField from 'components/shared/TextField';
-import { RadioField } from 'components/shared/RadioField';
+import { RadioGroup, RadioField } from 'components/shared/RadioField';
 import Button from 'components/shared/Button';
 import {
   DescriptionList,
@@ -49,7 +49,7 @@ const Phase = ({ formikKey, year, index, values, errors = [] }: PhaseProps) => {
                   >
                     Phase
                   </legend>
-                  <div className="est-lifecycle-cost__radio-row">
+                  <RadioGroup inline>
                     <Field
                       as={RadioField}
                       checked={values.phase === 'Development'}
@@ -69,7 +69,7 @@ const Phase = ({ formikKey, year, index, values, errors = [] }: PhaseProps) => {
                       value="Operations and Maintenance"
                       inline
                     />
-                  </div>
+                  </RadioGroup>
                 </div>
               </fieldset>
             </div>
@@ -162,7 +162,7 @@ const EstimatedLifecycleCost = ({
 
   return (
     <div className="est-lifecycle-cost grid-row">
-      <div className="tablet:grid-col-4">
+      <div className="tablet:grid-col-5">
         <div className="est-lifecycle-cost__help-box">
           <h3 className="est-lifecycle-cost__help-title text-bold">
             What do phases mean?
@@ -183,7 +183,7 @@ const EstimatedLifecycleCost = ({
           </dl>
         </div>
       </div>
-      <div className="tablet:grid-col-8">
+      <div className="tablet:grid-col-7">
         <div className="est-lifecycle-cost__year-costs margin-top-0">
           <span className="text-bold">Year 1</span>
           {years.year1.map((year: LifecyclePhase, index: number) => {

--- a/src/components/shared/RadioField/index.scss
+++ b/src/components/shared/RadioField/index.scss
@@ -1,9 +1,15 @@
 .easi-radio {
   &--inline {
     display: inline;
+    margin-left: 2rem;
   }
 
-  &--inline + &--inline {
-    margin-left: 2rem;
+  &__group {
+    &--inline {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      margin-left: -2rem;
+    }
   }
 }

--- a/src/components/shared/RadioField/index.tsx
+++ b/src/components/shared/RadioField/index.tsx
@@ -50,6 +50,22 @@ export const RadioField = ({
   );
 };
 
+type RadioGroupProps = {
+  children: React.ReactNode | React.ReactNodeArray;
+  inline?: boolean;
+};
+
+export const RadioGroup = ({ children, inline }: RadioGroupProps) => {
+  const classes = classnames('easi-radio__group', {
+    'easi-radio__group--inline': inline
+  });
+  return (
+    <div className={classes} role="radiogroup">
+      {children}
+    </div>
+  );
+};
+
 /**
  * TODO: I want to continue to iterate on this even though it isn't ready yet.
  * The thought is to create a compound component so that the "checked" state


### PR DESCRIPTION
I branched off to make this suggestion in how to handle the radio buttons overlapping the help and guidance box. I noticed the grid columns were changed to accomodate for the overlap, but this would continue to be a problem if the radio labels got longer or more margin/padding was introduced.

Instead of changing the grid columns, it would be better to make the radio buttons wrap and stack.
