### PR TITLE
Remove unique lifecycle cost validations for right now

### DIFF
--- a/pkg/appvalidation/business_case.go
+++ b/pkg/appvalidation/business_case.go
@@ -38,12 +38,14 @@ func BusinessCaseForCreation(businessCase *models.BusinessCase, intake *models.S
 		ModelID:     "",
 		Validations: apperrors.Validations{},
 	}
-	k, v := checkUniqLifecycleCosts(businessCase.LifecycleCostLines)
-	if k != "" {
-		expectedErr.WithValidation(k, v)
-	}
 
-	k, v = checkSystemIntakeSubmitted(intake)
+	// Uncomment below when UI has changed for unique lifecycle costs
+	//k, v := checkUniqLifecycleCosts(businessCase.LifecycleCostLines)
+	//if k != "" {
+	//	expectedErr.WithValidation(k, v)
+	//}
+
+	k, v := checkSystemIntakeSubmitted(intake)
 	if k != "" {
 		expectedErr.WithValidation(k, v)
 	}

--- a/pkg/appvalidation/business_case_test.go
+++ b/pkg/appvalidation/business_case_test.go
@@ -23,6 +23,7 @@ func (s AppValidateTestSuite) TestCheckUniqLifecycleCosts() {
 		k, _ := checkUniqLifecycleCosts(costs)
 		s.Equal("", k)
 	})
+
 	s.Run("returns validation when the lifecycle costs are invalid", func() {
 		elc1 := testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{})
 		elc2 := testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{})
@@ -44,6 +45,7 @@ func (s AppValidateTestSuite) TestCheckSystemIntakeSubmitted() {
 		k, _ := checkSystemIntakeSubmitted(&submittedIntake)
 		s.Equal("", k)
 	})
+
 	s.Run("returns false when the lifecycle costs are invalid", func() {
 		draftIntake := testhelpers.NewSystemIntake()
 		k, v := checkSystemIntakeSubmitted(&draftIntake)
@@ -63,26 +65,43 @@ func (s AppValidateTestSuite) TestBusinessCaseForSubmission() {
 		err := BusinessCaseForCreation(&businessCase, &submittedIntake)
 		s.NoError(err)
 	})
+
 	s.Run("returns validation error when business case fails validation", func() {
-		submittedIntake := testhelpers.NewSystemIntake()
-		elc1 := testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{})
-		elc2 := testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{})
+		intake := testhelpers.NewSystemIntake()
 		businessCase := models.BusinessCase{
-			SystemIntakeID: submittedIntake.ID,
-			LifecycleCostLines: models.EstimatedLifecycleCosts{
-				elc1,
-				elc2,
-			},
+			SystemIntakeID: intake.ID,
 		}
-		err := BusinessCaseForCreation(&businessCase, &submittedIntake)
+		err := BusinessCaseForCreation(&businessCase, &intake)
 		s.Error(err)
 		s.IsType(&apperrors.ValidationError{}, err)
 		expectedErrMessage := fmt.Sprintf("Could not validate *models.BusinessCase : " +
-			"{\"LifecycleCostPhase\":\"cannot have multiple costs for the same phase, solution, and year\"," +
-			"\"SystemIntake\":\"must have already been submitted\"}",
+			"{\"SystemIntake\":\"must have already been submitted\"}",
 		)
 		s.Equal(expectedErrMessage, err.Error())
 	})
+
+	// Uncomment below when UI has changed for unique lifecycle costs by
+	// replacing the previous test with this one.
+	//s.Run("returns validation error when business case fails validation", func() {
+	//	submittedIntake := testhelpers.NewSystemIntake()
+	//	elc1 := testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{})
+	//	elc2 := testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{})
+	//	businessCase := models.BusinessCase{
+	//		SystemIntakeID: submittedIntake.ID,
+	//		LifecycleCostLines: models.EstimatedLifecycleCosts{
+	//			elc1,
+	//			elc2,
+	//		},
+	//	}
+	//	err := BusinessCaseForCreation(&businessCase, &submittedIntake)
+	//	s.Error(err)
+	//	s.IsType(&apperrors.ValidationError{}, err)
+	//	expectedErrMessage := fmt.Sprintf("Could not validate *models.BusinessCase : " +
+	//		"{\"LifecycleCostPhase\":\"cannot have multiple costs for the same phase, solution, and year\"," +
+	//		"\"SystemIntake\":\"must have already been submitted\"}",
+	//	)
+	//	s.Equal(expectedErrMessage, err.Error())
+	//})
 }
 
 func (s AppValidateTestSuite) TestBusinessCaseForUpdate() {
@@ -95,6 +114,7 @@ func (s AppValidateTestSuite) TestBusinessCaseForUpdate() {
 		err := BusinessCaseForUpdate(&businessCase)
 		s.NoError(err)
 	})
+
 	s.Run("returns validation error when business case fails validation", func() {
 		elc2 := testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{})
 

--- a/pkg/services/business_case.go
+++ b/pkg/services/business_case.go
@@ -193,10 +193,11 @@ func NewUpdateBusinessCase(
 		if !ok {
 			return &models.BusinessCase{}, &apperrors.UnauthorizedError{Err: err}
 		}
-		err = appvalidation.BusinessCaseForUpdate(businessCase)
-		if err != nil {
-			return &models.BusinessCase{}, err
-		}
+		// Uncomment below when UI has changed for unique lifecycle costs
+		//err = appvalidation.BusinessCaseForUpdate(businessCase)
+		//if err != nil {
+		//	return &models.BusinessCase{}, err
+		//}
 		updatedAt := clock.Now()
 		businessCase.UpdatedAt = &updatedAt
 		businessCase, err = update(businessCase)

--- a/pkg/services/business_case_test.go
+++ b/pkg/services/business_case_test.go
@@ -163,17 +163,18 @@ func (s ServicesTestSuite) TestBusinessCaseCreator() {
 		s.Equal(&models.BusinessCase{}, businessCase)
 	})
 
-	s.Run("returns validation error when lifecycle cost phases are duplicated", func() {
-		input.LifecycleCostLines = models.EstimatedLifecycleCosts{
-			testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{}),
-			testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{}),
-		}
-		createBusinessCase := NewCreateBusinessCase(fetch, authorize, create, logger, mockClock)
-		businessCase, err := createBusinessCase(ctx, &input)
-
-		s.IsType(&apperrors.ValidationError{}, err)
-		s.Equal(&models.BusinessCase{}, businessCase)
-	})
+	// Uncomment below when UI has changed for unique lifecycle costs
+	//s.Run("returns validation error when lifecycle cost phases are duplicated", func() {
+	//	input.LifecycleCostLines = models.EstimatedLifecycleCosts{
+	//		testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{}),
+	//		testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{}),
+	//	}
+	//	createBusinessCase := NewCreateBusinessCase(fetch, authorize, create, logger, mockClock)
+	//	businessCase, err := createBusinessCase(ctx, &input)
+	//
+	//	s.IsType(&apperrors.ValidationError{}, err)
+	//	s.Equal(&models.BusinessCase{}, businessCase)
+	//})
 }
 
 func (s ServicesTestSuite) TestAuthorizeUpdateBusinessCase() {
@@ -262,15 +263,16 @@ func (s ServicesTestSuite) TestBusinessCaseUpdater() {
 		s.Equal(&models.BusinessCase{}, businessCase)
 	})
 
-	s.Run("returns validation error when lifecycle cost phases are duplicated", func() {
-		existingBusinessCase.LifecycleCostLines = models.EstimatedLifecycleCosts{
-			testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{}),
-			testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{}),
-		}
-		updateBusinessCase := NewUpdateBusinessCase(fetch, authorize, update, logger, mockClock)
-		businessCase, err := updateBusinessCase(ctx, &existingBusinessCase)
-
-		s.IsType(&apperrors.ValidationError{}, err)
-		s.Equal(&models.BusinessCase{}, businessCase)
-	})
+	// Uncomment below when UI has changed for unique lifecycle costs
+	//s.Run("returns validation error when lifecycle cost phases are duplicated", func() {
+	//	existingBusinessCase.LifecycleCostLines = models.EstimatedLifecycleCosts{
+	//		testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{}),
+	//		testhelpers.NewEstimatedLifecycleCost(testhelpers.EstimatedLifecycleCostOptions{}),
+	//	}
+	//	updateBusinessCase := NewUpdateBusinessCase(fetch, authorize, update, logger, mockClock)
+	//	businessCase, err := updateBusinessCase(ctx, &existingBusinessCase)
+	//
+	//	s.IsType(&apperrors.ValidationError{}, err)
+	//	s.Equal(&models.BusinessCase{}, businessCase)
+	//})
 }


### PR DESCRIPTION
# EASI-444

Changes proposed in this pull request:

- Temporarily removes lifecycle cost validations for post and put
- Maintains that a intake must be submitted

(Reminder for later, all code has comment 
```// Uncomment below when UI has changed for unique lifecycle costs``` 
for easy reverting)
