### PR TITLE
Add link to navigate to sharepoint

### DIFF
--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -88,7 +88,7 @@ const Home = ({ history }: HomeProps) => {
               service or make major changes and upgrades to an existing one. For
               all other requests, please use the{' '}
               <a
-                href="http://google.com"
+                href="https://share.cms.gov/Office/OIT/CIOCorner/Lists/Intake/NewForm.aspx"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
# EASI-502

This PR adds the link on the homepage to take a user from EASi to sharepoint. Right now it is configured to open in a new tab, but that can be changed if we want to.