### PR TITLE
Add disabled to initial dropdown values

### DIFF
--- a/src/components/shared/DropdownField/index.tsx
+++ b/src/components/shared/DropdownField/index.tsx
@@ -47,8 +47,11 @@ export const DropdownField = ({
 type DropdownItemProps = {
   name: string;
   value: string;
+  disabled?: boolean;
 };
 
-export const DropdownItem = ({ name, value }: DropdownItemProps) => (
-  <option value={value}>{name}</option>
+export const DropdownItem = ({ name, value, disabled }: DropdownItemProps) => (
+  <option value={value} disabled={disabled}>
+    {name}
+  </option>
 );

--- a/src/views/SystemIntake/ContactDetails/index.tsx
+++ b/src/views/SystemIntake/ContactDetails/index.tsx
@@ -89,7 +89,12 @@ const ContactDetails = ({ formikProps }: ContactDetailsProps) => {
               setFieldValue('requester.component', e.target.value);
             }}
           >
-            <Field as={DropdownItem} name="Select an option" value="" />
+            <Field
+              as={DropdownItem}
+              name="Select an option"
+              value=""
+              disabled
+            />
             {cmsDivionsAndOfficesOptions('RequesterComponent')}
           </Field>
         </FieldGroup>
@@ -152,7 +157,12 @@ const ContactDetails = ({ formikProps }: ContactDetailsProps) => {
             id="IntakeForm-BusinessOwnerComponent"
             name="businessOwner.component"
           >
-            <Field as={DropdownItem} name="Select an option" value="" />
+            <Field
+              as={DropdownItem}
+              name="Select an option"
+              value=""
+              disabled
+            />
             {cmsDivionsAndOfficesOptions('BusinessOwnerComponent')}
           </Field>
         </FieldGroup>
@@ -200,7 +210,12 @@ const ContactDetails = ({ formikProps }: ContactDetailsProps) => {
             label="Product Manager Component"
             name="productManager.component"
           >
-            <Field as={DropdownItem} name="Select an option" value="" />
+            <Field
+              as={DropdownItem}
+              name="Select an option"
+              value=""
+              disabled
+            />
             {cmsDivionsAndOfficesOptions('ProductManagerComponent')}
           </Field>
         </FieldGroup>

--- a/src/views/SystemIntake/RequestDetails/index.tsx
+++ b/src/views/SystemIntake/RequestDetails/index.tsx
@@ -201,7 +201,12 @@ const RequestDetails = ({ formikProps }: RequestDetailsProps) => {
             id="IntakeForm-CurrentStage"
             name="currentStage"
           >
-            <Field as={DropdownItem} name="Select" value="" />
+            <Field
+              as={DropdownItem}
+              name="Select an option"
+              value=""
+              disabled
+            />
             {processStages.map(stage => (
               <Field
                 as={DropdownItem}
@@ -232,7 +237,12 @@ const RequestDetails = ({ formikProps }: RequestDetailsProps) => {
             helpText="This information helps the Office of Acquisition and Grants Management (OAGM) track work"
             name="hasContract"
           >
-            <Field as={DropdownItem} name="Select" value="" />
+            <Field
+              as={DropdownItem}
+              name="Select an option"
+              value=""
+              disabled
+            />
             <Field
               as={DropdownItem}
               key="HasContract-Yes"


### PR DESCRIPTION
# EASI-508

I added a `disabled` prop to the `DropdownItem` component. This will make a `DropdownItem` not selectable.

This fixes the issue of allowing a default option to be selected.