### PR TITLE
Clear system intake from store on save and exit

### DIFF
--- a/src/reducers/systemIntakeReducer.test.ts
+++ b/src/reducers/systemIntakeReducer.test.ts
@@ -5,7 +5,8 @@ import {
 import {
   fetchSystemIntake,
   storeSystemIntake,
-  submitSystemIntake
+  submitSystemIntake,
+  removeSystemIntake
 } from 'types/routines';
 import systemIntakeReducer from './systemIntakeReducer';
 
@@ -33,6 +34,7 @@ describe('The system intake reducer', () => {
     existingContract: ''
   };
   it('returns the initial state', () => {
+    // @ts-ignore
     expect(systemIntakeReducer(undefined, {})).toEqual({
       systemIntake: initialSystemIntakeForm,
       isLoading: null,
@@ -180,7 +182,51 @@ describe('The system intake reducer', () => {
 
       expect(systemIntakeReducer(undefined, mockFulfillAction)).toEqual({
         systemIntake: initialSystemIntakeForm,
+        isLoading: false,
+        isSubmitting: null,
+        error: null
+      });
+    });
+  });
+
+  describe('removeSystemIntake', () => {
+    it('handles removeSystemIntake.TRIGGER', () => {
+      const mockRequestAction = {
+        type: removeSystemIntake.TRIGGER,
+        payload: undefined
+      };
+
+      expect(systemIntakeReducer(undefined, mockRequestAction)).toEqual({
+        systemIntake: initialSystemIntakeForm,
+        isLoading: false,
+        isSubmitting: false,
+        error: null
+      });
+    });
+
+    it('handles removeSystemIntake.FAILURE', () => {
+      const mockFailureAction = {
+        type: removeSystemIntake.FAILURE,
+        payload: 'Error Error'
+      };
+
+      expect(systemIntakeReducer(undefined, mockFailureAction)).toEqual({
+        systemIntake: initialSystemIntakeForm,
         isLoading: null,
+        isSubmitting: false,
+        error: 'Error Error'
+      });
+    });
+
+    it('handles removeSystemIntake.FULFILL', () => {
+      const mockFulfillAction = {
+        type: removeSystemIntake.FULFILL,
+        payload: undefined
+      };
+
+      expect(systemIntakeReducer(undefined, mockFulfillAction)).toEqual({
+        systemIntake: initialSystemIntakeForm,
+        isLoading: false,
         isSubmitting: false,
         error: null
       });

--- a/src/reducers/systemIntakeReducer.test.ts
+++ b/src/reducers/systemIntakeReducer.test.ts
@@ -6,7 +6,7 @@ import {
   fetchSystemIntake,
   storeSystemIntake,
   submitSystemIntake,
-  removeSystemIntake
+  clearSystemIntake
 } from 'types/routines';
 import systemIntakeReducer from './systemIntakeReducer';
 
@@ -182,49 +182,21 @@ describe('The system intake reducer', () => {
 
       expect(systemIntakeReducer(undefined, mockFulfillAction)).toEqual({
         systemIntake: initialSystemIntakeForm,
-        isLoading: false,
-        isSubmitting: null,
+        isLoading: null,
+        isSubmitting: false,
         error: null
       });
     });
   });
 
-  describe('removeSystemIntake', () => {
-    it('handles removeSystemIntake.TRIGGER', () => {
+  describe('clearSystemIntake', () => {
+    it('handles clearSystemIntake.TRIGGER', () => {
       const mockRequestAction = {
-        type: removeSystemIntake.TRIGGER,
+        type: clearSystemIntake.TRIGGER,
         payload: undefined
       };
 
       expect(systemIntakeReducer(undefined, mockRequestAction)).toEqual({
-        systemIntake: initialSystemIntakeForm,
-        isLoading: false,
-        isSubmitting: false,
-        error: null
-      });
-    });
-
-    it('handles removeSystemIntake.FAILURE', () => {
-      const mockFailureAction = {
-        type: removeSystemIntake.FAILURE,
-        payload: 'Error Error'
-      };
-
-      expect(systemIntakeReducer(undefined, mockFailureAction)).toEqual({
-        systemIntake: initialSystemIntakeForm,
-        isLoading: null,
-        isSubmitting: false,
-        error: 'Error Error'
-      });
-    });
-
-    it('handles removeSystemIntake.FULFILL', () => {
-      const mockFulfillAction = {
-        type: removeSystemIntake.FULFILL,
-        payload: undefined
-      };
-
-      expect(systemIntakeReducer(undefined, mockFulfillAction)).toEqual({
         systemIntake: initialSystemIntakeForm,
         isLoading: false,
         isSubmitting: false,

--- a/src/reducers/systemIntakeReducer.ts
+++ b/src/reducers/systemIntakeReducer.ts
@@ -6,7 +6,8 @@ import {
 import {
   fetchSystemIntake,
   storeSystemIntake,
-  submitSystemIntake
+  submitSystemIntake,
+  removeSystemIntake
 } from 'types/routines';
 import { Action } from 'redux-actions';
 
@@ -34,6 +35,23 @@ function systemIntakeReducer(
         systemIntake: prepareSystemIntakeForApp(action.payload)
       };
     case fetchSystemIntake.FULFILL:
+      return {
+        ...state,
+        isLoading: false
+      };
+    case removeSystemIntake.TRIGGER:
+      return {
+        ...state,
+        systemIntake: initialSystemIntakeForm,
+        isLoading: false,
+        error: null
+      };
+    case removeSystemIntake.FAILURE:
+      return {
+        ...state,
+        error: action.payload
+      };
+    case removeSystemIntake.FULFILL:
       return {
         ...state,
         isLoading: false

--- a/src/reducers/systemIntakeReducer.ts
+++ b/src/reducers/systemIntakeReducer.ts
@@ -7,7 +7,7 @@ import {
   fetchSystemIntake,
   storeSystemIntake,
   submitSystemIntake,
-  removeSystemIntake
+  clearSystemIntake
 } from 'types/routines';
 import { Action } from 'redux-actions';
 
@@ -39,22 +39,12 @@ function systemIntakeReducer(
         ...state,
         isLoading: false
       };
-    case removeSystemIntake.TRIGGER:
+    case clearSystemIntake.TRIGGER:
       return {
         ...state,
         systemIntake: initialSystemIntakeForm,
         isLoading: false,
         error: null
-      };
-    case removeSystemIntake.FAILURE:
-      return {
-        ...state,
-        error: action.payload
-      };
-    case removeSystemIntake.FULFILL:
-      return {
-        ...state,
-        isLoading: false
       };
     case storeSystemIntake.TRIGGER:
       return {

--- a/src/types/routines.ts
+++ b/src/types/routines.ts
@@ -8,7 +8,7 @@ export const fetchSystemIntake = createRoutine('FETCH_SYSTEM_INTAKE');
 export const saveSystemIntake = createRoutine('PUT_SYSTEM_INTAKE');
 export const storeSystemIntake = createRoutine('STORE_SYSTEM_INTAKE');
 export const submitSystemIntake = createRoutine('SUBMIT_SYSTEM_INTAKE');
-export const removeSystemIntake = createRoutine('REMOVE_SYSTEM_INTAKE');
+export const clearSystemIntake = createRoutine('CLEAR_SYSTEM_INTAKE');
 
 // SystemShorts routines
 export const fetchSystemShorts = createRoutine('FETCH_SYSTEM_SHORTS');

--- a/src/types/routines.ts
+++ b/src/types/routines.ts
@@ -8,6 +8,7 @@ export const fetchSystemIntake = createRoutine('FETCH_SYSTEM_INTAKE');
 export const saveSystemIntake = createRoutine('PUT_SYSTEM_INTAKE');
 export const storeSystemIntake = createRoutine('STORE_SYSTEM_INTAKE');
 export const submitSystemIntake = createRoutine('SUBMIT_SYSTEM_INTAKE');
+export const removeSystemIntake = createRoutine('REMOVE_SYSTEM_INTAKE');
 
 // SystemShorts routines
 export const fetchSystemShorts = createRoutine('FETCH_SYSTEM_SHORTS');

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -18,7 +18,7 @@ import {
   saveSystemIntake,
   storeSystemIntake,
   submitSystemIntake,
-  removeSystemIntake
+  clearSystemIntake
 } from 'types/routines';
 import usePrevious from 'hooks/usePrevious';
 import ContactDetails from './ContactDetails';
@@ -75,10 +75,6 @@ export const SystemIntake = () => {
     }
   };
 
-  const dispatchClearSystemIntake = () => {
-    dispatch(removeSystemIntake());
-  };
-
   useEffect(() => {
     if (systemId === 'new') {
       authService.getUser().then((user: any) => {
@@ -95,6 +91,10 @@ export const SystemIntake = () => {
     } else {
       dispatch(fetchSystemIntake(systemId));
     }
+    // This return will clear system intake from store when component is unmounted
+    return () => {
+      dispatch(clearSystemIntake());
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -226,7 +226,6 @@ export const SystemIntake = () => {
                           unstyled
                           onClick={() => {
                             dispatchSave();
-                            dispatchClearSystemIntake();
                             history.push('/');
                           }}
                         >

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -17,7 +17,8 @@ import {
   fetchSystemIntake,
   saveSystemIntake,
   storeSystemIntake,
-  submitSystemIntake
+  submitSystemIntake,
+  removeSystemIntake
 } from 'types/routines';
 import usePrevious from 'hooks/usePrevious';
 import ContactDetails from './ContactDetails';
@@ -72,6 +73,10 @@ export const SystemIntake = () => {
         history.replace(`/system/${current.values.id}/${pageObj.slug}`);
       }
     }
+  };
+
+  const dispatchClearSystemIntake = () => {
+    dispatch(removeSystemIntake());
   };
 
   useEffect(() => {
@@ -221,6 +226,7 @@ export const SystemIntake = () => {
                           unstyled
                           onClick={() => {
                             dispatchSave();
+                            dispatchClearSystemIntake();
                             history.push('/');
                           }}
                         >


### PR DESCRIPTION
# EASI-506

Changes proposed in this pull request:

- After clicking save and exit, I should be able to start a new system intake without the old existing one auto-filling my form.

Open questions: 
- Is remove the right verb to use? Or should I use clear?
- Should this be on save and exit or on starting a new form? I'm inclined to suggest on save and exit because it says I'm currently done with this particular system intake.