### PR TITLE
add server integration validations

### DIFF
--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -5,16 +5,16 @@ import "fmt"
 // NewEnvironment returns an environment from a string
 func NewEnvironment(config string) (Environment, error) {
 	switch config {
-	case LocalEnv.String():
-		return LocalEnv, nil
-	case TestEnv.String():
-		return TestEnv, nil
-	case DevEnv.String():
-		return DevEnv, nil
-	case ImplEnv.String():
-		return ImplEnv, nil
-	case ProdEnv.String():
-		return ProdEnv, nil
+	case localEnv.String():
+		return localEnv, nil
+	case testEnv.String():
+		return testEnv, nil
+	case devEnv.String():
+		return devEnv, nil
+	case implEnv.String():
+		return implEnv, nil
+	case prodEnv.String():
+		return prodEnv, nil
 	default:
 		return "", fmt.Errorf("unknown environment: %s", config)
 	}
@@ -27,30 +27,30 @@ const EnvironmentKey = "APP_ENV"
 type Environment string
 
 const (
-	// LocalEnv is the local environment
-	LocalEnv Environment = "local"
-	// TestEnv is the environment for running tests
-	TestEnv Environment = "test"
-	// DevEnv is the environment for the dev deployed env
-	DevEnv Environment = "dev"
-	// ImplEnv is the environment for the impl deployed env
-	ImplEnv Environment = "impl"
-	// ProdEnv is the environment for the impl deployed env
-	ProdEnv Environment = "prod"
+	// localEnv is the local environment
+	localEnv Environment = "local"
+	// testEnv is the environment for running tests
+	testEnv Environment = "test"
+	// devEnv is the environment for the dev deployed env
+	devEnv Environment = "dev"
+	// implEnv is the environment for the impl deployed env
+	implEnv Environment = "impl"
+	// prodEnv is the environment for the impl deployed env
+	prodEnv Environment = "prod"
 )
 
 // String gets the environment as a string
 func (e Environment) String() string {
 	switch e {
-	case LocalEnv:
+	case localEnv:
 		return "local"
-	case TestEnv:
+	case testEnv:
 		return "test"
-	case DevEnv:
+	case devEnv:
 		return "dev"
-	case ImplEnv:
+	case implEnv:
 		return "impl"
-	case ProdEnv:
+	case prodEnv:
 		return "prod"
 	default:
 		return ""
@@ -59,7 +59,7 @@ func (e Environment) String() string {
 
 // Local returns true if the environment is local
 func (e Environment) Local() bool {
-	if e == LocalEnv {
+	if e == localEnv {
 		return true
 	}
 	return false
@@ -67,7 +67,7 @@ func (e Environment) Local() bool {
 
 // Test returns true if the environment is local
 func (e Environment) Test() bool {
-	if e == TestEnv {
+	if e == testEnv {
 		return true
 	}
 	return false
@@ -75,7 +75,7 @@ func (e Environment) Test() bool {
 
 // Dev returns true if the environment is local
 func (e Environment) Dev() bool {
-	if e == DevEnv {
+	if e == devEnv {
 		return true
 	}
 	return false
@@ -83,7 +83,7 @@ func (e Environment) Dev() bool {
 
 // Impl returns true if the environment is local
 func (e Environment) Impl() bool {
-	if e == ImplEnv {
+	if e == implEnv {
 		return true
 	}
 	return false
@@ -91,7 +91,7 @@ func (e Environment) Impl() bool {
 
 // Prod returns true if the environment is local
 func (e Environment) Prod() bool {
-	if e == ProdEnv {
+	if e == prodEnv {
 		return true
 	}
 	return false
@@ -100,11 +100,11 @@ func (e Environment) Prod() bool {
 // Deployed returns true if in a deployed environment
 func (e Environment) Deployed() bool {
 	switch e {
-	case DevEnv:
+	case devEnv:
 		return true
-	case ImplEnv:
+	case implEnv:
 		return true
-	case ProdEnv:
+	case prodEnv:
 		return true
 	default:
 		return false

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -13,6 +13,8 @@ func NewEnvironment(config string) (Environment, error) {
 		return DevEnv, nil
 	case ImplEnv.String():
 		return ImplEnv, nil
+	case ProdEnv.String():
+		return ProdEnv, nil
 	default:
 		return "", fmt.Errorf("unknown environment: %s", config)
 	}
@@ -33,6 +35,8 @@ const (
 	DevEnv Environment = "dev"
 	// ImplEnv is the environment for the impl deployed env
 	ImplEnv Environment = "impl"
+	// ProdEnv is the environment for the impl deployed env
+	ProdEnv Environment = "prod"
 )
 
 // String gets the environment as a string
@@ -46,9 +50,51 @@ func (e Environment) String() string {
 		return "dev"
 	case ImplEnv:
 		return "impl"
+	case ProdEnv:
+		return "prod"
 	default:
 		return ""
 	}
+}
+
+// Local returns true if the environment is local
+func (e Environment) Local() bool {
+	if e == LocalEnv {
+		return true
+	}
+	return false
+}
+
+// Test returns true if the environment is local
+func (e Environment) Test() bool {
+	if e == TestEnv {
+		return true
+	}
+	return false
+}
+
+// Dev returns true if the environment is local
+func (e Environment) Dev() bool {
+	if e == TestEnv {
+		return true
+	}
+	return false
+}
+
+// Impl returns true if the environment is local
+func (e Environment) Impl() bool {
+	if e == ImplEnv {
+		return true
+	}
+	return false
+}
+
+// Prod returns true if the environment is local
+func (e Environment) Prod() bool {
+	if e == ProdEnv {
+		return true
+	}
+	return false
 }
 
 // DBHostConfigKey is the Postgres hostname config key

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -97,6 +97,20 @@ func (e Environment) Prod() bool {
 	return false
 }
 
+// Deployed returns true if in a deployed environment
+func (e Environment) Deployed() bool {
+	switch e {
+	case DevEnv:
+		return true
+	case ImplEnv:
+		return true
+	case ProdEnv:
+		return true
+	default:
+		return false
+	}
+}
+
 // DBHostConfigKey is the Postgres hostname config key
 const DBHostConfigKey = "PGHOST"
 

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -75,7 +75,7 @@ func (e Environment) Test() bool {
 
 // Dev returns true if the environment is local
 func (e Environment) Dev() bool {
-	if e == TestEnv {
+	if e == DevEnv {
 		return true
 	}
 	return false

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -1,5 +1,23 @@
 package appconfig
 
+import "fmt"
+
+// NewEnvironment returns an environment from a string
+func NewEnvironment(config string) (Environment, error) {
+	switch config {
+	case LocalEnv.String():
+		return LocalEnv, nil
+	case TestEnv.String():
+		return TestEnv, nil
+	case DevEnv.String():
+		return DevEnv, nil
+	case ImplEnv.String():
+		return ImplEnv, nil
+	default:
+		return "", fmt.Errorf("unknown environment: %s", config)
+	}
+}
+
 // EnvironmentKey is used to access the environment from a config
 const EnvironmentKey = "APP_ENV"
 

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -1,0 +1,76 @@
+package appconfig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	configTestSuite := &ConfigTestSuite{
+		Suite: suite.Suite{},
+	}
+	suite.Run(t, configTestSuite)
+}
+
+func (s ConfigTestSuite) TestNewEnvironment() {
+	var envTests = []struct {
+		env string
+	}{
+		{env: "local"},
+		{env: "test"},
+		{env: "dev"},
+		{env: "impl"},
+		{env: "prod"},
+	}
+	for _, t := range envTests {
+		s.Run(fmt.Sprintf("Can create a new %s environment", t.env), func() {
+			env, err := NewEnvironment(t.env)
+
+			s.NoError(err)
+			s.Equal(t.env, env.String())
+		})
+	}
+
+	s.Run(fmt.Sprintf("Fails with unknown environment"), func() {
+		env, err := NewEnvironment("Unknown")
+
+		s.Error(err)
+		s.Empty(env)
+	})
+}
+
+func (s ConfigTestSuite) TestLocal() {
+	env, _ := NewEnvironment("local")
+
+	s.True(env.Local())
+}
+
+func (s ConfigTestSuite) TestTest() {
+	env, _ := NewEnvironment("test")
+
+	s.True(env.Test())
+}
+
+func (s ConfigTestSuite) TestDev() {
+	env, _ := NewEnvironment("dev")
+
+	s.True(env.Dev())
+}
+
+func (s ConfigTestSuite) TestImpl() {
+	env, _ := NewEnvironment("impl")
+
+	s.True(env.Impl())
+}
+
+func (s ConfigTestSuite) TestProd() {
+	env, _ := NewEnvironment("prod")
+
+	s.True(env.Prod())
+}

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -77,18 +77,18 @@ func (s ConfigTestSuite) TestProd() {
 
 func (s ConfigTestSuite) TestDeployed() {
 	s.Run("local isn't deployed environment", func() {
-		s.False(LocalEnv.Deployed())
+		s.False(localEnv.Deployed())
 	})
 	s.Run("test isn't deployed environment", func() {
-		s.False(TestEnv.Deployed())
+		s.False(testEnv.Deployed())
 	})
 	s.Run("dev is deployed environment", func() {
-		s.True(DevEnv.Deployed())
+		s.True(devEnv.Deployed())
 	})
 	s.Run("impl is deployed environment", func() {
-		s.True(ImplEnv.Deployed())
+		s.True(implEnv.Deployed())
 	})
 	s.Run("prod is deployed environment", func() {
-		s.True(ProdEnv.Deployed())
+		s.True(prodEnv.Deployed())
 	})
 }

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -74,3 +74,21 @@ func (s ConfigTestSuite) TestProd() {
 
 	s.True(env.Prod())
 }
+
+func (s ConfigTestSuite) TestDeployed() {
+	s.Run("local isn't deployed environment", func() {
+		s.False(LocalEnv.Deployed())
+	})
+	s.Run("test isn't deployed environment", func() {
+		s.False(TestEnv.Deployed())
+	})
+	s.Run("dev is deployed environment", func() {
+		s.True(DevEnv.Deployed())
+	})
+	s.Run("impl is deployed environment", func() {
+		s.True(ImplEnv.Deployed())
+	})
+	s.Run("prod is deployed environment", func() {
+		s.True(ProdEnv.Deployed())
+	})
+}

--- a/pkg/appses/ses_test.go
+++ b/pkg/appses/ses_test.go
@@ -29,7 +29,12 @@ func TestSESTestSuite(t *testing.T) {
 	logger := zap.NewNop()
 	config := testhelpers.NewConfig()
 
-	if config.GetString(appconfig.EnvironmentKey) == appconfig.LocalEnv.String() {
+	env, err := appconfig.NewEnvironment(config.GetString(appconfig.EnvironmentKey))
+	if err != nil {
+		fmt.Printf("Failed to get environment: %v", err)
+		t.Fail()
+	}
+	if env.Local() {
 		fmt.Println("Skipping AWS SES test in local environment")
 		return
 	}

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -84,3 +84,9 @@ func (c Client) urlFromPath(path string) string {
 	}
 	return u.String()
 }
+
+// SendTestEmail sends an email to a no-reply address
+func (c Client) SendTestEmail() error {
+	const testToAddress = "success@simulator.amazonses.com"
+	return c.sender.Send(testToAddress, "test", "test")
+}

--- a/pkg/integration/cedar_test.go
+++ b/pkg/integration/cedar_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/cmsgov/easi-app/pkg/appconfig"
 	"github.com/cmsgov/easi-app/pkg/cedar"
 	"github.com/cmsgov/easi-app/pkg/handlers"
 	"github.com/cmsgov/easi-app/pkg/models"
@@ -18,7 +17,7 @@ import (
 // is set up.
 // Other tests should mock the API
 func (s *IntegrationTestSuite) TestCEDARConnection() {
-	if s.environment != appconfig.LocalEnv.String() {
+	if !s.environment.Local() {
 		fmt.Println("Skipped 'TestCEDARConnection' test")
 		return
 	}

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -27,7 +27,7 @@ type user struct {
 
 type IntegrationTestSuite struct {
 	suite.Suite
-	environment string
+	environment appconfig.Environment
 	logger      *zap.Logger
 	config      *viper.Viper
 	server      *httptest.Server
@@ -65,9 +65,14 @@ func TestIntegrationTestSuite(t *testing.T) {
 			t.Fail()
 		}
 
+		env, err := appconfig.NewEnvironment(config.GetString(appconfig.EnvironmentKey))
+		if err != nil {
+			fmt.Printf("Failed to get environment: %v", err)
+			t.Fail()
+		}
 		testSuite := &IntegrationTestSuite{
 			Suite:       suite.Suite{},
-			environment: config.GetString(appconfig.EnvironmentKey),
+			environment: env,
 			logger:      logger,
 			config:      config,
 			server:      testServer,

--- a/pkg/integration/system_intakes_test.go
+++ b/pkg/integration/system_intakes_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/guregu/null"
 
-	"github.com/cmsgov/easi-app/pkg/appconfig"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -100,7 +99,7 @@ func (s IntegrationTestSuite) TestSystemIntakeEndpoints() {
 	// is set up.
 	// Other tests should mock the API
 	s.Run("PUT will succeed if status is 'SUBMITTED' and it passes validation", func() {
-		if s.environment != appconfig.LocalEnv.String() {
+		if !s.environment.Local() {
 			fmt.Println("Skipped 'PUT will succeed if status is 'SUBMITTED' and it passes validation'")
 			return
 		}
@@ -137,7 +136,7 @@ func (s IntegrationTestSuite) TestSystemIntakeEndpoints() {
 	})
 
 	s.Run("PUT will fail if status is 'SUBMITTED', but it doesn't pass validation", func() {
-		if s.environment != appconfig.LocalEnv.String() {
+		if !s.environment.Local() {
 			fmt.Println("Skipped 'PUT will fail if status is 'SUBMITTED' and it doesn't pass validation'")
 			return
 		}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -19,13 +19,11 @@ func (s Server) checkRequiredConfig(config string) {
 
 // NewDBConfig returns a new DBConfig and check required fields
 func (s Server) NewDBConfig() storage.DBConfig {
-	environment := s.Config.GetString(appconfig.EnvironmentKey)
 	s.checkRequiredConfig(appconfig.DBHostConfigKey)
 	s.checkRequiredConfig(appconfig.DBPortConfigKey)
 	s.checkRequiredConfig(appconfig.DBNameConfigKey)
 	s.checkRequiredConfig(appconfig.DBUsernameConfigKey)
-	if environment != appconfig.LocalEnv.String() &&
-		environment != appconfig.TestEnv.String() {
+	if s.environment.Deployed() {
 		s.checkRequiredConfig(appconfig.DBPasswordConfigKey)
 	}
 	s.checkRequiredConfig(appconfig.DBSSLModeConfigKey)

--- a/pkg/server/health_check.go
+++ b/pkg/server/health_check.go
@@ -15,7 +15,7 @@ func (s Server) CheckCEDARClientConnection(client cedar.TranslatedClient) {
 	// and tests that we're authorized to retrieve information
 	_, err := client.FetchSystems(s.logger)
 	if err != nil {
-		s.logger.Panic("Failed to connect to CEDAR on startup", zap.Error(err))
+		s.logger.Fatal("Failed to connect to CEDAR on startup", zap.Error(err))
 	}
 }
 
@@ -25,6 +25,6 @@ func (s Server) CheckEmailClient(client email.Client) {
 	s.logger.Info("Testing email client")
 	err := client.SendTestEmail()
 	if err != nil {
-		s.logger.Panic("Failed to send test email", zap.Error(err))
+		s.logger.Fatal("Failed to send test email", zap.Error(err))
 	}
 }

--- a/pkg/server/healthcheck.go
+++ b/pkg/server/healthcheck.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/cedar"
+)
+
+// CheckCEDARClientConnection makes a call to CEDAR to test it is configured properly
+func (s Server) CheckCEDARClientConnection(client cedar.TranslatedClient) {
+	// FetchSystems is agnostic to user, doesn't modify state,
+	// and tests that we're authorized to retrieve information
+	_, err := client.FetchSystems(s.logger)
+	if err != nil {
+		s.logger.Panic("Failed to connect to CEDAR on startup", zap.Error(err))
+	}
+}

--- a/pkg/server/healthcheck.go
+++ b/pkg/server/healthcheck.go
@@ -4,14 +4,27 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/cedar"
+	"github.com/cmsgov/easi-app/pkg/email"
 )
 
 // CheckCEDARClientConnection makes a call to CEDAR to test it is configured properly
+// this method will panic on failures
 func (s Server) CheckCEDARClientConnection(client cedar.TranslatedClient) {
+	s.logger.Info("Testing CEDAR Connection")
 	// FetchSystems is agnostic to user, doesn't modify state,
 	// and tests that we're authorized to retrieve information
 	_, err := client.FetchSystems(s.logger)
 	if err != nil {
 		s.logger.Panic("Failed to connect to CEDAR on startup", zap.Error(err))
+	}
+}
+
+// CheckEmailClient sends a email to test it is configured properly
+// this method will panic on failures
+func (s Server) CheckEmailClient(client email.Client) {
+	s.logger.Info("Testing email client")
+	err := client.SendTestEmail()
+	if err != nil {
+		s.logger.Panic("Failed to send test email", zap.Error(err))
 	}
 }

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -38,7 +38,9 @@ func (s *Server) routes(
 		s.Config.GetString("CEDAR_API_KEY"),
 	)
 
-	s.CheckCEDARClientConnection(cedarClient)
+	if s.environment.Deployed() {
+		s.CheckCEDARClientConnection(cedarClient)
+	}
 
 	// set up Email Client
 	sesConfig := s.NewSESConfig()

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -38,6 +38,8 @@ func (s *Server) routes(
 		s.Config.GetString("CEDAR_API_KEY"),
 	)
 
+	s.CheckCEDARClientConnection(cedarClient)
+
 	// set up Email Client
 	sesConfig := s.NewSESConfig()
 	sesSender := appses.NewSender(sesConfig)

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -7,7 +7,6 @@ import (
 	_ "github.com/lib/pq" // pq is required to get the postgres driver into sqlx
 	"go.uber.org/zap"
 
-	"github.com/cmsgov/easi-app/pkg/appconfig"
 	"github.com/cmsgov/easi-app/pkg/appses"
 	"github.com/cmsgov/easi-app/pkg/cedar"
 	"github.com/cmsgov/easi-app/pkg/email"
@@ -51,7 +50,7 @@ func (s *Server) routes(
 		s.logger.Fatal("Failed to create email client", zap.Error(err))
 	}
 	// override email client with local one
-	if s.Config.GetString(appconfig.EnvironmentKey) == appconfig.LocalEnv.String() {
+	if s.environment.Local() {
 		localSender := local.NewSender(s.logger)
 		emailClient, err = email.NewClient(emailConfig, localSender)
 		if err != nil {

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -59,6 +59,10 @@ func (s *Server) routes(
 		}
 	}
 
+	if s.environment.Deployed() {
+		s.CheckEmailClient(emailClient)
+	}
+
 	// API base path is versioned
 	api := s.router.PathPrefix("/api/v1").Subrouter()
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,7 +52,7 @@ func NewServer(config *viper.Viper) *Server {
 	)
 
 	// If we're local use override with local auth middleware
-	if config.GetString(appconfig.EnvironmentKey) == appconfig.LocalEnv.String() {
+	if environment.Local() {
 		authMiddleware = local.NewLocalAuthorizeMiddleware(zapLogger)
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,7 +37,7 @@ func NewServer(config *viper.Viper) *Server {
 	// Set environment from config
 	environment, err := appconfig.NewEnvironment(config.GetString(appconfig.EnvironmentKey))
 	if err != nil {
-		zapLogger.Panic("Unable to set environment", zap.Error(err))
+		zapLogger.Fatal("Unable to set environment", zap.Error(err))
 	}
 
 	// Set the router

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,9 +16,10 @@ import (
 
 // Server holds dependencies for running the EASi server
 type Server struct {
-	router *mux.Router
-	Config *viper.Viper
-	logger *zap.Logger
+	router      *mux.Router
+	Config      *viper.Viper
+	logger      *zap.Logger
+	environment appconfig.Environment
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -31,6 +32,12 @@ func NewServer(config *viper.Viper) *Server {
 	zapLogger, err := zap.NewProduction()
 	if err != nil {
 		log.Fatal("Failed to initial logger.")
+	}
+
+	// Set environment from config
+	environment, err := appconfig.NewEnvironment(config.GetString(appconfig.EnvironmentKey))
+	if err != nil {
+		zapLogger.Panic("Unable to set environment", zap.Error(err))
 	}
 
 	// Set the router
@@ -53,9 +60,10 @@ func NewServer(config *viper.Viper) *Server {
 	clientAddress := config.GetString("CLIENT_ADDRESS")
 
 	s := &Server{
-		router: r,
-		Config: config,
-		logger: zapLogger,
+		router:      r,
+		Config:      config,
+		logger:      zapLogger,
+		environment: environment,
 	}
 
 	// set up routes


### PR DESCRIPTION
# EASI-551

Changes proposed in this pull request:

- Check CEDAR connection at startup by querying systems
- Check email client at startup by sending email
- Convenience methods for `Environment` to stop using `config.GetString` so much
- Add `Prod` environment
