### PR TITLE
Clear previous business case

### DIFF
--- a/src/reducers/businessCaseReducer.test.ts
+++ b/src/reducers/businessCaseReducer.test.ts
@@ -6,7 +6,8 @@ import {
   fetchBusinessCase,
   postBusinessCase,
   storeBusinessCase,
-  submitBusinessCase
+  submitBusinessCase,
+  clearBusinessCase
 } from 'types/routines';
 import businessCaseReducer from './businessCaseReducer';
 
@@ -292,6 +293,23 @@ describe('The business case reducer', () => {
       expect(businessCaseReducer(undefined, mockFulfillAction)).toEqual({
         form: businessCaseInitialData,
         isLoading: null,
+        isSaving: false,
+        isSubmitting: false,
+        error: null
+      });
+    });
+  });
+
+  describe('clearBusinessCase', () => {
+    it('handles clearBusinessCase.TRIGGER', () => {
+      const mockTriggerAction = {
+        type: clearBusinessCase.TRIGGER,
+        payload: null
+      };
+
+      expect(businessCaseReducer(undefined, mockTriggerAction)).toEqual({
+        form: businessCaseInitialData,
+        isLoading: false,
         isSaving: false,
         isSubmitting: false,
         error: null

--- a/src/reducers/businessCaseReducer.ts
+++ b/src/reducers/businessCaseReducer.ts
@@ -7,7 +7,8 @@ import {
   fetchBusinessCase,
   postBusinessCase,
   storeBusinessCase,
-  submitBusinessCase
+  submitBusinessCase,
+  clearBusinessCase
 } from 'types/routines';
 import { Action } from 'redux-actions';
 
@@ -91,6 +92,13 @@ function businessCaseReducer(
       return {
         ...state,
         isSubmitting: false
+      };
+    case clearBusinessCase.TRIGGER:
+      return {
+        ...state,
+        form: businessCaseInitialData,
+        isLoading: false,
+        error: null
       };
     default:
       return state;

--- a/src/types/routines.ts
+++ b/src/types/routines.ts
@@ -20,3 +20,4 @@ export const postBusinessCase = createRoutine('POST_BUSINESS_CASE');
 export const putBusinessCase = createRoutine('PUT_BUSINESS_CASE');
 export const storeBusinessCase = createRoutine('STORE_BUSINESS_CASE');
 export const submitBusinessCase = createRoutine('SUBMIT_BUSINESS_CASE');
+export const clearBusinessCase = createRoutine('CLEAR_BUSINESS_CASE');

--- a/src/views/BusinessCase/index.tsx
+++ b/src/views/BusinessCase/index.tsx
@@ -14,7 +14,8 @@ import {
   postBusinessCase,
   putBusinessCase,
   storeBusinessCase,
-  submitBusinessCase
+  submitBusinessCase,
+  clearBusinessCase
 } from 'types/routines';
 import { BusinessCaseModel } from 'types/businessCase';
 import { defaultProposedSolution } from 'data/businessCase';
@@ -159,6 +160,10 @@ export const BusinessCase = () => {
     } else {
       dispatch(fetchBusinessCase(businessCaseId));
     }
+
+    return () => {
+      dispatch(clearBusinessCase());
+    };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
# EASI-530

This PR  fixes the bug where they use sees the previous business case when trying to switch between business cases. This fix will allow the user to see the business case they are expecting to see when clicking on the banners.