### PR TITLE
remove sandbox from production build

### DIFF
--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -30,7 +30,9 @@ class App extends React.Component<MainProps, MainState> {
               <Switch>
                 <Route path="/" exact component={Home} />
                 <Route path="/login" exact component={Login} />
-                <Route path="/sandbox" exact component={Sandbox} />
+                {process.env.NODE_ENV === 'development' && (
+                  <Route path="/sandbox" exact component={Sandbox} />
+                )}
                 <Route
                   path="/governance-overview"
                   exact


### PR DESCRIPTION
This PR removes the sandbox page from the production build. The sandbox page will only appear on development environments.

To test this, you'll see `/sandbox` when running `yarn start`.

To run production build locally, run `yarn build` and follow the output instructions. This will probably involve installing a package to serve up the built files.
