### PR TITLE
Mw metrics endpoint

### DIFF
--- a/pkg/handlers/metrics.go
+++ b/pkg/handlers/metrics.go
@@ -1,0 +1,86 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+type fetchMetrics func(context context.Context, startTime time.Time, endTime time.Time) (*models.MetricsDigest, error)
+
+// MetricsHandler is the handler for retrieving metrics
+type MetricsHandler struct {
+	FetchMetrics fetchMetrics
+	Logger       *zap.Logger
+}
+
+// Handle handles a web request and returns a metrics digest
+func (h MetricsHandler) Handle() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		logger, ok := appcontext.Logger(r.Context())
+		if !ok {
+			h.Logger.Error("Failed to logger from context in metrics handler")
+			logger = h.Logger
+		}
+		switch r.Method {
+		case "GET":
+			// get our time params
+			startTimeParam, ok := r.URL.Query()["startTime"]
+			if !ok || len(startTimeParam[0]) < 1 {
+				http.Error(w, "startTime is required", http.StatusBadRequest)
+				return
+			}
+			startTime, err := time.Parse(time.RFC3339, startTimeParam[0])
+			if err != nil {
+				logger.Info("failed to parse starTime", zap.Error(err))
+				http.Error(w, "startTime must adhere to RFC 339", http.StatusBadRequest)
+				return
+			}
+			endTimeParam, ok := r.URL.Query()["endTime"]
+			if !ok || len(startTimeParam[0]) < 1 {
+				http.Error(w, "endTime is required", http.StatusBadRequest)
+				return
+			}
+			endTime, err := time.Parse(time.RFC3339, endTimeParam[0])
+			if err != nil {
+				logger.Info("failed to parse endTime", zap.Error(err))
+				http.Error(w, "endTime must adhere to RFC 339", http.StatusBadRequest)
+				return
+			}
+
+			metricsDigest, err := h.FetchMetrics(r.Context(), startTime, endTime)
+			if err != nil {
+				logger.Error(fmt.Sprintf("Failed to fetch metrics: %v", err))
+				http.Error(w, "failed to fetch metrics", http.StatusInternalServerError)
+				return
+			}
+
+			js, err := json.Marshal(metricsDigest)
+			if err != nil {
+				logger.Error(fmt.Sprintf("Failed to marshal metrics: %v", err))
+				http.Error(w, "failed to fetch metrics", http.StatusInternalServerError)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+
+			_, err = w.Write(js)
+			if err != nil {
+				logger.Error(fmt.Sprintf("Failed to write metrics response: %v", err))
+				http.Error(w, "failed to fetch metrics", http.StatusInternalServerError)
+				return
+			}
+		default:
+			logger.Info("Unsupported method requested")
+			http.Error(w, "Method not allowed for system intake", http.StatusMethodNotAllowed)
+			return
+		}
+	}
+}

--- a/pkg/handlers/metrics.go
+++ b/pkg/handlers/metrics.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
-type fetchMetrics func(context context.Context, startTime time.Time, endTime time.Time) (*models.MetricsDigest, error)
+type fetchMetrics func(context context.Context, startTime time.Time, endTime time.Time) (models.MetricsDigest, error)
 
 // MetricsHandler is the handler for retrieving metrics
 type MetricsHandler struct {

--- a/pkg/handlers/metrics_test.go
+++ b/pkg/handlers/metrics_test.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"time"
+
+	"github.com/facebookgo/clock"
+
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+func (s HandlerTestSuite) TestMetricsHandler() {
+
+	handlerClock := clock.NewMock()
+	expectedMetrics := models.MetricsDigest{
+		SystemIntakeMetrics: models.SystemIntakeMetrics{
+			Started:            5,
+			CompletedOfStarted: 2,
+			Completed:          3,
+			Funded:             2,
+		},
+	}
+	fetchMetrics := func(ctx context.Context, startTime time.Time, endTime time.Time) (models.MetricsDigest, error) {
+		return expectedMetrics, nil
+	}
+	metricsURL := url.URL{
+		Path: "/metrics",
+	}
+
+	s.Run("golden path passes", func() {
+		q := metricsURL.Query()
+		q.Add("startTime", handlerClock.Now().Add(time.Hour).Format(time.RFC3339))
+		u := url.URL{
+			RawQuery: q.Encode(),
+		}
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", u.String(), nil)
+		s.NoError(err)
+
+		MetricsHandler{
+			FetchMetrics: fetchMetrics,
+			Logger:       s.logger,
+			Clock:        handlerClock,
+		}.Handle()(rr, req)
+
+		s.Equal(http.StatusOK, rr.Code)
+
+		var metrics models.MetricsDigest
+		err = json.Unmarshal(rr.Body.Bytes(), &metrics)
+		s.NoError(err)
+		s.Equal(expectedMetrics, metrics)
+	})
+
+	s.Run("Invalid method is not allowed", func() {
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", metricsURL.String(), nil)
+		s.NoError(err)
+
+		MetricsHandler{
+			FetchMetrics: fetchMetrics,
+			Logger:       s.logger,
+			Clock:        handlerClock,
+		}.Handle()(rr, req)
+
+		s.Equal(http.StatusMethodNotAllowed, rr.Code)
+	})
+}

--- a/pkg/models/metrics.go
+++ b/pkg/models/metrics.go
@@ -1,0 +1,6 @@
+package models
+
+// MetricsDigest contains a set of metrics
+type MetricsDigest struct {
+	SystemIntakeMetrics SystemIntakeMetrics
+}

--- a/pkg/models/metrics.go
+++ b/pkg/models/metrics.go
@@ -2,5 +2,5 @@ package models
 
 // MetricsDigest contains a set of metrics
 type MetricsDigest struct {
-	SystemIntakeMetrics SystemIntakeMetrics
+	SystemIntakeMetrics SystemIntakeMetrics `json:"system_intake"`
 }

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -55,10 +55,10 @@ type SystemIntakes []SystemIntake
 
 // SystemIntakeMetrics is a model for storing metrics related to system intake
 type SystemIntakeMetrics struct {
-	StartTime          *time.Time `json:"startTime"`
-	EndTime            *time.Time `json:"endTime"`
-	Started            int        `json:"started"`
-	CompletedOfStarted int        `json:"completedOfStarted"`
-	Completed          int        `json:"completed"`
-	Funded             int        `json:"funded"`
+	StartTime          time.Time `json:"startTime"`
+	EndTime            time.Time `json:"endTime"`
+	Started            int       `json:"started"`
+	CompletedOfStarted int       `json:"completedOfStarted"`
+	Completed          int       `json:"completed"`
+	Funded             int       `json:"funded"`
 }

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"context"
 	"net/http"
+	"time"
 
 	"github.com/facebookgo/clock"
 	_ "github.com/lib/pq" // pq is required to get the postgres driver into sqlx
@@ -12,6 +14,7 @@ import (
 	"github.com/cmsgov/easi-app/pkg/email"
 	"github.com/cmsgov/easi-app/pkg/handlers"
 	"github.com/cmsgov/easi-app/pkg/local"
+	"github.com/cmsgov/easi-app/pkg/models"
 	"github.com/cmsgov/easi-app/pkg/services"
 	"github.com/cmsgov/easi-app/pkg/storage"
 )
@@ -151,6 +154,17 @@ func (s *Server) routes(
 		),
 	}
 	api.Handle("/business_cases", businessCasesHandler.Handle())
+
+	m := func(ctx context.Context, time time.Time, time2 time.Time) (*models.MetricsDigest, error) {
+		s.logger.Info("Metrics service", zap.Time("start time", time), zap.Time("end time", time2))
+		return &models.MetricsDigest{}, nil
+	}
+
+	metricsHandler := handlers.MetricsHandler{
+		FetchMetrics: m,
+		Logger:       s.logger,
+	}
+	api.Handle("/metrics", metricsHandler.Handle())
 
 	s.router.PathPrefix("/").Handler(handlers.CatchAllHandler{
 		Logger: s.logger,

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -153,7 +153,7 @@ func (s *Server) routes(
 	api.Handle("/business_cases", businessCasesHandler.Handle())
 
 	metricsHandler := handlers.MetricsHandler{
-		FetchMetrics: services.NewFetchMetrics(s.logger, store.GetSystemIntakeMetrics),
+		FetchMetrics: services.NewFetchMetrics(s.logger, store.FetchSystemIntakeMetrics),
 		Logger:       s.logger,
 		Clock:        handlerClock,
 	}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -153,7 +153,7 @@ func (s *Server) routes(
 	api.Handle("/business_cases", businessCasesHandler.Handle())
 
 	metricsHandler := handlers.MetricsHandler{
-		FetchMetrics: services.NewFetchMetrics(store.GetSystemIntakeMetrics),
+		FetchMetrics: services.NewFetchMetrics(s.logger, store.GetSystemIntakeMetrics),
 		Logger:       s.logger,
 		Clock:        handlerClock,
 	}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -89,7 +89,7 @@ func (s *Server) routes(
 	}
 	api.Handle("/systems", systemHandler.Handle())
 
-	saveClock := clock.New()
+	handlerClock := clock.New()
 	systemIntakeHandler := handlers.SystemIntakeHandler{
 		Logger: s.logger,
 		SaveSystemIntake: services.NewSaveSystemIntake(
@@ -99,7 +99,7 @@ func (s *Server) routes(
 			cedarClient.ValidateAndSubmitSystemIntake,
 			emailClient.SendSystemIntakeSubmissionEmail,
 			s.logger,
-			saveClock,
+			handlerClock,
 		),
 		FetchSystemIntakeByID: services.NewFetchSystemIntakeByID(
 			store.FetchSystemIntakeByID,
@@ -125,7 +125,7 @@ func (s *Server) routes(
 			services.NewAuthorizeCreateBusinessCase(s.logger),
 			store.CreateBusinessCase,
 			s.logger,
-			saveClock,
+			handlerClock,
 		),
 		FetchBusinessCaseByID: services.NewFetchBusinessCaseByID(
 			store.FetchBusinessCaseByID,
@@ -137,7 +137,7 @@ func (s *Server) routes(
 			store.UpdateBusinessCase,
 			emailClient.SendBusinessCaseSubmissionEmail,
 			s.logger,
-			saveClock,
+			handlerClock,
 		),
 	}
 	api.Handle("/business_case/{business_case_id}", businessCaseHandler.Handle())
@@ -155,6 +155,7 @@ func (s *Server) routes(
 	metricsHandler := handlers.MetricsHandler{
 		FetchMetrics: services.NewFetchMetrics(store.GetSystemIntakeMetrics),
 		Logger:       s.logger,
+		Clock:        handlerClock,
 	}
 	api.Handle("/metrics", metricsHandler.Handle())
 

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -1,9 +1,7 @@
 package server
 
 import (
-	"context"
 	"net/http"
-	"time"
 
 	"github.com/facebookgo/clock"
 	_ "github.com/lib/pq" // pq is required to get the postgres driver into sqlx
@@ -14,7 +12,6 @@ import (
 	"github.com/cmsgov/easi-app/pkg/email"
 	"github.com/cmsgov/easi-app/pkg/handlers"
 	"github.com/cmsgov/easi-app/pkg/local"
-	"github.com/cmsgov/easi-app/pkg/models"
 	"github.com/cmsgov/easi-app/pkg/services"
 	"github.com/cmsgov/easi-app/pkg/storage"
 )
@@ -155,13 +152,8 @@ func (s *Server) routes(
 	}
 	api.Handle("/business_cases", businessCasesHandler.Handle())
 
-	m := func(ctx context.Context, time time.Time, time2 time.Time) (*models.MetricsDigest, error) {
-		s.logger.Info("Metrics service", zap.Time("start time", time), zap.Time("end time", time2))
-		return &models.MetricsDigest{}, nil
-	}
-
 	metricsHandler := handlers.MetricsHandler{
-		FetchMetrics: m,
+		FetchMetrics: services.NewFetchMetrics(store.GetSystemIntakeMetrics),
 		Logger:       s.logger,
 	}
 	api.Handle("/metrics", metricsHandler.Handle())

--- a/pkg/services/metrics.go
+++ b/pkg/services/metrics.go
@@ -13,13 +13,17 @@ import (
 
 // NewFetchMetrics returns a service for fetching a metrics digest
 func NewFetchMetrics(
+	logger *zap.Logger,
 	fetchSystemIntakeMetrics func(time.Time, time.Time) (models.SystemIntakeMetrics, error),
 ) func(ctx context.Context, startTime time.Time, endTime time.Time) (models.MetricsDigest, error) {
 	return func(ctx context.Context, startTime time.Time, endTime time.Time) (models.MetricsDigest, error) {
-		logger, _ := appcontext.Logger(ctx)
+		localLogger, ok := appcontext.Logger(ctx)
+		if !ok {
+			localLogger = logger
+		}
 		systemIntakeMetrics, err := fetchSystemIntakeMetrics(startTime, endTime)
 		if err != nil {
-			logger.Error("failed to query system intake metrics", zap.Error(err))
+			localLogger.Error("failed to query system intake metrics", zap.Error(err))
 			return models.MetricsDigest{}, &apperrors.QueryError{
 				Err:       err,
 				Model:     models.SystemIntakeMetrics{},

--- a/pkg/services/metrics.go
+++ b/pkg/services/metrics.go
@@ -1,0 +1,23 @@
+package services
+
+import (
+	"context"
+	"time"
+
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+// NewFetchMetrics returns a service for fetching a metrics digest
+func NewFetchMetrics(
+	fetchSystemIntakeMetrics func(time.Time, time.Time) (models.SystemIntakeMetrics, error),
+) func(ctx context.Context, startTime time.Time, endTime time.Time) (models.MetricsDigest, error) {
+	return func(ctx context.Context, startTime time.Time, endTime time.Time) (models.MetricsDigest, error) {
+		systemIntakeMetrics, _ := fetchSystemIntakeMetrics(startTime, endTime)
+		systemIntakeMetrics.StartTime = startTime
+		systemIntakeMetrics.EndTime = endTime
+		metricsDigest := models.MetricsDigest{
+			SystemIntakeMetrics: systemIntakeMetrics,
+		}
+		return metricsDigest, nil
+	}
+}

--- a/pkg/services/metrics_test.go
+++ b/pkg/services/metrics_test.go
@@ -1,0 +1,48 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/facebookgo/clock"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+func (s ServicesTestSuite) TestNewFetchMetrics() {
+	serviceClock := clock.NewMock()
+	systemIntakeMetrics := models.SystemIntakeMetrics{}
+	fetchSystemIntakeMetrics := func(time.Time, time.Time) (models.SystemIntakeMetrics, error) {
+		return systemIntakeMetrics, nil
+	}
+
+	s.Run("golden path returns metric digest", func() {
+		fetchMetrics := NewFetchMetrics(s.logger, fetchSystemIntakeMetrics)
+		startTime := serviceClock.Now()
+		systemIntakeMetrics.StartTime = startTime
+		endTime := serviceClock.Now()
+		systemIntakeMetrics.EndTime = endTime
+
+		metricsDigest, err := fetchMetrics(context.Background(), startTime, endTime)
+
+		s.NoError(err)
+		s.Equal(models.MetricsDigest{SystemIntakeMetrics: systemIntakeMetrics}, metricsDigest)
+	})
+
+	s.Run("returns error if service fails", func() {
+		failFetchSystemIntakeMetrics := func(time.Time, time.Time) (models.SystemIntakeMetrics, error) {
+			return systemIntakeMetrics, errors.New("failed to fetch system intake metrics")
+		}
+		fetchMetrics := NewFetchMetrics(s.logger, failFetchSystemIntakeMetrics)
+		startTime := serviceClock.Now()
+		endTime := serviceClock.Now()
+
+		_, err := fetchMetrics(context.Background(), startTime, endTime)
+
+		s.Error(err)
+		s.IsType(&apperrors.QueryError{}, err)
+	})
+
+}

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -134,8 +134,8 @@ func (s *Store) FetchSystemIntakesByEuaID(euaID string) (models.SystemIntakes, e
 	return intakes, nil
 }
 
-// GetSystemIntakeMetrics gets a metrics digest for system intake
-func (s *Store) GetSystemIntakeMetrics(startTime time.Time, endTime time.Time) (models.SystemIntakeMetrics, error) {
+// FetchSystemIntakeMetrics gets a metrics digest for system intake
+func (s *Store) FetchSystemIntakeMetrics(startTime time.Time, endTime time.Time) (models.SystemIntakeMetrics, error) {
 	type startedQueryResponse struct {
 		StartedCount   int `db:"started_count"`
 		CompletedCount int `db:"completed_count"`

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -159,7 +159,7 @@ func (s StoreTestSuite) TestFetchSystemIntakesByEuaID() {
 	})
 }
 
-func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
+func (s StoreTestSuite) TestFetchSystemIntakeMetrics() {
 	// create a random year to avoid test collisions
 	// uses postgres max year minus 1000000
 	rand.Seed(time.Now().UnixNano())
@@ -184,7 +184,7 @@ func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
 			err := s.store.SaveSystemIntake(&intake)
 			s.NoError(err)
 
-			metrics, err := s.store.GetSystemIntakeMetrics(startDate, endDate)
+			metrics, err := s.store.FetchSystemIntakeMetrics(startDate, endDate)
 
 			s.NoError(err)
 			s.Equal(tt.expectedCount, metrics.Started)
@@ -227,7 +227,7 @@ func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
 			err := s.store.SaveSystemIntake(&intake)
 			s.NoError(err)
 
-			metrics, err := s.store.GetSystemIntakeMetrics(startDate, endDate)
+			metrics, err := s.store.FetchSystemIntakeMetrics(startDate, endDate)
 
 			s.NoError(err)
 			s.Equal(tt.expectedCount, metrics.CompletedOfStarted)
@@ -274,7 +274,7 @@ func (s StoreTestSuite) TestGetSystemIntakeMetrics() {
 			err := s.store.SaveSystemIntake(&intake)
 			s.NoError(err)
 
-			metrics, err := s.store.GetSystemIntakeMetrics(startDate, endDate)
+			metrics, err := s.store.FetchSystemIntakeMetrics(startDate, endDate)
 
 			s.NoError(err)
 			s.Equal(tt.completedCount, metrics.Completed)


### PR DESCRIPTION
# EASI-488

Changes proposed in this pull request:

- Adds handler for fetching metrics for a certain time period

You can test by hitting `/metrics?startTime={time}` to get metrics from `time` to now.
