### PR TITLE
Pass null to backend instead of empty string for alt b

### DIFF
--- a/src/data/businessCase.ts
+++ b/src/data/businessCase.ts
@@ -156,12 +156,13 @@ export const prepareBusinessCaseForApp = (
     hasAlternativeBLifecycleCostLines
       ? {
           alternativeB: {
-            title: businessCase.alternativeBTitle,
-            summary: businessCase.alternativeBSummary,
-            acquisitionApproach: businessCase.alternativeBAcquisitionApproach,
-            pros: businessCase.alternativeBPros,
-            cons: businessCase.alternativeBCons,
-            costSavings: businessCase.alternativeBCostSavings,
+            title: businessCase.alternativeBTitle || '',
+            summary: businessCase.alternativeBSummary || '',
+            acquisitionApproach:
+              businessCase.alternativeBAcquisitionApproach || '',
+            pros: businessCase.alternativeBPros || '',
+            cons: businessCase.alternativeBCons || '',
+            costSavings: businessCase.alternativeBCostSavings || '',
             estimatedLifecycleCost: lifecycleCostLines.B
           }
         }
@@ -271,22 +272,22 @@ export const prepareBusinessCaseForApi = (
     alternativeACostSavings: businessCase.alternativeA.costSavings,
     alternativeBTitle: businessCase.alternativeB
       ? businessCase.alternativeB.title
-      : '',
+      : null,
     alternativeBSummary: businessCase.alternativeB
       ? businessCase.alternativeB.summary
-      : '',
+      : null,
     alternativeBAcquisitionApproach: businessCase.alternativeB
       ? businessCase.alternativeB.acquisitionApproach
-      : '',
+      : null,
     alternativeBPros: businessCase.alternativeB
       ? businessCase.alternativeB.pros
-      : '',
+      : null,
     alternativeBCons: businessCase.alternativeB
       ? businessCase.alternativeB.cons
-      : '',
+      : null,
     alternativeBCostSavings: businessCase.alternativeB
       ? businessCase.alternativeB.costSavings
-      : '',
+      : null,
     lifecycleCostLines
   };
 };


### PR DESCRIPTION
# EASI-537

Currently, API requests set alternative B fields to empty string if they are not filled out. When a user attempts to submit, the backend sees empty string as it being filled.

This PR sets alternative B fields to be null by default.

Should we be validating for length instead on the backend?