### PR TITLE
Properly reset form(s) to initial state when clearing the form

### DIFF
--- a/src/reducers/businessCaseReducer.test.ts
+++ b/src/reducers/businessCaseReducer.test.ts
@@ -309,7 +309,7 @@ describe('The business case reducer', () => {
 
       expect(businessCaseReducer(undefined, mockTriggerAction)).toEqual({
         form: businessCaseInitialData,
-        isLoading: false,
+        isLoading: null,
         isSaving: false,
         isSubmitting: false,
         error: null

--- a/src/reducers/businessCaseReducer.ts
+++ b/src/reducers/businessCaseReducer.ts
@@ -94,12 +94,7 @@ function businessCaseReducer(
         isSubmitting: false
       };
     case clearBusinessCase.TRIGGER:
-      return {
-        ...state,
-        form: businessCaseInitialData,
-        isLoading: false,
-        error: null
-      };
+      return initialState;
     default:
       return state;
   }

--- a/src/reducers/systemIntakeReducer.test.ts
+++ b/src/reducers/systemIntakeReducer.test.ts
@@ -198,7 +198,7 @@ describe('The system intake reducer', () => {
 
       expect(systemIntakeReducer(undefined, mockRequestAction)).toEqual({
         systemIntake: initialSystemIntakeForm,
-        isLoading: false,
+        isLoading: null,
         isSubmitting: false,
         error: null
       });

--- a/src/reducers/systemIntakeReducer.ts
+++ b/src/reducers/systemIntakeReducer.ts
@@ -40,12 +40,7 @@ function systemIntakeReducer(
         isLoading: false
       };
     case clearSystemIntake.TRIGGER:
-      return {
-        ...state,
-        systemIntake: initialSystemIntakeForm,
-        isLoading: false,
-        error: null
-      };
+      return initialState;
     case storeSystemIntake.TRIGGER:
       return {
         ...state,


### PR DESCRIPTION
This PR resets the data to match the initial state of the reducer when cleared. Previously we were only resetting the form data.