### PR TITLE
Set base alpine image to minor revision 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /easi/
 COPY . .
 RUN  CGO_ENABLED=0 GOOS=linux go build -a -o bin/easi ./cmd/easi
 
-FROM alpine:3
+FROM alpine:3.11
 RUN apk --no-cache add ca-certificates
 WORKDIR /easi/
 COPY --from=builder /easi/bin/easi .


### PR DESCRIPTION
# Not Jira

Previously, the alpine image was set to major version 3. When alpine
3.12.0 was released we had builds failing because the ECR vulnerability
scanner does not support this version yet. Minor version 12 does not
appear to have any updates critical to our use case. Therefore we need
to pin to minor version 11 so that app development can continue.

Changes proposed in this pull request:

- Set base alpine image to minor revision 3.11