### PR TITLE
Add manual hold before deploy_dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,9 +319,13 @@ workflows:
           requires:
             - lint
             - test
-      - deploy_dev:
+      - hold_dev:
+          type: approval
           requires:
             - build_tag_push
+      - deploy_dev:
+          requires:
+            - hold_dev
       - deploy_impl:
           filters:
             branches:


### PR DESCRIPTION
# EASI-572

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add a manual hold step before performing deployments to DEV
