### PR TITLE
Remove deploy_dev requirement from deploy_impl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,8 +331,6 @@ workflows:
             branches:
               only:
                 - master
-          requires:
-            - deploy_dev
       - hold_prod:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,6 +335,8 @@ workflows:
             branches:
               only:
                 - master
+          requires:
+            - build_tag_push
       - hold_prod:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,6 +323,10 @@ workflows:
           type: approval
           requires:
             - build_tag_push
+          filters:
+            branches:
+              ignore:
+                - master
       - deploy_dev:
           requires:
             - hold_dev


### PR DESCRIPTION
# EASI-572
<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Remove the dependency on deploy_dev from deploy_impl

The hold_dev step added in #263 also procs in the master branch. deploy_impl depends on a successful deploy_dev job to run. That means that after merging a PR to master, an additional manual step is required to release the deploy_dev job so that deploy_impl can then run. 

But branch protection rules already ensure that a successful DEV deployment has been performed before any new code can be merged in to master. Therefore, we can remove this dependency and simply deploy directly to IMPL after merging to master. This will remove the extra post-merge release step _and_ eliminate one more redundant automated DEV deployment.

I also added an ignore filter for hold_dev so that there aren't dangling holds in the CI master branch builds. It might be better to put this ignore earlier in the process, maybe all the way at the beginning, but I need to think that through a bit more -- and it seems best to get this tweak merged in now so that app development can continue without being included in any of that confusion. :-)