### PR TITLE
Add aria label for governance collaborator name

### DIFF
--- a/src/components/shared/Label/index.test.tsx
+++ b/src/components/shared/Label/index.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Label from './index';
+
+describe('The Link component', () => {
+  it('renders without crashing', () => {
+    shallow(<Label htmlFor="test">Test</Label>);
+  });
+
+  it('displays children (text)', () => {
+    const component = shallow(<Label htmlFor="test">Test</Label>);
+
+    expect(component.find('label').text()).toEqual('Test');
+  });
+
+  it('displays children (HTML)', () => {
+    const component = shallow(
+      <Label htmlFor="test">
+        <div data-testid="label-child">Hi</div>
+      </Label>
+    );
+
+    expect(component.find('[data-testid="label-child"]').exists()).toEqual(
+      true
+    );
+  });
+
+  it('renders an aria-label', () => {
+    const component = shallow(
+      <Label htmlFor="test" ariaLabel="aria test">
+        Test
+      </Label>
+    );
+
+    expect(component.find('label').prop('aria-label')).toEqual('aria test');
+  });
+});

--- a/src/components/shared/Label/index.tsx
+++ b/src/components/shared/Label/index.tsx
@@ -5,13 +5,14 @@ type LabelProps = {
   children: React.ReactNode;
   htmlFor: string;
   className?: string;
+  ariaLabel?: string;
 };
 
-const Label = ({ children, htmlFor, className }: LabelProps) => {
+const Label = ({ children, htmlFor, className, ariaLabel }: LabelProps) => {
   const classes = classnames('usa-label', className);
 
   return (
-    <label className={classes} htmlFor={htmlFor}>
+    <label className={classes} htmlFor={htmlFor} aria-label={ariaLabel}>
       {children}
     </label>
   );

--- a/src/views/SystemIntake/ContactDetails/GovernanceTeamOptions.tsx
+++ b/src/views/SystemIntake/ContactDetails/GovernanceTeamOptions.tsx
@@ -58,7 +58,10 @@ const GovernanceTeamOptions = ({ formikProps }: GovernanceTeamOptionsProps) => {
                           scrollElement={`governanceTeams.teams.${idx}.collaborator`}
                           error={false}
                         >
-                          <Label htmlFor={`IntakeForm-${key}-Collaborator`}>
+                          <Label
+                            htmlFor={`IntakeForm-${key}-Collaborator`}
+                            ariaLabel={`Enter ${team.acronym} Collaborator Name`}
+                          >
                             {`${team.acronym} Collaborator Name`}
                           </Label>
                           {errors.governanceTeams &&


### PR DESCRIPTION
# EASI-568

The comments from our consult are a little out of date. We've added the team's acronym to the label already.

In this PR, I added an `aria-label` to the HTML label so that users using assistive technology will have a clear readout of what the input label is for.