### PR TITLE
Enable scheduled job to restart prod ECS service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ workflows:
   daily:
     triggers:
       - schedule:
-          cron: "0 22 * * *"   # 1500 Pacific time, 1800 Eastern time
+          cron: "0 7 * * *"   # 2300 PST, 0200 EST
           filters:
             branches:
               only:


### PR DESCRIPTION
# EASI-40

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Enable scheduled job to restart prod ECS service
- Push the job's scheduled time to 2300 PST, 0200 EST to avoid potential overlap with deployments at the earlier time
