### PR TITLE
Fix main content heading

### DIFF
--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -129,9 +129,11 @@ const Home = ({ history }: HomeProps) => {
   return (
     <div>
       <Header />
-      <MainContent className="grid-container margin-y-6">
-        {getSystemIntakeBanners()}
-        {getBusinessCaseBanners()}
+      <MainContent className="grid-container">
+        <div className="margin-y-6">
+          {getSystemIntakeBanners()}
+          {getBusinessCaseBanners()}
+        </div>
         <div className="tablet:grid-col-9">
           <h1 className="margin-top-6">Welcome to EASi</h1>
           <p className="line-height-body-5 font-body-lg text-light">


### PR DESCRIPTION
This PR fixes some spacing introduced when the `MainContent` component was added in #266.

This fix took less than 10 minutes so there is no JIRA ticket associated with it.

Before (Notice the spacing and border right above `Welcome to EASi`
![Screen Shot 2020-06-17 at 3 13 09 PM](https://user-images.githubusercontent.com/8367504/84956349-d786fc00-b0ad-11ea-91dd-d089e86a7363.png)

After (Extra spacing is gone)
![Screen Shot 2020-06-17 at 3 15 10 PM](https://user-images.githubusercontent.com/8367504/84956356-dce44680-b0ad-11ea-841a-e8408ebd5024.png)

