### PR TITLE
Make character counter accessible

### DIFF
--- a/src/components/CharacterCounter/index.scss
+++ b/src/components/CharacterCounter/index.scss
@@ -1,0 +1,5 @@
+.easi-character-counter {
+  display: inline-block;
+  color: #585c62;
+  line-height: 22px;
+}

--- a/src/components/CharacterCounter/index.test.tsx
+++ b/src/components/CharacterCounter/index.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import CharacterCounter from './index';
+
+describe('The CharacterCounter component', () => {
+  it('renders without crashing', () => {
+    shallow(<CharacterCounter id="TestId" characterCount={1000} />);
+  });
+});

--- a/src/components/CharacterCounter/index.tsx
+++ b/src/components/CharacterCounter/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import classnames from 'classnames';
+import './index.scss';
+
+type CharacterCounterProps = {
+  id: string;
+  characterCount: number;
+  className?: string;
+};
+
+const CharacterCounter = ({
+  id,
+  characterCount,
+  className
+}: CharacterCounterProps) => {
+  const classes = classnames(
+    'easi-character-counter',
+    'margin-top-1',
+    className
+  );
+  return (
+    <span
+      id={id}
+      className={classes}
+      aria-live="polite"
+      aria-atomic={false}
+    >{`${characterCount} characters remaining`}</span>
+  );
+};
+
+export default CharacterCounter;

--- a/src/views/BusinessCase/AlternativeSolution/index.tsx
+++ b/src/views/BusinessCase/AlternativeSolution/index.tsx
@@ -15,6 +15,7 @@ import {
 } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
 import MandatoryFieldsAlert from 'components/MandatoryFieldsAlert';
+import CharacterCounter from 'components/CharacterCounter';
 
 type AlternativeSolutionProps = {
   formikProps: FormikProps<BusinessCaseModel>;
@@ -139,9 +140,12 @@ const AlternativeSolution = ({
             id={`BusinessCase-${altId}Summary`}
             maxLength={2000}
             name={`${altId}.summary`}
+            aria-describedby={`BusinessCase-${altId}SummmaryCounter`}
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            altValues.summary.length} characters left`}</HelpText>
+          <CharacterCounter
+            id={`BusinessCase-${altId}SummmaryCounter`}
+            characterCount={2000 - altValues.summary.length}
+          />
         </FieldGroup>
 
         <FieldGroup
@@ -165,9 +169,12 @@ const AlternativeSolution = ({
             id={`BusinessCase-${altId}AcquisitionApproach`}
             maxLength={2000}
             name={`${altId}.acquisitionApproach`}
+            aria-describedby={`BusinessCase-${altId}AcquisitionApproachCounter`}
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            altValues.acquisitionApproach.length} characters left`}</HelpText>
+          <CharacterCounter
+            id={`BusinessCase-${altId}AcquisitionApproachCounter`}
+            characterCount={2000 - altValues.acquisitionApproach.length}
+          />
         </FieldGroup>
 
         <FieldGroup
@@ -188,9 +195,12 @@ const AlternativeSolution = ({
             id={`BusinessCase-${altId}Pros`}
             maxLength={2000}
             name={`${altId}.pros`}
+            aria-describedby={`BusinessCase-${altId}ProsCounter`}
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            altValues.pros.length} characters left`}</HelpText>
+          <CharacterCounter
+            id={`BusinessCase-${altId}ProsCounter`}
+            characterCount={2000 - altValues.pros.length}
+          />
         </FieldGroup>
 
         <FieldGroup
@@ -211,9 +221,12 @@ const AlternativeSolution = ({
             id={`BusinessCase-${altId}Cons`}
             maxLength={2000}
             name={`${altId}.cons`}
+            aria-describedby={`BusinessCase-${altId}ConsCounter`}
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            altValues.cons.length} characters left`}</HelpText>
+          <CharacterCounter
+            id={`BusinessCase-${altId}ConsCounter`}
+            characterCount={2000 - altValues.cons.length}
+          />
         </FieldGroup>
       </div>
       <div className="tablet:grid-col-9 margin-top-2">
@@ -259,9 +272,12 @@ const AlternativeSolution = ({
             id={`BusinessCase-${altId}CostSavings`}
             maxLength={2000}
             name={`${altId}.costSavings`}
+            aria-describedby={`BusinessCase-${altId}CostSavingsCounter`}
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            altValues.costSavings.length} characters left`}</HelpText>
+          <CharacterCounter
+            id={`BusinessCase-${altId}CostSavingsCounter`}
+            characterCount={2000 - altValues.costSavings.length}
+          />
         </FieldGroup>
 
         {altLetter === 'A' && !values.alternativeB && (

--- a/src/views/BusinessCase/AsIsSolution/index.tsx
+++ b/src/views/BusinessCase/AsIsSolution/index.tsx
@@ -10,6 +10,7 @@ import EstimatedLifecycleCost from 'components/EstimatedLifecycleCost';
 import { BusinessCaseModel } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
 import MandatoryFieldsAlert from 'components/MandatoryFieldsAlert';
+import CharacterCounter from 'components/CharacterCounter';
 
 type AsIsSolutionProps = {
   formikProps: FormikProps<BusinessCaseModel>;
@@ -82,9 +83,12 @@ const AsIsSolution = ({ formikProps }: AsIsSolutionProps) => {
             id="BusinessCase-AsIsSolutionSummary"
             maxLength={2000}
             name="asIsSolution.summary"
+            aria-describedby="BusinessCase-AsIsSolutionSummaryCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.asIsSolution.summary.length} characters left`}</HelpText>
+          <CharacterCounter
+            id="BusinessCase-AsIsSolutionSummaryCounter"
+            characterCount={2000 - values.asIsSolution.summary.length}
+          />
         </FieldGroup>
 
         <FieldGroup
@@ -105,9 +109,12 @@ const AsIsSolution = ({ formikProps }: AsIsSolutionProps) => {
             id="BusinessCase-AsIsSolutionPros"
             maxLength={2000}
             name="asIsSolution.pros"
+            aria-describedby="BusinessCase-AsIsSolutionProsCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.asIsSolution.pros.length} characters left`}</HelpText>
+          <CharacterCounter
+            id="BusinessCase-AsIsSolutionProsCounter"
+            characterCount={2000 - values.asIsSolution.pros.length}
+          />
         </FieldGroup>
 
         <FieldGroup
@@ -128,9 +135,12 @@ const AsIsSolution = ({ formikProps }: AsIsSolutionProps) => {
             id="BusinessCase-AsIsSolutionCons"
             maxLength={2000}
             name="asIsSolution.cons"
+            aria-describedby="BusinessCase-AsIsSolutionConsCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.asIsSolution.cons.length} characters left`}</HelpText>
+          <CharacterCounter
+            id="BusinessCase-AsIsSolutionConsCounter"
+            characterCount={2000 - values.asIsSolution.cons.length}
+          />
         </FieldGroup>
       </div>
       <div className="tablet:grid-col-9 margin-top-2">
@@ -182,9 +192,12 @@ const AsIsSolution = ({ formikProps }: AsIsSolutionProps) => {
             id="BusinessCase-AsIsSolutionCostSavings"
             maxLength={2000}
             name="asIsSolution.costSavings"
+            aria-describedby="BusinessCase-AsIsSolutionCostSavingsCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.asIsSolution.costSavings.length} characters left`}</HelpText>
+          <CharacterCounter
+            id="BusinessCase-AsIsSolutionCostSavingsCounter"
+            characterCount={2000 - values.asIsSolution.costSavings.length}
+          />
         </FieldGroup>
       </div>
     </div>

--- a/src/views/BusinessCase/PreferredSolution/index.tsx
+++ b/src/views/BusinessCase/PreferredSolution/index.tsx
@@ -10,6 +10,7 @@ import EstimatedLifecycleCost from 'components/EstimatedLifecycleCost';
 import { BusinessCaseModel } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
 import MandatoryFieldsAlert from 'components/MandatoryFieldsAlert';
+import CharacterCounter from 'components/CharacterCounter';
 
 type PreferredSolutionProps = {
   formikProps: FormikProps<BusinessCaseModel>;
@@ -94,10 +95,12 @@ const PreferredSolution = ({ formikProps }: PreferredSolutionProps) => {
             id="BusinessCase-PreferredSolutionSummary"
             maxLength={2000}
             name="preferredSolution.summary"
+            aria-describedby="BusinessCase-PreferredSolutionSummaryCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.preferredSolution.summary
-              .length} characters left`}</HelpText>
+          <CharacterCounter
+            id="BusinessCase-PreferredSolutionSummaryCounter"
+            characterCount={2000 - values.preferredSolution.summary.length}
+          />
         </FieldGroup>
 
         <FieldGroup
@@ -121,10 +124,14 @@ const PreferredSolution = ({ formikProps }: PreferredSolutionProps) => {
             id="BusinessCase-PreferredSolutionAcquisitionApproach"
             maxLength={2000}
             name="preferredSolution.acquisitionApproach"
+            aria-describedby="BusinessCase-PreferredSolutionAcquisitionApproachCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.preferredSolution.acquisitionApproach
-              .length} characters left`}</HelpText>
+          <CharacterCounter
+            id="BusinessCase-PreferredSolutionAcquisitionApproachCounter"
+            characterCount={
+              2000 - values.preferredSolution.acquisitionApproach.length
+            }
+          />
         </FieldGroup>
 
         <FieldGroup
@@ -145,9 +152,12 @@ const PreferredSolution = ({ formikProps }: PreferredSolutionProps) => {
             id="BusinessCase-PreferredSolutionPros"
             maxLength={2000}
             name="preferredSolution.pros"
+            aria-describedby="BusinessCase-PreferredSolutionProsCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.preferredSolution.pros.length} characters left`}</HelpText>
+          <CharacterCounter
+            id="BusinessCase-PreferredSolutionProsCounter"
+            characterCount={2000 - values.preferredSolution.pros.length}
+          />
         </FieldGroup>
 
         <FieldGroup
@@ -168,9 +178,12 @@ const PreferredSolution = ({ formikProps }: PreferredSolutionProps) => {
             id="BusinessCase-PreferredSolutionCons"
             maxLength={2000}
             name="preferredSolution.cons"
+            aria-describedby="BusinessCase-PreferredSolutionConsCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.preferredSolution.cons.length} characters left`}</HelpText>
+          <CharacterCounter
+            id="BusinessCase-PreferredSolutionConsCounter"
+            characterCount={2000 - values.preferredSolution.cons.length}
+          />
         </FieldGroup>
       </div>
       <div className="tablet:grid-col-9 margin-top-2">
@@ -221,10 +234,12 @@ const PreferredSolution = ({ formikProps }: PreferredSolutionProps) => {
             id="BusinessCase-PreferredSolutionCostSavings"
             maxLength={2000}
             name="preferredSolution.costSavings"
+            aria-describedby="BusinessCase-PreferredSolutionCostSavingsCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.preferredSolution.costSavings
-              .length} characters left`}</HelpText>
+          <CharacterCounter
+            id="BusinessCase-PreferredSolutionCostSavingsCounter"
+            characterCount={2000 - values.preferredSolution.costSavings.length}
+          />
         </FieldGroup>
       </div>
     </div>

--- a/src/views/BusinessCase/RequestDescription/index.tsx
+++ b/src/views/BusinessCase/RequestDescription/index.tsx
@@ -8,6 +8,7 @@ import HelpText from 'components/shared/HelpText';
 import { BusinessCaseModel } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
 import MandatoryFieldsAlert from 'components/MandatoryFieldsAlert';
+import CharacterCounter from 'components/CharacterCounter';
 
 type RequestDescriptionProps = {
   formikProps: FormikProps<BusinessCaseModel>;
@@ -60,9 +61,12 @@ const RequestDescription = ({ formikProps }: RequestDescriptionProps) => {
             id="BusinessCase-BusinessNeed"
             maxLength={2000}
             name="businessNeed"
+            aria-describedby="BusinessCase-BusinessNeedCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.businessNeed.length} characters left`}</HelpText>
+          <CharacterCounter
+            id="BusinessCase-BusinessNeedCounter"
+            characterCount={2000 - values.businessNeed.length}
+          />
         </FieldGroup>
 
         <FieldGroup scrollElement="cmsBenefit" error={!!flatErrors.cmsBenefit}>
@@ -81,9 +85,12 @@ const RequestDescription = ({ formikProps }: RequestDescriptionProps) => {
             id="BusinessCase-CmsBenefit"
             maxLength={2000}
             name="cmsBenefit"
+            aria-describedby="BusinessCase-CmsBenefitCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.cmsBenefit.length} characters left`}</HelpText>
+          <CharacterCounter
+            id="BusinessCase-CmsBenefitCounter"
+            characterCount={2000 - values.cmsBenefit.length}
+          />
         </FieldGroup>
 
         <FieldGroup
@@ -105,9 +112,12 @@ const RequestDescription = ({ formikProps }: RequestDescriptionProps) => {
             id="BusinessCase-PriorityAlignment"
             maxLength={2000}
             name="priorityAlignment"
+            aria-describedby="BusinessCase-PriorityAlignmentCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.priorityAlignment.length} characters left`}</HelpText>
+          <CharacterCounter
+            id="BusinessCase-PriorityAlignmentCounter"
+            characterCount={2000 - values.priorityAlignment.length}
+          />
         </FieldGroup>
 
         <FieldGroup
@@ -127,6 +137,11 @@ const RequestDescription = ({ formikProps }: RequestDescriptionProps) => {
             id="BusinessCase-SuccessIndicators"
             maxLength={2000}
             name="successIndicators"
+            aria-describedby="BusinessCase-SuccessIndicatorsCounter"
+          />
+          <CharacterCounter
+            id="BusinessCase-SuccessIndicatorsCounter"
+            characterCount={2000 - values.successIndicators.length}
           />
           <HelpText className="margin-top-1">{`${2000 -
             values.successIndicators.length} characters left`}</HelpText>

--- a/src/views/SystemIntake/RequestDetails/index.tsx
+++ b/src/views/SystemIntake/RequestDetails/index.tsx
@@ -12,6 +12,7 @@ import TextAreaField from 'components/shared/TextAreaField';
 import processStages from 'constants/enums/processStages';
 import CollapsableLink from 'components/shared/CollapsableLink';
 import MandatoryFieldsAlert from 'components/MandatoryFieldsAlert';
+import CharacterCounter from 'components/CharacterCounter';
 import flattenErrors from 'utils/flattenErrors';
 
 type RequestDetailsProps = {
@@ -93,9 +94,12 @@ const RequestDetails = ({ formikProps }: RequestDetailsProps) => {
             id="IntakeForm-BusinessNeed"
             maxLength={2000}
             name="businessNeed"
+            aria-describedby="IntakeForm-BusinessNeedCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.businessNeed.length} characters left`}</HelpText>
+          <CharacterCounter
+            id="IntakeForm-BusinessNeedCounter"
+            characterCount={2000 - values.businessNeed.length}
+          />
         </FieldGroup>
 
         <FieldGroup
@@ -115,9 +119,12 @@ const RequestDetails = ({ formikProps }: RequestDetailsProps) => {
             id="IntakeForm-BusinessSolution"
             maxLength={2000}
             name="businessSolution"
+            aria-describedby="IntakeForm-BusinessSolutionCounter"
           />
-          <HelpText className="margin-top-1">{`${2000 -
-            values.businessSolution.length} characters left`}</HelpText>
+          <CharacterCounter
+            id="IntakeForm-BusinessSolutionCounter"
+            characterCount={2000 - values.businessSolution.length}
+          />
         </FieldGroup>
 
         <FieldGroup


### PR DESCRIPTION
# EASI-569
This PR makes character counters for text areas accessible.

- Update `2000 characters left` to `2000 characters remaining` (confirmed with design)
- Create `CharacterCounter` component to reuse
    - Add accessibility HTML attributes (see [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) to learn more about `aria-live` and `aria-atomic`.

### How do I verify this?
Most of us have the new(er) Macbook Pros. Macbooks have macOS VoiceOver installed. This is a good screen reader for us to use for testing.

1. Hold down `command` and click the TouchID button 3 times and the VoiceOver prompt should appear.
2. Optional: You can "Learn More" and run through the tutorial.
3. Activate VoiceOver and navigate to the EASi app.
4. Warning: after activation VoiceOver, the screen reader will start reading out everything, so be prepared for some noice.
5. Navigate to the text areas, focus them, and start typing one letter at a time. You will notice the screen reader read each letter that is typed, followed by the number of characters remaining. This is how users using accessible technology should be alerted of the changes in the app.



