### PR TITLE
(Gov Banner) update aria-expanded to be dynamic

### DIFF
--- a/src/components/UsGovBanner/index.tsx
+++ b/src/components/UsGovBanner/index.tsx
@@ -28,7 +28,7 @@ const UsGovBanner = () => {
             <button
               type="button"
               className="usa-accordion__button usa-banner__button"
-              aria-expanded="false"
+              aria-expanded={displayContent}
               aria-controls="gov-banner"
               onClick={() => setDisplayContent(prev => !prev)}
             >


### PR DESCRIPTION
This PR updates the `aria-expanded` to be dynamic rather than being `false` all the time. This fixes the issue reported by Mario.