### PR TITLE
Make CollapsableLink accessible

### DIFF
--- a/src/components/shared/CollapsableLink/index.test.tsx
+++ b/src/components/shared/CollapsableLink/index.test.tsx
@@ -4,13 +4,34 @@ import CollapsableLink from './index';
 
 describe('The Collapsable Link componnet', () => {
   it('renders without crashing', () => {
-    shallow(<CollapsableLink label="testLabel">Hello!</CollapsableLink>);
+    shallow(
+      <CollapsableLink id="Test" label="testLabel">
+        Hello!
+      </CollapsableLink>
+    );
   });
 
-  it('renders label and not content when closed', () => {
+  it('hides content by children', () => {
     const component = shallow(
-      <CollapsableLink label="Label">Test</CollapsableLink>
+      <CollapsableLink id="Test" label="Test">
+        <div data-testid="children" />
+      </CollapsableLink>
     );
-    expect(component.text()).toEqual('Label');
+
+    expect(component.find('[data-testid="children"]').exists()).toEqual(false);
+    expect(component.find('button').prop('aria-expanded')).toEqual(false);
+  });
+
+  it('renders children content when expanded', () => {
+    const component = shallow(
+      <CollapsableLink id="Test" label="Test">
+        <div data-testid="children" />
+      </CollapsableLink>
+    );
+
+    component.find('button').simulate('click');
+
+    expect(component.find('[data-testid="children"]').exists()).toEqual(true);
+    expect(component.find('button').prop('aria-expanded')).toEqual(true);
   });
 });

--- a/src/components/shared/CollapsableLink/index.tsx
+++ b/src/components/shared/CollapsableLink/index.tsx
@@ -3,11 +3,12 @@ import classnames from 'classnames';
 import './index.scss';
 
 type CollapsableLinkProps = {
+  id: string;
   children: React.ReactNode | React.ReactNodeArray;
   label: string;
 };
 
-const CollapsableLink = ({ children, label }: CollapsableLinkProps) => {
+const CollapsableLink = ({ id, children, label }: CollapsableLinkProps) => {
   // TODO: should this state instead be held in the parent and passed in as prop?
   // Followup: if the state should remain here, how do we test the component when it's open?
   // That is, how do we initialize this component and set isOpen to true?
@@ -23,12 +24,16 @@ const CollapsableLink = ({ children, label }: CollapsableLinkProps) => {
         type="button"
         className="easi-collapsable-link__button"
         onClick={() => setOpen(!isOpen)}
+        aria-expanded={isOpen}
+        aria-controls={id}
       >
         <span className={arrowClassNames} />
         {label}
       </button>
       {isOpen && (
-        <div className="easi-collapsable-link__content">{children}</div>
+        <div id={id} className="easi-collapsable-link__content">
+          {children}
+        </div>
       )}
     </div>
   );

--- a/src/views/GovernanceOverview/index.tsx
+++ b/src/views/GovernanceOverview/index.tsx
@@ -143,8 +143,11 @@ const GovernanceOverview = () => {
           />
         </div>
         <div className="margin-top-6 margin-bottom-7">
-          <CollapsableLink label="Why does the governance process exist?">
-            <div>
+          <CollapsableLink
+            id="GovernanceOverview-WhyGovernanceExists"
+            label="Why does the governance process exist?"
+          >
+            <>
               These steps make sure
               <ul className="margin-bottom-0 margin-top-1 padding-left-205 line-height-body-5">
                 <li>your request fits into current CMS IT strategy</li>
@@ -152,7 +155,7 @@ const GovernanceOverview = () => {
                 <li>you have considered various solutions</li>
                 <li>CMS meets various policies and remains compliant</li>
               </ul>
-            </div>
+            </>
           </CollapsableLink>
         </div>
         <Button to="/system/new">Get started</Button>

--- a/src/views/SystemIntake/RequestDetails/index.tsx
+++ b/src/views/SystemIntake/RequestDetails/index.tsx
@@ -157,8 +157,11 @@ const RequestDetails = ({ formikProps }: RequestDetailsProps) => {
               value={false}
             />
 
-            <CollapsableLink label="How can the Enterprise Architecture team help me?">
-              <div>
+            <CollapsableLink
+              id="SystemIntake-WhatsEA"
+              label="How can the Enterprise Architecture team help me?"
+            >
+              <>
                 CMS&apos; Enterprise Architecture (EA) function will help you
                 build your Business Case by addressing the following:
                 <ul className="margin-bottom-0">
@@ -176,7 +179,7 @@ const RequestDetails = ({ formikProps }: RequestDetailsProps) => {
                   </li>
                   <li>Model your business processes and document workflows</li>
                 </ul>
-              </div>
+              </>
             </CollapsableLink>
           </fieldset>
         </FieldGroup>


### PR DESCRIPTION
# EASI-598 EASI-599

This work is a part of both issues above. The `CollapsableLink` component wasn't letter assistive technology know when the content is expanded and what content the link controls.

This is fixed by adding `aria-expanded` and `aria-controls` to the button/link.