### PR TITLE
add accessibility/tests to task list

### DIFF
--- a/src/views/GovernanceTaskList/index.test.tsx
+++ b/src/views/GovernanceTaskList/index.test.tsx
@@ -90,4 +90,71 @@ describe('The Goveranance Task List', () => {
       });
     });
   });
+
+  describe('Governance Task List Accessibility', () => {
+    const mockStore = configureMockStore();
+    const store = mockStore({});
+    let component;
+    it('button expansion is tied to the secondary ordered list', async done => {
+      await act(async () => {
+        component = mount(
+          <MemoryRouter initialEntries={['/']} initialIndex={0}>
+            <Provider store={store}>
+              <GovernanceTaskList />
+            </Provider>
+          </MemoryRouter>
+        );
+
+        const id = 'GovernanceTaskList-SecondaryList';
+        component
+          .find('.governance-task-list__remaining-steps-btn')
+          .simulate('click');
+        setImmediate(() => {
+          component.update();
+          expect(
+            component.find(`button[aria-controls="${id}"]`).exists()
+          ).toEqual(true);
+          expect(component.find(`ol#${id}`).exists()).toEqual(true);
+          done();
+        });
+      });
+    });
+
+    it('renders aria-expanded/label correctly', async done => {
+      await act(async () => {
+        component = mount(
+          <MemoryRouter initialEntries={['/']} initialIndex={0}>
+            <Provider store={store}>
+              <GovernanceTaskList />
+            </Provider>
+          </MemoryRouter>
+        );
+
+        expect(
+          component.find('.governance-task-list__remaining-steps-btn').text()
+        ).toEqual('Show remaining steps');
+        expect(
+          component
+            .find('.governance-task-list__remaining-steps-btn')
+            .prop('aria-expanded')
+        ).toEqual(false);
+        component
+          .find('.governance-task-list__remaining-steps-btn')
+          .simulate('click');
+
+        setImmediate(() => {
+          component.update();
+          expect(
+            component.find('.governance-task-list__remaining-steps-btn').text()
+          ).toEqual('Hide remaining steps');
+          expect(
+            component
+              .find('.governance-task-list__remaining-steps-btn')
+              .prop('aria-expanded')
+          ).toEqual(true);
+          done();
+        });
+      });
+    });
+  });
 });

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -65,12 +65,15 @@ const GovernanceTaskList = () => {
             type="button"
             className="governance-task-list__remaining-steps-btn"
             onClick={() => setDisplayRemainingSteps(prev => !prev)}
+            aria-expanded={displayRemainingSteps}
+            aria-controls="GovernanceTaskList-SecondaryList"
           >
             {displayRemainingSteps ? 'Hide' : 'Show'} remaining steps
           </button>
 
           {displayRemainingSteps && (
             <ol
+              id="GovernanceTaskList-SecondaryList"
               className="governance-task-list__task-list governance-task-list__task-list--secondary"
               start={4}
             >


### PR DESCRIPTION
There is no JIRA ticket associated to this at the moment. This work was completed in less than 30 minutes, so I took the liberty of making changes without a ticket associated.

This adds accessibility requirements needed for the Governance Task List. The specifically add `aria-expanded` on the "show/hide remaining items" to let users know if the list is displayed of hidden.

It also adds tests for those attributes.

