### PR TITLE
Add statuses to backend and to task list

### DIFF
--- a/migrations/V16__Rename_System_Intake_Statuses.sql
+++ b/migrations/V16__Rename_System_Intake_Statuses.sql
@@ -1,0 +1,3 @@
+-- There is no way to remove enums, so I've renamed the unused ones instead
+ALTER TYPE system_intake_status RENAME VALUE 'REVIEWED' TO 'ACCEPTED';
+ALTER TYPE system_intake_status RENAME VALUE 'REJECTED' TO 'CLOSED';

--- a/migrations/V17__Add_Approved_Intake_Status.sql
+++ b/migrations/V17__Add_Approved_Intake_Status.sql
@@ -1,0 +1,2 @@
+-- Must be done outside of a transactional migration
+ALTER TYPE system_intake_status ADD VALUE 'APPROVED';

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -15,10 +15,12 @@ const (
 	SystemIntakeStatusDRAFT SystemIntakeStatus = "DRAFT"
 	// SystemIntakeStatusSUBMITTED captures enum value "SUBMITTED"
 	SystemIntakeStatusSUBMITTED SystemIntakeStatus = "SUBMITTED"
-	// SystemIntakeStatusREVIEWED captures enum value "REVIEWED"
-	SystemIntakeStatusREVIEWED SystemIntakeStatus = "REVIEWED"
-	// SystemIntakeStatusREJECTED captures enum value "REJECTED"
-	SystemIntakeStatusREJECTED SystemIntakeStatus = "REJECTED"
+	// SystemIntakeStatusACCEPTED captures enum value "ACCEPTED"
+	SystemIntakeStatusACCEPTED SystemIntakeStatus = "ACCEPTED"
+	// SystemIntakeStatusCLOSED captures enum value "CLOSED"
+	SystemIntakeStatusCLOSED SystemIntakeStatus = "CLOSED"
+	// SystemIntakeStatusAPPROVED captures enum value "APPROVED"
+	SystemIntakeStatusAPPROVED SystemIntakeStatus = "APPROVED"
 )
 
 // SystemIntake is the model for the system intake form

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -53,7 +53,7 @@ class App extends React.Component<MainProps, MainState> {
                   process.env.REACT_APP_APP_ENV || ''
                 ) && (
                   <SecureRoute
-                    path="/governance-task-list"
+                    path="/governance-task-list/:systemId"
                     exact
                     component={GovernanceTaskList}
                   />

--- a/src/views/GovernanceTaskList/TaskListItem.test.tsx
+++ b/src/views/GovernanceTaskList/TaskListItem.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Link } from 'react-router-dom';
 import Button from 'components/shared/Button';
 
 import TaskListItem from './TaskListItem';
@@ -58,5 +59,47 @@ describe('The TaskListItem', () => {
 
     // TODO: very brittle; insert data-testid when Button refactor is complete
     expect(component.find(Button).exists()).toEqual(true);
+    expect(
+      component
+        .find(Button)
+        .dive()
+        .text()
+    ).toEqual('Start');
+  });
+
+  it('displays continue button', () => {
+    const component = shallow(
+      <TaskListItem
+        heading="Test Heading"
+        description="Test Description"
+        status="CONTINUE"
+        link="/"
+      />
+    );
+
+    // TODO: very brittle; insert data-testid when Button refactor is complete
+    expect(component.find(Button).exists()).toEqual(true);
+    expect(
+      component
+        .find(Button)
+        .dive()
+        .text()
+    ).toEqual('Continue');
+  });
+
+  it('displays a submitted request link', () => {
+    const component = shallow(
+      <TaskListItem
+        heading="Test Heading"
+        description="Test Description"
+        status="COMPLETED"
+        link="/system-intake/FOO"
+      />
+    );
+
+    // TODO: very brittle; insert data-testid when Button refactor is complete
+    expect(component.find(Link).exists()).toEqual(true);
+    expect(component.find(Link).text()).toEqual('View Submitted Request Form');
+    expect(component.find(Link).prop('to')).toEqual('/system-intake/FOO');
   });
 });

--- a/src/views/GovernanceTaskList/TaskListItem.test.tsx
+++ b/src/views/GovernanceTaskList/TaskListItem.test.tsx
@@ -57,8 +57,6 @@ describe('The TaskListItem', () => {
       />
     );
 
-    // TODO: very brittle; insert data-testid when Button refactor is complete
-    expect(component.find(Button).exists()).toEqual(true);
     expect(
       component
         .find(Button)
@@ -77,8 +75,6 @@ describe('The TaskListItem', () => {
       />
     );
 
-    // TODO: very brittle; insert data-testid when Button refactor is complete
-    expect(component.find(Button).exists()).toEqual(true);
     expect(
       component
         .find(Button)
@@ -87,7 +83,7 @@ describe('The TaskListItem', () => {
     ).toEqual('Continue');
   });
 
-  it('displays a submitted request link', () => {
+  describe('submitted request link', () => {
     const component = shallow(
       <TaskListItem
         heading="Test Heading"
@@ -97,9 +93,14 @@ describe('The TaskListItem', () => {
       />
     );
 
-    // TODO: very brittle; insert data-testid when Button refactor is complete
-    expect(component.find(Link).exists()).toEqual(true);
-    expect(component.find(Link).text()).toEqual('View Submitted Request Form');
-    expect(component.find(Link).prop('to')).toEqual('/system-intake/FOO');
+    it('displays the right text', () => {
+      expect(component.find(Link).text()).toEqual(
+        'View Submitted Request Form'
+      );
+    });
+
+    it('displays the right link', () => {
+      expect(component.find(Link).prop('to')).toEqual('/system-intake/FOO');
+    });
   });
 });

--- a/src/views/GovernanceTaskList/TaskListItem.tsx
+++ b/src/views/GovernanceTaskList/TaskListItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
+import { Link } from 'react-router-dom';
 import Button from 'components/shared/Button';
 
 type TaskListItemProps = {
@@ -45,6 +46,10 @@ const TaskListItem = ({
         </p>
 
         {status === 'START' && <Button to={link}>Start</Button>}
+        {status === 'CONTINUE' && <Button to={link}>Continue</Button>}
+        {status === 'COMPLETED' && (
+          <Link to={link}>View Submitted Request Form</Link>
+        )}
       </div>
     </li>
   );

--- a/src/views/GovernanceTaskList/index.test.tsx
+++ b/src/views/GovernanceTaskList/index.test.tsx
@@ -38,7 +38,7 @@ describe('The Goveranance Task List', () => {
 
   it('displays only the initial governance steps', async done => {
     const mockStore = configureMockStore();
-    const store = mockStore({ systemIntakes: { systemIntakes: [] } });
+    const store = mockStore({ systemIntake: { systemIntake: {} } });
     let component;
     await act(async () => {
       component = mount(
@@ -63,7 +63,7 @@ describe('The Goveranance Task List', () => {
 
   it('displays all governance steps', async done => {
     const mockStore = configureMockStore();
-    const store = mockStore({ systemIntakes: { systemIntakes: [] } });
+    const store = mockStore({ systemIntake: { systemIntake: {} } });
     let component;
     await act(async () => {
       component = mount(
@@ -93,7 +93,7 @@ describe('The Goveranance Task List', () => {
 
   it('renders the side nav actions', async done => {
     const mockStore = configureMockStore();
-    const store = mockStore({ systemIntakes: { systemIntakes: [] } });
+    const store = mockStore({ systemIntake: { systemIntake: {} } });
     let component;
     await act(async () => {
       component = mount(
@@ -113,7 +113,7 @@ describe('The Goveranance Task List', () => {
 
   describe('Governance Task List Accessibility', () => {
     const mockStore = configureMockStore();
-    const store = mockStore({});
+    const store = mockStore({ systemIntake: { systemIntake: {} } });
     let component;
     it('button expansion is tied to the secondary ordered list', async done => {
       await act(async () => {

--- a/src/views/GovernanceTaskList/index.test.tsx
+++ b/src/views/GovernanceTaskList/index.test.tsx
@@ -38,7 +38,7 @@ describe('The Goveranance Task List', () => {
 
   it('displays only the initial governance steps', async done => {
     const mockStore = configureMockStore();
-    const store = mockStore({});
+    const store = mockStore({ systemIntakes: { systemIntakes: [] } });
     let component;
     await act(async () => {
       component = mount(
@@ -63,7 +63,7 @@ describe('The Goveranance Task List', () => {
 
   it('displays all governance steps', async done => {
     const mockStore = configureMockStore();
-    const store = mockStore({});
+    const store = mockStore({ systemIntakes: { systemIntakes: [] } });
     let component;
     await act(async () => {
       component = mount(
@@ -93,7 +93,7 @@ describe('The Goveranance Task List', () => {
 
   it('renders the side nav actions', async done => {
     const mockStore = configureMockStore();
-    const store = mockStore({});
+    const store = mockStore({ systemIntakes: { systemIntakes: [] } });
     let component;
     await act(async () => {
       component = mount(

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useOktaAuth } from '@okta/okta-react';
 import Header from 'components/Header';
 import MainContent from 'components/MainContent';
 import BreadcrumbNav from 'components/BreadcrumbNav';
@@ -16,20 +15,16 @@ import './index.scss';
 
 const GovernanceTaskList = () => {
   const { systemId } = useParams();
-  const { authState } = useOktaAuth();
   const dispatch = useDispatch();
   const [displayRemainingSteps, setDisplayRemainingSteps] = useState(false);
 
   useEffect(() => {
-    if (systemId === 'new') {
-      return;
-    }
-    if (authState.isAuthenticated) {
+    if (systemId !== 'new') {
       dispatch(fetchSystemIntake(systemId));
     }
-  }, [dispatch, systemId, authState.isAuthenticated]);
+  }, [dispatch, systemId]);
   const systemIntake = useSelector(
-    (state: AppState) => state.systemIntake.systemIntake || null
+    (state: AppState) => state.systemIntake.systemIntake
   );
 
   const calculateIntakeStatus = (intake: SystemIntakeForm) => {
@@ -41,7 +36,7 @@ const GovernanceTaskList = () => {
     }
     return 'COMPLETED';
   };
-  const intakeState = calculateIntakeStatus(systemIntake);
+  const intakeStatus = calculateIntakeStatus(systemIntake);
   const chooseIntakeLink = (intake: SystemIntakeForm, status: string) => {
     const newIntakeLink = '/system/new';
     if (intake.id === '') {
@@ -53,6 +48,7 @@ const GovernanceTaskList = () => {
         link = `/system/${intake.id}/contact-details`;
         break;
       case 'COMPLETED':
+        // This will need to be changed once we have an intake review page
         link = '/';
         break;
       default:
@@ -60,7 +56,7 @@ const GovernanceTaskList = () => {
     }
     return link;
   };
-  const intakeLink = chooseIntakeLink(systemIntake, intakeState);
+  const intakeLink = chooseIntakeLink(systemIntake, intakeStatus);
 
   return (
     <div className="governance-task-list">
@@ -92,7 +88,7 @@ const GovernanceTaskList = () => {
                 heading="Fill in the request form"
                 description="Tell the Governance Admin Team about your idea. This step lets CMS build
               context about your request and start preparing for discussions with your team."
-                status={intakeState}
+                status={intakeStatus}
                 link={intakeLink}
               />
               <TaskListItem

--- a/src/views/Home/index.test.tsx
+++ b/src/views/Home/index.test.tsx
@@ -40,7 +40,7 @@ describe('The home page', () => {
   });
 
   describe('User is logged in', () => {
-    xit('displays login button', async done => {
+    it('displays login button', async done => {
       const mockStore = configureMockStore();
       const store = mockStore({
         systemIntakes: {
@@ -63,9 +63,9 @@ describe('The home page', () => {
 
         setImmediate(() => {
           component.update();
-          expect(
-            component.find('button[children="Start now"]').exists()
-          ).toEqual(true);
+          expect(component.find('a[children="Start now"]').exists()).toEqual(
+            true
+          );
           done();
         });
       });


### PR DESCRIPTION
# EASI-517

Changes proposed in this pull request:

- Adds migrations for getting all intake statuses the same
- Adds those statuses into our allowed type for the API
- Uses those statuses during step 1 in the task list
