### PR TITLE
Update session timeout to be based on a user's last activity rather than token

### DIFF
--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -50,7 +50,7 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
         tokenManager.renew(key);
       } else {
         console.log('logging out');
-        authService.logout();
+        authService.logout('/login');
       }
       console.log('---');
     });
@@ -93,20 +93,6 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
     },
     isModalOpen ? oneSecond : null
   );
-
-  // When a user is authenticated, this useInterval checks to see if they are
-  // inactive. If they are inactive for too long, they are logged out.
-  // useInterval(
-  //   () => {
-  //     const activeSessionWindow = DateTime.local()
-  //       .minus(TIMEOUT_WINDOW)
-  //       .toMillis();
-  //     if (lastActiveAt < activeSessionWindow) {
-  //       authService.logout();
-  //     }
-  //   },
-  //   authState.isAuthenticated ? oneSecond : null
-  // );
 
   // useInterval starts when a user is logged in AND the modal is not open
   // useInterval stops/pauses, when a use is logged out or the modal is open

--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -48,6 +48,9 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
       if (lastActiveAt > activeSessionWindow) {
         console.log('renewing', key);
         tokenManager.renew(key);
+      } else {
+        console.log('logging out');
+        authService.logout();
       }
       console.log('---');
     });
@@ -93,17 +96,17 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
 
   // When a user is authenticated, this useInterval checks to see if they are
   // inactive. If they are inactive for too long, they are logged out.
-  useInterval(
-    () => {
-      const activeSessionWindow = DateTime.local()
-        .minus(TIMEOUT_WINDOW)
-        .toMillis();
-      if (lastActiveAt < activeSessionWindow) {
-        authService.logout();
-      }
-    },
-    authState.isAuthenticated ? oneSecond : null
-  );
+  // useInterval(
+  //   () => {
+  //     const activeSessionWindow = DateTime.local()
+  //       .minus(TIMEOUT_WINDOW)
+  //       .toMillis();
+  //     if (lastActiveAt < activeSessionWindow) {
+  //       authService.logout();
+  //     }
+  //   },
+  //   authState.isAuthenticated ? oneSecond : null
+  // );
 
   // useInterval starts when a user is logged in AND the modal is not open
   // useInterval stops/pauses, when a use is logged out or the modal is open


### PR DESCRIPTION
Previously, the modal would appear based on the user's access token expiration. This wasn't working because I user can have continuous activity, but the access tokens aren't updated. That means the modal will display every time the access token is 5 minutes from expiration.

Instead, I've changed the modal to display when a user has been inactive based on the user's `lastActiveAt`.

Additionally I moved the logout logic to it's own hook because that logic shouldn't be dependent on the modal being open. As long as the user is logged in, the interval will be counting for a user's activity. This will protect us from any bugs, like if the modal doesn't show up for some reason. We will still be logging a user out when they've been inactive.
