### PR TITLE
Display contents of image scan response in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /easi/
 COPY . .
 RUN  CGO_ENABLED=0 GOOS=linux go build -a -o bin/easi ./cmd/easi
 
-FROM alpine:3.12
+FROM alpine:3.11
 RUN apk --no-cache add ca-certificates
 WORKDIR /easi/
 COPY --from=builder /easi/bin/easi .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /easi/
 COPY . .
 RUN  CGO_ENABLED=0 GOOS=linux go build -a -o bin/easi ./cmd/easi
 
-FROM alpine:3.11
+FROM alpine:3.12
 RUN apk --no-cache add ca-certificates
 WORKDIR /easi/
 COPY --from=builder /easi/bin/easi .

--- a/scripts/check_ecr_findings
+++ b/scripts/check_ecr_findings
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-set -u
+set -eu -o pipefail
 
 payload="{\"repository\": \"$1\", \"imageTag\": \"$2\"}"
-aws lambda invoke --function-name ecr-scan-findings --payload "$payload" scan_response.json || exit 1
+aws lambda invoke --function-name ecr-scan-findings --payload "$payload" scan_response.json
+jq < scan_response.json
 totalFindings="$(jq "fromjson | .totalFindings" scan_response.json)"
 if [[ "$totalFindings" != 0 ]]; then
   echo "Scan found $totalFindings findings!"

--- a/scripts/check_ecr_findings
+++ b/scripts/check_ecr_findings
@@ -5,10 +5,16 @@ set -eu -o pipefail
 payload="{\"repository\": \"$1\", \"imageTag\": \"$2\"}"
 aws lambda invoke --function-name ecr-scan-findings --payload "$payload" scan_response.json
 jq < scan_response.json
-totalFindings="$(jq "fromjson | .totalFindings" scan_response.json)"
-if [[ "$totalFindings" != 0 ]]; then
-  echo "Scan found $totalFindings findings!"
+parsed_response=$(jq fromjson scan_response.json)
+if [[ $(jq 'has("errorMessage")' <<< "$parsed_response") == "true" ]]; then
+  echo "Scan generated error"
   exit 1
 else
-  echo "Scan found no findings"
+  totalFindings="$(jq .totalFindings <<< "$parsed_response")"
+  if [[ "$totalFindings" != 0 ]]; then
+    echo "Scan found $totalFindings findings!"
+    exit 1
+  else
+    echo "Scan found no findings"
+  fi
 fi

--- a/scripts/check_ecr_findings
+++ b/scripts/check_ecr_findings
@@ -5,16 +5,10 @@ set -eu -o pipefail
 payload="{\"repository\": \"$1\", \"imageTag\": \"$2\"}"
 aws lambda invoke --function-name ecr-scan-findings --payload "$payload" scan_response.json
 jq < scan_response.json
-parsed_response=$(jq fromjson scan_response.json)
-if [[ $(jq 'has("errorMessage")' <<< "$parsed_response") == "true" ]]; then
-  echo "Scan generated error"
+totalFindings="$(jq "fromjson | .totalFindings" scan_response.json)"
+if [[ "$totalFindings" != 0 ]]; then
+  echo "Scan found $totalFindings findings!"
   exit 1
 else
-  totalFindings="$(jq .totalFindings <<< "$parsed_response")"
-  if [[ "$totalFindings" != 0 ]]; then
-    echo "Scan found $totalFindings findings!"
-    exit 1
-  else
-    echo "Scan found no findings"
-  fi
+  echo "Scan found no findings"
 fi


### PR DESCRIPTION
# EASI-556

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Display the contents of the image scan response in CI. This will at least provide some additional information when scans generate errors in future. I experimented with improved error handling, but the formatting of the lambda response (string vs. json) is different depending on whether the lambda returns an error or a success message. As for that, I'd prefer to refactor what the lambda returns on successful execution, rather than invest too much additional effort into how the bash script parses the response. The work to refactor the lambda will be tracked in a different story.