### PR TITLE
Add SSM parameter automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,7 @@ workflows:
                 - master
       - deploy_dev:
           requires:
+            - integration_tests
             - hold_dev
       - deploy_impl:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,8 +354,6 @@ workflows:
             - build_tag_push
       - hold_dev:
           type: approval
-          requires:
-            - integration_tests
           filters:
             branches:
               ignore:

--- a/scripts/deploy_service
+++ b/scripts/deploy_service
@@ -19,7 +19,9 @@ _payload() {
   local image_tag="${1:-}"
   local cluster_id="${3:-$APP_ENV-easi-app}"
 
-  result=$(jq --null-input '.command = "deploy" | .body.cluster_id = "'"$cluster_id"'" | .body.service_ids = ["'"$service_id"'"]') || return
+  secrets_regex="^/$APP_ENV/easi-app/\\S+$"
+
+  result=$(jq --null-input '.command = "deploy" | .body.cluster_id = "'"$cluster_id"'" | .body.service_ids = ["'"$service_id"'"] | .body.secrets = ["'"$secrets_regex"'"]') || return
 
   if [[ -n "$image_tag" ]]; then
     result=$(jq '.body.image = "'"$image_tag"'"' <<< "$result") || return

--- a/scripts/deploy_service
+++ b/scripts/deploy_service
@@ -19,7 +19,7 @@ _payload() {
   local image_tag="${1:-}"
   local cluster_id="${3:-$APP_ENV-easi-app}"
 
-  secrets_regex="^/$APP_ENV/easi-app/\\S+$"
+  secrets_regex="^/$APP_ENV/easi-app/\\\S+$"
 
   result=$(jq --null-input '.command = "deploy" | .body.cluster_id = "'"$cluster_id"'" | .body.service_ids = ["'"$service_id"'"] | .body.secrets = ["'"$secrets_regex"'"]') || return
 

--- a/scripts/deploy_service
+++ b/scripts/deploy_service
@@ -19,9 +19,12 @@ _payload() {
   local image_tag="${1:-}"
   local cluster_id="${3:-$APP_ENV-easi-app}"
 
-  secrets_regex="^/$APP_ENV/easi-app/\\\S+$"
 
-  result=$(jq --null-input '.command = "deploy" | .body.cluster_id = "'"$cluster_id"'" | .body.service_ids = ["'"$service_id"'"] | .body.secrets = ["'"$secrets_regex"'"]') || return
+  result=$(jq --null-input '.command = "deploy" | .body.cluster_id = "'"$cluster_id"'" | .body.service_ids = ["'"$service_id"'"]') || return
+  if [[ "$service_id" == "easi-app" ]] ; then
+    secrets_regex="^/$APP_ENV/easi-app/\\\S+$"
+    result="$(jq '.body.secrets = ["'"$secrets_regex"'"]' <<< "$result")"
+  fi
 
   if [[ -n "$image_tag" ]]; then
     result=$(jq '.body.image = "'"$image_tag"'"' <<< "$result") || return


### PR DESCRIPTION
# EASI-592

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add the `secrets` field to the deployment payload when the service being deployed is `easi-app`, to take advantage of [automated SSM parameter management](https://github.com/trussworks/terraform-aws-lambda-ecs-manager#ssm-parameters).
- Move the `integration_tests` dependency from `hold_dev` to `deploy_dev`. This means the hold can be approved at the start of the build process, saving time waiting for integration tests to pass before it can be released.