### PR TITLE
Fix biz case id to actually return on fetch intakes

### DIFF
--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -168,14 +168,14 @@ func (s *Store) FetchSystemIntakesByEuaID(euaID string) (models.SystemIntakes, e
 		)
 		return models.SystemIntakes{}, err
 	}
-	for _, intake := range intakes {
+	for k, intake := range intakes {
 		if intake.Status != models.SystemIntakeStatusDRAFT {
 			bizCaseID, fetchErr := s.FetchBusinessCaseIDByIntakeID(intake.ID)
 			if fetchErr != nil {
 				return models.SystemIntakes{}, fetchErr
 			}
 			if bizCaseID != &uuid.Nil {
-				intake.BusinessCaseID = bizCaseID
+				intakes[k].BusinessCaseID = bizCaseID
 			}
 		}
 	}

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -229,6 +229,15 @@ func (s StoreTestSuite) TestFetchSystemIntakesByEuaID() {
 
 		s.NoError(err, "failed to fetch system intakes")
 		s.Len(fetched, 2)
+		fetchedIntakeWithBizCase := func(fetched models.SystemIntakes) models.SystemIntake {
+			for _, intake := range fetched {
+				if intake.ID == id {
+					return intake
+				}
+			}
+			return models.SystemIntake{}
+		}
+		s.Equal(&bizCase.ID, fetchedIntakeWithBizCase(fetched).BusinessCaseID)
 	})
 }
 

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -146,6 +146,6 @@ export const prepareSystemIntakeForApp = (
     decidedAt: systemIntake.decidedAt
       ? DateTime.fromISO(systemIntake.decidedAt)
       : null,
-    businessCaseId: systemIntake.businessCaseId || null
+    businessCaseId: systemIntake.businessCase || null
   };
 };


### PR DESCRIPTION
# EASI-618

There was a bug caused here which saved biz case id to an intake that didn't get passed up the chain.

Changes proposed in this pull request:

- fixes a bug where we actually save and send the biz case id when fetching intakes by eua id.
