### PR TITLE
Skip deploy_dev on master branch builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,6 +359,10 @@ workflows:
               ignore:
                 - master
       - deploy_dev:
+          filters:
+            branches:
+              ignore:
+                - master
           requires:
             - integration_tests
             - hold_dev


### PR DESCRIPTION
# EASI-733

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Update `deploy_dev` job to ignore builds on the master branch. Previously, `deploy_dev` was inheriting the branch filter from `hold_dev`, but with the additional dependency on `integration_tests`, we need to explicitly add the branch filter on `deploy_dev` as well.
