### PR TITLE
EASI-621 intro security principal

### DIFF
--- a/pkg/authn/principal.go
+++ b/pkg/authn/principal.go
@@ -1,0 +1,87 @@
+// Package authn holds EASi authentication related primitives
+package authn
+
+import "fmt"
+
+const anonID = "ANON"
+
+// ANON is functionally a singleton for representing
+// a request without an identity
+var ANON Principal = (*anonymous)(nil)
+
+// Principal defines the expected behavior for
+// an entity that is making requests of the system.
+type Principal interface {
+	fmt.Stringer
+
+	// ID returns the system identifier
+	// for the given Principal
+	ID() string
+
+	// AllowEASi says whether this principal
+	// is authorized to operate within EASi
+	AllowEASi() bool
+
+	// AllowGRT says whether this principal
+	// is authorized to operate as part of
+	// the Review Team within EASi
+	AllowGRT() bool
+}
+
+type anonymous struct{}
+
+// String satisfies the fmt.Stringer interface
+func (*anonymous) String() string {
+	return "AnonymousPrincipal"
+}
+
+// ID returns an identifier that is not
+// expected to exist in upstream systems
+func (*anonymous) ID() string {
+	return anonID
+}
+
+// AllowEASi says Anonymous users are
+// not explicitly allowed to submit
+// info to EASi
+func (*anonymous) AllowEASi() bool {
+	return false
+}
+
+// AllowGRT says Anonymous users are
+// not explicitly ruled in as GRT
+func (*anonymous) AllowGRT() bool {
+	return false
+}
+
+// EUAPrincipal represents information
+// gleaned from the Okta JWT
+type EUAPrincipal struct {
+	EUAID       string
+	JobCodeEASi bool
+	JobCodeGRT  bool
+}
+
+// String satisfies the fmt.Stringer interface
+func (p *EUAPrincipal) String() string {
+	return fmt.Sprintf("EUAPrincipal: %s", p.EUAID)
+}
+
+// ID returns the EUA ID
+// for the given Principal
+func (p *EUAPrincipal) ID() string {
+	return p.EUAID
+}
+
+// AllowEASi says whether this principal
+// is authorized to operate within EASi
+func (p *EUAPrincipal) AllowEASi() bool {
+	return p.JobCodeEASi
+}
+
+// AllowGRT says whether this principal
+// is authorized to operate as part of
+// the Review Team within EASi
+func (p *EUAPrincipal) AllowGRT() bool {
+	return p.JobCodeGRT
+}

--- a/pkg/authn/principal_test.go
+++ b/pkg/authn/principal_test.go
@@ -1,0 +1,56 @@
+package authn
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrincipal(t *testing.T) {
+	// Arrange
+
+	// using current time for a bit of fuzzing
+	now := time.Now().Unix()
+	okEASi := (now%2 == 0)
+	okGRT := (now%3 == 0)
+	id := fmt.Sprintf("%X", now)
+	real := &EUAPrincipal{
+		EUAID:       id,
+		JobCodeEASi: okEASi,
+		JobCodeGRT:  okGRT,
+	}
+	testCases := map[string]struct {
+		p          Principal
+		expectID   string
+		expectEASi bool
+		expectGRT  bool
+	}{
+		"anonymous is unauthorized": {
+			p:          ANON,
+			expectID:   anonID,
+			expectEASi: false,
+			expectGRT:  false,
+		},
+		"regular eua user": {
+			p:          real,
+			expectID:   id,
+			expectEASi: okEASi,
+			expectGRT:  okGRT,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// Act - not needed
+
+			//Assert
+			assert.NotEmpty(t, tc.p.String(), "fmt.Stringer")
+			assert.NotEmpty(t, tc.p.ID(), "ID()")
+			assert.Equal(t, tc.expectID, tc.p.ID())
+			assert.Equal(t, tc.expectEASi, tc.p.AllowEASi())
+			assert.Equal(t, tc.expectGRT, tc.p.AllowGRT())
+		})
+	}
+}

--- a/pkg/authn/principal_test.go
+++ b/pkg/authn/principal_test.go
@@ -13,14 +13,10 @@ func TestPrincipal(t *testing.T) {
 
 	// using current time for a bit of fuzzing
 	now := time.Now().Unix()
-	okEASi := (now%2 == 0)
-	okGRT := (now%3 == 0)
+	okEASi := bool(now%2 == 0)
+	okGRT := bool(now%3 == 0)
 	id := fmt.Sprintf("%X", now)
-	real := &EUAPrincipal{
-		EUAID:       id,
-		JobCodeEASi: okEASi,
-		JobCodeGRT:  okGRT,
-	}
+
 	testCases := map[string]struct {
 		p          Principal
 		expectID   string
@@ -34,7 +30,11 @@ func TestPrincipal(t *testing.T) {
 			expectGRT:  false,
 		},
 		"regular eua user": {
-			p:          real,
+			p: &EUAPrincipal{
+				EUAID:       id,
+				JobCodeEASi: okEASi,
+				JobCodeGRT:  okGRT,
+			},
 			expectID:   id,
 			expectEASi: okEASi,
 			expectGRT:  okGRT,
@@ -48,9 +48,9 @@ func TestPrincipal(t *testing.T) {
 			//Assert
 			assert.NotEmpty(t, tc.p.String(), "fmt.Stringer")
 			assert.NotEmpty(t, tc.p.ID(), "ID()")
-			assert.Equal(t, tc.expectID, tc.p.ID())
-			assert.Equal(t, tc.expectEASi, tc.p.AllowEASi())
-			assert.Equal(t, tc.expectGRT, tc.p.AllowGRT())
+			assert.Equal(t, tc.expectID, tc.p.ID(), "ID()")
+			assert.Equal(t, tc.expectEASi, tc.p.AllowEASi(), "AllowEASi()")
+			assert.Equal(t, tc.expectGRT, tc.p.AllowGRT(), "AllowGRT()")
 		})
 	}
 }


### PR DESCRIPTION
# EASI-621

Changes proposed in this pull request:

* This is the first of several PRs that I will be submitting for this project. I feel that I will be better able to tell a story and bring folks along with me by doing little ones, rather than doing one big honkin' PR.
* The code here is strictly _additive_, and will not end up in the active-path of the application used until later PRs
* The `anonymous` type is part of a larger pattern that I feel helps reduce the need for `if err != nil then` clauses, by using "no-op" types that represent the negative cases. There are shades of this in this [blog post](https://dave.cheney.net/2019/01/27/eliminate-error-handling-by-eliminating-errors), and some concrete examples from other frameworks are the [go-kit NopLogger](https://godoc.org/github.com/go-kit/kit/log#NewNopLogger) or the [zap NopLogger](https://godoc.org/go.uber.org/zap#NewNop) or the [stdlib NopCloser](https://golang.org/pkg/io/ioutil/#NopCloser).
* The `EUAPrincipal` is pretty dumb, with the intent that the logic of deciding what authorizations are effective are delegated to the code that instantiates it. (This will be more evident in future PRs.)
* I believe there's been talk about having new permissions in the future (508 maybe? others?), but only on the order of ~3. That would imply adding that many more func signatures to `Principal`, which _may_ be pushing the bounds of good taste for a Go interface, but that can probably be a later-us problem.
* The included unit tests are a bit dumb (just setting and then getting values for the most part), but I'm trying to build examples of doing [table driven tests](https://dave.cheney.net/2019/05/07/prefer-table-driven-tests). 
* The unit test exhibits doing a little bit of "manual fuzzing", which is a technique I like for generating non-static content, which I feel can build more long-term confidence of the breadth of conditions that get tested.
* Also this is an example of preferring the stdlib over using `testify/suite`, but also note that I believe these techniques can peacefully co-exist. (I'll be pushing back against the TDR recommending using `testify/suite`, but that will be an async background task for me.)