### PR TITLE
EASI-621 Principal stored on context

### DIFF
--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/cmsgov/easi-app/pkg/authn"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -15,6 +16,7 @@ const (
 	loggerKey contextKey = iota
 	traceKey
 	userKey
+	principalKey
 )
 
 // WithLogger returns a context with the given logger
@@ -49,4 +51,18 @@ func WithUser(ctx context.Context, user models.User) context.Context {
 func User(ctx context.Context) (models.User, bool) {
 	user, ok := ctx.Value(userKey).(models.User)
 	return user, ok
+}
+
+// WithPrincipal decorates the context with the given security principal
+func WithPrincipal(c context.Context, p authn.Principal) context.Context {
+	return context.WithValue(c, principalKey, p)
+}
+
+// Principal returns the security principal, defaulting to
+// an Anonymous user if not assigned.
+func Principal(c context.Context) authn.Principal {
+	if p, ok := c.Value(principalKey).(authn.Principal); ok {
+		return p
+	}
+	return authn.ANON
 }

--- a/pkg/okta/okta_test.go
+++ b/pkg/okta/okta_test.go
@@ -94,6 +94,11 @@ func (s OktaTestSuite) TestAuthorizeMiddleware() {
 			user, ok := appcontext.User(r.Context())
 			s.True(ok)
 			s.Equal(s.config.GetString("OKTA_TEST_USERNAME"), user.EUAUserID)
+
+			// ensure the Principal is currently piggy-backing off the User
+			principal := appcontext.Principal(r.Context())
+			s.True(principal.AllowEASi(), "AllowEASi()")
+			s.Equal(user.EUAUserID, principal.ID(), "ID()")
 		})
 
 		authMiddleware(testHandler).ServeHTTP(rr, req)


### PR DESCRIPTION
# EASI-621

Changes proposed in this pull request:

* This is another small PR in a sequence (previous being #321) that will combine to address the functionality needed for EASI-621.
* This code is also strictly additive, but it does actually involve the new code from this PR as well as the code from #321 into the active path, yet there are no new consumers of the `Principal` just yet (that'll be the next PR).
* Notice that the func `appcontext.Principal(...)` does not have an error return. This is the realization of what I proposed on the previous PR, using an object for the negative case, rather than forcing an `if err != nil` clause in any consuming code.
* Notice that in the case of a successful JWT decoding, this PR now ensures that there is both a `User` object as well as a `Principal` object on the `context`. (Eventually any authorization logic relying on the `User` will be replaced with relying on the `Principal`.)