### PR TITLE
prefer contextual logger

### DIFF
--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -2,6 +2,8 @@ package appcontext
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -23,9 +25,21 @@ func WithLogger(ctx context.Context, logger *zap.Logger) context.Context {
 }
 
 // Logger returns the context's logger
+// DEPRECATED - prefer ZLogger going forward
 func Logger(ctx context.Context) (*zap.Logger, bool) {
 	logger, ok := ctx.Value(loggerKey).(*zap.Logger)
 	return logger, ok
+}
+
+// ZLogger will always return something that functions
+// as a zap.Logger, even if it wasn't already placed
+// on the context
+func ZLogger(ctx context.Context) *zap.Logger {
+	if logger, ok := ctx.Value(loggerKey).(*zap.Logger); ok {
+		return logger
+	}
+	fmt.Fprintln(os.Stderr, "Logger not found on context.")
+	return zap.NewNop()
 }
 
 // WithTrace returns a context with request trace

--- a/pkg/appcontext/context_test.go
+++ b/pkg/appcontext/context_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 )
@@ -41,6 +42,18 @@ func (s ContextTestSuite) TestLogger() {
 
 	s.True(ok)
 	s.Equal(expectedLogger, logger)
+}
+
+func TestZLogger(t *testing.T) {
+	// functional logger returned even when not set
+	fallback := ZLogger(context.Background())
+	fallback.Info("silently succeeds") // not nil
+
+	// Also ensure it retrieves a set logger
+	expectedLogger := zap.NewExample()
+	ctx := WithLogger(context.Background(), expectedLogger)
+	logger := ZLogger(ctx)
+	assert.Equal(t, expectedLogger, logger)
 }
 
 func (s ContextTestSuite) TestWithTrace() {

--- a/pkg/services/business_case.go
+++ b/pkg/services/business_case.go
@@ -25,8 +25,8 @@ func NewAuthorizeFetchBusinessCaseByID() func(ctx context.Context, businessCase 
 func NewFetchBusinessCaseByID(
 	config Config,
 	fetch func(id uuid.UUID) (*models.BusinessCase, error),
-	authorize func(context context.Context, businessCase *models.BusinessCase) (bool, error),
-) func(ctx context.Context, id uuid.UUID) (*models.BusinessCase, error) {
+	authorize func(c context.Context, b *models.BusinessCase) (bool, error),
+) func(c context.Context, id uuid.UUID) (*models.BusinessCase, error) {
 	return func(ctx context.Context, id uuid.UUID) (*models.BusinessCase, error) {
 		logger := appcontext.ZLogger(ctx)
 		businessCase, err := fetch(id)
@@ -53,18 +53,18 @@ func NewFetchBusinessCaseByID(
 // NewAuthorizeCreateBusinessCase returns a function
 // that authorizes a user for creating a business case
 func NewAuthorizeCreateBusinessCase(_ *zap.Logger) func(
-	context context.Context,
+	c context.Context,
 	intake *models.SystemIntake,
 ) (bool, error) {
-	return func(context context.Context, intake *models.SystemIntake) (bool, error) {
-		logger := appcontext.ZLogger(context)
+	return func(ctx context.Context, intake *models.SystemIntake) (bool, error) {
+		logger := appcontext.ZLogger(ctx)
 		if intake == nil {
 			logger.With(zap.Bool("Authorized", false)).
 				With(zap.String("Operation", "CreateBusinessCase")).
 				Info("intake does not exist")
 			return false, nil
 		}
-		user, ok := appcontext.User(context)
+		user, ok := appcontext.User(ctx)
 		if !ok {
 			// Default to failure to authorize and create a quick audit log
 			logger.With(zap.Bool("Authorized", false)).
@@ -91,10 +91,10 @@ func NewAuthorizeCreateBusinessCase(_ *zap.Logger) func(
 func NewCreateBusinessCase(
 	config Config,
 	fetchIntake func(id uuid.UUID) (*models.SystemIntake, error),
-	authorize func(context context.Context, intake *models.SystemIntake) (bool, error),
-	create func(businessCase *models.BusinessCase) (*models.BusinessCase, error),
-) func(context context.Context, businessCase *models.BusinessCase) (*models.BusinessCase, error) {
-	return func(context context.Context, businessCase *models.BusinessCase) (*models.BusinessCase, error) {
+	authorize func(c context.Context, i *models.SystemIntake) (bool, error),
+	create func(b *models.BusinessCase) (*models.BusinessCase, error),
+) func(c context.Context, b *models.BusinessCase) (*models.BusinessCase, error) {
+	return func(ctx context.Context, businessCase *models.BusinessCase) (*models.BusinessCase, error) {
 		intake, err := fetchIntake(businessCase.SystemIntakeID)
 		if err != nil {
 			// We return an empty id in this error because the business case hasn't been created
@@ -104,7 +104,7 @@ func NewCreateBusinessCase(
 				ResourceID: "",
 			}
 		}
-		ok, err := authorize(context, intake)
+		ok, err := authorize(ctx, intake)
 		if err != nil {
 			return &models.BusinessCase{}, err
 		}
@@ -126,7 +126,7 @@ func NewCreateBusinessCase(
 
 		businessCase, err = create(businessCase)
 		if err != nil {
-			appcontext.ZLogger(context).Error("failed to create a business case")
+			appcontext.ZLogger(ctx).Error("failed to create a business case")
 			return &models.BusinessCase{}, &apperrors.QueryError{
 				Err:       err,
 				Model:     businessCase,
@@ -148,8 +148,8 @@ func NewAuthorizeFetchBusinessCasesByEuaID() func(ctx context.Context, euaID str
 func NewFetchBusinessCasesByEuaID(
 	config Config,
 	fetch func(euaID string) (models.BusinessCases, error),
-	authorize func(context context.Context, euaID string) (bool, error),
-) func(ctx context.Context, euaID string) (models.BusinessCases, error) {
+	authorize func(c context.Context, euaID string) (bool, error),
+) func(c context.Context, euaID string) (models.BusinessCases, error) {
 	return func(ctx context.Context, euaID string) (models.BusinessCases, error) {
 		ok, err := authorize(ctx, euaID)
 		if err != nil {
@@ -175,18 +175,18 @@ func NewFetchBusinessCasesByEuaID(
 // NewAuthorizeUpdateBusinessCase returns a function
 // that authorizes a user for updating an existing business case
 func NewAuthorizeUpdateBusinessCase(_ *zap.Logger) func(
-	context context.Context,
-	businessCase *models.BusinessCase,
+	c context.Context,
+	bb *models.BusinessCase,
 ) (bool, error) {
-	return func(context context.Context, businessCase *models.BusinessCase) (bool, error) {
-		logger := appcontext.ZLogger(context)
+	return func(ctx context.Context, businessCase *models.BusinessCase) (bool, error) {
+		logger := appcontext.ZLogger(ctx)
 		if businessCase == nil {
 			logger.With(zap.Bool("Authorized", false)).
 				With(zap.String("Operation", "UpdateBusinessCase")).
 				Info("business case does not exist")
 			return false, nil
 		}
-		user, ok := appcontext.User(context)
+		user, ok := appcontext.User(ctx)
 		if !ok {
 			// Default to failure to authorize and create a quick audit log
 			logger.With(zap.Bool("Authorized", false)).
@@ -213,12 +213,12 @@ func NewAuthorizeUpdateBusinessCase(_ *zap.Logger) func(
 func NewUpdateBusinessCase(
 	config Config,
 	fetchBusinessCase func(id uuid.UUID) (*models.BusinessCase, error),
-	authorize func(context context.Context, businessCase *models.BusinessCase) (bool, error),
+	authorize func(c context.Context, b *models.BusinessCase) (bool, error),
 	update func(businessCase *models.BusinessCase) (*models.BusinessCase, error),
 	sendEmail func(requester string, intakeID uuid.UUID) error,
-) func(context context.Context, businessCase *models.BusinessCase) (*models.BusinessCase, error) {
-	return func(context context.Context, businessCase *models.BusinessCase) (*models.BusinessCase, error) {
-		logger := appcontext.ZLogger(context)
+) func(c context.Context, b *models.BusinessCase) (*models.BusinessCase, error) {
+	return func(ctx context.Context, businessCase *models.BusinessCase) (*models.BusinessCase, error) {
+		logger := appcontext.ZLogger(ctx)
 		existingBusinessCase, err := fetchBusinessCase(businessCase.ID)
 		if err != nil {
 			return &models.BusinessCase{}, &apperrors.ResourceConflictError{
@@ -227,7 +227,7 @@ func NewUpdateBusinessCase(
 				ResourceID: businessCase.ID.String(),
 			}
 		}
-		ok, err := authorize(context, existingBusinessCase)
+		ok, err := authorize(ctx, existingBusinessCase)
 		if err != nil {
 			return &models.BusinessCase{}, err
 		}

--- a/pkg/services/metrics.go
+++ b/pkg/services/metrics.go
@@ -15,7 +15,7 @@ import (
 func NewFetchMetrics(
 	config Config,
 	fetchSystemIntakeMetrics func(time.Time, time.Time) (models.SystemIntakeMetrics, error),
-) func(ctx context.Context, startTime time.Time, endTime time.Time) (models.MetricsDigest, error) {
+) func(c context.Context, st time.Time, et time.Time) (models.MetricsDigest, error) {
 	return func(ctx context.Context, startTime time.Time, endTime time.Time) (models.MetricsDigest, error) {
 		systemIntakeMetrics, err := fetchSystemIntakeMetrics(startTime, endTime)
 		if err != nil {

--- a/pkg/services/metrics.go
+++ b/pkg/services/metrics.go
@@ -17,13 +17,9 @@ func NewFetchMetrics(
 	fetchSystemIntakeMetrics func(time.Time, time.Time) (models.SystemIntakeMetrics, error),
 ) func(ctx context.Context, startTime time.Time, endTime time.Time) (models.MetricsDigest, error) {
 	return func(ctx context.Context, startTime time.Time, endTime time.Time) (models.MetricsDigest, error) {
-		localLogger, ok := appcontext.Logger(ctx)
-		if !ok {
-			localLogger = config.logger
-		}
 		systemIntakeMetrics, err := fetchSystemIntakeMetrics(startTime, endTime)
 		if err != nil {
-			localLogger.Error("failed to query system intake metrics", zap.Error(err))
+			appcontext.ZLogger(ctx).Error("failed to query system intake metrics", zap.Error(err))
 			return models.MetricsDigest{}, &apperrors.QueryError{
 				Err:       err,
 				Model:     models.SystemIntakeMetrics{},

--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -24,11 +24,11 @@ func NewAuthorizeFetchSystemIntakesByEuaID() func(ctx context.Context, euaID str
 func NewFetchSystemIntakesByEuaID(
 	config Config,
 	fetch func(euaID string) (models.SystemIntakes, error),
-	authorize func(context context.Context, euaID string) (bool, error),
-) func(context context.Context, euaID string) (models.SystemIntakes, error) {
-	return func(context context.Context, euaID string) (models.SystemIntakes, error) {
-		logger := appcontext.ZLogger(context)
-		ok, err := authorize(context, euaID)
+	authorize func(c context.Context, euaID string) (bool, error),
+) func(c context.Context, e string) (models.SystemIntakes, error) {
+	return func(ctx context.Context, euaID string) (models.SystemIntakes, error) {
+		logger := appcontext.ZLogger(ctx)
+		ok, err := authorize(ctx, euaID)
 		if err != nil {
 			logger.Error("failed to authorize fetch system intakes")
 			return models.SystemIntakes{}, err
@@ -53,10 +53,10 @@ func NewFetchSystemIntakesByEuaID(
 func NewCreateSystemIntake(
 	config Config,
 	create func(intake *models.SystemIntake) (*models.SystemIntake, error),
-) func(context context.Context, intake *models.SystemIntake) (*models.SystemIntake, error) {
-	return func(context context.Context, intake *models.SystemIntake) (*models.SystemIntake, error) {
-		logger := appcontext.ZLogger(context)
-		user, ok := appcontext.User(context)
+) func(c context.Context, i *models.SystemIntake) (*models.SystemIntake, error) {
+	return func(ctx context.Context, intake *models.SystemIntake) (*models.SystemIntake, error) {
+		logger := appcontext.ZLogger(ctx)
+		user, ok := appcontext.User(ctx)
 		if !ok {
 			// Default to failure to authorize and create a quick audit log
 			logger.With(zap.Bool("Authorized", false)).
@@ -82,12 +82,12 @@ func NewCreateSystemIntake(
 // NewAuthorizeUpdateSystemIntake returns a function
 // that authorizes a user for updating a system intake
 func NewAuthorizeUpdateSystemIntake(_ *zap.Logger) func(
-	context context.Context,
-	intake *models.SystemIntake,
+	c context.Context,
+	i *models.SystemIntake,
 ) (bool, error) {
-	return func(context context.Context, intake *models.SystemIntake) (bool, error) {
-		logger := appcontext.ZLogger(context)
-		user, ok := appcontext.User(context)
+	return func(ctx context.Context, intake *models.SystemIntake) (bool, error) {
+		logger := appcontext.ZLogger(ctx)
+		user, ok := appcontext.User(ctx)
 		if !ok {
 			logger.Error("unable to get EUA ID from context")
 			return false, &apperrors.ContextError{
@@ -116,13 +116,13 @@ func NewUpdateSystemIntake(
 	config Config,
 	update func(intake *models.SystemIntake) (*models.SystemIntake, error),
 	fetch func(id uuid.UUID) (*models.SystemIntake, error),
-	authorize func(context context.Context, intake *models.SystemIntake) (bool, error),
+	authorize func(context.Context, *models.SystemIntake) (bool, error),
 	validateAndSubmit func(intake *models.SystemIntake, logger *zap.Logger) (string, error),
 	sendSubmitEmail func(requester string, intakeID uuid.UUID) error,
 	fetchRequesterEmail func(logger *zap.Logger, euaID string) (string, error),
 	sendReviewEmail func(emailText string, recipientAddress string) error,
 	canDecideIntake bool,
-) func(context context.Context, intake *models.SystemIntake) (*models.SystemIntake, error) {
+) func(c context.Context, i *models.SystemIntake) (*models.SystemIntake, error) {
 	return func(ctx context.Context, intake *models.SystemIntake) (*models.SystemIntake, error) {
 		existingIntake, fetchErr := fetch(intake.ID)
 		if fetchErr != nil {
@@ -254,10 +254,10 @@ func NewAuthorizeFetchSystemIntakeByID() func(ctx context.Context, intake *model
 func NewFetchSystemIntakeByID(
 	config Config,
 	fetch func(id uuid.UUID) (*models.SystemIntake, error),
-	authorize func(context context.Context, intake *models.SystemIntake) (bool, error),
-) func(context context.Context, id uuid.UUID) (*models.SystemIntake, error) {
-	return func(context context.Context, id uuid.UUID) (*models.SystemIntake, error) {
-		logger := appcontext.ZLogger(context)
+	authorize func(c context.Context, i *models.SystemIntake) (bool, error),
+) func(c context.Context, u uuid.UUID) (*models.SystemIntake, error) {
+	return func(ctx context.Context, id uuid.UUID) (*models.SystemIntake, error) {
+		logger := appcontext.ZLogger(ctx)
 		intake, err := fetch(id)
 		if err != nil {
 			logger.Error("failed to fetch system intake")
@@ -267,7 +267,7 @@ func NewFetchSystemIntakeByID(
 				Operation: apperrors.QueryFetch,
 			}
 		}
-		ok, err := authorize(context, intake)
+		ok, err := authorize(ctx, intake)
 		if err != nil {
 			logger.Error("failed to authorize fetch system intake")
 			return &models.SystemIntake{}, err


### PR DESCRIPTION
# EASI-535

Changes proposed in this pull request:

* Reduce the need for so many `if err != nil` checks throughout the code, by making sure the cross-cutting concern method signature ALWAYS returns a `*zap.Logger`
* Make sure to use the contextual logger in the `service` package, this ensures access to things like the Request ID, which is not available on the non-contextual (aka system) logger.
* While in this code, I noticed several types of naming collisions and possibilities of variable shadowing, so I tidied that up, in pursuit of "easier to read and reason about".