### PR TITLE
Don't store cypress video in CI artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,15 +128,11 @@ jobs:
       - run:
           name: Run Cypress integration tests
           command: |
-            mkdir -p /home/circleci/project/cypress/videos
             ./scripts/run-cypress-test-docker
       - save_cache:
           key: yarn-deps-cache-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
-      - store_artifacts:
-          path: cypress/videos
-          destination: videos
       - run:
           name: Announce failure
           command: |

--- a/scripts/run-cypress-test-docker
+++ b/scripts/run-cypress-test-docker
@@ -15,7 +15,6 @@ if bash +x -o nounset -c "$(aws ecr get-login --no-include-email --region "us-we
   docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.circleci.yml up -d easi easi_client
   docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.circleci.yml up cypress cypress
 
-  docker container cp "${CYPRESS_CONTAINER}":/cypress/videos/systemIntake.spec.js.mp4 cypress/videos/systemIntake.spec.js.mp4
   EXIT_STATUS=$(docker container inspect "${CYPRESS_CONTAINER}" --format='{{.State.ExitCode}}')
   echo "done"
   exit "${EXIT_STATUS}"


### PR DESCRIPTION
# EASI-000

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Update the integration test step and script so that we're not storing the cypress video in CI artifacts
