### PR TITLE
Remove autosave on unmount

### DIFF
--- a/src/views/BusinessCase/index.tsx
+++ b/src/views/BusinessCase/index.tsx
@@ -4,7 +4,6 @@ import { useHistory, useParams, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { SecureRoute } from '@okta/okta-react';
 import { Button } from '@trussworks/react-uswds';
-import isUUID from 'validator/lib/isUUID';
 import { ObjectSchema } from 'yup';
 import MainContent from 'components/MainContent';
 import Header from 'components/Header';
@@ -160,19 +159,6 @@ export const BusinessCase = () => {
     }
 
     return () => {
-      // if has valid uuid, autosave business case when unmounting
-      if (isUUID(businessCaseId)) {
-        const {
-          current
-        }: { current: FormikProps<BusinessCaseModel> } = formikRef;
-        dispatch(
-          putBusinessCase({
-            businessCase,
-            ...current.values
-          })
-        );
-      }
-
       // clear business case when unmounting
       dispatch(clearBusinessCase());
     };

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
 import { SecureRoute, useOktaAuth } from '@okta/okta-react';
-import isUUID from 'validator/lib/isUUID';
 import MainContent from 'components/MainContent';
 import Header from 'components/Header';
 import { AppState } from 'reducers/rootReducer';
@@ -40,7 +39,6 @@ export const SystemIntake = () => {
 
   const dispatchSave = () => {
     const { current }: { current: FormikProps<SystemIntakeForm> } = formikRef;
-
     if (current && current.dirty && !isSaving) {
       if (systemId === 'new') {
         dispatch(postSystemIntake({ ...systemIntake, ...current.values }));
@@ -76,16 +74,6 @@ export const SystemIntake = () => {
       dispatch(fetchSystemIntake(systemId));
     }
     return () => {
-      // If has valid uuid, save it's current data before unmounting
-      if (isUUID(systemId)) {
-        const {
-          current
-        }: { current: FormikProps<SystemIntakeForm> } = formikRef;
-        dispatch(
-          saveSystemIntake({ ...systemIntake, ...current.values, id: systemId })
-        );
-      }
-
       // clear system intake from store when component is unmounting
       dispatch(clearSystemIntake());
     };


### PR DESCRIPTION
This PR fixes the issue where system intake data is deleted when a user attempts to "save and exit".

This was happening because we had additional code that attempts to save a user's form data when they leave the form. The user was redirected away from the page and the "autosave" was clearing out what was saved.

There's a better way to do this, but for now, we should revert this change so user's aren't affected.