### PR TITLE
Nelz use principal

### DIFF
--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -9,7 +9,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/authn"
-	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 type contextKey int
@@ -17,7 +16,6 @@ type contextKey int
 const (
 	loggerKey contextKey = iota
 	traceKey
-	userKey
 	principalKey
 )
 
@@ -54,17 +52,6 @@ func WithTrace(ctx context.Context) context.Context {
 func Trace(ctx context.Context) (uuid.UUID, bool) {
 	traceID, ok := ctx.Value(traceKey).(uuid.UUID)
 	return traceID, ok
-}
-
-// WithUser returns a context with the request User
-func WithUser(ctx context.Context, user models.User) context.Context {
-	return context.WithValue(ctx, userKey, user)
-}
-
-// User returns the context's User
-func User(ctx context.Context) (models.User, bool) {
-	user, ok := ctx.Value(userKey).(models.User)
-	return user, ok
 }
 
 // WithPrincipal decorates the context with the given security principal

--- a/pkg/handlers/business_case.go
+++ b/pkg/handlers/business_case.go
@@ -108,7 +108,8 @@ func (h BusinessCaseHandler) Handle() http.HandlerFunc {
 				return
 			}
 
-			user, ok := appcontext.User(r.Context())
+			principal := appcontext.Principal(r.Context())
+			user, ok := appcontext.User(r.Context()) // deprecated
 			if !ok {
 				h.WriteErrorResponse(
 					r.Context(),
@@ -119,6 +120,7 @@ func (h BusinessCaseHandler) Handle() http.HandlerFunc {
 					})
 				return
 			}
+			businessCaseToCreate.EUAUserID = principal.ID()
 			businessCaseToCreate.EUAUserID = user.EUAUserID
 
 			businessCase, err := h.CreateBusinessCase(r.Context(), &businessCaseToCreate)
@@ -165,12 +167,15 @@ func (h BusinessCaseHandler) Handle() http.HandlerFunc {
 			}
 			businessCaseToUpdate.ID = businessCaseID
 
-			user, ok := appcontext.User(r.Context())
+			principal := appcontext.Principal(r.Context())
+			user, ok := appcontext.User(r.Context()) // deprecated
 			if !ok {
 				h.WriteErrorResponse(r.Context(), w, err)
 				return
 			}
+			businessCaseToUpdate.EUAUserID = principal.ID()
 			businessCaseToUpdate.EUAUserID = user.EUAUserID
+
 			updatedBusinessCase, err := h.UpdateBusinessCase(r.Context(), &businessCaseToUpdate)
 			if err != nil {
 				h.Logger.Error(fmt.Sprintf("Failed to update business case to response: %v", err))

--- a/pkg/handlers/business_case.go
+++ b/pkg/handlers/business_case.go
@@ -109,8 +109,7 @@ func (h BusinessCaseHandler) Handle() http.HandlerFunc {
 			}
 
 			principal := appcontext.Principal(r.Context())
-			user, ok := appcontext.User(r.Context()) // deprecated
-			if !ok {
+			if !principal.AllowEASi() {
 				h.WriteErrorResponse(
 					r.Context(),
 					w,
@@ -121,7 +120,6 @@ func (h BusinessCaseHandler) Handle() http.HandlerFunc {
 				return
 			}
 			businessCaseToCreate.EUAUserID = principal.ID()
-			businessCaseToCreate.EUAUserID = user.EUAUserID
 
 			businessCase, err := h.CreateBusinessCase(r.Context(), &businessCaseToCreate)
 			if err != nil {
@@ -168,13 +166,11 @@ func (h BusinessCaseHandler) Handle() http.HandlerFunc {
 			businessCaseToUpdate.ID = businessCaseID
 
 			principal := appcontext.Principal(r.Context())
-			user, ok := appcontext.User(r.Context()) // deprecated
-			if !ok {
+			if !principal.AllowEASi() {
 				h.WriteErrorResponse(r.Context(), w, err)
 				return
 			}
 			businessCaseToUpdate.EUAUserID = principal.ID()
-			businessCaseToUpdate.EUAUserID = user.EUAUserID
 
 			updatedBusinessCase, err := h.UpdateBusinessCase(r.Context(), &businessCaseToUpdate)
 			if err != nil {

--- a/pkg/handlers/business_case_test.go
+++ b/pkg/handlers/business_case_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/authn"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -43,7 +44,7 @@ func newMockUpdateBusinessCase(err error) func(context context.Context, business
 
 func (s HandlerTestSuite) TestBusinessCaseHandler() {
 	requestContext := context.Background()
-	requestContext = appcontext.WithUser(requestContext, models.User{EUAUserID: "FAKE"})
+	requestContext = appcontext.WithPrincipal(requestContext, &authn.EUAPrincipal{EUAID: "FAKE", JobCodeEASi: true})
 	id, err := uuid.NewUUID()
 	s.NoError(err)
 	s.Run("golden path GET passes", func() {

--- a/pkg/handlers/business_cases.go
+++ b/pkg/handlers/business_cases.go
@@ -32,8 +32,7 @@ func (h BusinessCasesHandler) Handle() http.HandlerFunc {
 		switch r.Method {
 		case "GET":
 			principal := appcontext.Principal(r.Context())
-			user, ok := appcontext.User(r.Context()) // deprecated
-			if !ok {
+			if !principal.AllowEASi() {
 				h.WriteErrorResponse(
 					r.Context(),
 					w,
@@ -44,9 +43,7 @@ func (h BusinessCasesHandler) Handle() http.HandlerFunc {
 				return
 			}
 
-			fetchID := principal.ID()
-			fetchID = user.EUAUserID
-			businessCases, err := h.FetchBusinessCases(r.Context(), fetchID)
+			businessCases, err := h.FetchBusinessCases(r.Context(), principal.ID())
 			if err != nil {
 				h.WriteErrorResponse(r.Context(), w, err)
 				return

--- a/pkg/handlers/business_cases.go
+++ b/pkg/handlers/business_cases.go
@@ -31,7 +31,8 @@ func (h BusinessCasesHandler) Handle() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case "GET":
-			user, ok := appcontext.User(r.Context())
+			principal := appcontext.Principal(r.Context())
+			user, ok := appcontext.User(r.Context()) // deprecated
 			if !ok {
 				h.WriteErrorResponse(
 					r.Context(),
@@ -43,7 +44,9 @@ func (h BusinessCasesHandler) Handle() http.HandlerFunc {
 				return
 			}
 
-			businessCases, err := h.FetchBusinessCases(r.Context(), user.EUAUserID)
+			fetchID := principal.ID()
+			fetchID = user.EUAUserID
+			businessCases, err := h.FetchBusinessCases(r.Context(), fetchID)
 			if err != nil {
 				h.WriteErrorResponse(r.Context(), w, err)
 				return

--- a/pkg/handlers/business_cases_test.go
+++ b/pkg/handlers/business_cases_test.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/authn"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -23,7 +24,7 @@ func (s HandlerTestSuite) TestBusinessCasesHandler() {
 	s.Run("golden path FETCH passes", func() {
 		rr := httptest.NewRecorder()
 		requestContext := context.Background()
-		requestContext = appcontext.WithUser(requestContext, models.User{EUAUserID: "EUAID"})
+		requestContext = appcontext.WithPrincipal(requestContext, &authn.EUAPrincipal{EUAID: "EUAID", JobCodeEASi: true})
 		req, err := http.NewRequestWithContext(requestContext, "GET", "/business_cases/", bytes.NewBufferString("{}"))
 		s.NoError(err)
 		BusinessCasesHandler{

--- a/pkg/handlers/system_intake.go
+++ b/pkg/handlers/system_intake.go
@@ -140,7 +140,8 @@ func (h SystemIntakeHandler) Handle() http.HandlerFunc {
 				return
 			}
 
-			user, ok := appcontext.User(r.Context())
+			principal := appcontext.Principal(r.Context())
+			user, ok := appcontext.User(r.Context()) // deprecated
 			if !ok {
 				h.WriteErrorResponse(
 					r.Context(),
@@ -151,6 +152,7 @@ func (h SystemIntakeHandler) Handle() http.HandlerFunc {
 					})
 				return
 			}
+			intake.EUAUserID = principal.ID()
 			intake.EUAUserID = user.EUAUserID
 
 			updatedIntake, err := h.UpdateSystemIntake(r.Context(), &intake)

--- a/pkg/handlers/system_intake.go
+++ b/pkg/handlers/system_intake.go
@@ -141,8 +141,7 @@ func (h SystemIntakeHandler) Handle() http.HandlerFunc {
 			}
 
 			principal := appcontext.Principal(r.Context())
-			user, ok := appcontext.User(r.Context()) // deprecated
-			if !ok {
+			if !principal.AllowEASi() {
 				h.WriteErrorResponse(
 					r.Context(),
 					w,
@@ -153,7 +152,6 @@ func (h SystemIntakeHandler) Handle() http.HandlerFunc {
 				return
 			}
 			intake.EUAUserID = principal.ID()
-			intake.EUAUserID = user.EUAUserID
 
 			updatedIntake, err := h.UpdateSystemIntake(r.Context(), &intake)
 			if err != nil {

--- a/pkg/handlers/system_intake_test.go
+++ b/pkg/handlers/system_intake_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/authn"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -52,7 +53,7 @@ func newMockArchiveSystemIntake(err error) archiveSystemIntake {
 
 func (s HandlerTestSuite) TestSystemIntakeHandler() {
 	requestContext := context.Background()
-	requestContext = appcontext.WithUser(requestContext, models.User{EUAUserID: "FAKE"})
+	requestContext = appcontext.WithPrincipal(requestContext, &authn.EUAPrincipal{EUAID: "FAKE", JobCodeEASi: true})
 	requester := "Test Requester"
 	id, err := uuid.NewUUID()
 	s.NoError(err)

--- a/pkg/handlers/system_intakes.go
+++ b/pkg/handlers/system_intakes.go
@@ -32,8 +32,7 @@ func (h SystemIntakesHandler) Handle() http.HandlerFunc {
 		switch r.Method {
 		case "GET":
 			principal := appcontext.Principal(r.Context())
-			user, ok := appcontext.User(r.Context()) // deprecated
-			if !ok {
+			if !principal.AllowEASi() {
 				h.WriteErrorResponse(r.Context(), w, &apperrors.ContextError{
 					Operation: apperrors.ContextGet,
 					Object:    "User",
@@ -41,9 +40,7 @@ func (h SystemIntakesHandler) Handle() http.HandlerFunc {
 				return
 			}
 
-			fetchID := principal.ID()
-			fetchID = user.EUAUserID
-			systemIntakes, err := h.FetchSystemIntakes(r.Context(), fetchID)
+			systemIntakes, err := h.FetchSystemIntakes(r.Context(), principal.ID())
 			if err != nil {
 				h.WriteErrorResponse(r.Context(), w, err)
 				return

--- a/pkg/handlers/system_intakes.go
+++ b/pkg/handlers/system_intakes.go
@@ -31,7 +31,8 @@ func (h SystemIntakesHandler) Handle() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case "GET":
-			user, ok := appcontext.User(r.Context())
+			principal := appcontext.Principal(r.Context())
+			user, ok := appcontext.User(r.Context()) // deprecated
 			if !ok {
 				h.WriteErrorResponse(r.Context(), w, &apperrors.ContextError{
 					Operation: apperrors.ContextGet,
@@ -40,7 +41,9 @@ func (h SystemIntakesHandler) Handle() http.HandlerFunc {
 				return
 			}
 
-			systemIntakes, err := h.FetchSystemIntakes(r.Context(), user.EUAUserID)
+			fetchID := principal.ID()
+			fetchID = user.EUAUserID
+			systemIntakes, err := h.FetchSystemIntakes(r.Context(), fetchID)
 			if err != nil {
 				h.WriteErrorResponse(r.Context(), w, err)
 				return

--- a/pkg/handlers/system_intakes_test.go
+++ b/pkg/handlers/system_intakes_test.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/authn"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -23,7 +24,7 @@ func (s HandlerTestSuite) TestSystemIntakesHandler() {
 	s.Run("golden path FETCH passes", func() {
 		rr := httptest.NewRecorder()
 		requestContext := context.Background()
-		requestContext = appcontext.WithUser(requestContext, models.User{EUAUserID: "EUAID"})
+		requestContext = appcontext.WithPrincipal(requestContext, &authn.EUAPrincipal{EUAID: "EUAID", JobCodeEASi: true})
 		req, err := http.NewRequestWithContext(requestContext, "GET", "/system_intakes/", bytes.NewBufferString("{}"))
 		s.NoError(err)
 		SystemIntakesHandler{

--- a/pkg/local/authorization.go
+++ b/pkg/local/authorization.go
@@ -6,7 +6,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
-	"github.com/cmsgov/easi-app/pkg/models"
+	"github.com/cmsgov/easi-app/pkg/authn"
 )
 
 // If you're developing interfaces with LDAP, you may need to change this to your own EUA ID for testing purposes
@@ -15,7 +15,7 @@ const testEUAID = "ABCD"
 func authorizeMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.Info("Using local authorization middleware and populating EUA ID")
-		ctx := appcontext.WithUser(r.Context(), models.User{EUAUserID: testEUAID})
+		ctx := appcontext.WithPrincipal(r.Context(), &authn.EUAPrincipal{EUAID: testEUAID, JobCodeEASi: true})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/okta/okta.go
+++ b/pkg/okta/okta.go
@@ -77,8 +77,6 @@ func (f oktaMiddlewareFactory) newAuthorizeMiddleware(next http.Handler) http.Ha
 		}
 		logger = logger.With(zap.String("user", user.EUAUserID))
 
-		ctx := appcontext.WithUser(r.Context(), user)
-
 		// also add the authn.Principal to the context... since
 		// we don't yet have access to the Job Codes in the JWT, this builds
 		// on the current assumption that anyone with an appropriate
@@ -86,7 +84,7 @@ func (f oktaMiddlewareFactory) newAuthorizeMiddleware(next http.Handler) http.Ha
 		// as a viewer/submitter. Effectively, this is just a new
 		// way to re-state the same things the User type does, but
 		// it gives a foward path for eventually empowering GRT users.
-		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{
+		ctx := appcontext.WithPrincipal(r.Context(), &authn.EUAPrincipal{
 			EUAID:       user.EUAUserID,
 			JobCodeEASi: true,
 			JobCodeGRT:  false})

--- a/pkg/okta/okta_test.go
+++ b/pkg/okta/okta_test.go
@@ -91,14 +91,10 @@ func (s OktaTestSuite) TestAuthorizeMiddleware() {
 		req.Header.Set("AUTHORIZATION", fmt.Sprintf("Bearer %s", accessToken))
 		rr := httptest.NewRecorder()
 		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			user, ok := appcontext.User(r.Context())
-			s.True(ok)
-			s.Equal(s.config.GetString("OKTA_TEST_USERNAME"), user.EUAUserID)
-
-			// ensure the Principal is currently piggy-backing off the User
+			// ensure the Principal is has replaced the User
 			principal := appcontext.Principal(r.Context())
 			s.True(principal.AllowEASi(), "AllowEASi()")
-			s.Equal(user.EUAUserID, principal.ID(), "ID()")
+			s.Equal(s.config.GetString("OKTA_TEST_USERNAME"), principal.ID(), "ID()")
 		})
 
 		authMiddleware(testHandler).ServeHTTP(rr, req)

--- a/pkg/services/business_case.go
+++ b/pkg/services/business_case.go
@@ -64,8 +64,9 @@ func NewAuthorizeCreateBusinessCase(_ *zap.Logger) func(
 				Info("intake does not exist")
 			return false, nil
 		}
-		user, ok := appcontext.User(ctx)
-		if !ok {
+		principal := appcontext.Principal(ctx)
+		user, ok := appcontext.User(ctx) // deprecated
+		if !ok || !principal.AllowEASi() {
 			// Default to failure to authorize and create a quick audit log
 			logger.With(zap.Bool("Authorized", false)).
 				With(zap.String("Operation", "CreateBusinessCase")).
@@ -73,7 +74,7 @@ func NewAuthorizeCreateBusinessCase(_ *zap.Logger) func(
 			return false, nil
 		}
 		// If business case is owned by user, authorize
-		if user.EUAUserID == intake.EUAUserID {
+		if user.EUAUserID == intake.EUAUserID && principal.ID() == intake.EUAUserID {
 			logger.With(zap.Bool("Authorized", true)).
 				With(zap.String("Operation", "CreateBusinessCase")).
 				Info("user authorized to create business case")
@@ -186,8 +187,9 @@ func NewAuthorizeUpdateBusinessCase(_ *zap.Logger) func(
 				Info("business case does not exist")
 			return false, nil
 		}
-		user, ok := appcontext.User(ctx)
-		if !ok {
+		principal := appcontext.Principal(ctx)
+		user, ok := appcontext.User(ctx) // deprecated
+		if !ok || !principal.AllowEASi() {
 			// Default to failure to authorize and create a quick audit log
 			logger.With(zap.Bool("Authorized", false)).
 				With(zap.String("Operation", "UpdateBusinessCase")).
@@ -195,7 +197,7 @@ func NewAuthorizeUpdateBusinessCase(_ *zap.Logger) func(
 			return false, nil
 		}
 		// If intake is owned by user, authorize
-		if user.EUAUserID == businessCase.EUAUserID {
+		if user.EUAUserID == businessCase.EUAUserID && principal.ID() == businessCase.EUAUserID {
 			logger.With(zap.Bool("Authorized", true)).
 				With(zap.String("Operation", "UpdateBusinessCase")).
 				Info("user authorized to update business case")

--- a/pkg/services/business_case.go
+++ b/pkg/services/business_case.go
@@ -65,8 +65,7 @@ func NewAuthorizeCreateBusinessCase(_ *zap.Logger) func(
 			return false, nil
 		}
 		principal := appcontext.Principal(ctx)
-		user, ok := appcontext.User(ctx) // deprecated
-		if !ok || !principal.AllowEASi() {
+		if !principal.AllowEASi() {
 			// Default to failure to authorize and create a quick audit log
 			logger.With(zap.Bool("Authorized", false)).
 				With(zap.String("Operation", "CreateBusinessCase")).
@@ -74,7 +73,7 @@ func NewAuthorizeCreateBusinessCase(_ *zap.Logger) func(
 			return false, nil
 		}
 		// If business case is owned by user, authorize
-		if user.EUAUserID == intake.EUAUserID && principal.ID() == intake.EUAUserID {
+		if principal.ID() == intake.EUAUserID {
 			logger.With(zap.Bool("Authorized", true)).
 				With(zap.String("Operation", "CreateBusinessCase")).
 				Info("user authorized to create business case")
@@ -188,8 +187,7 @@ func NewAuthorizeUpdateBusinessCase(_ *zap.Logger) func(
 			return false, nil
 		}
 		principal := appcontext.Principal(ctx)
-		user, ok := appcontext.User(ctx) // deprecated
-		if !ok || !principal.AllowEASi() {
+		if !principal.AllowEASi() {
 			// Default to failure to authorize and create a quick audit log
 			logger.With(zap.Bool("Authorized", false)).
 				With(zap.String("Operation", "UpdateBusinessCase")).
@@ -197,7 +195,7 @@ func NewAuthorizeUpdateBusinessCase(_ *zap.Logger) func(
 			return false, nil
 		}
 		// If intake is owned by user, authorize
-		if user.EUAUserID == businessCase.EUAUserID && principal.ID() == businessCase.EUAUserID {
+		if principal.ID() == businessCase.EUAUserID {
 			logger.With(zap.Bool("Authorized", true)).
 				With(zap.String("Operation", "UpdateBusinessCase")).
 				Info("user authorized to update business case")

--- a/pkg/services/business_case_test.go
+++ b/pkg/services/business_case_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/authn"
 	"github.com/cmsgov/easi-app/pkg/models"
 	"github.com/cmsgov/easi-app/pkg/testhelpers"
 )
@@ -96,6 +97,7 @@ func (s ServicesTestSuite) TestAuthorizeCreateBusinessCase() {
 	s.Run("Mismatched EUA ID fails auth", func() {
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ZYXW"})
+		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ZYXW", JobCodeEASi: true})
 
 		intake := models.SystemIntake{
 			EUAUserID: "ABCD",
@@ -110,6 +112,7 @@ func (s ServicesTestSuite) TestAuthorizeCreateBusinessCase() {
 	s.Run("Matched EUA ID passes auth", func() {
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ABCD"})
+		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ABCD", JobCodeEASi: true})
 		intake := models.SystemIntake{
 			EUAUserID: "ABCD",
 		}
@@ -224,6 +227,7 @@ func (s ServicesTestSuite) TestAuthorizeUpdateBusinessCase() {
 	s.Run("Mismatched EUA ID fails auth", func() {
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ZYXW"})
+		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ZYXW", JobCodeEASi: true})
 
 		businessCase := models.BusinessCase{
 			EUAUserID: "ABCD",
@@ -238,6 +242,7 @@ func (s ServicesTestSuite) TestAuthorizeUpdateBusinessCase() {
 	s.Run("Matched EUA ID passes auth", func() {
 		ctx := context.Background()
 		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ABCD"})
+		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ABCD", JobCodeEASi: true})
 		businessCase := models.BusinessCase{
 			EUAUserID: "ABCD",
 		}

--- a/pkg/services/business_case_test.go
+++ b/pkg/services/business_case_test.go
@@ -96,7 +96,6 @@ func (s ServicesTestSuite) TestAuthorizeCreateBusinessCase() {
 
 	s.Run("Mismatched EUA ID fails auth", func() {
 		ctx := context.Background()
-		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ZYXW"})
 		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ZYXW", JobCodeEASi: true})
 
 		intake := models.SystemIntake{
@@ -111,7 +110,6 @@ func (s ServicesTestSuite) TestAuthorizeCreateBusinessCase() {
 
 	s.Run("Matched EUA ID passes auth", func() {
 		ctx := context.Background()
-		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ABCD"})
 		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ABCD", JobCodeEASi: true})
 		intake := models.SystemIntake{
 			EUAUserID: "ABCD",
@@ -226,7 +224,6 @@ func (s ServicesTestSuite) TestAuthorizeUpdateBusinessCase() {
 
 	s.Run("Mismatched EUA ID fails auth", func() {
 		ctx := context.Background()
-		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ZYXW"})
 		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ZYXW", JobCodeEASi: true})
 
 		businessCase := models.BusinessCase{
@@ -241,7 +238,6 @@ func (s ServicesTestSuite) TestAuthorizeUpdateBusinessCase() {
 
 	s.Run("Matched EUA ID passes auth", func() {
 		ctx := context.Background()
-		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ABCD"})
 		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ABCD", JobCodeEASi: true})
 		businessCase := models.BusinessCase{
 			EUAUserID: "ABCD",

--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -246,12 +246,12 @@ func NewUpdateSystemIntake(
 // NewAuthorizeArchiveSystemIntake returns a function
 // that authorizes a user for archiving a system intake
 func NewAuthorizeArchiveSystemIntake(logger *zap.Logger) func(
-	context context.Context,
-	intake *models.SystemIntake,
+	c context.Context,
+	i *models.SystemIntake,
 ) (bool, error) {
-	return func(context context.Context, intake *models.SystemIntake) (bool, error) {
-		user, ok := appcontext.User(context)
-		if !ok {
+	return func(ctx context.Context, intake *models.SystemIntake) (bool, error) {
+		principal := appcontext.Principal(ctx)
+		if !principal.AllowEASi() {
 			logger.Error("unable to get EUA ID from context")
 			return false, &apperrors.ContextError{
 				Operation: apperrors.ContextGet,
@@ -260,7 +260,7 @@ func NewAuthorizeArchiveSystemIntake(logger *zap.Logger) func(
 		}
 
 		// If intake doesn't exist or owned by user, authorize
-		if intake == nil || user.EUAUserID == intake.EUAUserID {
+		if intake == nil || principal.ID() == intake.EUAUserID {
 			logger.With(zap.Bool("Authorized", true)).
 				With(zap.String("Operation", "UpdateSystemIntake")).
 				Info("user authorized to save system intake")

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -56,7 +56,6 @@ func (s ServicesTestSuite) TestNewCreateSystemIntake() {
 	serviceConfig := NewConfig(logger)
 	serviceConfig.clock = clock.NewMock()
 	ctx := context.Background()
-	ctx = appcontext.WithUser(ctx, models.User{EUAUserID: fakeEuaID}) // deprecated
 	ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: fakeEuaID, JobCodeEASi: true})
 
 	s.Run("successfully creates a system intake without an error", func() {
@@ -105,7 +104,6 @@ func (s ServicesTestSuite) TestAuthorizeSaveSystemIntake() {
 
 	s.Run("Mismatched EUA ID fails auth", func() {
 		ctx := context.Background()
-		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ZYXW"}) // deprecated
 		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ZYXW", JobCodeEASi: true})
 
 		intake := models.SystemIntake{
@@ -120,7 +118,6 @@ func (s ServicesTestSuite) TestAuthorizeSaveSystemIntake() {
 
 	s.Run("Matched EUA ID passes auth", func() {
 		ctx := context.Background()
-		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ABCD"}) // deprecated
 		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ABCD", JobCodeEASi: true})
 
 		intake := models.SystemIntake{

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -439,7 +439,7 @@ func (s ServicesTestSuite) TestAuthorizeArchiveSystemIntake() {
 
 	s.Run("Mismatched EUA ID fails auth", func() {
 		ctx := context.Background()
-		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ZYXW"})
+		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ZYXW", JobCodeEASi: true})
 		intake := models.SystemIntake{
 			EUAUserID: "ABCD",
 		}
@@ -452,7 +452,7 @@ func (s ServicesTestSuite) TestAuthorizeArchiveSystemIntake() {
 
 	s.Run("Matched EUA ID passes auth", func() {
 		ctx := context.Background()
-		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ABCD"})
+		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ABCD", JobCodeEASi: true})
 		intake := models.SystemIntake{
 			EUAUserID: "ABCD",
 		}

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/authn"
 	models2 "github.com/cmsgov/easi-app/pkg/cedar/cedarldap/gen/models"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
@@ -55,7 +56,8 @@ func (s ServicesTestSuite) TestNewCreateSystemIntake() {
 	serviceConfig := NewConfig(logger)
 	serviceConfig.clock = clock.NewMock()
 	ctx := context.Background()
-	ctx = appcontext.WithUser(ctx, models.User{EUAUserID: fakeEuaID})
+	ctx = appcontext.WithUser(ctx, models.User{EUAUserID: fakeEuaID}) // deprecated
+	ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: fakeEuaID, JobCodeEASi: true})
 
 	s.Run("successfully creates a system intake without an error", func() {
 		create := func(intake *models.SystemIntake) (*models.SystemIntake, error) {
@@ -103,7 +105,9 @@ func (s ServicesTestSuite) TestAuthorizeSaveSystemIntake() {
 
 	s.Run("Mismatched EUA ID fails auth", func() {
 		ctx := context.Background()
-		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ZYXW"})
+		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ZYXW"}) // deprecated
+		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ZYXW", JobCodeEASi: true})
+
 		intake := models.SystemIntake{
 			EUAUserID: "ABCD",
 		}
@@ -116,7 +120,9 @@ func (s ServicesTestSuite) TestAuthorizeSaveSystemIntake() {
 
 	s.Run("Matched EUA ID passes auth", func() {
 		ctx := context.Background()
-		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ABCD"})
+		ctx = appcontext.WithUser(ctx, models.User{EUAUserID: "ABCD"}) // deprecated
+		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ABCD", JobCodeEASi: true})
+
 		intake := models.SystemIntake{
 			EUAUserID: "ABCD",
 		}


### PR DESCRIPTION
# EASI-621

Changes proposed in this pull request:

* This PR makes the `authn.Principal` the load bearing object for authorization in the system, replacing the `model.User`
* Actually wiring up code to set `EUAPrincipal.AllowGRT()` will happen in on a later ticket (EASI-740) after EUA + Okta configurations have happened 
