### PR TITLE
Only test cedar connection for prod and dedupe cedar keys

### DIFF
--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -146,3 +146,9 @@ const ClientProtocolKey = "CLIENT_PROTOCOL"
 
 // EmailTemplateDirectoryKey is the key for getting the email template directory
 const EmailTemplateDirectoryKey = "EMAIL_TEMPLATE_DIR"
+
+// CEDARAPIURL is the key for the CEDAR base url
+const CEDARAPIURL = "CEDAR_API_URL"
+
+// CEDARAPIKey is the key for accessing CEDAR
+const CEDARAPIKey = "CEDAR_API_KEY"

--- a/pkg/integration/cedar_test.go
+++ b/pkg/integration/cedar_test.go
@@ -28,7 +28,7 @@ func (s *IntegrationTestSuite) TestCEDARConnection() {
 
 	cedarEasiClient := cedareasi.NewTranslatedClient(
 		s.config.GetString("CEDAR_API_URL"),
-		s.config.GetString("CEDAR_EASI_API_KEY"),
+		s.config.GetString("CEDAR_API_KEY"),
 	)
 
 	handlers.NewSystemsListHandler(

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -62,3 +62,9 @@ func (s Server) NewSESConfig() appses.Config {
 		Source:    s.Config.GetString(appconfig.AWSSESSourceKey),
 	}
 }
+
+// NewCEDARClientCheck checks if CEDAR clients are not connectable
+func (s Server) NewCEDARClientCheck() {
+	s.checkRequiredConfig(appconfig.CEDARAPIURL)
+	s.checkRequiredConfig(appconfig.CEDARAPIKey)
+}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -36,7 +36,9 @@ func (s *Server) routes(
 	s.router.HandleFunc("/api/v1/healthcheck", healthCheckHandler.Handle())
 
 	// check we have all of the configs for CEDAR clients
-	s.NewCEDARClientCheck()
+	if s.environment.Deployed() {
+		s.NewCEDARClientCheck()
+	}
 
 	// set up CEDAR client
 	cedarEasiClient := cedareasi.NewTranslatedClient(

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -35,18 +35,21 @@ func (s *Server) routes(
 	)
 	s.router.HandleFunc("/api/v1/healthcheck", healthCheckHandler.Handle())
 
+	// check we have all of the configs for CEDAR clients
+	s.NewCEDARClientCheck()
+
 	// set up CEDAR client
 	cedarEasiClient := cedareasi.NewTranslatedClient(
 		s.Config.GetString("CEDAR_API_URL"),
-		s.Config.GetString("CEDAR_EASI_API_KEY"),
+		s.Config.GetString("CEDAR_API_KEY"),
 	)
 
 	cedarLdapClient := cedarldap.NewTranslatedClient(
 		s.Config.GetString("CEDAR_API_URL"),
-		s.Config.GetString("CEDAR_LDAP_API_KEY"),
+		s.Config.GetString("CEDAR_API_KEY"),
 	)
 
-	if s.environment.Deployed() {
+	if s.environment.Prod() {
 		s.CheckCEDAREasiClientConnection(cedarEasiClient)
 		s.CheckCEDARLdapClientConnection(cedarLdapClient)
 	}


### PR DESCRIPTION
# EASI-718

Changes proposed in this pull request:

- Given instability of CEDAR dev, we will no longer check the connection to CEDAR in dev or impl
- Checks that we still have necessary configs for CEDAR clients
- Simplifies CEDAR api keys to a single key
