### PR TITLE
req context in storage layer

### DIFF
--- a/pkg/integration/business_case_test.go
+++ b/pkg/integration/business_case_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -27,7 +28,7 @@ func (s IntegrationTestSuite) TestBusinessCaseEndpoints() {
 	intake.Status = models.SystemIntakeStatusSUBMITTED
 	intake.EUAUserID = s.user.euaID
 
-	createdIntake, err := s.store.CreateSystemIntake(&intake)
+	createdIntake, err := s.store.CreateSystemIntake(context.Background(), &intake)
 	intakeID := createdIntake.ID
 	s.NoError(err)
 

--- a/pkg/services/metrics.go
+++ b/pkg/services/metrics.go
@@ -14,10 +14,10 @@ import (
 // NewFetchMetrics returns a service for fetching a metrics digest
 func NewFetchMetrics(
 	config Config,
-	fetchSystemIntakeMetrics func(time.Time, time.Time) (models.SystemIntakeMetrics, error),
+	fetchSystemIntakeMetrics func(context.Context, time.Time, time.Time) (models.SystemIntakeMetrics, error),
 ) func(c context.Context, st time.Time, et time.Time) (models.MetricsDigest, error) {
 	return func(ctx context.Context, startTime time.Time, endTime time.Time) (models.MetricsDigest, error) {
-		systemIntakeMetrics, err := fetchSystemIntakeMetrics(startTime, endTime)
+		systemIntakeMetrics, err := fetchSystemIntakeMetrics(ctx, startTime, endTime)
 		if err != nil {
 			appcontext.ZLogger(ctx).Error("failed to query system intake metrics", zap.Error(err))
 			return models.MetricsDigest{}, &apperrors.QueryError{

--- a/pkg/services/metrics_test.go
+++ b/pkg/services/metrics_test.go
@@ -17,7 +17,7 @@ func (s ServicesTestSuite) TestNewFetchMetrics() {
 	serviceConfig := NewConfig(zap.NewNop())
 	serviceConfig.clock = serviceClock
 	systemIntakeMetrics := models.SystemIntakeMetrics{}
-	fetchSystemIntakeMetrics := func(time.Time, time.Time) (models.SystemIntakeMetrics, error) {
+	fetchSystemIntakeMetrics := func(context.Context, time.Time, time.Time) (models.SystemIntakeMetrics, error) {
 		return systemIntakeMetrics, nil
 	}
 
@@ -35,7 +35,7 @@ func (s ServicesTestSuite) TestNewFetchMetrics() {
 	})
 
 	s.Run("returns error if service fails", func() {
-		failFetchSystemIntakeMetrics := func(time.Time, time.Time) (models.SystemIntakeMetrics, error) {
+		failFetchSystemIntakeMetrics := func(context.Context, time.Time, time.Time) (models.SystemIntakeMetrics, error) {
 			return systemIntakeMetrics, errors.New("failed to fetch system intake metrics")
 		}
 		fetchMetrics := NewFetchMetrics(serviceConfig, failFetchSystemIntakeMetrics)


### PR DESCRIPTION
# EASI-535

Changes proposed in this pull request:

* this continues the work previously done at the `services` layer into the `storage` layer
* use the request context for finding the logger to write out logs
* this ensures that things like `request ID` are still associated with logs emitted when problems arise talking to the database