### PR TITLE
Add more commands for local cypress tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,14 @@ postgres@localhost:postgres>
 Use the following command to run all services locally, *including* cypress tests:
 
 ```console
+# build the images
+docker-compose -f docker-compose.yml -f docker-compose.circleci.yml -f docker-compose.local.yml build --parallel
+
+# run the services in the background
 docker-compose -f docker-compose.yml -f docker-compose.circleci.yml -f docker-compose.local.yml up --detach
+
+# watch the logs
+docker-compose -f docker-compose.yml -f docker-compose.circleci.yml -f docker-compose.local.yml logs -f
 ```
 
 Note: you can modify the command above to run only some of the services. For


### PR DESCRIPTION
# EASI-000

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Elaborate on the docker commands for running Cypress tests locally
