### PR TITLE
job codes

### DIFF
--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -1,6 +1,0 @@
-package models
-
-// User stores the user context for a request
-type User struct {
-	EUAUserID string
-}

--- a/pkg/okta/okta.go
+++ b/pkg/okta/okta.go
@@ -46,7 +46,7 @@ func (f oktaMiddlewareFactory) newPrincipal(jwt *jwtverifier.Jwt) (*authn.EUAPri
 
 	// need to check the claims for empowerment as a reviewer
 	jcGRT := false
-	if list, ok := jwt.Claims["replace_me"]; ok {
+	if list, ok := jwt.Claims["groups"]; ok {
 		// json arrays decode to `[]interface{}`
 		if codes, ok := list.([]interface{}); ok {
 			for _, code := range codes {
@@ -95,8 +95,8 @@ func (f oktaMiddlewareFactory) newAuthorizeMiddleware(next http.Handler) http.Ha
 			)
 			return
 		}
-		logger = logger.With(zap.String("user", principal.ID()))
-		logger.With(zap.Bool("grt", principal.AllowGRT())).Info("Principal Found!")
+		logger = logger.With(zap.String("user", principal.ID())).With(zap.Bool("grt", principal.AllowGRT()))
+		logger.Info("Principal Found!") // debugging only
 
 		ctx := r.Context()
 		ctx = appcontext.WithPrincipal(ctx, principal)

--- a/pkg/okta/okta.go
+++ b/pkg/okta/okta.go
@@ -96,7 +96,6 @@ func (f oktaMiddlewareFactory) newAuthorizeMiddleware(next http.Handler) http.Ha
 			return
 		}
 		logger = logger.With(zap.String("user", principal.ID())).With(zap.Bool("grt", principal.AllowGRT()))
-		logger.Info("Principal Found!") // debugging only
 
 		ctx := r.Context()
 		ctx = appcontext.WithPrincipal(ctx, principal)

--- a/pkg/okta/okta_test.go
+++ b/pkg/okta/okta_test.go
@@ -43,6 +43,7 @@ func (s OktaTestSuite) TestAuthorizeMiddleware() {
 		handlers.NewHandlerBase(s.logger),
 		s.config.GetString("OKTA_CLIENT_ID"),
 		s.config.GetString("OKTA_ISSUER"),
+		false,
 	)
 
 	s.Run("a valid token executes the handler", func() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -50,7 +50,7 @@ func NewServer(config *viper.Viper) *Server {
 		handlers.NewHandlerBase(zapLogger),
 		config.GetString("OKTA_CLIENT_ID"),
 		config.GetString("OKTA_ISSUER"),
-		!environment.Prod(),
+		config.GetBool("ALT_JOB_CODES"),
 	)
 
 	// If we're local use override with local auth middleware

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -50,6 +50,7 @@ func NewServer(config *viper.Viper) *Server {
 		handlers.NewHandlerBase(zapLogger),
 		config.GetString("OKTA_CLIENT_ID"),
 		config.GetString("OKTA_ISSUER"),
+		!environment.Prod(),
 	)
 
 	// If we're local use override with local auth middleware


### PR DESCRIPTION
# EASI-740

Changes proposed in this pull request:

* remove `model.User` which is no longer used
* have the inner method actually build the `EUAPrincipal`, including setting the GRT permissions
