### PR TITLE
add feedback for accessibility statement.

### DIFF
--- a/src/i18n/en-US/accessibilityStatement.ts
+++ b/src/i18n/en-US/accessibilityStatement.ts
@@ -3,63 +3,77 @@ const accessibilityStatement = {
   mainTitle: 'Accessibility & Nondiscrimination Notice',
 
   // CMS Accessible Communications
-  communicationsTitle: 'CMS accessible communications',
-
-  communicationsParagraph1:
-    'CMS provides free auxiliary aids and services including information in accessible formats like Braille, large print, data/audio files, relay services and TTY communications. If you request information in an accessible format from CMS, you won’t be disadvantaged by any additional time necessary to provide it. This means you will get extra time to take any action if there’s a delay in fulfilling your request.',
-  communicationsParagraph2:
-    'To request Medicare or Marketplace information in an accessible format you can:',
-
-  communicationsHowToRequestListElem1: '<strong>Call us:</strong>',
-  communicationsHowToRequestListElem1SubList: [
-    'For Medicare: 1-800-MEDICARE (1-800-633-4227). TTY: 1-877-486-2048',
-    'For the Health Insurance Marketplace: (1-800-318-2596). TTY: 1-855-889-4325'
-  ],
-
-  communicationsHowToRequestListElem2: '<strong>Email us:</strong>: ',
-  communicationsHowToRequestListElem2Email: 'altformatrequest@cms.hhs.gov',
-  communicationsHowToRequestListElem3:
-    '<strong>Send us a fax:</strong> 1-844-530-3676',
-  communicationsHowToRequestListElem4: '<strong>Send us a letter:</strong>',
-  communicationsHowToRequestListCMSAddressList: [
-    'Centers for Medicare & Medicaid Services',
-    'Offices of Hearings and Inquiries (OHI)',
-    '7500 Security Boulevard, Mail Stop S1-13-25',
-    'Baltimore, MD 21244-1850',
-    'Attn: Customer Accessibility Resource Staff'
-  ],
-
-  communicationsParagraph3:
-    'Your request should include your name, phone number, type of information you need (if known) and the mailing address where we should send the materials. We may contact you for additional information.',
-  communicationsParagraph4:
-    '<strong>Note:</strong> If you’re enrolled in a Medicare Advantage Plan or Prescription Drug Plan, contact your plan to request their information in an accessible format. For Medicaid, contact your State or local Medicaid office.',
+  communications: {
+    heading: 'CMS accessible communications',
+    description:
+      'CMS provides free auxiliary aids and services including information in accessible formats like Braille, large print, data/audio files, relay services and TTY communications. If you request information in an accessible format from CMS, you won’t be disadvantaged by any additional time necessary to provide it. This means you will get extra time to take any action if there’s a delay in fulfilling your request.',
+    accessibleFormatRequest:
+      'To request Medicare or Marketplace information in an accessible format you can:',
+    phone: {
+      label: 'Call us:',
+      medicare:
+        'For Medicare: 1-800-MEDICARE (1-800-633-4227). TTY: 1-877-486-2048',
+      healthInsuranceMarketplace:
+        'For the Health Insurance Marketplace: (1-800-318-2596). TTY: 1-855-889-4325'
+    },
+    email: {
+      label: 'Email us:',
+      address: 'altformatrequest@cms.hhs.gov'
+    },
+    fax: {
+      label: 'Send us a fax:',
+      number: '1-844-530-3676'
+    },
+    physicalMail: {
+      label: 'Send us a letter:',
+      address: {
+        line1: 'Centers for Medicare & Medicaid Services',
+        line2: 'Offices of Hearings and Inquiries (OHI)',
+        street: '7500 Security Boulevard, Mail Stop S1-13-25',
+        cityStateZip: 'Baltimore, MD 21244-1850',
+        attention: 'Attn: Customer Accessibility Resource Staff'
+      }
+    },
+    requestInstructions:
+      'Your request should include your name, phone number, type of information you need (if known) and the mailing address where we should send the materials. We may contact you for additional information.',
+    note:
+      '<0>Note:</0> If you’re enrolled in a Medicare Advantage Plan or Prescription Drug Plan, contact your plan to request their information in an accessible format. For Medicaid, contact your State or local Medicaid office.'
+  },
 
   // Nondiscrimination Notice
-  nondiscriminationTitle: 'Nondiscrimination Notice',
-  nondiscriminationParagraph:
-    "The Centers for Medicare & Medicaid Services (CMS) is the federal agency that runs the Medicare, Medicaid, and Children's Health Insurance Programs, and the federally facilitated Marketplace. CMS doesn’t exclude, deny benefits to, or otherwise discriminate against any person on the basis of race, color, national origin, disability, sex, or age in admission to, participation in, or receipt of the services and benefits under any of its programs and activities, whether carried out by CMS directly or through a contractor or any other entity with which CMS arranges to carry out its programs and activities.",
-
+  nondiscrimination: {
+    heading: 'Nondiscrimination Notice',
+    description:
+      "The Centers for Medicare & Medicaid Services (CMS) is the federal agency that runs the Medicare, Medicaid, and Children's Health Insurance Programs, and the federally facilitated Marketplace. CMS doesn’t exclude, deny benefits to, or otherwise discriminate against any person on the basis of race, color, national origin, disability, sex, or age in admission to, participation in, or receipt of the services and benefits under any of its programs and activities, whether carried out by CMS directly or through a contractor or any other entity with which CMS arranges to carry out its programs and activities."
+  },
   // How to file a complaint
-  fileComplaintHowToTitle: 'How to file a complaint',
-
-  fileComplaintHowToParagraph1:
-    'You can contact CMS in any of the ways included in this notice if you have any concerns about getting information in a format that you can use.',
-  fileComplaintHowToParagraph2:
-    'You may also file a complaint if you think you’ve been subjected to discrimination in a CMS program or activity, including experiencing issues with getting information in an accessible format from any Medicare Advantage Plan, Medicare Prescription Drug Plan, State or local Medicaid office or Marketplace Qualified Health Plans. There are 3 ways to file a complaint with the U.S. Department of Health and Human Services, Office for Civil Rights:',
-
-  fileComplaintHowToListElem1: 'Online',
-  fileComplaintHowToListElem2:
-    '<strong>By phone:</strong> Call 1-800-368-1019. TTY users can call 1-800-537-7697.',
-  fileComplaintHowToListElem3:
-    '<strong>In writing:</strong> Send information about your complaint to:',
+  complaintFiling: {
+    heading: 'How to file a complaint',
+    contact:
+      'You can contact CMS in any of the ways included in this notice if you have any concerns about getting information in a format that you can use.',
+    description:
+      'You may also file a complaint if you think you’ve been subjected to discrimination in a CMS program or activity, including experiencing issues with getting information in an accessible format from any Medicare Advantage Plan, Medicare Prescription Drug Plan, State or local Medicaid office or Marketplace Qualified Health Plans. There are 3 ways to file a complaint with the U.S. Department of Health and Human Services, Office for Civil Rights:',
+    online: 'Online',
+    phone: {
+      label: 'By phone:',
+      number: 'Call 1-800-368-1019. TTY users can call 1-800-537-7697.'
+    },
+    physicalMail: {
+      label: 'In writing:',
+      line1: 'Office for Civil Rights',
+      line2: 'U.S. Department of Health and Human Services',
+      street1: ' 200 Independence Avenue, SW',
+      street2: 'Room 509F, HHH Building',
+      cityStateZip: 'Washington, D.C. 20201'
+    }
+  },
 
   // Medicare.gov accessibility & compliance with Section 508
-  complianceTitle: 'Medicare.gov accessibility & compliance with Section 508',
-  complianceParagraph1:
-    'CMS is committed to making its electronic and information technologies accessible to people with disabilities. If you can’t access content or use features on this website due to a disability, contact our Section 508 Team at ',
-  complianceEmail: '508Feedback@cms.hhs.gov',
-  complianceParagraph2:
-    '. To help us better serve you, upload the material in question and/or include the URL if possible and let us know the specific problems you’re having.',
+  compliance: {
+    heading: 'Medicare.gov accessibility & compliance with Section 508',
+    description:
+      'CMS is committed to making its electronic and information technologies accessible to people with disabilities. If you can’t access content or use features on this website due to a disability, contact our Section 508 Team at <1>508Feedback@cms.hhs.gov</1>. To help us better serve you, upload the material in question and/or include the URL if possible and let us know the specific problems you’re having.'
+  },
 
   // Additional Information
   additionalInformationTitle: 'Additional Information',

--- a/src/views/AccessibilityStatement/index.tsx
+++ b/src/views/AccessibilityStatement/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import { Link } from '@trussworks/react-uswds';
 
 import Header from 'components/Header';
 import MainContent from 'components/MainContent';
@@ -43,9 +44,9 @@ const AccesibilityStatement = () => {
                 {t('accessibilityStatement:communications.email.label')}
               </strong>
               &nbsp;
-              <a href="mailto:altformatrequest@cms.hhs.gov">
+              <Link href="mailto:altformatrequest@cms.hhs.gov">
                 {t('accessibilityStatement:communications.email.address')}
-              </a>
+              </Link>
             </li>
             <li>
               <strong>
@@ -107,13 +108,15 @@ const AccesibilityStatement = () => {
 
           <ol>
             <li>
-              <a
+              <Link
+                aria-label="Open a new tab to file a complaint"
                 href="https://www.hhs.gov/civil-rights/filing-a-complaint/complaint-process/index.html"
                 target="_blank"
                 rel="noopener noreferrer"
+                variant="external"
               >
                 {t('accessibilityStatement:complaintFiling.online')}
-              </a>
+              </Link>
             </li>
             <li>
               <strong>
@@ -154,7 +157,7 @@ const AccesibilityStatement = () => {
           <h2>{t('accessibilityStatement:compliance.heading')}</h2>
           <Trans i18nKey="accessibilityStatement:compliance.description">
             indexZero
-            <a href="mailto:508Feedback@cms.hhs.gov">localeLink</a>
+            <Link href="mailto:508Feedback@cms.hhs.gov">localeLink</Link>
             indexTwo
           </Trans>
         </div>
@@ -164,22 +167,26 @@ const AccesibilityStatement = () => {
 
           <ul>
             <li>
-              <a
+              <Link
+                aria-label="Open 'What is 504' in a new tab"
                 href="https://www.hhs.gov/web/section-508/what-is-section-504/index.html"
                 target="_blank"
                 rel="noopener noreferrer"
+                variant="external"
               >
                 {t('accessibilityStatement:additionalInformation508')}
-              </a>
+              </Link>
             </li>
             <li>
-              <a
+              <Link
+                aria-label="Open Civil Rights for Individuals and Advocates in a new tab"
                 href="https://www.hhs.gov/civil-rights/for-individuals/index.html"
                 target="_blank"
                 rel="noopener noreferrer"
+                variant="external"
               >
                 {t('accessibilityStatement:additionalInformationCivilRights')}
-              </a>
+              </Link>
             </li>
           </ul>
         </div>

--- a/src/views/AccessibilityStatement/index.tsx
+++ b/src/views/AccessibilityStatement/index.tsx
@@ -1,113 +1,188 @@
 import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
 import Header from 'components/Header';
 import MainContent from 'components/MainContent';
-import { Trans, useTranslation } from 'react-i18next';
 
 const AccesibilityStatement = () => {
   const { t } = useTranslation();
 
-  const communicationsHowToRequestListElem1SubList: string[] = t(
-    'accessibilityStatement:communicationsHowToRequestListElem1SubList',
-    { returnObjects: true }
-  );
-  const communicationsHowToRequestListCMSAddressList: string[] = t(
-    'accessibilityStatement:communicationsHowToRequestListCMSAddressList',
-    { returnObjects: true }
-  );
-
   return (
     <div>
       <Header />
-      <MainContent className="grid-container">
+      <MainContent className="grid-container line-height-body-5">
         {/* Surround in Trans tags to properly format embedded HTML tags in i18n file */}
-        <Trans>
-          <h1>{t('accessibilityStatement:mainTitle')}</h1>
+        <h1>{t('accessibilityStatement:mainTitle')}</h1>
 
-          {/* Accessible Communications */}
-          <h2>{t('accessibilityStatement:communicationsTitle')}</h2>
-          <p>{t('accessibilityStatement:communicationsParagraph1')}</p>
-          <p>{t('accessibilityStatement:communicationsParagraph2')}</p>
-
-          <ol>
-            <li>
-              {t('accessibilityStatement:communicationsHowToRequestListElem1')}
-              <ul>
-                {communicationsHowToRequestListElem1SubList.map(k => (
-                  <li key={k}>{k}</li>
-                ))}
-              </ul>
-            </li>
-            <li>
-              {t('accessibilityStatement:communicationsHowToRequestListElem2')}
-              <a href="mailto:altformatrequest@cms.hhs.gov">
-                {t(
-                  'accessibilityStatement:communicationsHowToRequestListElem2Email'
-                )}
-              </a>
-            </li>
-            <li>
-              {t('accessibilityStatement:communicationsHowToRequestListElem3')}
-            </li>
-            <li>
-              {t('accessibilityStatement:communicationsHowToRequestListElem4')}
-              <ul list-style="list-style-type:none;">
-                {communicationsHowToRequestListCMSAddressList.map(k => (
-                  <p key={k}>{k}</p>
-                ))}
-              </ul>
-            </li>
-          </ol>
-
-          <p>{t('accessibilityStatement:communicationsParagraph3')}</p>
-
-          <p>{t('accessibilityStatement:communicationsParagraph4')}</p>
-
-          {/* Non-Discrimination Notice */}
-          <h2>{t('accessibilityStatement:nondiscriminationTitle')}</h2>
-          <p>{t('accessibilityStatement:nondiscriminationParagraph')}</p>
-
-          {/* How to File a Compliant */}
-          <h2>{t('accessibilityStatement:fileComplaintHowToTitle')}</h2>
-          <p>{t('accessibilityStatement:fileComplaintHowToParagraph1')}</p>
-          <p>{t('accessibilityStatement:fileComplaintHowToParagraph2')}</p>
-
-          <ol>
-            <li>
-              <a href="https://www.hhs.gov/civil-rights/filing-a-complaint/complaint-process/index.html">
-                {t('accessibilityStatement:fileComplaintHowToListElem1')}
-              </a>
-            </li>
-            <li>{t('accessibilityStatement:fileComplaintHowToListElem2')}</li>
-            <li>{t('accessibilityStatement:fileComplaintHowToListElem3')}</li>
-          </ol>
-
-          {/* 508 Compliance */}
-          <h2>{t('accessibilityStatement:complianceTitle')}</h2>
-
+        {/* Accessible Communications */}
+        <div>
+          <h2>{t('accessibilityStatement:communications.heading')}</h2>
+          <p>{t('accessibilityStatement:communications.description')}</p>
           <p>
-            {t('accessibilityStatement:complianceParagraph1')}
-            <a href="mailto:508Feedback@cms.hhs.gov">
-              {t('accessibilityStatement:complianceEmail')}
-            </a>
-            {t('accessibilityStatement:complianceParagraph2')}
+            {t('accessibilityStatement:communications.accessibleFormatRequest')}
           </p>
 
-          {/* Additional Information */}
+          <ol>
+            <li>
+              <strong>
+                {t('accessibilityStatement:communications.phone.label')}
+              </strong>
+              <ul>
+                <li>
+                  {t('accessibilityStatement:communications.phone.medicare')}
+                </li>
+                <li>
+                  {t(
+                    'accessibilityStatement:communications.phone.healthInsuranceMarketplace'
+                  )}
+                </li>
+              </ul>
+            </li>
+            <li>
+              <strong>
+                {t('accessibilityStatement:communications.email.label')}
+              </strong>
+              &nbsp;
+              <a href="mailto:altformatrequest@cms.hhs.gov">
+                {t('accessibilityStatement:communications.email.address')}
+              </a>
+            </li>
+            <li>
+              <strong>
+                {t('accessibilityStatement:communications.fax.label')}
+              </strong>
+              &nbsp;
+              <span>
+                {t('accessibilityStatement:communications.fax.number')}
+              </span>
+            </li>
+            <li>
+              <strong>
+                {t('accessibilityStatement:communications.physicalMail.label')}
+              </strong>
+              <address className="margin-left-2">
+                {t(
+                  'accessibilityStatement:communications.physicalMail.address.line1'
+                )}
+                <br />
+                {t(
+                  'accessibilityStatement:communications.physicalMail.address.line2'
+                )}
+                <br />
+                {t(
+                  'accessibilityStatement:communications.physicalMail.address.street'
+                )}
+                <br />
+                {t(
+                  'accessibilityStatement:communications.physicalMail.address.cityStateZip'
+                )}
+                <br />
+                {t(
+                  'accessibilityStatement:communications.physicalMail.address.attention'
+                )}
+              </address>
+            </li>
+          </ol>
+
+          <p>
+            {t('accessibilityStatement:communications.requestInstructions')}
+          </p>
+
+          <Trans i18nKey="accessibilityStatement:communications.note">
+            <strong>indexZero</strong>&nbsp;indexOne
+          </Trans>
+        </div>
+
+        {/* Non-Discrimination Notice */}
+        <div>
+          <h2>{t('accessibilityStatement:nondiscrimination.heading')}</h2>
+          <p>{t('accessibilityStatement:nondiscrimination.description')}</p>
+        </div>
+
+        {/* How to File a Compliant */}
+        <div>
+          <h2>{t('accessibilityStatement:complaintFiling.heading')}</h2>
+          <p>{t('accessibilityStatement:complaintFiling.contact')}</p>
+          <p>{t('accessibilityStatement:complaintFiling.description')}</p>
+
+          <ol>
+            <li>
+              <a
+                href="https://www.hhs.gov/civil-rights/filing-a-complaint/complaint-process/index.html"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {t('accessibilityStatement:complaintFiling.online')}
+              </a>
+            </li>
+            <li>
+              <strong>
+                {t('accessibilityStatement:complaintFiling.phone.label')}
+              </strong>
+              &nbsp;
+              <span>
+                {t('accessibilityStatement:complaintFiling.phone.number')}
+              </span>
+            </li>
+            <li>
+              <strong>
+                {t('accessibilityStatement:complaintFiling.physicalMail.label')}
+              </strong>
+              <address className="margin-left-2">
+                {t('accessibilityStatement:complaintFiling.physicalMail.line1')}
+                <br />
+                {t('accessibilityStatement:complaintFiling.physicalMail.line2')}
+                <br />
+                {t(
+                  'accessibilityStatement:complaintFiling.physicalMail.street1'
+                )}
+                <br />
+                {t(
+                  'accessibilityStatement:complaintFiling.physicalMail.street2'
+                )}
+                <br />
+                {t(
+                  'accessibilityStatement:complaintFiling.physicalMail.cityStateZip'
+                )}
+              </address>
+            </li>
+          </ol>
+        </div>
+
+        {/* 508 Compliance */}
+        <div>
+          <h2>{t('accessibilityStatement:compliance.heading')}</h2>
+          <Trans i18nKey="accessibilityStatement:compliance.description">
+            indexZero
+            <a href="mailto:508Feedback@cms.hhs.gov">localeLink</a>
+            indexTwo
+          </Trans>
+        </div>
+
+        <div>
           <h2>{t('accessibilityStatement:additionalInformationTitle')}</h2>
 
           <ul>
             <li>
-              <a href="https://www.hhs.gov/web/section-508/what-is-section-504/index.html">
+              <a
+                href="https://www.hhs.gov/web/section-508/what-is-section-504/index.html"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 {t('accessibilityStatement:additionalInformation508')}
               </a>
             </li>
             <li>
-              <a href="https://www.hhs.gov/civil-rights/for-individuals/index.html">
+              <a
+                href="https://www.hhs.gov/civil-rights/for-individuals/index.html"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 {t('accessibilityStatement:additionalInformationCivilRights')}
               </a>
             </li>
           </ul>
-        </Trans>
+        </div>
       </MainContent>
     </div>
   );

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { LoginCallback, SecureRoute } from '@okta/okta-react';
 
+import AccessibilityStatement from 'views/AccessibilityStatement';
 import AuthenticationWrapper from 'views/AuthenticationWrapper';
 import BusinessCase from 'views/BusinessCase';
+import Cookies from 'views/Cookies/index';
 import GovernanceOverview from 'views/GovernanceOverview';
 import GovernanceTaskList from 'views/GovernanceTaskList';
 import GrtBusinessCaseReview from 'views/GrtBusinessCaseReview';
@@ -13,8 +15,6 @@ import Login from 'views/Login';
 import Sandbox from 'views/Sandbox';
 import SystemIntake from 'views/SystemIntake';
 import TimeOutWrapper from 'views/TimeOutWrapper';
-import Cookies from 'views/Cookies/index';
-import AccessibilityStatement from 'views/AccessibilityStatement';
 
 import './index.scss';
 
@@ -53,11 +53,7 @@ class App extends React.Component<MainProps, MainState> {
                   exact
                   component={GovernanceOverview}
                 />
-                <Route
-                  path="/cookies"
-                  exact
-                  component={Cookies}
-                />
+                <Route path="/cookies" exact component={Cookies} />
                 <Route
                   path="/accessibility-statement"
                   exact


### PR DESCRIPTION
This PR represents my feedback for @downeyn-cms's #355 PR. I left feedback on the Accessibility Statement. They should also be incorporated into other static pages.

Overall, I thought #355 was pretty good. You achieved the main goal of creating the pages and using i18n to reflect the copy. I've outlined a few suggestions and you can align them with my change set.

1. **Be mindful of the named keys in the i18n file**
    - Naming is hard, but the thing I wanted to avoid is using identifiers like `paragraph1`, `paragraph2`, `element1`, element2`, etc. (with the exception of addresses because that's how they're named, literally). As a maintainer, this isn't descriptive and I would need to count out paragraphs and compare the file to what is one the page. If there are more descriptive keys, it is easier to figure out which line of text corresponds to what is on the page.
    - I also "enveloped" some of the keys. You can checkout the nesting structure. Let me know if that's something you like/dislike.
2. **`Trans` component**
    - I think you were using `Trans` incorrectly. I can pair with you on it if the documentation doesn't make sense. It's a little tricky/strange.
3. **Semantic HTML**
    - `ol`/`ul` cannot be "legally" inside of a `p`. That's a small nit, but having properly structured HTML is important.
    - I updated the address to use an `address` tag. This should help with assistive technology.
4. I also added the class name `line-height-body-5` to the entire page to give the text some room to "breathe".
5. Generally, it's best practice to make external links open in a new tab so a user doesn't lose context of the current page they're on. However, that call is up to the product requirements. I've updated external links to open in a new tab.

Please let me know how you feel about this. Reach out and grab some of my calendar time if you want to pair.