### PR TITLE
omit alternative b data so that business case can submit

### DIFF
--- a/src/data/businessCase.ts
+++ b/src/data/businessCase.ts
@@ -74,6 +74,48 @@ type lifecycleCostLinesType = {
   B: EstimatedLifecycleCostLines;
 };
 
+// Function that lets us know if a user has filled out an alternative B
+export const hasAlternativeB = (alternativeB: ProposedBusinessCaseSolution) => {
+  if (!alternativeB) {
+    return false;
+  }
+
+  const {
+    title,
+    summary,
+    acquisitionApproach,
+    hosting,
+    hasUserInterface,
+    pros,
+    cons,
+    costSavings,
+    estimatedLifecycleCost
+  } = alternativeB;
+
+  let hasLineItem;
+  Object.values(estimatedLifecycleCost).forEach(phaseCost => {
+    phaseCost.forEach(lineItem => {
+      if (lineItem.phase || lineItem.cost) {
+        hasLineItem = true;
+      }
+    });
+  });
+
+  return (
+    title ||
+    summary ||
+    acquisitionApproach ||
+    hosting.type ||
+    hosting.location ||
+    hosting.cloudServiceType ||
+    hasUserInterface ||
+    pros ||
+    cons ||
+    costSavings ||
+    hasLineItem
+  );
+};
+
 export const prepareBusinessCaseForApp = (
   businessCase: any
 ): BusinessCaseModel => {
@@ -186,6 +228,7 @@ export const prepareBusinessCaseForApp = (
 export const prepareBusinessCaseForApi = (
   businessCase: BusinessCaseModel
 ): any => {
+  const alternativeBExists = hasAlternativeB(businessCase.alternativeB);
   const solutionNameMap: {
     solutionLifecycleCostLines: EstimatedLifecycleCostLines;
     solutionApiName: string;
@@ -205,7 +248,7 @@ export const prepareBusinessCaseForApi = (
         businessCase.alternativeA.estimatedLifecycleCost,
       solutionApiName: 'A'
     },
-    ...(businessCase.alternativeB
+    ...(alternativeBExists
       ? [
           {
             solutionLifecycleCostLines:
@@ -293,79 +336,38 @@ export const prepareBusinessCaseForApi = (
     alternativeAPros: businessCase.alternativeA.pros,
     alternativeACons: businessCase.alternativeA.cons,
     alternativeACostSavings: businessCase.alternativeA.costSavings,
-    alternativeBTitle: businessCase.alternativeB
+    alternativeBTitle: alternativeBExists
       ? businessCase.alternativeB.title
       : null,
-    alternativeBSummary: businessCase.alternativeB
+    alternativeBSummary: alternativeBExists
       ? businessCase.alternativeB.summary
       : null,
-    alternativeBAcquisitionApproach: businessCase.alternativeB
+    alternativeBAcquisitionApproach: alternativeBExists
       ? businessCase.alternativeB.acquisitionApproach
       : null,
-    alternativeBHostingType: businessCase.alternativeB
+    alternativeBHostingType: alternativeBExists
       ? businessCase.alternativeB.hosting.type
       : null,
-    alternativeBHostingLocation: businessCase.alternativeB
+    alternativeBHostingLocation: alternativeBExists
       ? businessCase.alternativeB.hosting.location
       : null,
-    alternativeBHostingCloudServiceType: businessCase.alternativeB
+    alternativeBHostingCloudServiceType: alternativeBExists
       ? businessCase.alternativeB.hosting.cloudServiceType
       : null,
-    alternativeBHasUI: businessCase.alternativeB
+    alternativeBHasUI: alternativeBExists
       ? businessCase.alternativeB.hasUserInterface
       : null,
-    alternativeBPros: businessCase.alternativeB
+    alternativeBPros: alternativeBExists
       ? businessCase.alternativeB.pros
       : null,
-    alternativeBCons: businessCase.alternativeB
+    alternativeBCons: alternativeBExists
       ? businessCase.alternativeB.cons
       : null,
-    alternativeBCostSavings: businessCase.alternativeB
+    alternativeBCostSavings: alternativeBExists
       ? businessCase.alternativeB.costSavings
       : null,
     lifecycleCostLines
   };
-};
-
-export const hasAlternativeB = (alternativeB: ProposedBusinessCaseSolution) => {
-  if (!alternativeB) {
-    return false;
-  }
-
-  const {
-    title,
-    summary,
-    acquisitionApproach,
-    hosting,
-    hasUserInterface,
-    pros,
-    cons,
-    costSavings,
-    estimatedLifecycleCost
-  } = alternativeB;
-
-  let hasLineItem;
-  Object.values(estimatedLifecycleCost).forEach(phaseCost => {
-    phaseCost.forEach(lineItem => {
-      if (lineItem.phase || lineItem.cost) {
-        hasLineItem = true;
-      }
-    });
-  });
-
-  return (
-    title ||
-    summary ||
-    acquisitionApproach ||
-    hosting.type ||
-    hosting.location ||
-    hosting.cloudServiceType ||
-    hasUserInterface ||
-    pros ||
-    cons ||
-    costSavings ||
-    hasLineItem
-  );
 };
 
 export const hostingTypeMap: any = {

--- a/src/views/BusinessCase/Confirmation/__snapshots__/index.test.tsx.snap
+++ b/src/views/BusinessCase/Confirmation/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`The Business Case Confirmation page matches the snapshot 1`] = `
 <div
-  className="margin-bottom-7"
+  className="grid-container margin-bottom-7"
 >
   <div>
     <h1

--- a/src/views/BusinessCase/Confirmation/index.tsx
+++ b/src/views/BusinessCase/Confirmation/index.tsx
@@ -6,7 +6,7 @@ const Confirmation = () => {
   const { businessCaseId } = useParams();
   const { t } = useTranslation();
   return (
-    <div className="margin-bottom-7">
+    <div className="grid-container margin-bottom-7">
       <div>
         <h1 className="font-heading-xl margin-top-4">
           {t('businessCase:submission.confirmation.heading')}


### PR DESCRIPTION
Since `businessCase.alternativeB` is always truthy we need to use the function to check if any of the fields are filled. This was just a missing piece I forgot to change previously.

The major block of code moving is just moving the function to be instantiated before it is used to satisfy lint rules
