### PR TITLE
error not fatal for CEDAR problems

### DIFF
--- a/pkg/server/health_check.go
+++ b/pkg/server/health_check.go
@@ -16,7 +16,7 @@ func (s Server) CheckCEDAREasiClientConnection(client cedareasi.TranslatedClient
 	// and tests that we're authorized to retrieve information
 	_, err := client.FetchSystems(s.logger)
 	if err != nil {
-		s.logger.Fatal("Failed to connect to CEDAR EASi on startup", zap.Error(err))
+		s.logger.Error("Failed to connect to CEDAR EASi on startup", zap.Error(err))
 	}
 }
 

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -53,8 +53,10 @@ func (s *Server) routes(
 		s.Config.GetString("CEDAR_API_KEY"),
 	)
 
-	s.CheckCEDAREasiClientConnection(cedarEasiClient)
-	s.CheckCEDARLdapClientConnection(cedarLdapClient)
+	if s.environment.Deployed() {
+		s.CheckCEDAREasiClientConnection(cedarEasiClient)
+		s.CheckCEDARLdapClientConnection(cedarLdapClient)
+	}
 
 	// set up Email Client
 	sesConfig := s.NewSESConfig()

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -53,10 +53,8 @@ func (s *Server) routes(
 		s.Config.GetString("CEDAR_API_KEY"),
 	)
 
-	if s.environment.Prod() {
-		s.CheckCEDAREasiClientConnection(cedarEasiClient)
-		s.CheckCEDARLdapClientConnection(cedarLdapClient)
-	}
+	s.CheckCEDAREasiClientConnection(cedarEasiClient)
+	s.CheckCEDARLdapClientConnection(cedarLdapClient)
 
 	// set up Email Client
 	sesConfig := s.NewSESConfig()


### PR DESCRIPTION
# EASI-827

Changes proposed in this pull request:

- CEDAR checks happen on startup in all the "deployed" environments (e.g. DEV, IMPL, PROD)
- CEDAR checks only log at `ERROR` severity and do not take down the app during startup
