### PR TITLE
Update USWDS to 2.8.1, Footer, and Gov Banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "reselect": "^4.0.0",
     "serialize-javascript": "^3.1.0",
     "typescript": "3.6.4",
-    "uswds": "^2.2.1",
+    "uswds": "^2.8.1",
     "uuid": "^7.0.3",
     "validator": "^13.1.1",
     "wait-on": "^5.0.0",

--- a/src/components/UsGovBanner/index.tsx
+++ b/src/components/UsGovBanner/index.tsx
@@ -6,9 +6,9 @@ import flagImg from 'uswds/src/img/us_flag_small.png';
 const UsGovBanner = () => {
   const [displayContent, setDisplayContent] = useState(false);
   return (
-    <div className="usa-banner">
+    <section className="usa-banner" aria-label="Official government website">
       <div className="usa-accordion">
-        <div className="usa-banner__header">
+        <header className="usa-banner__header">
           <div className="usa-banner__inner">
             <div className="grid-col-auto">
               <img
@@ -37,7 +37,7 @@ const UsGovBanner = () => {
               </span>
             </button>
           </div>
-        </div>
+        </header>
         <div
           className="usa-banner__content usa-accordion__content"
           id="gov-banner"
@@ -52,10 +52,9 @@ const UsGovBanner = () => {
               />
               <div className="usa-media-block__body">
                 <p>
-                  <strong>The .gov means it’s official.</strong>
-                  <br /> Federal government websites often end in .gov or .mil.
-                  Before sharing sensitive information, make sure you’re on a
-                  federal government site.
+                  <strong>Official websites use .gov</strong>
+                  <br />A <strong>.gov</strong> website belongs to an official
+                  government organization in the United States.
                 </p>
               </div>
             </div>
@@ -67,17 +66,37 @@ const UsGovBanner = () => {
               />
               <div className="usa-media-block__body">
                 <p>
-                  <strong>The site is secure.</strong>
-                  <br /> The <strong>https://</strong> ensures that you are
-                  connecting to the official website and that any information
-                  you provide is encrypted and transmitted securely.
+                  <strong>Secure .gov websites use HTTPS</strong>
+                  <br />A <strong>lock</strong> (
+                  <span className="icon-lock">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="52"
+                      height="64"
+                      viewBox="0 0 52 64"
+                      className="usa-banner__lock-image"
+                      role="img"
+                      aria-labelledby="banner-lock-title banner-lock-description"
+                    >
+                      <title id="banner-lock-title">Lock</title>
+                      <desc id="banner-lock-description">A locked padlock</desc>
+                      <path
+                        fill="#000000"
+                        fillRule="evenodd"
+                        d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
+                      />
+                    </svg>
+                  </span>
+                  ) or <strong>https://</strong> means you’ve safely connected
+                  to the .gov website. Share sensitive information only on
+                  official, secure websites.
                 </p>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/src/stylesheets/_settings.scss
+++ b/src/stylesheets/_settings.scss
@@ -6,6 +6,7 @@ $theme-hero-image: '~uswds/src/img/hero.png';
 // Override defaultUSWDS maximum width settings
 $theme-header-max-width: 'desktop-lg';
 $theme-grid-container-max-width: 'desktop-lg';
+$theme-footer-max-width: 'desktop-lg';
 
 //Override default USWDS body font
 $theme-font-type-sans: 'public-sans';

--- a/src/stylesheets/custom.scss
+++ b/src/stylesheets/custom.scss
@@ -38,13 +38,3 @@
   font-family: 'Public Sans';
 }
 
-.usa-footer {
-  // Ideally, this width should be set in _settings.scss, alongside the other variables
-  // but I don't see a scss variable in the USWDS docs to set.
-  // We should investigate and see if USWDS has a variable they can support similarly
-  // to the header.
-  // e.g. $theme-footer-max-width: 'desktop-lg';
-  &__primary-container {
-    max-width: 75rem;
-  }
-}

--- a/src/views/GovernanceOverview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceOverview/__snapshots__/index.test.tsx.snap
@@ -8,13 +8,14 @@ exports[`The governance overview page matches the snapshot 1`] = `
     className="usa-header easi-header"
     role="banner"
   >
-    <div
+    <section
+      aria-label="Official government website"
       className="usa-banner"
     >
       <div
         className="usa-accordion"
       >
-        <div
+        <header
           className="usa-banner__header"
         >
           <div
@@ -58,7 +59,7 @@ exports[`The governance overview page matches the snapshot 1`] = `
               </span>
             </button>
           </div>
-        </div>
+        </header>
         <div
           className="usa-banner__content usa-accordion__content"
           hidden={true}
@@ -80,10 +81,14 @@ exports[`The governance overview page matches the snapshot 1`] = `
               >
                 <p>
                   <strong>
-                    The .gov means it’s official.
+                    Official websites use .gov
                   </strong>
                   <br />
-                   Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you’re on a federal government site.
+                  A 
+                  <strong>
+                    .gov
+                  </strong>
+                   website belongs to an official government organization in the United States.
                 </p>
               </div>
             </div>
@@ -100,21 +105,55 @@ exports[`The governance overview page matches the snapshot 1`] = `
               >
                 <p>
                   <strong>
-                    The site is secure.
+                    Secure .gov websites use HTTPS
                   </strong>
                   <br />
-                   The 
+                  A 
+                  <strong>
+                    lock
+                  </strong>
+                   (
+                  <span
+                    className="icon-lock"
+                  >
+                    <svg
+                      aria-labelledby="banner-lock-title banner-lock-description"
+                      className="usa-banner__lock-image"
+                      height="64"
+                      role="img"
+                      viewBox="0 0 52 64"
+                      width="52"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <title
+                        id="banner-lock-title"
+                      >
+                        Lock
+                      </title>
+                      <desc
+                        id="banner-lock-description"
+                      >
+                        A locked padlock
+                      </desc>
+                      <path
+                        d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
+                        fill="#000000"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  ) or 
                   <strong>
                     https://
                   </strong>
-                   ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
+                   means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
                 </p>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </section>
     <div
       className="grid-container easi-header__basic"
     >

--- a/src/views/NotFound/__snapshots__/index.test.tsx.snap
+++ b/src/views/NotFound/__snapshots__/index.test.tsx.snap
@@ -8,13 +8,14 @@ exports[`The Not Found Page matches the snapshot 1`] = `
     className="usa-header easi-header"
     role="banner"
   >
-    <div
+    <section
+      aria-label="Official government website"
       className="usa-banner"
     >
       <div
         className="usa-accordion"
       >
-        <div
+        <header
           className="usa-banner__header"
         >
           <div
@@ -58,7 +59,7 @@ exports[`The Not Found Page matches the snapshot 1`] = `
               </span>
             </button>
           </div>
-        </div>
+        </header>
         <div
           className="usa-banner__content usa-accordion__content"
           hidden={true}
@@ -80,10 +81,14 @@ exports[`The Not Found Page matches the snapshot 1`] = `
               >
                 <p>
                   <strong>
-                    The .gov means it’s official.
+                    Official websites use .gov
                   </strong>
                   <br />
-                   Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you’re on a federal government site.
+                  A 
+                  <strong>
+                    .gov
+                  </strong>
+                   website belongs to an official government organization in the United States.
                 </p>
               </div>
             </div>
@@ -100,21 +105,55 @@ exports[`The Not Found Page matches the snapshot 1`] = `
               >
                 <p>
                   <strong>
-                    The site is secure.
+                    Secure .gov websites use HTTPS
                   </strong>
                   <br />
-                   The 
+                  A 
+                  <strong>
+                    lock
+                  </strong>
+                   (
+                  <span
+                    className="icon-lock"
+                  >
+                    <svg
+                      aria-labelledby="banner-lock-title banner-lock-description"
+                      className="usa-banner__lock-image"
+                      height="64"
+                      role="img"
+                      viewBox="0 0 52 64"
+                      width="52"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <title
+                        id="banner-lock-title"
+                      >
+                        Lock
+                      </title>
+                      <desc
+                        id="banner-lock-description"
+                      >
+                        A locked padlock
+                      </desc>
+                      <path
+                        d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
+                        fill="#000000"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  ) or 
                   <strong>
                     https://
                   </strong>
-                   ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
+                   means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
                 </p>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </section>
     <div
       className="grid-container easi-header__basic"
     >

--- a/src/views/TermsAndConditions/__snapshots__/index.test.tsx.snap
+++ b/src/views/TermsAndConditions/__snapshots__/index.test.tsx.snap
@@ -8,13 +8,14 @@ exports[`The Terms & Conditions page matches the snapshot 1`] = `
     className="usa-header easi-header"
     role="banner"
   >
-    <div
+    <section
+      aria-label="Official government website"
       className="usa-banner"
     >
       <div
         className="usa-accordion"
       >
-        <div
+        <header
           className="usa-banner__header"
         >
           <div
@@ -58,7 +59,7 @@ exports[`The Terms & Conditions page matches the snapshot 1`] = `
               </span>
             </button>
           </div>
-        </div>
+        </header>
         <div
           className="usa-banner__content usa-accordion__content"
           hidden={true}
@@ -80,10 +81,14 @@ exports[`The Terms & Conditions page matches the snapshot 1`] = `
               >
                 <p>
                   <strong>
-                    The .gov means it’s official.
+                    Official websites use .gov
                   </strong>
                   <br />
-                   Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you’re on a federal government site.
+                  A 
+                  <strong>
+                    .gov
+                  </strong>
+                   website belongs to an official government organization in the United States.
                 </p>
               </div>
             </div>
@@ -100,21 +105,55 @@ exports[`The Terms & Conditions page matches the snapshot 1`] = `
               >
                 <p>
                   <strong>
-                    The site is secure.
+                    Secure .gov websites use HTTPS
                   </strong>
                   <br />
-                   The 
+                  A 
+                  <strong>
+                    lock
+                  </strong>
+                   (
+                  <span
+                    className="icon-lock"
+                  >
+                    <svg
+                      aria-labelledby="banner-lock-title banner-lock-description"
+                      className="usa-banner__lock-image"
+                      height="64"
+                      role="img"
+                      viewBox="0 0 52 64"
+                      width="52"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <title
+                        id="banner-lock-title"
+                      >
+                        Lock
+                      </title>
+                      <desc
+                        id="banner-lock-description"
+                      >
+                        A locked padlock
+                      </desc>
+                      <path
+                        d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
+                        fill="#000000"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </span>
+                  ) or 
                   <strong>
                     https://
                   </strong>
-                   ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
+                   means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
                 </p>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </section>
     <div
       className="grid-container easi-header__basic"
     >

--- a/yarn.lock
+++ b/yarn.lock
@@ -5373,6 +5373,11 @@ elem-dataset@^1.1.1:
   resolved "https://registry.yarnpkg.com/elem-dataset/-/elem-dataset-1.1.1.tgz#18f07fa7fc71ebd49b0f9f63819cb03c8276577a"
   integrity sha1-GPB/p/xx69SbD59jgZywPIJ2V3o=
 
+elem-dataset@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/elem-dataset/-/elem-dataset-2.0.0.tgz#4ed8b2b0217898bdf78c1a01b4eb722a1c89e799"
+  integrity sha512-e7gieGopWw5dMdEgythH3lUS7nMizutPDTtkzfQW/q2gCvFnACyNnK3ytCncAXKxdBXQWcXeKaYTTODiMnp8mw==
+
 element-closest@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/element-closest/-/element-closest-2.0.2.tgz#72a740a107453382e28df9ce5dbb5a8df0f966ec"
@@ -14132,7 +14137,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-uswds@^2.2.1, uswds@^2.7.0:
+uswds@^2.7.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.8.0.tgz#635e829555a359562f28ab51e1b6c983f149f739"
   integrity sha512-LI7ZNbh823ehtThvebwQ5eHNKGY791vcT5d3T9gJ+RY511HgstWLRSEEso7YO/ifjoV/FwuTAtDwQqt7zsXRvA==
@@ -14141,6 +14146,20 @@ uswds@^2.2.1, uswds@^2.7.0:
     del "^5.1.0"
     domready "^1.0.8"
     elem-dataset "^1.1.1"
+    lodash.debounce "^4.0.7"
+    object-assign "^4.1.1"
+    receptor "^1.0.0"
+    resolve-id-refs "^0.1.0"
+
+uswds@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.8.1.tgz#937505ad8f7be4c131e6d4e01d0128cf0995a49c"
+  integrity sha512-x7RkaVFVuRxptsuUZka6Mc+wUUL98keorOUFVxrBIgd3KV18upuF5V7osm9sN/q6bGvwh2zJyfONETLUU8Eemg==
+  dependencies:
+    classlist-polyfill "^1.0.3"
+    del "^5.1.0"
+    domready "^1.0.8"
+    elem-dataset "^2.0.0"
     lodash.debounce "^4.0.7"
     object-assign "^4.1.1"
     receptor "^1.0.0"


### PR DESCRIPTION
This PR updates USWDS to v2.8.1.

This update allows us to:
- Override SCSS variable to set footer width (rather than targeting class names)
- Use the new Gov Banner. See https://designsystem.digital.gov/whats-new/updates/2020/09/08/Improvements-banner/
    - Update snapshot tests because of the gov banner changes