### PR TITLE
Fix Footer link outline

### DIFF
--- a/src/components/Footer/index.scss
+++ b/src/components/Footer/index.scss
@@ -1,4 +1,10 @@
 .easi-footer {
+  // Since we don't have the "Return to top" enabled, there isn't padding by
+  // default to display the top outline when the link is focus.
+  &--slim {
+    padding-top: .25em;
+  }
+
   &__secondary-logo-wrap {
     display: flex;
     align-items: center;


### PR DESCRIPTION
This PR adds padding to accommodate for the link outline. On USWDS, they have a "Return to top" button that contains the proper padding to accommodate for the outline width.

Since we don't have that button, we need to add additional padding so the outline isn't cut off.
