### PR TITLE
Use the zap development logger for local development.

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -29,16 +29,21 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // NewServer sets up the dependencies for a server
 func NewServer(config *viper.Viper) *Server {
-	// Set up logger first so we can use it
-	zapLogger, err := zap.NewProduction()
-	if err != nil {
-		log.Fatal("Failed to initial logger.")
-	}
 
 	// Set environment from config
 	environment, err := appconfig.NewEnvironment(config.GetString(appconfig.EnvironmentKey))
 	if err != nil {
-		zapLogger.Fatal("Unable to set environment", zap.Error(err))
+		log.Fatalf("Unable to set environment: %v", err)
+	}
+
+	var zapLogger *zap.Logger
+	if environment.Dev() || environment.Local() {
+		zapLogger, err = zap.NewDevelopment()
+	} else {
+		zapLogger, err = zap.NewProduction()
+	}
+	if err != nil {
+		log.Fatalf("Failed to initial logger: %v", err)
 	}
 
 	// Set the router


### PR DESCRIPTION
# Use Development logger for development

Changes proposed in this pull request:

- Use [zap.NewDevelopment](https://godoc.org/go.uber.org/zap#NewDevelopment) to create the logger when running in the `local` or `dev` environment. This formats log messages in a more human-legible way, although the request itself is still shown as JSON. It's still a big improvement, though, especially for stack traces.

Here is the before and after of this change. Before, everything is on one line:

```
{"level":"error","ts":1600278397.170604,"caller":"cedareasi/translated_client.go:165","msg":"Failed to submit intake for CEDAR with error: Post \"https://webmethods-apigw.cedardev.cms.gov/gateway/EASi%20Core%20API/1.0/intake/governance\": context deadline exceeded","traceID":"f6e0745e-97b8-4963-8df5-686ce7ee69ce","stacktrace":"github.com/cmsgov/easi-app/pkg/cedar/cedareasi.submitSystemIntake\n\t/Users/jimb/code/easi-app/pkg/cedar/cedareasi/translated_client.go:165\ngithub.com/cmsgov/easi-app/pkg/cedar/cedareasi.TranslatedClient.ValidateAndSubmitSystemIntake\n\t/Users/jimb/code/easi-app/pkg/cedar/cedareasi/translated_client.go:194\ngithub.com/cmsgov/easi-app/pkg/services.NewUpdateSystemIntake.func1\n\t/Users/jimb/code/easi-app/pkg/services/system_intakes.go:161\ngithub.com/cmsgov/easi-app/pkg/handlers.SystemIntakeHandler.Handle.func1\n\t/Users/jimb/code/easi-app/pkg/handlers/system_intake.go:156\nnet/http.HandlerFunc.ServeHTTP\n\t/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:2042\ngithub.com/cmsgov/easi-app/pkg/local.authorizeMiddleware.func1\n\t/Users/jimb/code/easi-app/pkg/local/authorization.go:19\nnet/http.HandlerFunc.ServeHTTP\n\t/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:2042\ngithub.com/cmsgov/easi-app/pkg/server.newCORSMiddleware.func1.1\n\t/Users/jimb/code/easi-app/pkg/server/cors.go:17\nnet/http.HandlerFunc.ServeHTTP\n\t/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:2042\ngithub.com/cmsgov/easi-app/pkg/server.loggerMiddleware.func1\n\t/Users/jimb/code/easi-app/pkg/server/logger.go:37\nnet/http.HandlerFunc.ServeHTTP\n\t/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:2042\ngithub.com/cmsgov/easi-app/pkg/server.traceMiddleware.func1\n\t/Users/jimb/code/easi-app/pkg/server/trace.go:14\nnet/http.HandlerFunc.ServeHTTP\n\t/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:2042\ngithub.com/gorilla/mux.(*Router).ServeHTTP\n\t/Users/jimb/.asdf/installs/golang/1.15/packages/pkg/mod/github.com/gorilla/mux@v1.7.4/mux.go:210\ngithub.com/cmsgov/easi-app/pkg/server.(*Server).ServeHTTP\n\t/Users/jimb/code/easi-app/pkg/server/server.go:27\nnet/http.serverHandler.ServeHTTP\n\t/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:2843\nnet/http.(*conn).serve\n\t/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:1925"}
```

And after, the stack trace is printed on multiple lines instead of being separated by `\n` and the time and log level are much more prominent:

```
2020-09-16T13:02:26.523-0500	ERROR	cedareasi/translated_client.go:165	Failed to submit intake for CEDAR with error: Post "https://webmethods-apigw.cedardev.cms.gov/gateway/EASi%20Core%20API/1.0/intake/governance": context deadline exceeded	{"traceID": "9af963db-59d9-4db1-b1af-feafddb46cbe"}
github.com/cmsgov/easi-app/pkg/cedar/cedareasi.submitSystemIntake
	/Users/jimb/code/easi-app/pkg/cedar/cedareasi/translated_client.go:165
github.com/cmsgov/easi-app/pkg/cedar/cedareasi.TranslatedClient.ValidateAndSubmitSystemIntake
	/Users/jimb/code/easi-app/pkg/cedar/cedareasi/translated_client.go:194
github.com/cmsgov/easi-app/pkg/services.NewUpdateSystemIntake.func1
	/Users/jimb/code/easi-app/pkg/services/system_intakes.go:161
github.com/cmsgov/easi-app/pkg/handlers.SystemIntakeHandler.Handle.func1
	/Users/jimb/code/easi-app/pkg/handlers/system_intake.go:156
net/http.HandlerFunc.ServeHTTP
	/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:2042
github.com/cmsgov/easi-app/pkg/local.authorizeMiddleware.func1
	/Users/jimb/code/easi-app/pkg/local/authorization.go:19
net/http.HandlerFunc.ServeHTTP
	/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:2042
github.com/cmsgov/easi-app/pkg/server.newCORSMiddleware.func1.1
	/Users/jimb/code/easi-app/pkg/server/cors.go:17
net/http.HandlerFunc.ServeHTTP
	/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:2042
github.com/cmsgov/easi-app/pkg/server.loggerMiddleware.func1
	/Users/jimb/code/easi-app/pkg/server/logger.go:37
net/http.HandlerFunc.ServeHTTP
	/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:2042
github.com/cmsgov/easi-app/pkg/server.traceMiddleware.func1
	/Users/jimb/code/easi-app/pkg/server/trace.go:14
net/http.HandlerFunc.ServeHTTP
	/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:2042
github.com/gorilla/mux.(*Router).ServeHTTP
	/Users/jimb/.asdf/installs/golang/1.15/packages/pkg/mod/github.com/gorilla/mux@v1.7.4/mux.go:210
github.com/cmsgov/easi-app/pkg/server.(*Server).ServeHTTP
	/Users/jimb/code/easi-app/pkg/server/server.go:27
net/http.serverHandler.ServeHTTP
	/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:2843
net/http.(*conn).serve
	/Users/jimb/.asdf/installs/golang/1.15/go/src/net/http/server.go:1925
```

To accomplish this change, we need to initialize the environment before the logger. This is a change in behavior from the previous implementation.