### PR TITLE
emit traceID on response header as well

### DIFF
--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -43,9 +43,9 @@ func ZLogger(ctx context.Context) *zap.Logger {
 }
 
 // WithTrace returns a context with request trace
-func WithTrace(ctx context.Context) context.Context {
+func WithTrace(ctx context.Context) (context.Context, uuid.UUID) {
 	traceID := uuid.New()
-	return context.WithValue(ctx, traceKey, traceID)
+	return context.WithValue(ctx, traceKey, traceID), traceID
 }
 
 // Trace returns the context's trace UUID

--- a/pkg/appcontext/context_test.go
+++ b/pkg/appcontext/context_test.go
@@ -59,12 +59,11 @@ func TestZLogger(t *testing.T) {
 }
 
 func (s ContextTestSuite) TestWithTrace() {
-	ctx := context.Background()
-
-	ctx = WithTrace(ctx)
+	ctx, tID := WithTrace(context.Background())
 	traceID := ctx.Value(traceKey).(uuid.UUID)
 
 	s.NotEqual(uuid.UUID{}, traceID)
+	s.Equal(tID, traceID)
 }
 
 func (s ContextTestSuite) TestTrace() {

--- a/pkg/handlers/handler_base_test.go
+++ b/pkg/handlers/handler_base_test.go
@@ -33,10 +33,7 @@ func (w *failWriter) Header() http.Header {
 }
 
 func (s HandlerTestSuite) TestWriteErrorResponse() {
-	ctx := context.Background()
-	ctx = appcontext.WithTrace(ctx)
-	traceID, ok := appcontext.Trace(ctx)
-	s.True(ok)
+	ctx, traceID := appcontext.WithTrace(context.Background())
 
 	var responseTests = []struct {
 		appErr      error

--- a/pkg/server/trace.go
+++ b/pkg/server/trace.go
@@ -8,10 +8,13 @@ import (
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 )
 
+const traceHeader = "X-TRACE-ID"
+
 func traceMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		next.ServeHTTP(w, r.WithContext(appcontext.WithTrace(ctx)))
+		ctx, traceID := appcontext.WithTrace(r.Context())
+		w.Header().Add(traceHeader, traceID.String())
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/pkg/server/trace_test.go
+++ b/pkg/server/trace_test.go
@@ -10,10 +10,12 @@ import (
 )
 
 func (s ServerTestSuite) TestTraceMiddleware() {
+	traceValue := ""
 	// this is the actual test, since the context is cancelled post request
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		traceID, ok := appcontext.Trace(r.Context())
 
+		traceValue = traceID.String()
 		s.True(ok)
 		s.NotEqual(uuid.UUID{}, traceID)
 	})
@@ -23,4 +25,7 @@ func (s ServerTestSuite) TestTraceMiddleware() {
 	middleware := NewTraceMiddleware(s.logger)
 
 	middleware(testHandler).ServeHTTP(rr, req)
+
+	// Ensure what is in the header matches what is on the context
+	s.Equal(traceValue, rr.Header().Get(traceHeader))
 }


### PR DESCRIPTION
# EASI-860

Changes proposed in this pull request:

- Adding what is logged as the `traceID` to the response header `X-TRACE-ID`
- Basically a direct port of https://github.com/trussworks/go-sample-api/pull/11
