### PR TITLE
Only access expiresAt when accessToken exists.

### DIFF
--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -12,7 +12,8 @@ import { AppState } from 'reducers/rootReducer';
 
 const accessTokenExpires = () => {
   const token = localStorage.getItem('okta-token-storage') || '';
-  return JSON.parse(token).accessToken.expiresAt;
+  const { accessToken } = JSON.parse(token);
+  return accessToken && accessToken.expiresAt;
 };
 
 const calculcateTokenExpiration = () => {


### PR DESCRIPTION
I've been getting these errors locally. I haven't dug into the real cause, but in order to get the issue to go away and unblock development I added a check to prevent the issue.

Here's what I'm seeing before this change:

<img width="1048" alt="Screen Shot 2020-09-21 at 1 56 56 PM" src="https://user-images.githubusercontent.com/3331/93810783-c1408d00-fc14-11ea-993e-ec4b64d888cd.png">

And after, I don't see it.