### PR TITLE
Attempt to catch frontend compilation warnings earlier in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,10 @@ jobs:
           command: pre-commit run --all-files --show-diff-on-failure
       - run:
           name: Run Frontend Tests
-          command: yarn test
+          command: yarn run test
+      - run:
+          name: Build Frontend Code
+          command: yarn run build
       - save_cache:
           key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
           paths:

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "scripts": {
     "start": "craco -r @cypress/instrument-cra start",
-    "build": "craco build",
+    "build": "CI=true craco build",
     "test": "craco test",
     "test:coverage": "craco test --coverage --watchAll=false",
     "eject": "react-scripts eject",


### PR DESCRIPTION
# EASI-876

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Build the frontend code in the `lint` job to catch compilation warnings earlier in the CI pipeline
- Add `CI=true` to the `build` script in package.json so that running a yarn build locally or in the Dockerized Cypress tests will also error our on compilation warnings

This is to address an issue where a particular build passed the `lint` and `integration_tests` jobs, but failed when building the static assets in the `deploy_dev` job.

CircleCI sets `CI=true` automatically in all the different jobs in the CI workflow. The `yarn test` in the `lint` job and the `yarn run build` in the `deploy_dev `job have `CI` set to true because they're either running directly in a CircleCI command or in a Bash script. The `integration_tests` job is a little different because for that the `yarn run build` is running inside a separate Docker container, so it doesn't automatically inherit the `CI=true` unless we set that explicitly either in Dockerfile.client or in package.json.