### PR TITLE
Redirect users when a system intake exists

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -27,7 +27,6 @@ export AWS_REGION=us-west-2
 export AWS_SES_SOURCE="\"EASi Local\" <no-reply-$APP_ENV@info.easi.cms.gov>"
 
 # OKTA variables
-
 export OKTA_CLIENT_ID=0oa2e913coDQeG19S297
 export OKTA_CLIENT_ID_DEV=0oa2e913coDQeG19S297
 export REACT_APP_OKTA_CLIENT_ID=$OKTA_CLIENT_ID
@@ -40,6 +39,12 @@ export OKTA_ISSUER=$OKTA_DOMAIN/oauth2/$OKTA_SERVER_ID
 export REACT_APP_OKTA_ISSUER=$OKTA_ISSUER
 export OKTA_REDIRECT_URI=http://localhost:3000/implicit/callback
 export REACT_APP_OKTA_REDIRECT_URI=$OKTA_REDIRECT_URI
+
+# OKTA test account
+# Needed to run Cypress tests. Look in 1Password.
+export OKTA_TEST_USERNAME=
+export OKTA_TEST_PASSWORD=
+export OKTA_TEST_SECRET=
 
 # For connecting to a local postgres instance
 export PGHOST=localhost

--- a/cypress/integration/taskList.spec.js
+++ b/cypress/integration/taskList.spec.js
@@ -1,0 +1,48 @@
+describe('The System Intake Form', () => {
+  before(() => {
+    cy.login();
+    // TODO HACK
+    cy.wait(1000);
+    cy.saveLocalStorage();
+  });
+
+  beforeEach(() => {
+    cy.server();
+    cy.route('POST', '/api/v1/system_intake').as('postSystemIntake');
+    cy.route('PUT', '/api/v1/system_intake').as('putSystemIntake');
+    cy.restoreLocalStorage();
+    cy.visit('/governance-task-list/new');
+  });
+
+  it('shows a continue link when a user clicks back until they reach the task list', () => {
+    cy.contains('a', 'Start').click();
+
+    cy.systemIntake.contactDetails.fillNonBranchingFields();
+    cy.get('#IntakeForm-HasIssoNo')
+      .check({ force: true })
+      .should('be.checked');
+
+    cy.get('#IntakeForm-NoGovernanceTeam')
+      .check({ force: true })
+      .should('be.checked');
+
+    cy.contains('button', 'Next').click();
+    cy.wait('@postSystemIntake');
+
+    cy.contains('h1', 'Request details');
+
+    cy.get('#IntakeForm-RequestName').type('Test Request Name');
+
+    // User should be redirected to /system/:uuid/contact-details
+    cy.go('back');
+    cy.contains('h1', 'Contact details');
+    cy.location().should(loc => {
+      expect(loc.pathname).to.not.include('new');
+    });
+
+    // User should see that they can continue instead of starting a new intake
+    cy.go('back');
+    cy.contains('h3', 'Fill in the request form');
+    cy.contains('a', 'Continue').should('be.visible');
+  });
+});

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -63,7 +63,7 @@ class App extends React.Component<MainProps, MainState> {
                   component={PrepareForGRT}
                 />
 
-                {['local', 'dev', 'impl'].includes(
+                {['local', 'dev', 'impl', 'test'].includes(
                   process.env.REACT_APP_APP_ENV || ''
                 ) && (
                   <SecureRoute

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -146,15 +146,21 @@ const GovernanceTaskList = () => {
   const history = useHistory();
   const [displayRemainingSteps, setDisplayRemainingSteps] = useState(false);
   const { t } = useTranslation();
+  const systemIntake = useSelector(
+    (state: AppState) => state.systemIntake.systemIntake
+  );
 
   useEffect(() => {
     if (systemId !== 'new') {
       dispatch(fetchSystemIntake(systemId));
     }
   }, [dispatch, systemId]);
-  const systemIntake = useSelector(
-    (state: AppState) => state.systemIntake.systemIntake
-  );
+
+  useEffect(() => {
+    if (systemId === 'new' && systemIntake.id) {
+      history.replace(`/governance-task-list/${systemIntake.id}`);
+    }
+  }, [history, systemIntake.id, systemId]);
 
   useEffect(() => {
     if (systemIntake.id && systemIntake.businessCaseId) {


### PR DESCRIPTION
# EASI-634

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Users who visit `/governance-task-list/new` page via the back button will be redirected to the page for their recently created system intake. This is similar to what we do on the contact details page.
- The `OKTA_TEST_*` environment variables are now documented in `.envrc` to help developer know that they need to be set.
