### PR TITLE
context to wrapper of generated client

### DIFF
--- a/pkg/cedar/cedareasi/translated_client_test.go
+++ b/pkg/cedar/cedareasi/translated_client_test.go
@@ -1,20 +1,20 @@
 package cedareasi
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/facebookgo/clock"
 	"github.com/google/uuid"
 	"github.com/guregu/null"
-	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/apperrors"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
-	logger := zap.NewNop()
+	ctx := context.Background()
 	clockTime := clock.NewMock().Now()
 	id := uuid.New()
 	intake := models.SystemIntake{
@@ -44,13 +44,13 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 		AlfabetID:               null.String{},
 	}
 	s.Run("A valid system intake passes validation", func() {
-		err := ValidateSystemIntakeForCedar(&intake, logger)
+		err := ValidateSystemIntakeForCedar(ctx, &intake)
 		s.NoError(err)
 	})
 
 	s.Run("An intake without a required null string fails", func() {
 		intake.Component = null.String{}
-		err := ValidateSystemIntakeForCedar(&intake, logger)
+		err := ValidateSystemIntakeForCedar(ctx, &intake)
 		s.IsType(&apperrors.ValidationError{}, err)
 		expectedErrString := fmt.Sprintf(
 			"Could not validate *models.SystemIntake %s: {\"Component\":\"is required\"}",
@@ -63,7 +63,7 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 
 	s.Run("An intake without a required null bool fails", func() {
 		intake.ExistingFunding = null.Bool{}
-		err := ValidateSystemIntakeForCedar(&intake, logger)
+		err := ValidateSystemIntakeForCedar(ctx, &intake)
 		s.IsType(&apperrors.ValidationError{}, err)
 		expectedErrString := fmt.Sprintf(
 			"Could not validate *models.SystemIntake %s: {\"ExistingFunding\":\"is required\"}",
@@ -77,7 +77,7 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 
 	s.Run("An intake with existing funding requires a funding source", func() {
 		intake.ExistingFunding = null.BoolFrom(true)
-		err := ValidateSystemIntakeForCedar(&intake, logger)
+		err := ValidateSystemIntakeForCedar(ctx, &intake)
 		s.IsType(&apperrors.ValidationError{}, err)
 		expectedErrString := fmt.Sprintf(
 			"Could not validate *models.SystemIntake %s: {\"FundingSource\":\"is required\"}",
@@ -92,7 +92,7 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 	s.Run("An intake with a required funding source fails if it is not 6 digits", func() {
 		intake.ExistingFunding = null.BoolFrom(true)
 		intake.FundingSource = null.StringFrom("12")
-		err := ValidateSystemIntakeForCedar(&intake, logger)
+		err := ValidateSystemIntakeForCedar(ctx, &intake)
 		s.IsType(&apperrors.ValidationError{}, err)
 		expectedErrString := fmt.Sprintf(
 			"Could not validate *models.SystemIntake %s: {\"FundingSource\":\"must be a 6 digit string\"}",
@@ -108,7 +108,7 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 	s.Run("An intake with a required funding source passes if it is 6 digits", func() {
 		intake.ExistingFunding = null.BoolFrom(true)
 		intake.FundingSource = null.StringFrom("123456")
-		err := ValidateSystemIntakeForCedar(&intake, logger)
+		err := ValidateSystemIntakeForCedar(ctx, &intake)
 		s.NoError(err)
 
 		// Reset intake fields
@@ -119,13 +119,13 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 	s.Run("An intake with a no existing funding doesn't validate funding source", func() {
 		intake.ExistingFunding = null.BoolFrom(false)
 		intake.FundingSource = null.String{}
-		err := ValidateSystemIntakeForCedar(&intake, logger)
+		err := ValidateSystemIntakeForCedar(ctx, &intake)
 		s.NoError(err)
 	})
 
 	s.Run("An intake without a required string fails", func() {
 		intake.EUAUserID = ""
-		err := ValidateSystemIntakeForCedar(&intake, logger)
+		err := ValidateSystemIntakeForCedar(ctx, &intake)
 		s.IsType(&apperrors.ValidationError{}, err)
 		expectedErrString := fmt.Sprintf(
 			"Could not validate *models.SystemIntake %s: {\"EUAUserID\":\"is required\"}",
@@ -139,7 +139,7 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 
 	s.Run("An intake without a required id fails", func() {
 		intake.ID = uuid.Nil
-		err := ValidateSystemIntakeForCedar(&intake, logger)
+		err := ValidateSystemIntakeForCedar(ctx, &intake)
 		s.IsType(&apperrors.ValidationError{}, err)
 		expectedErrString := fmt.Sprintf(
 			"Could not validate *models.SystemIntake %s: {\"ID\":\"is required\"}",
@@ -153,7 +153,7 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 
 	s.Run("An intake without a required time fails", func() {
 		intake.SubmittedAt = &time.Time{}
-		err := ValidateSystemIntakeForCedar(&intake, logger)
+		err := ValidateSystemIntakeForCedar(ctx, &intake)
 		s.IsType(&apperrors.ValidationError{}, err)
 		expectedErrString := fmt.Sprintf(
 			"Could not validate *models.SystemIntake %s: {\"SubmittedAt\":\"is required\"}",

--- a/pkg/handlers/systems.go
+++ b/pkg/handlers/systems.go
@@ -1,16 +1,14 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
-	"go.uber.org/zap"
-
-	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
-type fetchSystems func(logger *zap.Logger) (models.SystemShorts, error)
+type fetchSystems func(context.Context) (models.SystemShorts, error)
 
 // NewSystemsListHandler is a constructor for SystemListHandler
 func NewSystemsListHandler(base HandlerBase, fetch fetchSystems) SystemsListHandler {
@@ -29,13 +27,7 @@ type SystemsListHandler struct {
 // Handle handles a web request and returns a list of systems
 func (h SystemsListHandler) Handle() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		logger, ok := appcontext.Logger(r.Context())
-		if !ok {
-			h.Logger.Error("Failed to logger from context in systems list handler")
-			logger = h.Logger
-		}
-
-		systems, err := h.FetchSystems(logger)
+		systems, err := h.FetchSystems(r.Context())
 		if err != nil {
 			h.WriteErrorResponse(r.Context(), w, err)
 			return

--- a/pkg/handlers/systems_test.go
+++ b/pkg/handlers/systems_test.go
@@ -1,11 +1,10 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-
-	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/models"
 )
@@ -32,7 +31,7 @@ func (s HandlerTestSuite) TestSystemsHandler() {
 	})
 }
 
-func makeFakeSystemShorts(logger *zap.Logger) (models.SystemShorts, error) {
+func makeFakeSystemShorts(_ context.Context) (models.SystemShorts, error) {
 	system1 := models.SystemShort{Acronym: "CHSE", Name: "Cheese"}
 	system2 := models.SystemShort{Acronym: "PPRN", Name: "Pepperoni"}
 	system3 := models.SystemShort{Acronym: "MTLV", Name: "Meat Lovers"}

--- a/pkg/server/health_check.go
+++ b/pkg/server/health_check.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"context"
+
 	"go.uber.org/zap"
 
+	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/cedar/cedareasi"
 	"github.com/cmsgov/easi-app/pkg/cedar/cedarldap"
 	"github.com/cmsgov/easi-app/pkg/email"
@@ -14,7 +17,7 @@ func (s Server) CheckCEDAREasiClientConnection(client cedareasi.TranslatedClient
 	s.logger.Info("Testing CEDAR EASi Connection")
 	// FetchSystems is agnostic to user, doesn't modify state,
 	// and tests that we're authorized to retrieve information
-	_, err := client.FetchSystems(s.logger)
+	_, err := client.FetchSystems(appcontext.WithLogger(context.Background(), s.logger))
 	if err != nil {
 		s.logger.Error("Failed to connect to CEDAR EASi on startup", zap.Error(err))
 	}

--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -234,7 +234,7 @@ func NewSubmitSystemIntake(
 	config Config,
 	authorize func(context.Context, *models.SystemIntake) (bool, error),
 	update func(context.Context, *models.SystemIntake) (*models.SystemIntake, error),
-	validateAndSubmit func(intake *models.SystemIntake, logger *zap.Logger) (string, error),
+	validateAndSubmit func(context.Context, *models.SystemIntake) (string, error),
 	emailReviewer func(requester string, intakeID uuid.UUID) error,
 ) func(context.Context, *models.SystemIntake, *models.SystemIntake) (*models.SystemIntake, error) {
 	return func(ctx context.Context, existing *models.SystemIntake, incoming *models.SystemIntake) (*models.SystemIntake, error) {
@@ -259,7 +259,7 @@ func NewSubmitSystemIntake(
 		}
 
 		incoming.SubmittedAt = &updatedTime
-		alfabetID, validateAndSubmitErr := validateAndSubmit(incoming, appcontext.ZLogger(ctx))
+		alfabetID, validateAndSubmitErr := validateAndSubmit(ctx, incoming)
 		if validateAndSubmitErr != nil {
 			return &models.SystemIntake{}, validateAndSubmitErr
 		}

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -383,7 +383,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	update := func(ctx context.Context, intake *models.SystemIntake) (*models.SystemIntake, error) {
 		return intake, nil
 	}
-	submit := func(intake *models.SystemIntake, logger *zap.Logger) (string, error) {
+	submit := func(c context.Context, intake *models.SystemIntake) (string, error) {
 		return "ALFABET-ID", nil
 	}
 	submitEmailCount := 0
@@ -438,7 +438,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	s.Run("returns error when validation fails", func() {
 		existing := models.SystemIntake{Requester: "existing"}
 		incoming := models.SystemIntake{Requester: "incoming"}
-		failValidationSubmit := func(intake *models.SystemIntake, logger *zap.Logger) (string, error) {
+		failValidationSubmit := func(_ context.Context, intake *models.SystemIntake) (string, error) {
 			return "", &apperrors.ValidationError{
 				Err:     errors.New("validation failed on these fields: ID"),
 				ModelID: intake.ID.String(),
@@ -456,7 +456,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	s.Run("returns error when submission fails", func() {
 		existing := models.SystemIntake{Requester: "existing"}
 		incoming := models.SystemIntake{Requester: "incoming"}
-		failValidationSubmit := func(intake *models.SystemIntake, logger *zap.Logger) (string, error) {
+		failValidationSubmit := func(_ context.Context, intake *models.SystemIntake) (string, error) {
 			return "", &apperrors.ExternalAPIError{
 				Err:       errors.New("CEDAR return result: unexpected failure"),
 				ModelID:   intake.ID.String(),

--- a/pkg/services/systems.go
+++ b/pkg/services/systems.go
@@ -1,7 +1,7 @@
 package services
 
 import (
-	"go.uber.org/zap"
+	"context"
 
 	"github.com/cmsgov/easi-app/pkg/models"
 )
@@ -15,7 +15,7 @@ func makeDummySystemShort(id string, acronym string, name string) models.SystemS
 }
 
 // NewFetchFakeSystems creates some fake systems TODO: deprecate in favor of CEDAR
-func NewFetchFakeSystems() func(logger *zap.Logger) (models.SystemShorts, error) {
+func NewFetchFakeSystems() func(context.Context) (models.SystemShorts, error) {
 	systems := models.SystemShorts{
 		makeDummySystemShort("1", "GRPE", "Grape"),
 		makeDummySystemShort("2", "APPL", "Apple"),
@@ -28,7 +28,7 @@ func NewFetchFakeSystems() func(logger *zap.Logger) (models.SystemShorts, error)
 		makeDummySystemShort("9", "MNGO", "Mango"),
 		makeDummySystemShort("10", "MGST", "Mangosteen"),
 	}
-	return func(logger *zap.Logger) (models.SystemShorts, error) {
+	return func(_ context.Context) (models.SystemShorts, error) {
 		return systems, nil
 	}
 }


### PR DESCRIPTION
# EASI-685

Changes proposed in this pull request:

- just doing some housekeeping, propagating the "context is first param to every layer" pattern to the package that wraps the generated client
