### PR TITLE
Don't error if email fails to send on submit intake

### DIFF
--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -284,7 +284,7 @@ func NewSubmitSystemIntake(
 		// only send an email when everything went ok
 		err = emailReviewer(incoming.Requester, incoming.ID)
 		if err != nil {
-			return &models.SystemIntake{}, err
+			appcontext.ZLogger(ctx).Error("Submit Intake email failed to send: ", zap.Error(err))
 		}
 
 		return incoming, nil

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -486,22 +486,6 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 		s.Equal(&models.SystemIntake{}, intake)
 	})
 
-	s.Run("returns notification error when submit email fails", func() {
-		existing := models.SystemIntake{Requester: "existing"}
-		incoming := models.SystemIntake{Requester: "incoming"}
-		failSendEmail := func(requester string, intakeID uuid.UUID) error {
-			return &apperrors.NotificationError{
-				Err:             errors.New("failed to send Email"),
-				DestinationType: apperrors.DestinationTypeEmail,
-			}
-		}
-		submitSystemIntake := NewSubmitSystemIntake(serviceConfig, authorize, update, submit, failSendEmail)
-		intake, err := submitSystemIntake(ctx, &existing, &incoming)
-
-		s.IsType(&apperrors.NotificationError{}, err)
-		s.Equal(&models.SystemIntake{}, intake)
-	})
-
 	s.Run("returns query error if update fails", func() {
 		existing := models.SystemIntake{Requester: "existing"}
 		incoming := models.SystemIntake{Requester: "incoming"}


### PR DESCRIPTION
# EASI-797

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- A follow up to refactoring the system intake submit: if the confirmation email fails to send, this should not error, but only log an error. 
