### PR TITLE
Separate POST and PUT requests in business case setup cypress test

### DIFF
--- a/cypress/integration/businessCase.spec.js
+++ b/cypress/integration/businessCase.spec.js
@@ -1,7 +1,7 @@
 describe('The Business Case Form', () => {
   let intakeId;
   const systemIntake = {
-    status: 'SUBMITTED',
+    status: 'DRAFT',
     requester: 'John Requester',
     component: 'Center for Consumer Information and Insurance Oversight',
     businessOwner: 'John BusinessOwner',
@@ -38,6 +38,15 @@ describe('The Business Case Form', () => {
         body: systemIntake
       }).then(response => {
         intakeId = response.body.id;
+        systemIntake.status = 'SUBMITTED';
+      });
+      cy.request({
+        method: 'PUT',
+        url: Cypress.env('systemIntakeApi'),
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        },
+        body: systemIntake
       });
     });
   });

--- a/cypress/integration/businessCase.spec.js
+++ b/cypress/integration/businessCase.spec.js
@@ -39,6 +39,7 @@ describe('The Business Case Form', () => {
       }).then(response => {
         intakeId = response.body.id;
         systemIntake.status = 'SUBMITTED';
+        systemIntake.id = intakeId;
       });
       cy.request({
         method: 'PUT',

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -18,12 +18,14 @@ Cypress.Commands.add('login', () => {
   cy.get('body').then($body => {
     if ($body.find('input[name="answer"]').length) {
       cy.get('input[name="answer"]').then(() => {
-        cy.task('generateOTP', Cypress.env('otpSecret'), { log: false }).then(token => {
-          cy.get('input[name="answer"]').type(token, { log: false });
-          cy.get('input[name="rememberDevice"]').check({ force: true });
-          cy.get('input[value="Verify"').click();
-          cy.wait('@oidcConfig');
-        });
+        cy.task('generateOTP', Cypress.env('otpSecret'), { log: false }).then(
+          token => {
+            cy.get('input[name="answer"]').type(token, { log: false });
+            cy.get('input[name="rememberDevice"]').check({ force: true });
+            cy.get('input[value="Verify"').click();
+            cy.wait('@oidcConfig');
+          }
+        );
       });
     }
   });

--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -65,6 +65,16 @@ func NewCreateSystemIntake(
 			return &models.SystemIntake{}, &apperrors.UnauthorizedError{}
 		}
 		intake.EUAUserID = principal.ID()
+
+		if intake.Status != models.SystemIntakeStatusDRAFT {
+			err := apperrors.NewValidationError(
+				errors.New("intake is not in DRAFT state"),
+				intake,
+				intake.ID.String(),
+			)
+			return &models.SystemIntake{}, &err
+		}
+
 		// app validation belongs here
 		createdIntake, err := create(ctx, intake)
 		if err != nil {


### PR DESCRIPTION
To set up business case cypress tests, we create and submit a system intake. We used to do this in one request, POSTing a system intake with status SUBMITTED. However, we should only be allowing new intakes with status DRAFT. This PR 

Modifies the server to only allow new intakes with DRAFT status
Updates integration tests to POST a DRAFT intake and then PUT a SUBMITTED intake.