### PR TITLE
Add REACT_APP env vars to lint job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,14 @@ jobs:
   lint:
     docker:
       - image: *circleci_docker_primary
+        environment:
+          REACT_APP_API_ADDRESS: http://localhost:8080/api/v1
+          REACT_APP_APP_ENV: test
+          REACT_APP_OKTA_CLIENT_ID: 0oa2e913coDQeG19S297
+          REACT_APP_OKTA_DOMAIN: https://test.idp.idm.cms.gov
+          REACT_APP_OKTA_SERVER_ID: aus2e96etlbFPnBHt297
+          REACT_APP_OKTA_ISSUER: https://test.idp.idm.cms.gov/oauth2/aus2e96etlbFPnBHt297
+          REACT_APP_OKTA_REDIRECT_URI: http://localhost:3000/implicit/callback
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
# EASI-884

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add the REACT_APP environment variables to the lint job in CI so front end unit tests can access them

This PR uses the env var values as set in .envrc, withe the exception of REACT_APP_APP_ENV, which is set to `test`.