### PR TITLE
Add GRT business case reviewer view

### DIFF
--- a/src/components/BusinessCaseReview/AlternativeAnalysisReview/index.tsx
+++ b/src/components/BusinessCaseReview/AlternativeAnalysisReview/index.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+
+import ResponsiveTabs from 'components/shared/ResponsiveTabs';
+import { hasAlternativeB } from 'data/businessCase';
+import {
+  BusinessCaseSolution,
+  ProposedBusinessCaseSolution
+} from 'types/businessCase';
+import AsIsSolutionReview from 'views/BusinessCase/Review/AsIsSolutionReview';
+import ProposedBusinessCaseSolutionReview from 'views/BusinessCase/Review/ProposedBusinessCaseSolutionReview';
+
+type AlternativeAnalysisReviewProps = {
+  asIsSolution: BusinessCaseSolution;
+  preferredSolution: ProposedBusinessCaseSolution;
+  alternativeA: ProposedBusinessCaseSolution;
+  alternativeB?: ProposedBusinessCaseSolution;
+};
+
+const AlternativeAnalysisReview = (values: AlternativeAnalysisReviewProps) => {
+  const {
+    asIsSolution,
+    preferredSolution,
+    alternativeA,
+    alternativeB
+  } = values;
+
+  const [activeSolutionTab, setActiveSolutionTab] = useState(
+    '"As is" solution'
+  );
+
+  const getFilledSolutions = () => {
+    const solutions = [
+      '"As is" solution',
+      'Preferred solution',
+      'Alternative A'
+    ];
+    if (alternativeB && hasAlternativeB(alternativeB)) {
+      solutions.push('Alternative B');
+    }
+    return solutions;
+  };
+  return (
+    <ResponsiveTabs
+      activeTab={activeSolutionTab}
+      tabs={getFilledSolutions()}
+      handleTabClick={tab => {
+        setActiveSolutionTab(tab);
+      }}
+    >
+      <div
+        className="bg-white easi-business-case__review-solutions-wrapper"
+        style={{ overflow: 'auto' }}
+      >
+        {(tab => {
+          switch (tab) {
+            case '"As is" solution':
+              return <AsIsSolutionReview solution={asIsSolution} />;
+            case 'Preferred solution':
+              return (
+                <ProposedBusinessCaseSolutionReview
+                  name="Preferred solution"
+                  solution={preferredSolution}
+                />
+              );
+            case 'Alternative A':
+              return (
+                <ProposedBusinessCaseSolutionReview
+                  name="Alternative A"
+                  solution={alternativeA}
+                />
+              );
+            case 'Alternative B':
+              if (alternativeB && hasAlternativeB(alternativeB)) {
+                return (
+                  <ProposedBusinessCaseSolutionReview
+                    name="Alternative B"
+                    solution={alternativeB}
+                  />
+                );
+              }
+              return null;
+            default:
+              return <div />;
+          }
+        })(activeSolutionTab)}
+      </div>
+    </ResponsiveTabs>
+  );
+};
+
+export default AlternativeAnalysisReview;

--- a/src/components/BusinessCaseReview/GeneralRequestInfoReview/index.tsx
+++ b/src/components/BusinessCaseReview/GeneralRequestInfoReview/index.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import ReviewRow from 'components/ReviewRow';
+import {
+  DescriptionDefinition,
+  DescriptionList,
+  DescriptionTerm
+} from 'components/shared/DescriptionGroup';
+import { GeneralRequestInfoForm } from 'types/businessCase';
+
+type GeneralRequestInfoReviewProps = {
+  values: GeneralRequestInfoForm;
+};
+
+const GeneralRequestInfoReview = ({
+  values
+}: GeneralRequestInfoReviewProps) => {
+  return (
+    <DescriptionList title="General request information">
+      <ReviewRow>
+        <div>
+          <DescriptionTerm term="Request Name" />
+          <DescriptionDefinition definition={values.requestName} />
+        </div>
+        <div>
+          <DescriptionTerm term="Business Owner" />
+          <DescriptionDefinition definition={values.businessOwner.name} />
+        </div>
+      </ReviewRow>
+      <ReviewRow>
+        <div>
+          <DescriptionTerm term="Requester" />
+          <DescriptionDefinition definition={values.requester.name} />
+        </div>
+        <div>
+          <DescriptionTerm term="Requester Phone Number" />
+          <DescriptionDefinition definition={values.requester.phoneNumber} />
+        </div>
+      </ReviewRow>
+    </DescriptionList>
+  );
+};
+
+export default GeneralRequestInfoReview;

--- a/src/components/BusinessCaseReview/RequestDescriptionReview/index.tsx
+++ b/src/components/BusinessCaseReview/RequestDescriptionReview/index.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import ReviewRow from 'components/ReviewRow';
+import {
+  DescriptionDefinition,
+  DescriptionList,
+  DescriptionTerm
+} from 'components/shared/DescriptionGroup';
+import { RequestDescriptionForm } from 'types/businessCase';
+
+type RequestDescriptionReviewProps = {
+  values: RequestDescriptionForm;
+};
+
+const RequestDescriptionReview = ({
+  values
+}: RequestDescriptionReviewProps) => {
+  return (
+    <DescriptionList title="Request description">
+      <ReviewRow>
+        <div className="margin-bottom-205 line-height-body-3">
+          <DescriptionTerm term="What is your business or user need?" />
+          <DescriptionDefinition
+            className="text-pre"
+            definition={values.businessNeed}
+          />
+        </div>
+      </ReviewRow>
+      <ReviewRow>
+        <div className="margin-bottom-205 line-height-body-3">
+          <DescriptionTerm term="How will CMS benefit from this effort?" />
+          <DescriptionDefinition
+            className="text-pre"
+            definition={values.cmsBenefit}
+          />
+        </div>
+      </ReviewRow>
+      <ReviewRow>
+        <div className="margin-bottom-205 line-height-body-3">
+          <DescriptionTerm term="How does this effort align with organizational priorities?" />
+          <DescriptionDefinition
+            className="text-pre"
+            definition={values.priorityAlignment}
+          />
+        </div>
+      </ReviewRow>
+      <ReviewRow>
+        <div className="margin-bottom-205 line-height-body-3">
+          <DescriptionTerm term="How will you determine whether or not this effort is successful?" />
+          <DescriptionDefinition
+            className="text-pre"
+            definition={values.successIndicators}
+          />
+        </div>
+      </ReviewRow>
+    </DescriptionList>
+  );
+};
+
+export default RequestDescriptionReview;

--- a/src/components/BusinessCaseReview/index.tsx
+++ b/src/components/BusinessCaseReview/index.tsx
@@ -1,106 +1,42 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-import ReviewRow from 'components/ReviewRow';
-import {
-  DescriptionDefinition,
-  DescriptionList,
-  DescriptionTerm
-} from 'components/shared/DescriptionGroup';
-import ResponsiveTabs from 'components/shared/ResponsiveTabs';
-import { hasAlternativeB } from 'data/businessCase';
 import { BusinessCaseModel } from 'types/businessCase';
-import AsIsSolutionReview from 'views/BusinessCase/Review/AsIsSolutionReview';
-import ProposedBusinessCaseSolutionReview from 'views/BusinessCase/Review/ProposedBusinessCaseSolutionReview';
+
+import AlternativeAnalysisReview from './AlternativeAnalysisReview';
+import GeneralRequestInfoReview from './GeneralRequestInfoReview';
+import RequestDescriptionReview from './RequestDescriptionReview';
 
 type BusinessCaseReviewProps = {
   values: BusinessCaseModel;
 };
 
 const BusinessCaseReview = ({ values }: BusinessCaseReviewProps) => {
-  const [activeSolutionTab, setActiveSolutionTab] = useState(
-    '"As is" solution'
-  );
-
-  const getFilledSolutions = () => {
-    const solutions = [
-      '"As is" solution',
-      'Preferred solution',
-      'Alternative A'
-    ];
-    if (hasAlternativeB(values.alternativeB)) {
-      solutions.push('Alternative B');
-    }
-    return solutions;
-  };
-
   return (
     <>
       <div className="grid-container">
         <h2 className="font-heading-xl">General request information</h2>
-        <DescriptionList title="General request information">
-          <ReviewRow>
-            <div>
-              <DescriptionTerm term="Request Name" />
-              <DescriptionDefinition definition={values.requestName} />
-            </div>
-            <div>
-              <DescriptionTerm term="Business Owner" />
-              <DescriptionDefinition definition={values.businessOwner.name} />
-            </div>
-          </ReviewRow>
-          <ReviewRow>
-            <div>
-              <DescriptionTerm term="Requester" />
-              <DescriptionDefinition definition={values.requester.name} />
-            </div>
-            <div>
-              <DescriptionTerm term="Requester Phone Number" />
-              <DescriptionDefinition
-                definition={values.requester.phoneNumber}
-              />
-            </div>
-          </ReviewRow>
-        </DescriptionList>
+        <GeneralRequestInfoReview
+          values={{
+            requestName: values.requestName,
+            businessOwner: {
+              name: values.businessOwner.name
+            },
+            requester: {
+              name: values.requester.name,
+              phoneNumber: values.requester.phoneNumber
+            }
+          }}
+        />
 
         <h2 className="font-heading-xl margin-top-6">Request description</h2>
-        <DescriptionList title="Request description">
-          <ReviewRow>
-            <div className="margin-bottom-205 line-height-body-3">
-              <DescriptionTerm term="What is your business or user need?" />
-              <DescriptionDefinition
-                className="text-pre"
-                definition={values.businessNeed}
-              />
-            </div>
-          </ReviewRow>
-          <ReviewRow>
-            <div className="margin-bottom-205 line-height-body-3">
-              <DescriptionTerm term="How will CMS benefit from this effort?" />
-              <DescriptionDefinition
-                className="text-pre"
-                definition={values.cmsBenefit}
-              />
-            </div>
-          </ReviewRow>
-          <ReviewRow>
-            <div className="margin-bottom-205 line-height-body-3">
-              <DescriptionTerm term="How does this effort align with organizational priorities?" />
-              <DescriptionDefinition
-                className="text-pre"
-                definition={values.priorityAlignment}
-              />
-            </div>
-          </ReviewRow>
-          <ReviewRow>
-            <div className="margin-bottom-205 line-height-body-3">
-              <DescriptionTerm term="How will you determine whether or not this effort is successful?" />
-              <DescriptionDefinition
-                className="text-pre"
-                definition={values.successIndicators}
-              />
-            </div>
-          </ReviewRow>
-        </DescriptionList>
+        <RequestDescriptionReview
+          values={{
+            businessNeed: values.businessNeed,
+            cmsBenefit: values.cmsBenefit,
+            priorityAlignment: values.priorityAlignment,
+            successIndicators: values.successIndicators
+          }}
+        />
       </div>
 
       <div className="grid-container">
@@ -110,53 +46,12 @@ const BusinessCaseReview = ({ values }: BusinessCaseReviewProps) => {
       </div>
       <div className="bg-base-lightest padding-top-2 padding-bottom-8">
         <div className="grid-container">
-          <ResponsiveTabs
-            activeTab={activeSolutionTab}
-            tabs={getFilledSolutions()}
-            handleTabClick={tab => {
-              setActiveSolutionTab(tab);
-            }}
-          >
-            <div
-              className="bg-white easi-business-case__review-solutions-wrapper"
-              style={{ overflow: 'auto' }}
-            >
-              {(tab => {
-                switch (tab) {
-                  case '"As is" solution':
-                    return (
-                      <AsIsSolutionReview solution={values.asIsSolution} />
-                    );
-                  case 'Preferred solution':
-                    return (
-                      <ProposedBusinessCaseSolutionReview
-                        name="Preferred solution"
-                        solution={values.preferredSolution}
-                      />
-                    );
-                  case 'Alternative A':
-                    return (
-                      <ProposedBusinessCaseSolutionReview
-                        name="Alternative A"
-                        solution={values.alternativeA}
-                      />
-                    );
-                  case 'Alternative B':
-                    if (hasAlternativeB(values.alternativeB)) {
-                      return (
-                        <ProposedBusinessCaseSolutionReview
-                          name="Alternative B"
-                          solution={values.alternativeB}
-                        />
-                      );
-                    }
-                    return null;
-                  default:
-                    return <div />;
-                }
-              })(activeSolutionTab)}
-            </div>
-          </ResponsiveTabs>
+          <AlternativeAnalysisReview
+            asIsSolution={values.asIsSolution}
+            preferredSolution={values.preferredSolution}
+            alternativeA={values.alternativeA}
+            alternativeB={values.alternativeB}
+          />
         </div>
       </div>
     </>

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,372 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The GRT business case review matches the snapshot 1`] = `
+<div>
+  <h1
+    className="margin-top-0"
+  >
+    Business Case
+  </h1>
+  <h2
+    className="font-heading-xl"
+  >
+    General request information
+  </h2>
+  <dl
+    title="General request information"
+  >
+    <div
+      className="easi-review-row"
+    >
+      <div>
+        <dt
+          className="text-bold margin-bottom-05"
+        >
+          Request Name
+        </dt>
+        <dd
+          className="description-definition margin-0"
+        >
+          Easy Access to System Information
+        </dd>
+      </div>
+      <div>
+        <dt
+          className="text-bold margin-bottom-05"
+        >
+          Business Owner
+        </dt>
+        <dd
+          className="description-definition margin-0"
+        >
+          Jane Doe
+        </dd>
+      </div>
+    </div>
+    <div
+      className="easi-review-row"
+    >
+      <div>
+        <dt
+          className="text-bold margin-bottom-05"
+        >
+          Requester
+        </dt>
+        <dd
+          className="description-definition margin-0"
+        >
+          Jane Doe
+        </dd>
+      </div>
+      <div>
+        <dt
+          className="text-bold margin-bottom-05"
+        >
+          Requester Phone Number
+        </dt>
+        <dd
+          className="description-definition margin-0"
+        >
+          1234567890
+        </dd>
+      </div>
+    </div>
+  </dl>
+  <h2
+    className="font-heading-xl margin-top-6"
+  >
+    Request description
+  </h2>
+  <dl
+    title="Request description"
+  >
+    <div
+      className="easi-review-row"
+    >
+      <div
+        className="margin-bottom-205 line-height-body-3"
+      >
+        <dt
+          className="text-bold margin-bottom-05"
+        >
+          What is your business or user need?
+        </dt>
+        <dd
+          className="description-definition margin-0 text-pre"
+        >
+          Mock business need
+        </dd>
+      </div>
+    </div>
+    <div
+      className="easi-review-row"
+    >
+      <div
+        className="margin-bottom-205 line-height-body-3"
+      >
+        <dt
+          className="text-bold margin-bottom-05"
+        >
+          How will CMS benefit from this effort?
+        </dt>
+        <dd
+          className="description-definition margin-0 text-pre"
+        >
+          Mock CMS benefit
+        </dd>
+      </div>
+    </div>
+    <div
+      className="easi-review-row"
+    >
+      <div
+        className="margin-bottom-205 line-height-body-3"
+      >
+        <dt
+          className="text-bold margin-bottom-05"
+        >
+          How does this effort align with organizational priorities?
+        </dt>
+        <dd
+          className="description-definition margin-0 text-pre"
+        >
+          Mock priority alignment
+        </dd>
+      </div>
+    </div>
+    <div
+      className="easi-review-row"
+    >
+      <div
+        className="margin-bottom-205 line-height-body-3"
+      >
+        <dt
+          className="text-bold margin-bottom-05"
+        >
+          How will you determine whether or not this effort is successful?
+        </dt>
+        <dd
+          className="description-definition margin-0 text-pre"
+        >
+          Mock success indicators
+        </dd>
+      </div>
+    </div>
+  </dl>
+  <h2
+    className="font-heading-xl margin-top-6 margin-bottom-2"
+  >
+    Alternatives analysis
+  </h2>
+  <div
+    className="easi-responsive-tabs bg-base-lightest"
+  >
+    <div
+      className="easi-responsive-tabs__navigation"
+    >
+      <div
+        className="easi-responsive-tabs__tabs-wrapper"
+      >
+        <ul
+          className="easi-responsive-tabs__tab-list"
+        >
+          <li
+            className="easi-responsive-tabs__tab easi-responsive-tabs__tab--selected"
+          >
+            <button
+              className="easi-responsive-tabs__tab-btn"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="easi-responsive-tabs__tab-divider"
+              >
+                <span
+                  className="easi-responsive-tabs__tab-text"
+                >
+                  "As is" solution
+                </span>
+              </span>
+            </button>
+          </li>
+          <li
+            className="easi-responsive-tabs__tab"
+          >
+            <button
+              className="easi-responsive-tabs__tab-btn"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="easi-responsive-tabs__tab-divider"
+              >
+                <span
+                  className="easi-responsive-tabs__tab-text"
+                >
+                  Preferred solution
+                </span>
+              </span>
+            </button>
+          </li>
+          <li
+            className="easi-responsive-tabs__tab"
+          >
+            <button
+              className="easi-responsive-tabs__tab-btn"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="easi-responsive-tabs__tab-divider"
+              >
+                <span
+                  className="easi-responsive-tabs__tab-text"
+                >
+                  Alternative A
+                </span>
+              </span>
+            </button>
+          </li>
+        </ul>
+      </div>
+      <div />
+    </div>
+    <div
+      className="bg-white easi-business-case__review-solutions-wrapper"
+      style={
+        Object {
+          "overflow": "auto",
+        }
+      }
+    >
+      <div>
+        <dl
+          title="As-Is Solution"
+        >
+          <div
+            className="easi-review-row"
+          >
+            <div
+              className="line-height-body-3"
+            >
+              <dt
+                className="text-bold margin-bottom-05"
+              >
+                “As is” solution: Title
+              </dt>
+              <dd
+                className="description-definition margin-0"
+              >
+                Mock As is Solution
+              </dd>
+            </div>
+          </div>
+          <div
+            className="easi-review-row"
+          >
+            <div
+              className="line-height-body-3"
+            >
+              <dt
+                className="text-bold margin-bottom-05"
+              >
+                “As is” solution: Summary
+              </dt>
+              <dd
+                className="description-definition margin-0 text-pre"
+              >
+                Mock As is solution summary
+              </dd>
+            </div>
+          </div>
+          <div
+            className="easi-review-row"
+          >
+            <div
+              className="line-height-body-3"
+            >
+              <dt
+                className="text-bold margin-bottom-05"
+              >
+                “As is” solution: Pros
+              </dt>
+              <dd
+                className="description-definition margin-0 text-pre"
+              >
+                Mock As is solution  pros
+              </dd>
+            </div>
+          </div>
+          <div
+            className="easi-review-row"
+          >
+            <div
+              className="line-height-body-3"
+            >
+              <dt
+                className="text-bold margin-bottom-05"
+              >
+                “As is” solution: Cons
+              </dt>
+              <dd
+                className="description-definition margin-0 text-pre"
+              >
+                Mock As is solution cons
+              </dd>
+            </div>
+          </div>
+        </dl>
+        <div
+          className="easi-review-row"
+        >
+          <div>
+            <div
+              className="bg-base-lightest overflow-auto padding-x-2"
+            >
+              <dl
+                title="System total cost"
+              >
+                <dt
+                  className="text-bold margin-bottom-05"
+                >
+                  System total cost
+                </dt>
+                <dd
+                  className="description-definition margin-0"
+                >
+                  $15
+                </dd>
+              </dl>
+            </div>
+          </div>
+        </div>
+        <div
+          className="easi-review-row"
+        >
+          <div
+            className="line-height-body-3"
+          >
+            <dt
+              className="text-bold margin-bottom-05"
+            >
+              What is the cost savings or avoidance associated with this solution?
+            </dt>
+            <dd
+              className="description-definition margin-0 text-pre"
+            >
+              
+            </dd>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <a
+    className="usa-button margin-top-5"
+    href="/governance-review-team//actions"
+    onClick={[Function]}
+  >
+    Take an action
+  </a>
+</div>
+`;

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/index.test.tsx
@@ -15,6 +15,7 @@ window.matchMedia = (): any => ({
 describe('The GRT business case review', () => {
   const mockBusinessCase = {
     ...businessCaseInitialData,
+    id: '54e829a9-6ce3-4b4b-81b0-7781b1e22821',
     requestName: 'Easy Access to System Information',
     requester: {
       name: 'Jane Doe',

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/index.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
+
+import { businessCaseInitialData } from 'data/businessCase';
+
+import BusinessCaseReview from './index';
+
+window.matchMedia = (): any => ({
+  addListener: () => {},
+  removeListener: () => {}
+});
+
+describe('The GRT business case review', () => {
+  const mockBusinessCase = {
+    ...businessCaseInitialData,
+    requestName: 'Easy Access to System Information',
+    requester: {
+      name: 'Jane Doe',
+      phoneNumber: '1234567890'
+    },
+    businessOwner: {
+      name: 'Jane Doe'
+    },
+    businessNeed: 'Mock business need',
+    cmsBenefit: 'Mock CMS benefit',
+    priorityAlignment: 'Mock priority alignment',
+    successIndicators: 'Mock success indicators',
+    asIsSolution: {
+      title: 'Mock As is Solution',
+      summary: 'Mock As is solution summary',
+      pros: 'Mock As is solution  pros',
+      cons: 'Mock As is solution cons',
+      estimatedLifecycleCost: {
+        year1: [{ phase: 'Development', cost: '1' }],
+        year2: [{ phase: 'Development', cost: '2' }],
+        year3: [{ phase: 'Development', cost: '3' }],
+        year4: [{ phase: 'Development', cost: '4' }],
+        year5: [{ phase: 'Development', cost: '5' }]
+      },
+      costSavings: ''
+    }
+  };
+
+  it('renders without crashing', () => {
+    shallow(<BusinessCaseReview businessCase={businessCaseInitialData} />);
+  });
+
+  it('matches the snapshot', () => {
+    const tree = renderer
+      .create(
+        <MemoryRouter>
+          <BusinessCaseReview businessCase={mockBusinessCase} />
+        </MemoryRouter>
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/index.tsx
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/index.tsx
@@ -14,6 +14,15 @@ type BusinessCaseReviewProps = {
 const BusinessCaseReview = ({ businessCase }: BusinessCaseReviewProps) => {
   const { t } = useTranslation('governanceReviewTeam');
 
+  if (!businessCase.id) {
+    return (
+      <div>
+        <h1 className="margin-top-0">{t('general:businessCase')}</h1>
+        <p>Business Case has not been submitted</p>
+      </div>
+    );
+  }
+
   return (
     <div>
       <h1 className="margin-top-0">{t('general:businessCase')}</h1>

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/index.tsx
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/index.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { Link as UswdsLink } from '@trussworks/react-uswds';
+
+import AlternativeAnalysisReview from 'components/BusinessCaseReview/AlternativeAnalysisReview';
+import GeneralRequestInfoReview from 'components/BusinessCaseReview/GeneralRequestInfoReview';
+import RequestDescriptionReview from 'components/BusinessCaseReview/RequestDescriptionReview';
+import { BusinessCaseModel } from 'types/businessCase';
+
+type BusinessCaseReviewProps = {
+  businessCase: BusinessCaseModel;
+};
+const BusinessCaseReview = ({ businessCase }: BusinessCaseReviewProps) => {
+  const { t } = useTranslation('governanceReviewTeam');
+
+  return (
+    <div>
+      <h1 className="margin-top-0">{t('general:businessCase')}</h1>
+      <h2 className="font-heading-xl">General request information</h2>
+      <GeneralRequestInfoReview
+        values={{
+          requestName: businessCase.requestName,
+          businessOwner: {
+            name: businessCase.businessOwner.name
+          },
+          requester: {
+            name: businessCase.requester.name,
+            phoneNumber: businessCase.requester.phoneNumber
+          }
+        }}
+      />
+
+      <h2 className="font-heading-xl margin-top-6">Request description</h2>
+      <RequestDescriptionReview
+        values={{
+          businessNeed: businessCase.businessNeed,
+          cmsBenefit: businessCase.cmsBenefit,
+          priorityAlignment: businessCase.priorityAlignment,
+          successIndicators: businessCase.successIndicators
+        }}
+      />
+      <h2 className="font-heading-xl margin-top-6 margin-bottom-2">
+        Alternatives analysis
+      </h2>
+      <AlternativeAnalysisReview
+        asIsSolution={businessCase.asIsSolution}
+        preferredSolution={businessCase.preferredSolution}
+        alternativeA={businessCase.alternativeA}
+        alternativeB={businessCase.alternativeB}
+      />
+      <UswdsLink
+        className="usa-button margin-top-5"
+        variant="unstyled"
+        to={`/governance-review-team/${businessCase.systemIntakeId}/actions`}
+        asCustom={Link}
+      >
+        Take an action
+      </UswdsLink>
+    </div>
+  );
+};
+
+export default BusinessCaseReview;

--- a/src/views/GovernanceReviewTeam/index.tsx
+++ b/src/views/GovernanceReviewTeam/index.tsx
@@ -39,7 +39,7 @@ const GovernanceReviewTeam = () => {
     if (systemIntake.businessCaseId) {
       dispatch(fetchBusinessCase(systemIntake.businessCaseId));
     }
-  }, [dispatch, systemIntake]);
+  }, [dispatch, systemIntake.businessCaseId]);
 
   const component = cmsDivisionsAndOffices.find(
     c => c.name === systemIntake.requester.component

--- a/src/views/GovernanceReviewTeam/index.tsx
+++ b/src/views/GovernanceReviewTeam/index.tsx
@@ -12,7 +12,9 @@ import MainContent from 'components/MainContent';
 import PageWrapper from 'components/PageWrapper';
 import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
 import { AppState } from 'reducers/rootReducer';
-import { fetchSystemIntake } from 'types/routines';
+import { fetchBusinessCase, fetchSystemIntake } from 'types/routines';
+
+import BusinessCaseReview from './BusinessCaseReview';
 
 import './index.scss';
 
@@ -21,13 +23,23 @@ const GovernanceReviewTeam = () => {
   const dispatch = useDispatch();
   const { systemId, activePage } = useParams();
 
+  const systemIntake = useSelector(
+    (state: AppState) => state.systemIntake.systemIntake
+  );
+
+  const businessCase = useSelector(
+    (state: AppState) => state.businessCase.form
+  );
+
   useEffect(() => {
     dispatch(fetchSystemIntake(systemId));
   }, [dispatch, systemId]);
 
-  const systemIntake = useSelector(
-    (state: AppState) => state.systemIntake.systemIntake
-  );
+  useEffect(() => {
+    if (systemIntake.businessCaseId) {
+      dispatch(fetchBusinessCase(systemIntake.businessCaseId));
+    }
+  }, [dispatch, systemIntake]);
 
   const component = cmsDivisionsAndOffices.find(
     c => c.name === systemIntake.requester.component
@@ -120,14 +132,14 @@ const GovernanceReviewTeam = () => {
               {t('actions')}
             </Link>
           </nav>
-          <section>
+          <section className="tablet:grid-col-9">
             <Route
               path="/governance-review-team/:systemId/system-intake"
               render={() => <h1>{t('general:intake')}</h1>}
             />
             <Route
               path="/governance-review-team/:systemId/business-case"
-              render={() => <h1>{t('general:businessCase')}</h1>}
+              render={() => <BusinessCaseReview businessCase={businessCase} />}
             />
             <Route
               path="/governance-review-team/:systemId/decision"


### PR DESCRIPTION
# EASI-847

This PR adds the business case view to the GRT reviewer.

http://localhost:3000/governance-review-team/:systemId/business-case

Because of the page structure in the requester review (full width background color), it can't be easily reused in the GRT reviewer view. I broke it into even smaller chunks by page. Each page of the business case has its own review component that are building blocks for the business case review.

Not only do we need to verify the GRT reviewer business case view, but we also have to verify there are no regressions on the requester reviewer view.

(We have snapshots of the business case review so we should be good since it matches the diff)