### PR TITLE
Mock current date in snapshot test

### DIFF
--- a/src/views/GovernanceReviewTeam/IntakeReview/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/IntakeReview/index.test.tsx
@@ -41,9 +41,9 @@ describe('The GRT intake review view', () => {
     needsEaSupport: false,
     hasContract: 'The quick brown fox jumps over the lazy dog.',
     grtReviewEmailBody: 'The quick brown fox jumps over the lazy dog.',
-    decidedAt: new Date().toISOString(),
+    decidedAt: new Date(2020, 8, 30).toISOString(),
     businessCaseId: null,
-    submittedAt: new Date().toISOString()
+    submittedAt: new Date(2020, 8, 30).toISOString()
   };
 
   it('renders without crashing', () => {
@@ -51,6 +51,7 @@ describe('The GRT intake review view', () => {
   });
 
   it('matches the snapshot', () => {
+    Date.now = jest.fn(() => new Date(2020, 8, 30).valueOf());
     const tree = renderer
       .create(
         <MemoryRouter>

--- a/src/views/GovernanceReviewTeam/IntakeReview/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/IntakeReview/index.test.tsx
@@ -6,6 +6,16 @@ import { shallow } from 'enzyme';
 import IntakeReview from './index';
 
 describe('The GRT intake review view', () => {
+  let dateSpy;
+  beforeAll(() => {
+    // September 30, 2020
+    dateSpy = jest.spyOn(Date, 'now').mockImplementation(() => 1601449200000);
+  });
+
+  afterAll(() => {
+    dateSpy.mockRestore();
+  });
+
   const mockSystemIntake = {
     id: '53d762ea-0bc8-4af0-b24d-0b5844bacea5',
     euaUserID: 'ABCD',
@@ -41,9 +51,9 @@ describe('The GRT intake review view', () => {
     needsEaSupport: false,
     hasContract: 'The quick brown fox jumps over the lazy dog.',
     grtReviewEmailBody: 'The quick brown fox jumps over the lazy dog.',
-    decidedAt: new Date(2020, 8, 30).toISOString(),
+    decidedAt: new Date().toISOString(),
     businessCaseId: null,
-    submittedAt: new Date(2020, 8, 30).toISOString()
+    submittedAt: new Date().toISOString()
   };
 
   it('renders without crashing', () => {
@@ -51,7 +61,6 @@ describe('The GRT intake review view', () => {
   });
 
   it('matches the snapshot', () => {
-    Date.now = jest.fn(() => new Date(2020, 8, 30).valueOf());
     const tree = renderer
       .create(
         <MemoryRouter>


### PR DESCRIPTION
For the System Intake Review page, it uses the current time to indicate the submission date before the intake is submitted. We added a snapshot test, but the date will change every day because it uses the current time.

This PR mocks the date so we don't have this issue again.

Below is an example of the date changed from yesterday to today
```
                    Submission Date
                  </dt>
                  <dd
                    className="description-definition margin-0"
                  >
    -               Sep 30, 2020
    +               Oct 1, 2020
                  </dd>
                </div>
```