### PR TITLE
update request name to project name

### DIFF
--- a/cypress/integration/systemIntake.spec.js
+++ b/cypress/integration/systemIntake.spec.js
@@ -150,9 +150,9 @@ describe('The System Intake Form', () => {
         /^Enterprise Architecture, Enterprise Architecture Collaborator$/
       );
 
-    cy.contains('.easi-review-row dt', 'Request Name')
+    cy.contains('.easi-review-row dt', 'Project Name')
       .siblings('dd')
-      .contains('Request Name');
+      .contains('Test Request Name');
 
     cy.contains('dt', 'What is your business need?')
       .siblings('dd')

--- a/src/components/BusinessCaseReview/GeneralRequestInfoReview/index.tsx
+++ b/src/components/BusinessCaseReview/GeneralRequestInfoReview/index.tsx
@@ -19,7 +19,7 @@ const GeneralRequestInfoReview = ({
     <DescriptionList title="General request information">
       <ReviewRow>
         <div>
-          <DescriptionTerm term="Request Name" />
+          <DescriptionTerm term="Project Name" />
           <DescriptionDefinition definition={values.requestName} />
         </div>
         <div>

--- a/src/components/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/components/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -20,7 +20,7 @@ Array [
           <dt
             className="text-bold margin-bottom-05"
           >
-            Request Name
+            Project Name
           </dt>
           <dd
             className="description-definition margin-0"

--- a/src/components/SystemIntakeReview/index.tsx
+++ b/src/components/SystemIntakeReview/index.tsx
@@ -114,7 +114,7 @@ export const SystemIntakeReview = ({ systemIntake }: SystemIntakeReview) => {
       <DescriptionList title="Request Details">
         <ReviewRow>
           <div>
-            <DescriptionTerm term="Request Name" />
+            <DescriptionTerm term="Project Name" />
             <DescriptionDefinition definition={systemIntake.requestName} />
           </div>
         </ReviewRow>

--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -1,6 +1,6 @@
 const intake = {
   fields: {
-    requestName: 'Request name',
+    requestName: 'Project name',
     requester: 'Requester',
     submissionDate: 'Submission date',
     requestFor: 'Request for',

--- a/src/validations/businessCaseSchema.ts
+++ b/src/validations/businessCaseSchema.ts
@@ -4,7 +4,7 @@ import * as Yup from 'yup';
 const phoneNumberRegex = /( *-*[0-9] *?){10,}/;
 const BusinessCaseValidationSchema = {
   generalRequestInfo: Yup.object().shape({
-    requestName: Yup.string().required('Enter the Request Name'),
+    requestName: Yup.string().required('Enter the Project Name'),
     requester: Yup.object().shape({
       name: Yup.string().required("Enter the Requester's name"),
       phoneNumber: Yup.string()

--- a/src/views/BusinessCase/GeneralRequestInfo/index.tsx
+++ b/src/views/BusinessCase/GeneralRequestInfo/index.tsx
@@ -82,7 +82,7 @@ const GeneralRequestInfo = ({
                   scrollElement="requestName"
                   error={!!flatErrors.requestName}
                 >
-                  <Label htmlFor="BusinessCase-RequestName">Request Name</Label>
+                  <Label htmlFor="BusinessCase-RequestName">Project Name</Label>
                   <FieldErrorMsg>{flatErrors.requestName}</FieldErrorMsg>
                   <Field
                     as={TextField}

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`The GRT business case review matches the snapshot 1`] = `
         <dt
           className="text-bold margin-bottom-05"
         >
-          Request Name
+          Project Name
         </dt>
         <dd
           className="description-definition margin-0"

--- a/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,7 @@ Array [
             <dd
               className="description-definition margin-0"
             >
-              Oct 1, 2020
+              Sep 30, 2020
             </dd>
           </div>
         </div>

--- a/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,7 @@ Array [
             <dd
               className="description-definition margin-0"
             >
-              Sep 30, 2020
+              Oct 1, 2020
             </dd>
           </div>
         </div>
@@ -171,7 +171,7 @@ Array [
             <dt
               className="text-bold margin-bottom-05"
             >
-              Request Name
+              Project Name
             </dt>
             <dd
               className="description-definition margin-0"

--- a/src/views/SystemIntake/RequestDetails/index.tsx
+++ b/src/views/SystemIntake/RequestDetails/index.tsx
@@ -107,7 +107,7 @@ const RequestDetails = ({
                   scrollElement="requestName"
                   error={!!flatErrors.requestName}
                 >
-                  <Label htmlFor="IntakeForm-RequestName">Request Name</Label>
+                  <Label htmlFor="IntakeForm-RequestName">Project Name</Label>
                   <FieldErrorMsg>{flatErrors.requestName}</FieldErrorMsg>
                   <Field
                     as={TextField}


### PR DESCRIPTION
# EASI-825

This PR updates the user facing "Request Name" to "Project Name". This PR **only** updates that specific field label because that is what's confusing users.

All other instances of "request" will be kept as is until further notice.

We should probably find a way to document the discrepancy between "project" and "request". It can be confusing for folks joining the team.

Intake
![Screen Shot 2020-10-01 at 4 52 50 PM](https://user-images.githubusercontent.com/8367504/94874521-0a5bc280-0407-11eb-9afb-4d7308389985.png)
![Screen Shot 2020-10-01 at 4 52 59 PM](https://user-images.githubusercontent.com/8367504/94874524-0cbe1c80-0407-11eb-8835-e22d2ce72a70.png)

Business Case
![Screen Shot 2020-10-01 at 4 54 05 PM](https://user-images.githubusercontent.com/8367504/94874535-121b6700-0407-11eb-9a88-cbae1340efa3.png)
![Screen Shot 2020-10-01 at 4 56 06 PM](https://user-images.githubusercontent.com/8367504/94874540-147dc100-0407-11eb-83e6-4fd46fe5b481.png)
