### PR TITLE
Add sorting to GRT request table

### DIFF
--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -1,6 +1,6 @@
 const intake = {
   fields: {
-    requestName: 'Project name',
+    projectName: 'Project name',
     requester: 'Requester',
     submissionDate: 'Submission date',
     requestFor: 'Request for',

--- a/src/react-table-config.d.ts
+++ b/src/react-table-config.d.ts
@@ -1,0 +1,137 @@
+import {
+  UseColumnOrderInstanceProps,
+  UseColumnOrderState,
+  UseExpandedHooks,
+  UseExpandedInstanceProps,
+  UseExpandedOptions,
+  UseExpandedRowProps,
+  UseExpandedState,
+  UseFiltersColumnOptions,
+  UseFiltersColumnProps,
+  UseFiltersInstanceProps,
+  UseFiltersOptions,
+  UseFiltersState,
+  UseGlobalFiltersColumnOptions,
+  UseGlobalFiltersInstanceProps,
+  UseGlobalFiltersOptions,
+  UseGlobalFiltersState,
+  UseGroupByCellProps,
+  UseGroupByColumnOptions,
+  UseGroupByColumnProps,
+  UseGroupByHooks,
+  UseGroupByInstanceProps,
+  UseGroupByOptions,
+  UseGroupByRowProps,
+  UseGroupByState,
+  UsePaginationInstanceProps,
+  UsePaginationOptions,
+  UsePaginationState,
+  UseResizeColumnsColumnOptions,
+  UseResizeColumnsColumnProps,
+  UseResizeColumnsOptions,
+  UseResizeColumnsState,
+  UseRowSelectHooks,
+  UseRowSelectInstanceProps,
+  UseRowSelectOptions,
+  UseRowSelectRowProps,
+  UseRowSelectState,
+  UseRowStateCellProps,
+  UseRowStateInstanceProps,
+  UseRowStateOptions,
+  UseRowStateRowProps,
+  UseRowStateState,
+  UseSortByColumnOptions,
+  UseSortByColumnProps,
+  UseSortByHooks,
+  UseSortByInstanceProps,
+  UseSortByOptions,
+  UseSortByState
+} from 'react-table';
+
+declare module 'react-table' {
+  // take this file as-is, or comment out the sections that don't apply to your plugin configuration
+
+  export interface TableOptions<D extends Record<string, unknown>>
+    extends UseExpandedOptions<D>,
+      UseFiltersOptions<D>,
+      UseGlobalFiltersOptions<D>,
+      UseGroupByOptions<D>,
+      UsePaginationOptions<D>,
+      UseResizeColumnsOptions<D>,
+      UseRowSelectOptions<D>,
+      UseRowStateOptions<D>,
+      UseSortByOptions<D>,
+      // note that having Record here allows you to add anything to the options, this matches the spirit of the
+      // underlying js library, but might be cleaner if it's replaced by a more specific type that matches your
+      // feature set, this is a safe default.
+      Record<string, any> {}
+
+  export interface Hooks<
+    D extends Record<string, unknown> = Record<string, unknown>
+  >
+    extends UseExpandedHooks<D>,
+      UseGroupByHooks<D>,
+      UseRowSelectHooks<D>,
+      UseSortByHooks<D> {}
+
+  export interface TableInstance<
+    D extends Record<string, unknown> = Record<string, unknown>
+  >
+    extends UseColumnOrderInstanceProps<D>,
+      UseExpandedInstanceProps<D>,
+      UseFiltersInstanceProps<D>,
+      UseGlobalFiltersInstanceProps<D>,
+      UseGroupByInstanceProps<D>,
+      UsePaginationInstanceProps<D>,
+      UseRowSelectInstanceProps<D>,
+      UseRowStateInstanceProps<D>,
+      UseSortByInstanceProps<D> {}
+
+  export interface TableState<
+    D extends Record<string, unknown> = Record<string, unknown>
+  >
+    extends UseColumnOrderState<D>,
+      UseExpandedState<D>,
+      UseFiltersState<D>,
+      UseGlobalFiltersState<D>,
+      UseGroupByState<D>,
+      UsePaginationState<D>,
+      UseResizeColumnsState<D>,
+      UseRowSelectState<D>,
+      UseRowStateState<D>,
+      UseSortByState<D> {}
+
+  export interface HeaderGroup<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseSortByColumnProps<D> {}
+
+  export interface ColumnInterface<
+    D extends Record<string, unknown> = Record<string, unknown>
+  >
+    extends UseFiltersColumnOptions<D>,
+      UseGlobalFiltersColumnOptions<D>,
+      UseGroupByColumnOptions<D>,
+      UseResizeColumnsColumnOptions<D>,
+      UseSortByColumnOptions<D> {}
+
+  export interface ColumnInstance<
+    D extends Record<string, unknown> = Record<string, unknown>
+  >
+    extends UseFiltersColumnProps<D>,
+      UseGroupByColumnProps<D>,
+      UseResizeColumnsColumnProps<D>,
+      UseSortByColumnProps<D> {}
+
+  export interface Cell<
+    D extends Record<string, unknown> = Record<string, unknown>,
+    V = any
+  > extends UseGroupByCellProps<D>, UseRowStateCellProps<D> {}
+
+  export interface Row<
+    D extends Record<string, unknown> = Record<string, unknown>
+  >
+    extends UseExpandedRowProps<D>,
+      UseGroupByRowProps<D>,
+      UseRowSelectRowProps<D>,
+      UseRowStateRowProps<D> {}
+}

--- a/src/views/GovernanceReviewTeam/AllRequests.tsx
+++ b/src/views/GovernanceReviewTeam/AllRequests.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { useTable } from 'react-table';
+import { useSortBy, useTable } from 'react-table';
 import { Table } from '@trussworks/react-uswds';
+import classnames from 'classnames';
 import { DateTime } from 'luxon';
 
 import Footer from 'components/Footer';
@@ -22,7 +23,7 @@ const AllRequests = () => {
         }
       },
       {
-        Header: t('intake:fields.requestName'),
+        Header: t('intake:fields.projectName'),
         accessor: 'requestName',
         Cell: ({ row, value }: any) => {
           return (
@@ -36,7 +37,10 @@ const AllRequests = () => {
         Header: t('intake:fields.component'),
         accessor: 'requester.component'
       },
-      { Header: t('allRequests.table.requestType'), accessor: 'type' }
+      {
+        Header: t('allRequests.table.requestType'),
+        accessor: 'type'
+      }
     ],
     [t]
   );
@@ -47,7 +51,7 @@ const AllRequests = () => {
     () => [
       {
         id: 'addaa218-34d3-4dd8-a12f-38f6ff33b22d',
-        submittedAt: new Date().toISOString(),
+        submittedAt: new Date(2020, 6, 26).toISOString(),
         requestName: 'Easy Access to System Information',
         requester: {
           name: 'Christopher Hui',
@@ -58,8 +62,30 @@ const AllRequests = () => {
       },
       {
         id: '229f9b64-18fc-4ee1-95c4-9d4b143d215c',
-        submittedAt: new Date().toISOString(),
+        submittedAt: new Date(2020, 9, 19).toISOString(),
         requestName: 'Hard Access to System Information',
+        requester: {
+          name: 'George Baukerton',
+          component: 'Office of Information Technology'
+        },
+        status: 'Submitted',
+        type: 'Re-compete'
+      },
+      {
+        id: '229f9b64-18fc-4ee1-95c4-9d4b143d215d',
+        submittedAt: new Date().toISOString(),
+        requestName: 'Super System',
+        requester: {
+          name: 'George Baukerton',
+          component: 'Office of Information Technology'
+        },
+        status: 'Submitted',
+        type: 'Re-compete'
+      },
+      {
+        id: '229f9b64-18fc-4ee1-95c4-9d4b143d215e',
+        submittedAt: new Date(2020, 8, 26).toISOString(),
+        requestName: 'Monster System',
         requester: {
           name: 'George Baukerton',
           component: 'Office of Information Technology'
@@ -77,10 +103,24 @@ const AllRequests = () => {
     headerGroups,
     rows,
     prepareRow
-  } = useTable({
-    columns,
-    data
-  });
+  } = useTable(
+    {
+      columns,
+      data,
+      initialState: {
+        // @ts-ignore
+        sortBy: [{ id: 'submittedAt', desc: true }]
+      }
+    },
+    useSortBy
+  );
+
+  const getHeaderSortIcon = (isDesc: boolean) => {
+    return classnames('margin-left-1', {
+      'fa fa-caret-down': isDesc,
+      'fa fa-caret-up': !isDesc
+    });
+  };
 
   /* eslint-disable react/jsx-props-no-spreading */
   return (
@@ -92,22 +132,27 @@ const AllRequests = () => {
             {t('allRequests.aria.openRequestsTable')}
           </caption>
           <thead>
-            {headerGroups.map(headerGroup => (
+            {headerGroups.map((headerGroup: any) => (
               <tr {...headerGroup.getHeaderGroupProps()}>
-                {headerGroup.headers.map(column => (
-                  <th {...column.getHeaderProps()}>
+                {headerGroup.headers.map((column: any) => (
+                  <th {...column.getHeaderProps(column.getSortByToggleProps())}>
                     {column.render('Header')}
+                    {column.isSorted && (
+                      <span
+                        className={getHeaderSortIcon(column.isSortedDesc)}
+                      />
+                    )}
                   </th>
                 ))}
               </tr>
             ))}
           </thead>
           <tbody {...getTableBodyProps()}>
-            {rows.map(row => {
+            {rows.map((row: any) => {
               prepareRow(row);
               return (
                 <tr {...row.getRowProps()}>
-                  {row.cells.map((cell, i) => {
+                  {row.cells.map((cell: any, i: number) => {
                     if (i === 0) {
                       return (
                         <th {...cell.getCellProps()} scope="row">

--- a/src/views/GovernanceReviewTeam/AllRequests.tsx
+++ b/src/views/GovernanceReviewTeam/AllRequests.tsx
@@ -122,6 +122,19 @@ const AllRequests = () => {
     });
   };
 
+  const getColumnSortStatus = (
+    column: any
+  ): 'descending' | 'ascending' | 'none' => {
+    if (column.isSorted) {
+      if (column.isSortedDesc) {
+        return 'descending';
+      }
+      return 'ascending';
+    }
+
+    return 'none';
+  };
+
   /* eslint-disable react/jsx-props-no-spreading */
   return (
     <PageWrapper>
@@ -135,7 +148,10 @@ const AllRequests = () => {
             {headerGroups.map((headerGroup: any) => (
               <tr {...headerGroup.getHeaderGroupProps()}>
                 {headerGroup.headers.map((column: any) => (
-                  <th {...column.getHeaderProps(column.getSortByToggleProps())}>
+                  <th
+                    {...column.getHeaderProps(column.getSortByToggleProps())}
+                    aria-sort={getColumnSortStatus(column)}
+                  >
                     {column.render('Header')}
                     {column.isSorted && (
                       <span

--- a/src/views/GovernanceReviewTeam/AllRequests.tsx
+++ b/src/views/GovernanceReviewTeam/AllRequests.tsx
@@ -108,14 +108,13 @@ const AllRequests = () => {
       columns,
       data,
       initialState: {
-        // @ts-ignore
         sortBy: [{ id: 'submittedAt', desc: true }]
       }
     },
     useSortBy
   );
 
-  const getHeaderSortIcon = (isDesc: boolean) => {
+  const getHeaderSortIcon = (isDesc: boolean | undefined) => {
     return classnames('margin-left-1', {
       'fa fa-caret-down': isDesc,
       'fa fa-caret-up': !isDesc
@@ -145,9 +144,9 @@ const AllRequests = () => {
             {t('allRequests.aria.openRequestsTable')}
           </caption>
           <thead>
-            {headerGroups.map((headerGroup: any) => (
+            {headerGroups.map(headerGroup => (
               <tr {...headerGroup.getHeaderGroupProps()}>
-                {headerGroup.headers.map((column: any) => (
+                {headerGroup.headers.map(column => (
                   <th
                     {...column.getHeaderProps(column.getSortByToggleProps())}
                     aria-sort={getColumnSortStatus(column)}
@@ -164,11 +163,11 @@ const AllRequests = () => {
             ))}
           </thead>
           <tbody {...getTableBodyProps()}>
-            {rows.map((row: any) => {
+            {rows.map(row => {
               prepareRow(row);
               return (
                 <tr {...row.getRowProps()}>
-                  {row.cells.map((cell: any, i: number) => {
+                  {row.cells.map((cell, i) => {
                     if (i === 0) {
                       return (
                         <th {...cell.getCellProps()} scope="row">

--- a/src/views/GovernanceReviewTeam/IntakeReview/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/IntakeReview/index.test.tsx
@@ -45,6 +45,10 @@ describe('The GRT intake review view', () => {
       isFunded: false,
       fundingNumber: ''
     },
+    costs: {
+      expectedIncreaseAmount: '',
+      isExpectingIncrease: ''
+    },
     businessNeed: 'The quick brown fox jumps over the lazy dog.',
     businessSolution: 'The quick brown fox jumps over the lazy dog.',
     currentStage: 'The quick brown fox jumps over the lazy dog.',

--- a/src/views/GovernanceReviewTeam/index.tsx
+++ b/src/views/GovernanceReviewTeam/index.tsx
@@ -15,7 +15,6 @@ import { AppState } from 'reducers/rootReducer';
 import { fetchBusinessCase, fetchSystemIntake } from 'types/routines';
 
 import BusinessCaseReview from './BusinessCaseReview';
-
 import IntakeReview from './IntakeReview';
 
 import './index.scss';
@@ -73,7 +72,7 @@ const GovernanceReviewTeam = () => {
             </BreadcrumbNav>
             <dl className="easi-grt__request-info">
               <div>
-                <dt>{t('intake:fields.requestName')}</dt>
+                <dt>{t('intake:fields.projectName')}</dt>
                 <dd>{systemIntake.requestName}</dd>
               </div>
               <div className="easi-grt__request-info-col">


### PR DESCRIPTION
# EASI-803

This PR adds sorting to the GRT request table.

Notes:
- This is not type safe. I used a few `any` because I couldn't figure out how to merge some types. See [here](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-table#example-type-file)
- For now, we are inheriting the default label/title for the header sorting. It will read as `Toggle sort by`.
- It also uses the `aria-sort` attribute. My hope will be that using these two together will be sufficient for assistive technology users.