### PR TITLE
Add cost increase questions to the Contract Details page

### DIFF
--- a/cypress/integration/systemIntake.spec.js
+++ b/cypress/integration/systemIntake.spec.js
@@ -46,7 +46,7 @@ describe('The System Intake Form', () => {
       .check({ force: true })
       .should('be.checked');
 
-    cy.get('IntakeForm-CostsExpectingIncreaseNo')
+    cy.get('#IntakeForm-CostsExpectingIncreaseNo')
       .check({ force: true })
       .should('be.checked');
 

--- a/cypress/integration/systemIntake.spec.js
+++ b/cypress/integration/systemIntake.spec.js
@@ -102,6 +102,10 @@ describe('The System Intake Form', () => {
       .type('111111')
       .should('have.value', '111111');
 
+    cy.get('IntakeForm-CostsExpectingIncreaseNo')
+      .check({ force: true })
+      .should('be.checked');
+
     cy.contains('button', 'Next').click();
 
     cy.wait('@putSystemIntake');

--- a/cypress/integration/systemIntake.spec.js
+++ b/cypress/integration/systemIntake.spec.js
@@ -46,6 +46,10 @@ describe('The System Intake Form', () => {
       .check({ force: true })
       .should('be.checked');
 
+    cy.get('IntakeForm-CostsExpectingIncreaseNo')
+      .check({ force: true })
+      .should('be.checked');
+
     cy.contains('button', 'Next').click();
 
     cy.wait('@putSystemIntake');
@@ -102,9 +106,13 @@ describe('The System Intake Form', () => {
       .type('111111')
       .should('have.value', '111111');
 
-    cy.get('IntakeForm-CostsExpectingIncreaseNo')
+    cy.get('#IntakeForm-CostsExpectingIncreaseYes')
       .check({ force: true })
       .should('be.checked');
+
+    cy.get('#IntakeForm-CostsExpectedIncrease')
+      .type('99999')
+      .should('have.value', '99999');
 
     cy.contains('button', 'Next').click();
 

--- a/migrations/V24__Add_Cost_increase_To_intake.sql
+++ b/migrations/V24__Add_Cost_increase_To_intake.sql
@@ -1,0 +1,2 @@
+ALTER TABLE system_intake ADD COLUMN cost_increase text;
+ALTER TABLE system_intake ADD COLUMN cost_increase_amount text;

--- a/pkg/cedar/cedareasi/translated_client.go
+++ b/pkg/cedar/cedareasi/translated_client.go
@@ -122,6 +122,14 @@ func ValidateSystemIntakeForCedar(ctx context.Context, intake *models.SystemInta
 	if validate.RequireTime(*intake.SubmittedAt) {
 		expectedError.WithValidation("SubmittedAt", validationMessage)
 	}
+	if validate.RequireNullString(intake.CostIncrease) {
+		expectedError.WithValidation("CostIncrease", validationMessage)
+	}
+	if intake.CostIncrease.String == "YES" {
+		if validate.RequireNullString(intake.CostIncreaseAmount) {
+			expectedError.WithValidation("CostIncreaseAmount", validationMessage)
+		}
+	}
 	if len(expectedError.Validations) > 0 {
 		return &expectedError
 	}

--- a/pkg/cedar/cedareasi/translated_client_test.go
+++ b/pkg/cedar/cedareasi/translated_client_test.go
@@ -39,6 +39,8 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 		ProcessStatus:           null.StringFrom("Just an idea"),
 		EASupportRequest:        null.BoolFrom(false),
 		ExistingContract:        null.StringFrom("No"),
+		CostIncrease:            null.StringFrom("NO"),
+		CostIncreaseAmount:      null.StringFrom(""),
 		UpdatedAt:               &clockTime,
 		SubmittedAt:             &clockTime,
 		AlfabetID:               null.String{},

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -48,6 +48,8 @@ type SystemIntake struct {
 	ProcessStatus           null.String        `json:"processStatus" db:"process_status"`
 	EASupportRequest        null.Bool          `json:"eaSupportRequest" db:"ea_support_request"`
 	ExistingContract        null.String        `json:"existingContract" db:"existing_contract"`
+	CostIncrease            null.String        `json:"costIncrease" db:"cost_increase"`
+	CostIncreaseAmount      null.String        `json:"costIncreaseAmount" db:"cost_increase_amount"`
 	CreatedAt               *time.Time         `json:"createdAt" db:"created_at"`
 	UpdatedAt               *time.Time         `json:"updatedAt" db:"updated_at"`
 	SubmittedAt             *time.Time         `json:"submittedAt" db:"submitted_at"`

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -20,7 +20,7 @@ func (s *Store) CreateSystemIntake(ctx context.Context, intake *models.SystemInt
 	createAt := s.clock.Now()
 	intake.CreatedAt = &createAt
 	intake.UpdatedAt = &createAt
-	const createIntakeSQL = `	
+	const createIntakeSQL = `
 		INSERT INTO system_intake (
 			id,
 			eua_user_id,
@@ -43,9 +43,11 @@ func (s *Store) CreateSystemIntake(ctx context.Context, intake *models.SystemInt
 			process_status,
 			ea_support_request,
 			existing_contract,
+			cost_increase,
+			cost_increase_amount,
 			created_at,
 			updated_at
-		) 
+		)
 		VALUES (
 			:id,
 			:eua_user_id,
@@ -68,6 +70,8 @@ func (s *Store) CreateSystemIntake(ctx context.Context, intake *models.SystemInt
 			:process_status,
 			:ea_support_request,
 			:existing_contract,
+			:cost_increase,
+			:cost_increase_amount,
 		    :created_at,
 		    :updated_at
 		)`
@@ -89,7 +93,7 @@ func (s *Store) CreateSystemIntake(ctx context.Context, intake *models.SystemInt
 func (s *Store) UpdateSystemIntake(ctx context.Context, intake *models.SystemIntake) (*models.SystemIntake, error) {
 	// We are explicitly not updating ID, EUAUserID and SystemIntakeID
 	const updateSystemIntakeSQL = `
-		UPDATE system_intake 
+		UPDATE system_intake
 		SET
 		    status = :status,
 			requester = :requester,
@@ -111,7 +115,9 @@ func (s *Store) UpdateSystemIntake(ctx context.Context, intake *models.SystemInt
 			ea_support_request = :ea_support_request,
 			existing_contract = :existing_contract,
 		    grt_review_email_body = :grt_review_email_body,
-		    requester_email_address = :requester_email_address,
+			requester_email_address = :requester_email_address,
+			cost_increase = :cost_increase,
+			cost_increase_amount = :cost_increase_amount,
 			updated_at = :updated_at,
 			submitted_at = :submitted_at,
 		    decided_at = :decided_at,
@@ -191,8 +197,8 @@ func (s *Store) FetchSystemIntakeMetrics(ctx context.Context, startTime time.Tim
 	}
 	const startedCountSQL = `
 		WITH "started" AS (
-		    SELECT * 
-		    FROM system_intake 
+		    SELECT *
+		    FROM system_intake
 		    WHERE created_at >=  $1
 		      AND created_at < $2
 		)
@@ -213,11 +219,11 @@ func (s *Store) FetchSystemIntakeMetrics(ctx context.Context, startTime time.Tim
 	const fundedCountSQL = `
 		WITH "completed" AS (
 		    SELECT existing_funding
-		    FROM system_intake 
-		    WHERE submitted_at >=  $1 
-		      AND submitted_at < $2    
-		) 
-		SELECT count(*) AS completed_count, 
+		    FROM system_intake
+		    WHERE submitted_at >=  $1
+		      AND submitted_at < $2
+		)
+		SELECT count(*) AS completed_count,
 		       coalesce(sum(CASE WHEN existing_funding IS true THEN 1 ELSE 0 END),0) AS funded_count
 		FROM completed
 	`

--- a/pkg/testhelpers/system_intake.go
+++ b/pkg/testhelpers/system_intake.go
@@ -31,5 +31,7 @@ func NewSystemIntake() models.SystemIntake {
 		ProcessStatus:           null.StringFrom("Just an idea"),
 		EASupportRequest:        null.BoolFrom(false),
 		ExistingContract:        null.StringFrom("Yes"),
+		CostIncrease:            null.StringFrom("NO"),
+		CostIncreaseAmount:      null.StringFrom(""),
 	}
 }

--- a/src/components/SystemIntakeReview/index.tsx
+++ b/src/components/SystemIntakeReview/index.tsx
@@ -7,6 +7,7 @@ import {
   DescriptionList,
   DescriptionTerm
 } from 'components/shared/DescriptionGroup';
+import { yesNoMap } from 'data/common';
 import { SystemIntakeForm } from 'types/systemIntake';
 import convertBoolToYesNo from 'utils/convertBoolToYesNo';
 
@@ -28,6 +29,15 @@ export const SystemIntakeReview = ({ systemIntake }: SystemIntakeReview) => {
       return `${hasIsso}, ${systemIntake.isso.name}`;
     }
     return hasIsso;
+  };
+  const expectedCosts = () => {
+    const {
+      costs: { expectedIncreaseAmount, isExpectingIncrease }
+    } = systemIntake;
+    if (expectedIncreaseAmount) {
+      return `${yesNoMap[isExpectingIncrease]}, ${expectedIncreaseAmount}`;
+    }
+    return yesNoMap[isExpectingIncrease];
   };
   return (
     <div>
@@ -162,6 +172,12 @@ export const SystemIntakeReview = ({ systemIntake }: SystemIntakeReview) => {
           <div>
             <DescriptionTerm term="Does the project have funding?" />
             <DescriptionDefinition definition={fundingDefinition()} />
+          </div>
+        </ReviewRow>
+        <ReviewRow>
+          <div>
+            <DescriptionTerm term="Do you expect costs for this request to increase?" />
+            <DescriptionDefinition definition={expectedCosts()} />
           </div>
         </ReviewRow>
       </DescriptionList>

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -88,7 +88,9 @@ export const prepareSystemIntakeForApi = (systemIntake: SystemIntakeForm) => {
     processStatus: systemIntake.currentStage,
     eaSupportRequest: systemIntake.needsEaSupport,
     existingContract: systemIntake.hasContract,
-    grtReviewEmailBody: systemIntake.grtReviewEmailBody
+    grtReviewEmailBody: systemIntake.grtReviewEmailBody,
+    costIncrease: systemIntake.costs.isExpectingIncrease,
+    costIncreaseAmount: systemIntake.costs.expectedIncreaseAmount
   };
 };
 
@@ -142,8 +144,8 @@ export const prepareSystemIntakeForApp = (
       fundingNumber: systemIntake.fundingSource || ''
     },
     costs: {
-      isExpectingIncrease: systemIntake.expectingCostIncrease || '',
-      expectedIncreaseAmount: systemIntake.expectedIncreaseAmount || ''
+      isExpectingIncrease: systemIntake.costIncrease || '',
+      expectedIncreaseAmount: systemIntake.costIncreaseAmount || ''
     },
     businessNeed: systemIntake.businessNeed || '',
     businessSolution: systemIntake.solution || '',

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -39,6 +39,10 @@ export const initialSystemIntakeForm: SystemIntakeForm = {
     isFunded: null,
     fundingNumber: ''
   },
+  costs: {
+    isExpectingIncrease: '',
+    expectedIncreaseAmount: ''
+  },
   businessNeed: '',
   businessSolution: '',
   currentStage: '',
@@ -136,6 +140,10 @@ export const prepareSystemIntakeForApp = (
           ? null
           : systemIntake.existingFunding,
       fundingNumber: systemIntake.fundingSource || ''
+    },
+    costs: {
+      isExpectingIncrease: systemIntake.expectingCostIncrease || '',
+      expectedIncreaseAmount: systemIntake.expectedIncreaseAmount || ''
     },
     businessNeed: systemIntake.businessNeed || '',
     businessSolution: systemIntake.solution || '',

--- a/src/types/systemIntake.ts
+++ b/src/types/systemIntake.ts
@@ -58,6 +58,10 @@ export type ContractDetailsForm = {
     isFunded: boolean | null;
     fundingNumber: string;
   };
+  costs: {
+    isExpectingIncrease: string;
+    expectedIncreaseAmount: string;
+  };
 };
 
 // Redux store type for a system intake

--- a/src/validations/systemIntakeSchema.ts
+++ b/src/validations/systemIntakeSchema.ts
@@ -91,6 +91,17 @@ const SystemIntakeValidationSchema: any = {
             'Tell us your funding number. This is a six digit number and starts with 00'
           )
       })
+    }),
+    costs: Yup.object().shape({
+      isExpectingIncrease: Yup.string().required(
+        'Tell us whether you are expecting costs for this request to increase'
+      ),
+      expectedIncreaseAmount: Yup.string().when('isExpectingIncrease', {
+        is: 'yes',
+        then: Yup.string().required(
+          'Tell us approximately how much do you expect the cost to increase'
+        )
+      })
     })
   })
 };

--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -13,6 +13,7 @@ import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import { RadioField } from 'components/shared/RadioField';
+import TextAreaField from 'components/shared/TextAreaField';
 import TextField from 'components/shared/TextField';
 import { yesNoMap } from 'data/common';
 import { ContractDetailsForm, SystemIntakeForm } from 'types/systemIntake';
@@ -224,10 +225,12 @@ const ContractDetails = ({
                             {flatErrors['costs.expectedIncreaseAmount']}
                           </FieldErrorMsg>
                           <Field
-                            as={TextField}
+                            as={TextAreaField}
+                            className="system-intake__cost-amount"
                             error={!!flatErrors['costs.expectedIncreaseAmount']}
                             id="IntakeForm-CostsExpectedIncrease"
                             name="costs.expectedIncreaseAmount"
+                            maxLength={100}
                           />
                         </FieldGroup>
                       </div>

--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -14,6 +14,7 @@ import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import { RadioField } from 'components/shared/RadioField';
 import TextField from 'components/shared/TextField';
+import { yesNoMap } from 'data/common';
 import { ContractDetailsForm, SystemIntakeForm } from 'types/systemIntake';
 import flattenErrors from 'utils/flattenErrors';
 import SystemIntakeValidationSchema from 'validations/systemIntakeSchema';
@@ -33,7 +34,8 @@ const ContractDetails = ({
 
   const initialValues: ContractDetailsForm = {
     fundingSource: systemIntake.fundingSource,
-    hasContract: systemIntake.hasContract
+    hasContract: systemIntake.hasContract,
+    costs: systemIntake.costs
   };
 
   return (
@@ -184,6 +186,79 @@ const ContractDetails = ({
                     />
                   </fieldset>
                 </FieldGroup>
+
+                <FieldGroup
+                  scrollElement="conts.isExpectingIncrease"
+                  error={!!flatErrors['costs.isExpectingIncrease']}
+                >
+                  <fieldset className="usa-fieldset margin-top-4">
+                    <legend className="usa-label margin-bottom-1">
+                      Do you expect costs for this request to increase?
+                    </legend>
+                    <HelpText className="margin-bottom-1">
+                      This information helps the team decide on the right
+                      approval process for this request
+                    </HelpText>
+                    <FieldErrorMsg>
+                      {flatErrors['costs.isExpectingIncrease']}
+                    </FieldErrorMsg>
+                    <Field
+                      as={RadioField}
+                      checked={values.costs.isExpectingIncrease === 'YES'}
+                      id="IntakeForm-CostsExpectingIncreaseYes"
+                      name="costs.isExpectingIncrease"
+                      label={yesNoMap.YES}
+                      value="YES"
+                    />
+                    {values.costs.isExpectingIncrease === 'YES' && (
+                      <div className="width-mobile margin-top-neg-2 margin-left-3 margin-bottom-1">
+                        <FieldGroup
+                          scrollElement="costs.expectedIncreaseAmount"
+                          error={!!flatErrors['costs.expectedIncreaseAmount']}
+                        >
+                          <Label htmlFor="IntakeForm-CostsExpectedIncrease">
+                            Approximately how much do you expect the cost to
+                            increase?
+                          </Label>
+                          <FieldErrorMsg>
+                            {flatErrors['costs.expectedIncreaseAmount']}
+                          </FieldErrorMsg>
+                          <Field
+                            as={TextField}
+                            error={!!flatErrors['costs.expectedIncreaseAmount']}
+                            id="IntakeForm-CostsExpectedIncrease"
+                            name="costs.expectedIncreaseAmount"
+                          />
+                        </FieldGroup>
+                      </div>
+                    )}
+                    <Field
+                      as={RadioField}
+                      checked={values.costs.isExpectingIncrease === 'NO'}
+                      id="IntakeForm-CostsExpectingIncreaseNo"
+                      name="costs.isExpectingIncrease"
+                      label={yesNoMap.NO}
+                      value="NO"
+                      onChange={() => {
+                        setFieldValue('costs.isExpectingIncrease', 'NO');
+                        setFieldValue('costs.expectedIncreaseAmount', '');
+                      }}
+                    />
+                    <Field
+                      as={RadioField}
+                      checked={values.costs.isExpectingIncrease === 'NOT_SURE'}
+                      id="IntakeForm-CostsExpectingIncreaseNotSure"
+                      name="costs.isExpectingIncrease"
+                      label={yesNoMap.NOT_SURE}
+                      value="NOT_SURE"
+                      onChange={() => {
+                        setFieldValue('costs.isExpectingIncrease', 'NOT_SURE');
+                        setFieldValue('costs.expectedIncreaseAmount', '');
+                      }}
+                    />
+                  </fieldset>
+                </FieldGroup>
+
                 <Button
                   type="button"
                   outline

--- a/src/views/SystemIntake/index.scss
+++ b/src/views/SystemIntake/index.scss
@@ -3,6 +3,12 @@
     opacity: 0.3;
   }
 
+  &__cost-amount {
+    &.usa-textarea {
+      height: 5em;
+    }
+  }
+
   &__review-row {
     display: grid;
     grid-gap: 1.25rem;


### PR DESCRIPTION
# EASI-833

This PR allows the use to fill out questions about cost increases on the Contract Details page. This includes the questions being added on the frontend as well as API/backend work to save.

Open Question:
This does not include any work with CEDAR. We'll need to work with CEDAR to make sure they can support the additional fields.