### PR TITLE
data layer for lcid

### DIFF
--- a/migrations/V25__Add_System_Intake_Lifecycle_Fields.sql
+++ b/migrations/V25__Add_System_Intake_Lifecycle_Fields.sql
@@ -1,0 +1,8 @@
+ALTER TABLE system_intake ADD COLUMN lcid text;
+ALTER TABLE system_intake
+  ADD CONSTRAINT lcid_check CHECK (lcid ~ '^[0-9]{6}$');
+CREATE INDEX lcid_idx ON system_intake (lcid) WHERE LENGTH(lcid)>0;
+
+ALTER TABLE system_intake ADD COLUMN expires_at timestamp with time zone;
+ALTER TABLE system_intake ADD COLUMN lifecycle_scope text;
+ALTER TABLE system_intake ADD COLUMN next_steps text;

--- a/migrations/V25__Add_System_Intake_Lifecycle_Fields.sql
+++ b/migrations/V25__Add_System_Intake_Lifecycle_Fields.sql
@@ -3,6 +3,6 @@ ALTER TABLE system_intake
   ADD CONSTRAINT lcid_check CHECK (lcid ~ '^[0-9]{6}$');
 CREATE INDEX lcid_idx ON system_intake (lcid) WHERE LENGTH(lcid)>0;
 
-ALTER TABLE system_intake ADD COLUMN expires_at timestamp with time zone;
-ALTER TABLE system_intake ADD COLUMN lifecycle_scope text;
-ALTER TABLE system_intake ADD COLUMN next_steps text;
+ALTER TABLE system_intake ADD COLUMN lcid_expires_at timestamp with time zone;
+ALTER TABLE system_intake ADD COLUMN lcid_scope text;
+ALTER TABLE system_intake ADD COLUMN lcid_next_steps text;

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -60,9 +60,9 @@ type SystemIntake struct {
 	RequesterEmailAddress   null.String        `json:"requesterEmailAddress" db:"requester_email_address"`
 	BusinessCaseID          *uuid.UUID         `json:"businessCase"`
 	LifecycleID             null.String        `json:"lcid" db:"lcid"`
-	ExpiresAt               *time.Time         `json:"expiresAt" db:"expires_at"`
-	LifecycleScope          null.String        `json:"lifecycleScope" db:"lifecycle_scope"`
-	NextSteps               null.String        `json:"nextSteps" db:"next_steps"`
+	LifecycleExpiresAt      *time.Time         `json:"lcidExpiresAt" db:"lcid_expires_at"`
+	LifecycleScope          null.String        `json:"lcidScope" db:"lcid_scope"`
+	LifecycleNextSteps      null.String        `json:"lcidNextSteps" db:"lcid_next_steps"`
 }
 
 // SystemIntakes is a list of System Intakes

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -59,6 +59,10 @@ type SystemIntake struct {
 	GrtReviewEmailBody      null.String        `json:"grtReviewEmailBody" db:"grt_review_email_body"`
 	RequesterEmailAddress   null.String        `json:"requesterEmailAddress" db:"requester_email_address"`
 	BusinessCaseID          *uuid.UUID         `json:"businessCase"`
+	LifecycleID             null.String        `json:"lcid" db:"lcid"`
+	ExpiresAt               *time.Time         `json:"expiresAt" db:"expires_at"`
+	LifecycleScope          null.String        `json:"lifecycleScope" db:"lifecycle_scope"`
+	NextSteps               null.String        `json:"nextSteps" db:"next_steps"`
 }
 
 // SystemIntakes is a list of System Intakes

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -124,9 +124,9 @@ func (s *Store) UpdateSystemIntake(ctx context.Context, intake *models.SystemInt
 		    archived_at = :archived_at,
 			alfabet_id = :alfabet_id,
 			lcid = :lcid,
-			expires_at = :expires_at,
-			lifecycle_scope = :lifecycle_scope,
-			next_steps = :next_steps
+			lcid_expires_at = :lcid_expires_at,
+			lcid_scope = :lcid_scope,
+			lcid_next_steps = :lcid_next_steps
 		WHERE system_intake.id = :id
 	`
 	_, err := s.DB.NamedExec(

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -122,7 +122,11 @@ func (s *Store) UpdateSystemIntake(ctx context.Context, intake *models.SystemInt
 			submitted_at = :submitted_at,
 		    decided_at = :decided_at,
 		    archived_at = :archived_at,
-			alfabet_id = :alfabet_id
+			alfabet_id = :alfabet_id,
+			lcid = :lcid,
+			expires_at = :expires_at,
+			lifecycle_scope = :lifecycle_scope,
+			next_steps = :next_steps
 		WHERE system_intake.id = :id
 	`
 	_, err := s.DB.NamedExec(

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -140,10 +140,10 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 			Requester: "Test requester",
 
 			// These fields should NOT be written during a create
-			LifecycleID:    null.StringFrom("ABCDEF"),
-			ExpiresAt:      &now,
-			LifecycleScope: null.StringFrom("ABCDEF"),
-			NextSteps:      null.StringFrom("ABCDEF"),
+			LifecycleID:        null.StringFrom("ABCDEF"),
+			LifecycleExpiresAt: &now,
+			LifecycleScope:     null.StringFrom("ABCDEF"),
+			LifecycleNextSteps: null.StringFrom("ABCDEF"),
 		}
 		_, err := s.store.CreateSystemIntake(ctx, &originalIntake)
 		s.NoError(err)
@@ -151,18 +151,18 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		partial, err := s.store.FetchSystemIntakeByID(ctx, originalIntake.ID)
 		s.NoError(err)
 		s.Empty(partial.LifecycleID)
-		s.Empty(partial.ExpiresAt)
+		s.Empty(partial.LifecycleExpiresAt)
 		s.Empty(partial.LifecycleScope)
-		s.Empty(partial.NextSteps)
+		s.Empty(partial.LifecycleNextSteps)
 
 		// Update
 		lcid := "200110" // first LCID issued on 2020-01-11
 		content1 := "ABC"
 		content2 := "XYZ"
 		partial.LifecycleID = null.StringFrom(lcid)
-		partial.ExpiresAt = &now
+		partial.LifecycleExpiresAt = &now
 		partial.LifecycleScope = null.StringFrom(content1)
-		partial.NextSteps = null.StringFrom(content2)
+		partial.LifecycleNextSteps = null.StringFrom(content2)
 
 		_, err = s.store.UpdateSystemIntake(ctx, partial)
 		s.NoError(err, "failed to update system intake")
@@ -171,9 +171,9 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		s.NoError(err)
 
 		s.Equal(lcid, updated.LifecycleID.String)
-		s.NotEmpty(updated.ExpiresAt)
+		s.NotEmpty(updated.LifecycleExpiresAt)
 		s.Equal(content1, updated.LifecycleScope.String)
-		s.Equal(content2, updated.NextSteps.String)
+		s.Equal(content2, updated.LifecycleNextSteps.String)
 	})
 
 	s.Run("LifecycleID format", func() {

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -131,6 +131,76 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 
 		s.Equal(originalEUA, updated.EUAUserID)
 	})
+
+	s.Run("Lifecycle fields only upon update", func() {
+		now := time.Now()
+		originalIntake := models.SystemIntake{
+			EUAUserID: testhelpers.RandomEUAID(),
+			Status:    models.SystemIntakeStatusDRAFT,
+			Requester: "Test requester",
+
+			// These fields should NOT be written during a create
+			LifecycleID:    null.StringFrom("ABCDEF"),
+			ExpiresAt:      &now,
+			LifecycleScope: null.StringFrom("ABCDEF"),
+			NextSteps:      null.StringFrom("ABCDEF"),
+		}
+		_, err := s.store.CreateSystemIntake(ctx, &originalIntake)
+		s.NoError(err)
+
+		partial, err := s.store.FetchSystemIntakeByID(ctx, originalIntake.ID)
+		s.NoError(err)
+		s.Empty(partial.LifecycleID)
+		s.Empty(partial.ExpiresAt)
+		s.Empty(partial.LifecycleScope)
+		s.Empty(partial.NextSteps)
+
+		// Update
+		lcid := "200110" // first LCID issued on 2020-01-11
+		content1 := "ABC"
+		content2 := "XYZ"
+		partial.LifecycleID = null.StringFrom(lcid)
+		partial.ExpiresAt = &now
+		partial.LifecycleScope = null.StringFrom(content1)
+		partial.NextSteps = null.StringFrom(content2)
+
+		_, err = s.store.UpdateSystemIntake(ctx, partial)
+		s.NoError(err, "failed to update system intake")
+
+		updated, err := s.store.FetchSystemIntakeByID(ctx, originalIntake.ID)
+		s.NoError(err)
+
+		s.Equal(lcid, updated.LifecycleID.String)
+		s.NotEmpty(updated.ExpiresAt)
+		s.Equal(content1, updated.LifecycleScope.String)
+		s.Equal(content2, updated.NextSteps.String)
+	})
+
+	s.Run("LifecycleID format", func() {
+		originalIntake := models.SystemIntake{
+			EUAUserID: testhelpers.RandomEUAID(),
+			Status:    models.SystemIntakeStatusDRAFT,
+			Requester: "Test requester",
+		}
+
+		_, err := s.store.CreateSystemIntake(ctx, &originalIntake)
+		s.NoError(err)
+
+		partial, err := s.store.FetchSystemIntakeByID(ctx, originalIntake.ID)
+		s.NoError(err)
+
+		fails := []string{
+			"20001",   // short
+			"2000110", // long
+			"20001A",  // non-numeric
+		}
+
+		for _, fail := range fails {
+			partial.LifecycleID = null.StringFrom(fail)
+			_, err = s.store.UpdateSystemIntake(ctx, partial)
+			s.Error(err, "expected lcid format error")
+		}
+	})
 }
 
 func (s StoreTestSuite) TestFetchSystemIntakeByID() {


### PR DESCRIPTION
# EASI-782

Changes proposed in this pull request:

- Added 4 new fields to the `SystemIntake`
- Modified the data layer to write these new fields to the database on `Update...`
- DID NOT add these fields to the `Create...` method, as it is my understanding that these fields are not relevant at the beginning of a `SystemIntake` life span
