### PR TITLE
Opinionated proposal

### DIFF
--- a/pkg/storage/business_case.go
+++ b/pkg/storage/business_case.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 
@@ -46,7 +47,7 @@ func (s *Store) FetchBusinessCaseByID(ctx context.Context, id uuid.UUID) (*model
 			fmt.Sprintf("Failed to fetch business case %s", err),
 			zap.String("id", id.String()),
 		)
-		if err.Error() == "sql: no rows in result set" {
+		if errors.Is(err, sql.ErrNoRows) {
 			return &models.BusinessCase{}, &apperrors.ResourceNotFoundError{Err: err, Resource: models.BusinessCase{}}
 		}
 		return &models.BusinessCase{}, err
@@ -67,7 +68,7 @@ func (s *Store) FetchBusinessCaseIDByIntakeID(ctx context.Context, intakeID uuid
 
 	err := s.DB.Get(&businessCaseID, fetchBusinessCaseIDSQL, intakeID)
 	if err != nil {
-		if err.Error() == "sql: no rows in result set" {
+		if errors.Is(err, sql.ErrNoRows) {
 			return businessCaseID, nil
 		}
 

--- a/pkg/storage/business_case_test.go
+++ b/pkg/storage/business_case_test.go
@@ -109,8 +109,11 @@ func (s StoreTestSuite) TestFetchBusinessCasesByEuaID() {
 
 		intake2 := testhelpers.NewSystemIntake()
 		intake2.EUAUserID = intake.EUAUserID
-		intake2.Status = models.SystemIntakeStatusARCHIVED
+		intake2.Status = models.SystemIntakeStatusDRAFT
 		_, err = s.store.CreateSystemIntake(ctx, &intake2)
+		s.NoError(err)
+		intake2.Status = models.SystemIntakeStatusARCHIVED
+		_, err = s.store.UpdateSystemIntake(ctx, &intake2)
 		s.NoError(err)
 
 		businessCase := testhelpers.NewBusinessCase()

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -141,6 +141,7 @@ func (s *Store) UpdateSystemIntake(ctx context.Context, intake *models.SystemInt
 			zap.String("id", intake.ID.String()),
 			zap.String("user", intake.EUAUserID),
 		)
+		return nil, err
 	}
 	// the SystemIntake may have been updated to Archived, so we want to use
 	// the un-filtered fetch to return the saved object

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -103,7 +103,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 
 		updated, err := s.store.UpdateSystemIntake(ctx, intake)
 		s.NoError(err, "failed to update system intake")
-		s.Equal(intake, updated)
+		s.Equal(intake.ISSO, updated.ISSO)
 	})
 
 	s.Run("EUA ID will not update", func() {
@@ -228,7 +228,7 @@ func (s StoreTestSuite) TestFetchSystemIntakeByID() {
 
 		s.Error(err)
 		s.IsType(&apperrors.ResourceNotFoundError{}, err)
-		s.Equal(&models.SystemIntake{}, fetched)
+		s.Nil(fetched)
 	})
 
 	s.Run("fetches biz case id if exists and intake is past draft status", func() {
@@ -267,7 +267,7 @@ func (s StoreTestSuite) TestFetchSystemIntakeByID() {
 
 		s.Error(err)
 		s.IsType(&apperrors.ResourceNotFoundError{}, err)
-		s.Equal(&models.SystemIntake{}, fetched)
+		s.Nil(fetched)
 	})
 }
 


### PR DESCRIPTION
# EASI-782

Changes proposed in this pull request:

- Ensure we return the actual DB copy of the `SystemIntake` after a `Create...` or `Update...` operation; very subtle bugs, even in test code, are possible if you don't do a full round-trip to the DB to verify what was actually written
- Use modern idiomatic Go `errors.Is(...)` rather than relying on strings to identify errors from the SQL layer
- Decompose filtering "ARCHIVED" `SystemIntakes`; this is probably the most "controversial" assertion I'm making here; generally I feel the data layer should be fully empowered to get any/all entities, and it is up to the business logic layer to explicitly declare what statuses are of interest for any given operation (though the data layer can of course provide helpers, but they should be intentionally invoked).
