### PR TITLE
Add envrc.local variable for ease of testing LDAP

### DIFF
--- a/pkg/local/authorization.go
+++ b/pkg/local/authorization.go
@@ -9,20 +9,24 @@ import (
 	"github.com/cmsgov/easi-app/pkg/authn"
 )
 
-// If you're developing interfaces with LDAP, you may need to change this to your own EUA ID for testing purposes
-const testEUAID = "ABCD"
+// If you're developing interfaces with LDAP, you may need to set the LOCAL_TEST_EUAID variable to your a valid EUAID (such as your own)
+const defaultTestEUAID = "ABCD"
 
-func authorizeMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
+func authorizeMiddleware(logger *zap.Logger, next http.Handler, testEUAID string) http.Handler {
+	euaID := defaultTestEUAID
+	if testEUAID != "" {
+		euaID = testEUAID
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.Info("Using local authorization middleware and populating EUA ID")
-		ctx := appcontext.WithPrincipal(r.Context(), &authn.EUAPrincipal{EUAID: testEUAID, JobCodeEASi: true})
+		ctx := appcontext.WithPrincipal(r.Context(), &authn.EUAPrincipal{EUAID: euaID, JobCodeEASi: true})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
 // NewLocalAuthorizeMiddleware stubs out context info while ignoring remote authorization
-func NewLocalAuthorizeMiddleware(logger *zap.Logger) func(http.Handler) http.Handler {
+func NewLocalAuthorizeMiddleware(logger *zap.Logger, testEUAID string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		return authorizeMiddleware(logger, next)
+		return authorizeMiddleware(logger, next, testEUAID)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -60,7 +60,7 @@ func NewServer(config *viper.Viper) *Server {
 
 	// If we're local use override with local auth middleware
 	if environment.Local() {
-		authMiddleware = local.NewLocalAuthorizeMiddleware(zapLogger)
+		authMiddleware = local.NewLocalAuthorizeMiddleware(zapLogger, config.GetString("LOCAL_TEST_EUAID"))
 	}
 
 	// set up server dependencies


### PR DESCRIPTION
Currently, when you want to test something that interacts with the LDAP API (reviewing a system intake, e.g.), you need to change the testEUAID variable in local authorization to an ID that actually exists in CEDAR. This PR adds a new envrc.local variable where you can store a working EUAID (presumably your own) for ease of testing. 