### PR TITLE
Use updated ECS manager lambdas

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,12 +338,12 @@ jobs:
       - run:
           name: Run migrations
           command: |
-            ./scripts/deploy_service "easi-app-db-migrate" "4" "easi-db-migrate"
-            ./scripts/db_lambda_invoke "prod-ecs-manager" "4" "easi-app-db-migrate"
+            ./scripts/deploy_service "easi-app-db-migrate" "5" "easi-db-migrate"
+            ./scripts/db_lambda_invoke "prod-ecs-manager" "5" "easi-app-db-migrate"
       - run:
           name: Deploy ECS service
           command: |
-            ./scripts/deploy_service "easi-app" "4" "easi-backend"
+            ./scripts/deploy_service "easi-app" "5" "easi-backend"
             ./scripts/healthcheck
       - run:
           name: Build static assets and release to S3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,12 +256,12 @@ jobs:
       - run:
           name: Run migrations
           command: |
-            ./scripts/deploy_service "easi-app-db-migrate" "16" "easi-db-migrate"
-            ./scripts/db_lambda_invoke "dev-ecs-manager" "16" "easi-app-db-migrate"
+            ./scripts/deploy_service "easi-app-db-migrate" "17" "easi-db-migrate"
+            ./scripts/db_lambda_invoke "dev-ecs-manager" "17" "easi-app-db-migrate"
       - run:
           name: Deploy ECS service
           command: |
-            ./scripts/deploy_service "easi-app" "16" "easi-backend"
+            ./scripts/deploy_service "easi-app" "17" "easi-backend"
             ./scripts/healthcheck
       - run:
           name: Build static assets and release to S3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,12 +297,12 @@ jobs:
       - run:
           name: Run migrations
           command: |
-            ./scripts/deploy_service "easi-app-db-migrate" "4" "easi-db-migrate"
-            ./scripts/db_lambda_invoke "impl-ecs-manager" "4" "easi-app-db-migrate"
+            ./scripts/deploy_service "easi-app-db-migrate" "5" "easi-db-migrate"
+            ./scripts/db_lambda_invoke "impl-ecs-manager" "5" "easi-app-db-migrate"
       - run:
           name: Deploy ECS service
           command: |
-            ./scripts/deploy_service "easi-app" "4" "easi-backend"
+            ./scripts/deploy_service "easi-app" "5" "easi-backend"
             ./scripts/healthcheck
       - run:
           name: Build static assets and release to S3


### PR DESCRIPTION
# EASI-933

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Update the versions of the ECS manager lambda used to deploy backend changes to the deployed environments

This change is needed to address an issue caused by a recent update to boto3 that broke deployments of the ECS service.
