### PR TITLE
svc layer for lcid assignment

### DIFF
--- a/pkg/services/auth.go
+++ b/pkg/services/auth.go
@@ -1,0 +1,22 @@
+package services
+
+import (
+	"context"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+)
+
+// NewAuthorizeRequireGRTJobCode returns a function
+// that authorizes a user as being a member of the
+// GRT (Governance Review Team)
+func NewAuthorizeRequireGRTJobCode() func(context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
+		logger := appcontext.ZLogger(ctx)
+		principal := appcontext.Principal(ctx)
+		if !principal.AllowGRT() {
+			logger.Info("not a member of the GRT")
+			return false, nil
+		}
+		return true, nil
+	}
+}

--- a/pkg/services/auth_test.go
+++ b/pkg/services/auth_test.go
@@ -1,0 +1,40 @@
+package services
+
+import (
+	"context"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/authn"
+)
+
+func (s ServicesTestSuite) TestAuthorizeRequireGRTJobCode() {
+	fnAuth := NewAuthorizeRequireGRTJobCode()
+	nonGRT := authn.EUAPrincipal{EUAID: "FAKE", JobCodeEASi: true, JobCodeGRT: false}
+	yesGRT := authn.EUAPrincipal{EUAID: "FAKE", JobCodeEASi: true, JobCodeGRT: true}
+
+	testCases := map[string]struct {
+		ctx     context.Context
+		allowed bool
+	}{
+		"anonymous": {
+			ctx:     context.Background(),
+			allowed: false,
+		},
+		"non grt": {
+			ctx:     appcontext.WithPrincipal(context.Background(), &nonGRT),
+			allowed: false,
+		},
+		"has grt": {
+			ctx:     appcontext.WithPrincipal(context.Background(), &yesGRT),
+			allowed: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		s.Run(name, func() {
+			ok, err := fnAuth(tc.ctx)
+			s.NoError(err)
+			s.Equal(tc.allowed, ok)
+		})
+	}
+}

--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -349,26 +349,11 @@ func NewFetchSystemIntakeByID(
 	}
 }
 
-// NewAuthorizeRequireGRTJobCode returns a function
-// that authorizes a user as being a member of the
-// GRT (Governance Review Team)
-func NewAuthorizeRequireGRTJobCode() func(context.Context, *models.SystemIntake) (bool, error) {
-	return func(ctx context.Context, intake *models.SystemIntake) (bool, error) {
-		logger := appcontext.ZLogger(ctx)
-		principal := appcontext.Principal(ctx)
-		if !principal.AllowGRT() {
-			logger.Error("not a member of the GRT")
-			return false, nil
-		}
-		return true, nil
-	}
-}
-
 // NewUpdateLifecycleFields provides a way to update several of the fields
 // associated with assigning a LifecycleID
 func NewUpdateLifecycleFields(
 	config Config,
-	authorize func(context.Context, *models.SystemIntake) (bool, error),
+	authorize func(context.Context) (bool, error),
 	fetch func(c context.Context, id uuid.UUID) (*models.SystemIntake, error),
 	update func(context.Context, *models.SystemIntake) (*models.SystemIntake, error),
 	generateLCID func(context.Context) (string, error),
@@ -383,7 +368,7 @@ func NewUpdateLifecycleFields(
 			}
 		}
 
-		ok, err := authorize(ctx, existing)
+		ok, err := authorize(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -513,38 +513,6 @@ func (s ServicesTestSuite) TestSystemIntakeArchiver() {
 	})
 }
 
-func (s ServicesTestSuite) TestAuthorizeRequireGRTJobCode() {
-	fnAuth := NewAuthorizeRequireGRTJobCode()
-	nonGRT := authn.EUAPrincipal{EUAID: "FAKE", JobCodeEASi: true, JobCodeGRT: false}
-	yesGRT := authn.EUAPrincipal{EUAID: "FAKE", JobCodeEASi: true, JobCodeGRT: true}
-
-	testCases := map[string]struct {
-		ctx     context.Context
-		allowed bool
-	}{
-		"anonymous": {
-			ctx:     context.Background(),
-			allowed: false,
-		},
-		"non grt": {
-			ctx:     appcontext.WithPrincipal(context.Background(), &nonGRT),
-			allowed: false,
-		},
-		"has grt": {
-			ctx:     appcontext.WithPrincipal(context.Background(), &yesGRT),
-			allowed: true,
-		},
-	}
-
-	for name, tc := range testCases {
-		s.Run(name, func() {
-			ok, err := fnAuth(tc.ctx, nil)
-			s.NoError(err)
-			s.Equal(tc.allowed, ok)
-		})
-	}
-}
-
 func (s ServicesTestSuite) TestUpdateLifecycleFields() {
 	today := time.Now()
 	input := &models.SystemIntake{
@@ -555,7 +523,7 @@ func (s ServicesTestSuite) TestUpdateLifecycleFields() {
 		LifecycleScope:     null.StringFrom(fmt.Sprintf("scope %s", today)),
 	}
 
-	fnAuthorize := func(context.Context, *models.SystemIntake) (bool, error) { return true, nil }
+	fnAuthorize := func(context.Context) (bool, error) { return true, nil }
 	fnFetch := func(c context.Context, id uuid.UUID) (*models.SystemIntake, error) {
 		return &models.SystemIntake{ID: id}, nil
 	}
@@ -592,8 +560,8 @@ func (s ServicesTestSuite) TestUpdateLifecycleFields() {
 	})
 
 	// build the error-generating pieces
-	fnAuthorizeErr := func(context.Context, *models.SystemIntake) (bool, error) { return false, errors.New("auth error") }
-	fnAuthorizeFail := func(context.Context, *models.SystemIntake) (bool, error) { return false, nil }
+	fnAuthorizeErr := func(context.Context) (bool, error) { return false, errors.New("auth error") }
+	fnAuthorizeFail := func(context.Context) (bool, error) { return false, nil }
 	fnFetchErr := func(c context.Context, id uuid.UUID) (*models.SystemIntake, error) {
 		return nil, errors.New("fetch error")
 	}

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -3,6 +3,10 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
+
+	"github.com/guregu/null"
 
 	"github.com/facebookgo/clock"
 	"github.com/google/uuid"
@@ -507,5 +511,122 @@ func (s ServicesTestSuite) TestSystemIntakeArchiver() {
 		err := archiveSystemIntake(ctx, fakeID)
 		s.IsType(&apperrors.QueryError{}, err)
 	})
+}
 
+func (s ServicesTestSuite) TestAuthorizeRequireGRTJobCode() {
+	fnAuth := NewAuthorizeRequireGRTJobCode()
+	nonGRT := authn.EUAPrincipal{EUAID: "FAKE", JobCodeEASi: true, JobCodeGRT: false}
+	yesGRT := authn.EUAPrincipal{EUAID: "FAKE", JobCodeEASi: true, JobCodeGRT: true}
+
+	testCases := map[string]struct {
+		ctx     context.Context
+		allowed bool
+	}{
+		"anonymous": {
+			ctx:     context.Background(),
+			allowed: false,
+		},
+		"non grt": {
+			ctx:     appcontext.WithPrincipal(context.Background(), &nonGRT),
+			allowed: false,
+		},
+		"has grt": {
+			ctx:     appcontext.WithPrincipal(context.Background(), &yesGRT),
+			allowed: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		s.Run(name, func() {
+			ok, err := fnAuth(tc.ctx, nil)
+			s.NoError(err)
+			s.Equal(tc.allowed, ok)
+		})
+	}
+}
+
+func (s ServicesTestSuite) TestUpdateLifecycleFields() {
+	today := time.Now()
+	input := &models.SystemIntake{
+		ID:                 uuid.New(),
+		LifecycleID:        null.StringFrom("010010"),
+		LifecycleExpiresAt: &today,
+		LifecycleNextSteps: null.StringFrom(fmt.Sprintf("next %s", today)),
+		LifecycleScope:     null.StringFrom(fmt.Sprintf("scope %s", today)),
+	}
+
+	fnAuthorize := func(context.Context, *models.SystemIntake) (bool, error) { return true, nil }
+	fnFetch := func(c context.Context, id uuid.UUID) (*models.SystemIntake, error) {
+		return &models.SystemIntake{ID: id}, nil
+	}
+	fnUpdate := func(c context.Context, i *models.SystemIntake) (*models.SystemIntake, error) {
+		if i.LifecycleID.ValueOrZero() == "" {
+			return nil, errors.New("missing lcid")
+		}
+		if !i.LifecycleExpiresAt.Equal(today) {
+			return nil, errors.New("incorrect date")
+		}
+		if !i.LifecycleNextSteps.Equal(input.LifecycleNextSteps) {
+			return nil, errors.New("incorrect next")
+		}
+		if !i.LifecycleScope.Equal(input.LifecycleScope) {
+			return nil, errors.New("incorrect scope")
+		}
+		return i, nil
+	}
+	fnGenerate := func(context.Context) (string, error) { return "993659", nil }
+	cfg := Config{clock: clock.NewMock()}
+	happy := NewUpdateLifecycleFields(cfg, fnAuthorize, fnFetch, fnUpdate, fnGenerate)
+
+	s.Run("happy path provided lcid", func() {
+		err := happy(context.Background(), input)
+		s.NoError(err)
+	})
+
+	// from here on out, we always expect the LCID to get generated
+	input.LifecycleID = null.StringFrom("")
+
+	s.Run("happy path generates lcid", func() {
+		err := happy(context.Background(), input)
+		s.NoError(err)
+	})
+
+	// build the error-generating pieces
+	fnAuthorizeErr := func(context.Context, *models.SystemIntake) (bool, error) { return false, errors.New("auth error") }
+	fnAuthorizeFail := func(context.Context, *models.SystemIntake) (bool, error) { return false, nil }
+	fnFetchErr := func(c context.Context, id uuid.UUID) (*models.SystemIntake, error) {
+		return nil, errors.New("fetch error")
+	}
+	fnUpdateErr := func(c context.Context, i *models.SystemIntake) (*models.SystemIntake, error) {
+		return nil, errors.New("update error")
+	}
+	fnGenerateErr := func(context.Context) (string, error) { return "", errors.New("gen error") }
+
+	// build the table-driven test of error cases for unhappy path
+	testCases := map[string]struct {
+		fn func(context.Context, *models.SystemIntake) error
+	}{
+		"error path fetch": {
+			fn: NewUpdateLifecycleFields(cfg, fnAuthorize, fnFetchErr, fnUpdate, fnGenerate),
+		},
+		"error path auth": {
+			fn: NewUpdateLifecycleFields(cfg, fnAuthorizeErr, fnFetch, fnUpdate, fnGenerate),
+		},
+		"error path auth fail": {
+			fn: NewUpdateLifecycleFields(cfg, fnAuthorizeFail, fnFetch, fnUpdate, fnGenerate),
+		},
+		"error path generate": {
+			fn: NewUpdateLifecycleFields(cfg, fnAuthorize, fnFetch, fnUpdate, fnGenerateErr),
+		},
+		"error path update": {
+			fn: NewUpdateLifecycleFields(cfg, fnAuthorize, fnFetch, fnUpdateErr, fnGenerate),
+		},
+	}
+
+	for expectedErr, tc := range testCases {
+		s.Run(expectedErr, func() {
+			err := tc.fn(context.Background(), input)
+			s.Error(err)
+		})
+	}
 }


### PR DESCRIPTION
# EASI-782

Changes proposed in this pull request:

- Accept, lightly verify, and store `lifecycleID` related information in the service/biz-logic layer
