### PR TITLE
Update lambda versions in ecs restart jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
           name: Restart ECS app service
           command: |
-            ./scripts/deploy_service "easi-app" "4" ""
+            ./scripts/deploy_service "easi-app" "5" ""
 
   restart_prod_ecs_app_service:
     docker:
@@ -48,7 +48,7 @@ jobs:
       - run:
           name: Restart ECS app service
           command: |
-            ./scripts/deploy_service "easi-app" "4" ""
+            ./scripts/deploy_service "easi-app" "5" ""
 
   build_db_migrate_image:
     docker:


### PR DESCRIPTION
# EASI-933

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Update the lambda versions in the ECS restart jobs

This change was inadvertently left out of https://github.com/CMSgov/easi-app/pull/427