### PR TITLE
Add request repository reducer

### DIFF
--- a/src/reducers/requestRepoReducer.test.ts
+++ b/src/reducers/requestRepoReducer.test.ts
@@ -1,0 +1,171 @@
+import { initialSystemIntakeForm } from 'data/systemIntake';
+import { fetchRequestRepoIntakes } from 'types/routines';
+
+import requestRepoReducer from './requestRepoReducer';
+
+describe('The request repository reducer', () => {
+  const mockApiSystemIntake = {
+    id: '',
+    status: 'DRAFT',
+    requester: '',
+    component: '',
+    businessOwner: '',
+    businessOwnerComponent: '',
+    productManager: '',
+    productManagerComponent: '',
+    isso: '',
+    trbCollaborator: '',
+    oitSecurityCollaborator: '',
+    eaCollaborator: '',
+    projectName: '',
+    existingFunding: null,
+    fundingSource: '',
+    businessNeed: '',
+    solution: '',
+    processStatus: '',
+    eaSupportRequest: null,
+    existingContract: ''
+  };
+
+  it('returns the initial state', () => {
+    expect(
+      requestRepoReducer(undefined, { type: '', payload: undefined })
+    ).toEqual({
+      openIntakes: [],
+      closedIntakes: [],
+      isLoading: null,
+      error: null
+    });
+  });
+
+  describe('fetchRequestRepoIntakes', () => {
+    it('handles fetchRequestRepoIntakes.REQUEST', () => {
+      const mockRequestAction = {
+        type: fetchRequestRepoIntakes.REQUEST,
+        payload: undefined
+      };
+
+      expect(requestRepoReducer(undefined, mockRequestAction)).toEqual({
+        openIntakes: [],
+        closedIntakes: [],
+        isLoading: true,
+        error: null
+      });
+    });
+
+    it('handles fetchRequestRepoIntakes.SUCCESS', () => {
+      const mockSuccessAction = {
+        type: fetchRequestRepoIntakes.SUCCESS,
+        payload: [
+          {
+            ...mockApiSystemIntake,
+            projectName: 'Test 1',
+            status: 'INTAKE_DRAFT'
+          },
+          {
+            ...mockApiSystemIntake,
+            projectName: 'Test 2',
+            status: 'READY_FOR_GRT'
+          },
+          {
+            ...mockApiSystemIntake,
+            projectName: 'Test 3',
+            status: 'LCID_ISSUED'
+          },
+          {
+            ...mockApiSystemIntake,
+            projectName: 'Test 4',
+            status: 'WITHDRAWN'
+          }
+        ]
+      };
+
+      expect(
+        requestRepoReducer(
+          {
+            openIntakes: [],
+            closedIntakes: [],
+            isLoading: true,
+            error: null
+          },
+          mockSuccessAction
+        )
+      ).toEqual({
+        openIntakes: [
+          {
+            ...initialSystemIntakeForm,
+            requestName: 'Test 1',
+            status: 'INTAKE_DRAFT'
+          },
+          {
+            ...initialSystemIntakeForm,
+            requestName: 'Test 2',
+            status: 'READY_FOR_GRT'
+          }
+        ],
+        closedIntakes: [
+          {
+            ...initialSystemIntakeForm,
+            requestName: 'Test 3',
+            status: 'LCID_ISSUED'
+          },
+          {
+            ...initialSystemIntakeForm,
+            requestName: 'Test 4',
+            status: 'WITHDRAWN'
+          }
+        ],
+        isLoading: true,
+        error: null
+      });
+    });
+
+    it('handles fetchRequestRepoIntakes.FAILURE', () => {
+      const mockFailureAction = {
+        type: fetchRequestRepoIntakes.FAILURE,
+        payload: 'Error'
+      };
+
+      expect(
+        requestRepoReducer(
+          {
+            openIntakes: [],
+            closedIntakes: [],
+            isLoading: true,
+            error: null
+          },
+          mockFailureAction
+        )
+      ).toEqual({
+        openIntakes: [],
+        closedIntakes: [],
+        isLoading: true,
+        error: 'Error'
+      });
+    });
+
+    it('handles fetchRequestRepoIntakes.FULFILL', () => {
+      const mockFulfillAction = {
+        type: fetchRequestRepoIntakes.FULFILL,
+        payload: undefined
+      };
+
+      expect(
+        requestRepoReducer(
+          {
+            openIntakes: [],
+            closedIntakes: [],
+            isLoading: true,
+            error: null
+          },
+          mockFulfillAction
+        )
+      ).toEqual({
+        openIntakes: [],
+        closedIntakes: [],
+        isLoading: false,
+        error: null
+      });
+    });
+  });
+});

--- a/src/reducers/requestRepoReducer.ts
+++ b/src/reducers/requestRepoReducer.ts
@@ -1,0 +1,66 @@
+import { Action } from 'redux-actions';
+
+import { prepareSystemIntakeForApp } from 'data/systemIntake';
+import { fetchRequestRepoIntakes } from 'types/routines';
+import { SystemIntakeForm } from 'types/systemIntake';
+import { isIntakeClosed, isIntakeOpen } from 'utils/systemIntake';
+
+type RequestRepoState = {
+  openIntakes: SystemIntakeForm[];
+  closedIntakes: SystemIntakeForm[];
+  isLoading: boolean | null;
+  error: string | null;
+};
+
+const initialState: RequestRepoState = {
+  openIntakes: [],
+  closedIntakes: [],
+  isLoading: null,
+  error: null
+};
+
+function requestRepoReducer(
+  state = initialState,
+  action: Action<any>
+): RequestRepoState {
+  switch (action.type) {
+    case fetchRequestRepoIntakes.REQUEST:
+      return {
+        ...state,
+        isLoading: true
+      };
+    case fetchRequestRepoIntakes.SUCCESS: {
+      const openIntakes: SystemIntakeForm[] = [];
+      const closedIntakes: SystemIntakeForm[] = [];
+      action.payload.forEach((intake: any) => {
+        if (isIntakeOpen(intake.status)) {
+          openIntakes.push(prepareSystemIntakeForApp(intake));
+        } else if (isIntakeClosed(intake.status)) {
+          closedIntakes.push(prepareSystemIntakeForApp(intake));
+        } else {
+          console.warn(`Intake ${intake.projectName} has an invalid status.`);
+        }
+      });
+
+      return {
+        ...state,
+        openIntakes,
+        closedIntakes
+      };
+    }
+    case fetchRequestRepoIntakes.FAILURE:
+      return {
+        ...state,
+        error: action.payload
+      };
+    case fetchRequestRepoIntakes.FULFILL:
+      return {
+        ...state,
+        isLoading: false
+      };
+    default:
+      return state;
+  }
+}
+
+export default requestRepoReducer;

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -6,6 +6,7 @@ import systemIntakesReducer from 'reducers/systemIntakesReducer';
 import authReducer from './authReducer';
 import businessCaseReducer from './businessCaseReducer';
 import businessCasesReducer from './businessCasesReducer';
+import requestRepoReducer from './requestRepoReducer';
 import systemIntakeReducer from './systemIntakeReducer';
 import systemsReducer from './systemsReducer';
 
@@ -16,7 +17,8 @@ const rootReducer = combineReducers({
   businessCase: businessCaseReducer,
   businessCases: businessCasesReducer,
   action: actionReducer,
-  auth: authReducer
+  auth: authReducer,
+  requestRepository: requestRepoReducer
 });
 
 export default rootReducer;

--- a/src/sagas/requestRepositorySaga.ts
+++ b/src/sagas/requestRepositorySaga.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import { call, put, takeLatest } from 'redux-saga/effects';
+
+import { updateLastActiveAt } from 'reducers/authReducer';
+import { fetchRequestRepoIntakes } from 'types/routines';
+
+function fetchRequestRepos() {
+  // TODO: Need to get correct endpoint
+  return axios.get(`${process.env.REACT_APP_API_ADDRESS}/grt/intakes`);
+}
+function* getRequestRepoIntakes() {
+  try {
+    yield put(fetchRequestRepoIntakes.request());
+    const response = yield call(fetchRequestRepos);
+    yield put(fetchRequestRepoIntakes.success(response.data));
+    yield put(updateLastActiveAt);
+  } catch (error) {
+    yield put(fetchRequestRepoIntakes.failure(error.message));
+  } finally {
+    yield put(fetchRequestRepoIntakes.fulfill());
+  }
+}
+
+export default function* requestRepositorySaga() {
+  yield takeLatest(fetchRequestRepoIntakes.TRIGGER, getRequestRepoIntakes);
+}

--- a/src/sagas/rootSaga.ts
+++ b/src/sagas/rootSaga.ts
@@ -3,6 +3,7 @@ import { all } from 'redux-saga/effects';
 import actionSaga from 'sagas/actionSaga';
 import businessCaseSaga from 'sagas/businessCaseSaga';
 import businessCasesSaga from 'sagas/businessCasesSaga';
+import requestRepositorySaga from 'sagas/requestRepositorySaga';
 import searchSaga from 'sagas/searchSaga';
 import systemIntakeSaga from 'sagas/systemIntakeSaga';
 import systemIntakesSaga from 'sagas/systemIntakesSaga';
@@ -14,6 +15,7 @@ export default function* rootSaga() {
     systemIntakeSaga(),
     businessCaseSaga(),
     businessCasesSaga(),
-    actionSaga()
+    actionSaga(),
+    requestRepositorySaga()
   ]);
 }

--- a/src/types/routines.ts
+++ b/src/types/routines.ts
@@ -26,6 +26,11 @@ export const storeBusinessCase = createRoutine('STORE_BUSINESS_CASE');
 export const submitBusinessCase = createRoutine('SUBMIT_BUSINESS_CASE');
 export const clearBusinessCase = createRoutine('CLEAR_BUSINESS_CASE');
 
+// Request Repository
+export const fetchRequestRepoIntakes = createRoutine(
+  'FETCH_REQUEST_REPO_INTAKES'
+);
+
 // Action routines
 export const postSystemIntakeAction = createRoutine<Action>(
   'POST_SYSTEM_INTAKE_ACTION'


### PR DESCRIPTION
# EASI-805

Before we can generate a CSV of requests that populate in the table for reviewers to download, we need to be able to request that data and store it on the front end. In this PR, I added all the necessary boilerplate to be able to request and store that data on the client. 

Once get endpoint is created for reviewers, I will be able to add it to https://github.com/CMSgov/easi-app/blob/4819d9a96087676eb82334a0a0fdbcdb09d8eaa6/src/sagas/requestRepositorySaga.ts#L9