### PR TITLE
Configure Docker authentication for image pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ jobs:
   restart_impl_ecs_app_service:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           AWS_DEFAULT_REGION: us-west-2
           APP_ENV: impl
@@ -31,6 +34,9 @@ jobs:
   restart_prod_ecs_app_service:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           AWS_DEFAULT_REGION: us-west-2
           APP_ENV: prod
@@ -53,6 +59,9 @@ jobs:
   build_db_migrate_image:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           AWS_DEFAULT_REGION: us-west-2
     steps:
@@ -71,6 +80,9 @@ jobs:
   test:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           APP_ENV: test
           AWS_REGION: us-west-2 # easi app tests expect AWS_REGION instead of AWS_DEFAULT_REGION
@@ -87,6 +99,9 @@ jobs:
           PGSSLMODE: disable
           FLAG_SOURCE: LOCAL
       - image: *postgres
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           POSTGRES_DB: postgres
           POSTGRES_PASSWORD: easirox
@@ -120,6 +135,9 @@ jobs:
   integration_tests:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           APP_ENV: test
           AWS_DEFAULT_REGION: us-west-2
@@ -164,6 +182,9 @@ jobs:
   pre_deps:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - restore_cache:
@@ -202,6 +223,9 @@ jobs:
   lint:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - restore_cache:
@@ -244,6 +268,9 @@ jobs:
   client_test:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           REACT_APP_API_ADDRESS: http://localhost:8080/api/v1
           REACT_APP_APP_ENV: test
@@ -283,6 +310,9 @@ jobs:
   build_db_clean_image:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           AWS_DEFAULT_REGION: us-west-2
     steps:
@@ -301,6 +331,9 @@ jobs:
   build_tag_push:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           AWS_DEFAULT_REGION: us-west-2
     steps:
@@ -323,6 +356,9 @@ jobs:
   deploy_dev:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           AWS_DEFAULT_REGION: us-west-2
           APP_ENV: dev
@@ -378,6 +414,9 @@ jobs:
   deploy_impl:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           AWS_DEFAULT_REGION: us-west-2
           APP_ENV: impl
@@ -433,6 +472,9 @@ jobs:
   deploy_prod:
     docker:
       - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           AWS_DEFAULT_REGION: us-west-2
           APP_ENV: prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,10 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
+          name: Docker Hub login
+          command: |
+            ./scripts/dockerhub-login
+      - run:
           name: Build the flyway migrations for testing
           command: |
             ./scripts/build_db_image "Dockerfile.db_migrations" "easi-db-migrate"
@@ -155,6 +159,10 @@ jobs:
       - run:
           name: Install dependencies
           command: yarn install
+      - run:
+          name: Docker Hub login
+          command: |
+            ./scripts/dockerhub-login
       - run:
           name: Run Cypress integration tests
           command: |
@@ -319,6 +327,10 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
+          name: Docker Hub login
+          command: |
+            ./scripts/dockerhub-login
+      - run:
           name: Build the db cleaner image and push to ECR
           command: |
             ./scripts/build_db_image "Dockerfile.db_clean" "easi-db-clean" "latest"
@@ -339,6 +351,10 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - run:
+          name: Docker Hub login
+          command: |
+            ./scripts/dockerhub-login
       - run:
           name: Build the app and push to ECR
           command: |

--- a/scripts/dockerhub-login
+++ b/scripts/dockerhub-login
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if (set +x -o nounset; echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin); then
+  :
+else
+  echo "Login failed"
+  exit 1
+fi


### PR DESCRIPTION
# EASI-907

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add Docker authentication where CI pulls images from Docker Hub

Starting November 1, 2020, Docker Hub will impose rate limits based on the originating IP.

See the following links for additional information:
* https://circleci.com/docs/2.0/private-images/
* https://discuss.circleci.com/t/updated-authenticate-with-docker-to-avoid-impact-of-nov-1st-rate-limits/37567

This PR adds the `auth:` configuration to `docker` executors that pull images from Docker Hub. It also adds a separate Docker login step to jobs that use `setup_remote_docker` and pull images from Docker Hub in their steps (for example, if a job has a step that builds a Docker image and the `FROM` command references an image from Docker Hub). The remote docker environment doesn't inherit that `auth` setting (there's a comment to that effect in the CircleCI discussion above and I've also confirmed it in separate testing).
