### PR TITLE
lcid transport layer

### DIFF
--- a/pkg/handlers/system_intakes_test.go
+++ b/pkg/handlers/system_intakes_test.go
@@ -3,9 +3,13 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
 
 	"golang.org/x/net/context"
 
@@ -50,4 +54,105 @@ func (s HandlerTestSuite) TestSystemIntakesHandler() {
 		s.NoError(err)
 		s.Equal("Something went wrong", responseErr.Message)
 	})
+}
+
+func (s HandlerTestSuite) TestLCIDHandler() {
+
+	testCases := map[string]struct {
+		verb     string
+		intakeID string
+		body     string
+		status   int
+	}{
+		"happy path assign": {
+			verb:     "POST",
+			intakeID: uuid.New().String(),
+			body: `{
+				"lcid": "123456",
+				"lcidExpiresAt": "2021-09-10",
+				"lcidNextSteps": "fuhgeddaboutit",
+				"lcidScope": "telescope"
+			}`,
+			status: http.StatusNoContent,
+		},
+		"happy path generate": {
+			verb:     "POST",
+			intakeID: uuid.New().String(),
+			body: `{
+				"lcidExpiresAt": "2021-09-10",
+				"lcidNextSteps": "fuhgeddaboutit",
+				"lcidScope": "telescope"
+			}`,
+			status: http.StatusNoContent,
+		},
+		"write error": {
+			verb:     "POST",
+			intakeID: uuid.Nil.String(),
+			body: `{
+				"lcidExpiresAt": "2021-09-10",
+				"lcidNextSteps": "fuhgeddaboutit",
+				"lcidScope": "telescope"
+			}`,
+			status: http.StatusInternalServerError,
+		},
+		"missing scope": {
+			verb:     "POST",
+			intakeID: uuid.New().String(),
+			body: `{
+				"lcidExpiresAt": "2021-09-10",
+				"lcidNextSteps": "fuhgeddaboutit"
+			}`,
+			status: http.StatusUnprocessableEntity,
+		},
+		"missing next steps": {
+			verb:     "POST",
+			intakeID: uuid.New().String(),
+			body: `{
+				"lcidExpiresAt": "2021-09-10",
+				"lcidScope": "telescope"
+			}`,
+			status: http.StatusUnprocessableEntity,
+		},
+		"missing expires": {
+			verb:     "POST",
+			intakeID: uuid.New().String(),
+			body: `{
+				"lcidNextSteps": "fuhgeddaboutit",
+				"lcidScope": "telescope"
+			}`,
+			status: http.StatusUnprocessableEntity,
+		},
+		"cannot parse date": {
+			verb:     "POST",
+			intakeID: uuid.New().String(),
+			body: `{
+				"lcidExpiresAt": "ooga-wakka",
+				"lcidNextSteps": "fuhgeddaboutit",
+				"lcidScope": "telescope"
+			}`,
+			status: http.StatusUnprocessableEntity,
+		},
+	}
+
+	fnLCID := func(c context.Context, i *models.SystemIntake) error {
+		if i.ID == uuid.Nil {
+			return errors.New("forced error")
+		}
+		return nil
+	}
+	var handler http.Handler = NewSystemIntakeLifecycleIDHandler(s.base, fnLCID).Handle()
+
+	for name, tc := range testCases {
+		s.Run(name, func() {
+			rr := httptest.NewRecorder()
+			req, err := http.NewRequest(tc.verb, "/system_intake/{intake_id}/lcid", bytes.NewBufferString(tc.body))
+			s.NoError(err)
+			req = mux.SetURLVars(req, map[string]string{
+				"intake_id": tc.intakeID,
+			})
+			handler.ServeHTTP(rr, req)
+
+			s.Equal(tc.status, rr.Code)
+		})
+	}
 }

--- a/pkg/local/authorization.go
+++ b/pkg/local/authorization.go
@@ -19,7 +19,7 @@ func authorizeMiddleware(logger *zap.Logger, next http.Handler, testEUAID string
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.Info("Using local authorization middleware and populating EUA ID")
-		ctx := appcontext.WithPrincipal(r.Context(), &authn.EUAPrincipal{EUAID: euaID, JobCodeEASi: true})
+		ctx := appcontext.WithPrincipal(r.Context(), &authn.EUAPrincipal{EUAID: euaID, JobCodeEASi: true, JobCodeGRT: true})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -240,6 +240,18 @@ func (s *Server) routes(
 	)
 	api.Handle("/system_intake/{intake_id}/actions/{action_type}", systemIntakeActionHandler.Handle())
 
+	systemIntakeLifecycleIDHandler := handlers.NewSystemIntakeLifecycleIDHandler(
+		base,
+		services.NewUpdateLifecycleFields(
+			serviceConfig,
+			services.NewAuthorizeRequireGRTJobCode(),
+			store.FetchSystemIntakeByID,
+			store.UpdateSystemIntake,
+			store.GenerateLifecycleID,
+		),
+	)
+	api.Handle("/system_intake/{intake_id}/lcid", systemIntakeLifecycleIDHandler.Handle())
+
 	s.router.PathPrefix("/").Handler(handlers.NewCatchAllHandler(
 		base,
 	).Handle())


### PR DESCRIPTION
# EASI-782

Changes proposed in this pull request:

- Create the transport layer translation and associated verifications for assigning a `LifecycleID`
- Wire up a route for using this functionality at `POST /api/v1/system_intake/{intake_id}/lcid`
- For local development, updated the fictional user to have GRT permissions

To test this, I stood up the server and issued the following command (against a SystemIntake that already existed):
```console
$ curl -v -X POST 127.0.0.1:8080/api/v1/system_intake/4d0665d7-83c9-4403-a25e-7c991ea68178/lcid --data-raw '{
                                "lcidExpiresAt": "2021-09-10",
                                "lcidNextSteps": "fuhgeddaboutit",
                                "lcidScope": "telescope"
                        }'
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
> POST /api/v1/system_intake/4d0665d7-83c9-4403-a25e-7c991ea68178/lcid HTTP/1.1
> Host: 127.0.0.1:8080
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Length: 109
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 109 out of 109 bytes
< HTTP/1.1 204 No Content
< Access-Control-Allow-Headers: Accept, Content-Type, Content-Length, Accept-Encoding, Authorization
< Access-Control-Allow-Methods: GET, OPTIONS, PUT, POST, DELETE
< Access-Control-Allow-Origin: http://localhost:3000
< X-Trace-Id: 32b838db-8b50-4eb7-9f17-395442b953e1
< Date: Thu, 22 Oct 2020 15:08:48 GMT
<
* Connection #0 to host 127.0.0.1 left intact
* Closing connection 0
```

To check that I couldn't re-assign an LCID, I ran the same command again and got the appropriate error:
```console
 $ curl -v -X POST 127.0.0.1:8080/api/v1/system_intake/4d0665d7-83c9-4403-a25e-7c991ea68178/lcid --data-raw '{
                                "lcidExpiresAt": "2021-09-10",
                                "lcidNextSteps": "fuhgeddaboutit",
                                "lcidScope": "telescope"
                        }'
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
> POST /api/v1/system_intake/4d0665d7-83c9-4403-a25e-7c991ea68178/lcid HTTP/1.1
> Host: 127.0.0.1:8080
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Length: 109
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 109 out of 109 bytes
< HTTP/1.1 409 Conflict
< Access-Control-Allow-Headers: Accept, Content-Type, Content-Length, Accept-Encoding, Authorization
< Access-Control-Allow-Methods: GET, OPTIONS, PUT, POST, DELETE
< Access-Control-Allow-Origin: http://localhost:3000
< Content-Type: application/json
< X-Trace-Id: 724fa413-3b30-4fac-8a8e-2f3efb41595e
< Date: Thu, 22 Oct 2020 15:09:21 GMT
< Content-Length: 103
<
* Connection #0 to host 127.0.0.1 left intact
{"errors":[],"code":409,"message":"Resource conflict","traceID":"724fa413-3b30-4fac-8a8e-2f3efb41595e"}* Closing connection 0
```