### PR TITLE
Authorizers don't return errors when not necessary

### DIFF
--- a/pkg/services/auth.go
+++ b/pkg/services/auth.go
@@ -24,7 +24,7 @@ func NewAuthorizeUserIsIntakeRequester() func(
 		}
 
 		// If intake is owned by user, authorize
-		if principal.AllowEASi() && principal.ID() == intake.EUAUserID {
+		if principal.ID() == intake.EUAUserID {
 			return true, nil
 		}
 		// Default to failure to authorize and create a quick audit log

--- a/pkg/services/auth.go
+++ b/pkg/services/auth.go
@@ -6,7 +6,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
-	"github.com/cmsgov/easi-app/pkg/apperrors"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -20,11 +19,8 @@ func NewAuthorizeUserIsIntakeRequester() func(
 		logger := appcontext.ZLogger(ctx)
 		principal := appcontext.Principal(ctx)
 		if !principal.AllowEASi() {
-			logger.Error("unable to get EUA ID from context")
-			return false, &apperrors.ContextError{
-				Operation: apperrors.ContextGet,
-				Object:    "EUA ID",
-			}
+			logger.Info("does not have EASi job code")
+			return false, nil
 		}
 
 		// If intake is owned by user, authorize
@@ -46,11 +42,8 @@ func NewAuthorizeHasEASiRole() func(
 		logger := appcontext.ZLogger(ctx)
 		principal := appcontext.Principal(ctx)
 		if !principal.AllowEASi() {
-			logger.Error("unable to get EUA ID from context")
-			return false, &apperrors.ContextError{
-				Operation: apperrors.ContextGet,
-				Object:    "EUA ID",
-			}
+			logger.Error("does not have EASi job code")
+			return false, nil
 		}
 		logger.With(zap.Bool("Authorized", true)).
 			Info("user authorized as EASi user")

--- a/pkg/services/auth_test.go
+++ b/pkg/services/auth_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
-	"github.com/cmsgov/easi-app/pkg/apperrors"
 	"github.com/cmsgov/easi-app/pkg/authn"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
@@ -12,13 +11,14 @@ import (
 func (s ServicesTestSuite) TestAuthorizeUserIsIntakeRequester() {
 	authorizeSaveSystemIntake := NewAuthorizeUserIsIntakeRequester()
 
-	s.Run("No EUA ID fails auth", func() {
+	s.Run("No EASi job code fails auth", func() {
 		ctx := context.Background()
+		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{JobCodeEASi: false})
 
 		ok, err := authorizeSaveSystemIntake(ctx, &models.SystemIntake{})
 
 		s.False(ok)
-		s.IsType(&apperrors.ContextError{}, err)
+		s.NoError(err)
 	})
 
 	s.Run("Mismatched EUA ID fails auth", func() {


### PR DESCRIPTION
<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Change authorizers to not throw an error when the user is unauthorized
