### PR TITLE
Deliver ALL (un-archived) SystemIntakes to GRT members

### DIFF
--- a/pkg/handlers/system_intakes.go
+++ b/pkg/handlers/system_intakes.go
@@ -5,12 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/apperrors"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
-type fetchSystemIntakes func(context.Context, string) (models.SystemIntakes, error)
+type fetchSystemIntakes func(context.Context) (models.SystemIntakes, error)
 
 // NewSystemIntakesHandler is a constructor for SystemIntakesHandler
 func NewSystemIntakesHandler(base HandlerBase, fetch fetchSystemIntakes) SystemIntakesHandler {
@@ -31,16 +30,7 @@ func (h SystemIntakesHandler) Handle() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case "GET":
-			principal := appcontext.Principal(r.Context())
-			if !principal.AllowEASi() {
-				h.WriteErrorResponse(r.Context(), w, &apperrors.ContextError{
-					Operation: apperrors.ContextGet,
-					Object:    "User",
-				})
-				return
-			}
-
-			systemIntakes, err := h.FetchSystemIntakes(r.Context(), principal.ID())
+			systemIntakes, err := h.FetchSystemIntakes(r.Context())
 			if err != nil {
 				h.WriteErrorResponse(r.Context(), w, err)
 				return

--- a/pkg/handlers/system_intakes_test.go
+++ b/pkg/handlers/system_intakes_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func newMockFetchSystemIntakes(systemIntakes models.SystemIntakes, err error) fetchSystemIntakes {
-	return func(context context.Context, euaID string) (models.SystemIntakes, error) {
+	return func(context context.Context) (models.SystemIntakes, error) {
 		return systemIntakes, err
 	}
 }

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -176,10 +176,11 @@ func (s *Server) routes(
 
 	systemIntakesHandler := handlers.NewSystemIntakesHandler(
 		base,
-		services.NewFetchSystemIntakesByEuaID(
+		services.NewFetchSystemIntakes(
 			serviceConfig,
 			store.FetchSystemIntakesByEuaID,
-			services.NewAuthorizeFetchSystemIntakesByEuaID(),
+			store.FetchSystemIntakesNotArchived,
+			services.NewAuthorizeHasEASiRole(),
 		),
 	)
 	api.Handle("/system_intakes", systemIntakesHandler.Handle())

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -228,6 +228,26 @@ func (s *Store) FetchSystemIntakesByEuaID(ctx context.Context, euaID string) (mo
 	return intakes, nil
 }
 
+// FetchSystemIntakesNotArchived queries the DB for all system intakes that are not archived
+func (s *Store) FetchSystemIntakesNotArchived(ctx context.Context) (models.SystemIntakes, error) {
+	intakes := []models.SystemIntake{}
+	err := s.db.Select(&intakes, "SELECT * FROM system_intake WHERE status != 'ARCHIVED'")
+	if err != nil {
+		appcontext.ZLogger(ctx).Error(fmt.Sprintf("Failed to fetch system intakes %s", err))
+		return models.SystemIntakes{}, err
+	}
+	for k, intake := range intakes {
+		if intake.Status != models.SystemIntakeStatusDRAFT {
+			bizCaseID, fetchErr := s.FetchBusinessCaseIDByIntakeID(ctx, intake.ID)
+			if fetchErr != nil {
+				return models.SystemIntakes{}, fetchErr
+			}
+			intakes[k].BusinessCaseID = bizCaseID
+		}
+	}
+	return intakes, nil
+}
+
 func generateLifecyclePrefix(t time.Time, loc *time.Location) string {
 	return t.In(loc).Format("06002")
 }

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -507,6 +507,52 @@ func (s StoreTestSuite) TestFetchSystemIntakesByEuaID() {
 	})
 }
 
+func (s StoreTestSuite) TestFetchSystemIntakesNotArchived() {
+	s.Run("ensure positive and negative cases", func() {
+		ctx := context.Background()
+
+		// seed the db with intakes that we DO expect to be returned
+		expected := map[string]bool{}
+		for ix := 0; ix < 5; ix++ {
+			intake := testhelpers.NewSystemIntake()
+			result, err := s.store.CreateSystemIntake(ctx, &intake)
+			s.NoError(err)
+			expected[result.ID.String()] = false
+		}
+
+		// seed the db with ARCHIVED intakes that should NOT be returned
+		unexpected := map[string]bool{}
+		for ix := 0; ix < 5; ix++ {
+			intake := testhelpers.NewSystemIntake()
+			result, err := s.store.CreateSystemIntake(ctx, &intake)
+			s.NoError(err)
+
+			result.Status = models.SystemIntakeStatusARCHIVED
+			_, err = s.store.UpdateSystemIntake(ctx, result)
+			s.NoError(err)
+
+			unexpected[result.ID.String()] = true
+		}
+
+		intakes, err := s.store.FetchSystemIntakesNotArchived(ctx)
+		s.NoError(err)
+
+		for _, intake := range intakes {
+			id := intake.ID.String()
+			s.T().Logf("intake: %s\n", id)
+			expected[id] = true
+
+			// failure if we got back one of the ARCHIVED intakes
+			s.False(unexpected[id], "unexpected intake", id)
+		}
+
+		// failure if we did not see all the expected seeded not-ARCHIVED intakes
+		for id, found := range expected {
+			s.True(found, "did not receive expected intake", id)
+		}
+	})
+}
+
 func (s StoreTestSuite) TestFetchSystemIntakeMetrics() {
 	ctx := context.Background()
 

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -539,7 +539,6 @@ func (s StoreTestSuite) TestFetchSystemIntakesNotArchived() {
 
 		for _, intake := range intakes {
 			id := intake.ID.String()
-			s.T().Logf("intake: %s\n", id)
 			expected[id] = true
 
 			// failure if we got back one of the ARCHIVED intakes


### PR DESCRIPTION
# EASI-789

Changes proposed in this pull request:

- Created a data-layer accessor for grabbing all (un-archived) `SystemIntakes`
- Moved the decision on whether to deliver ALL or EUA-only `SystemIntakes` to the business logic (`services`) layer
