### PR TITLE
fix minor bug in contract details form inputs

### DIFF
--- a/cypress/integration/taskList.spec.js
+++ b/cypress/integration/taskList.spec.js
@@ -15,7 +15,7 @@ describe('The Task List', () => {
   });
 
   it('shows a continue link when a user clicks back until they reach the task list', () => {
-    cy.contains('a', 'Start').click();
+    cy.get('[data-testid="intake-start-btn"]').click();
 
     cy.systemIntake.contactDetails.fillNonBranchingFields();
     cy.get('#IntakeForm-HasIssoNo')

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -56,6 +56,7 @@ const intakeLinkComponent = (
     case 'START':
       return (
         <UswdsLink
+          data-testid="intake-start-btn"
           className="usa-button"
           variant="unstyled"
           asCustom={Link}

--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -210,6 +210,7 @@ const ContractDetails = ({
                       onChange={() => {
                         setFieldValue('fundingSource.isFunded', false);
                         setFieldValue('fundingSource.fundingNumber', '');
+                        setFieldValue('fundingSource.source', '');
                       }}
                       value={false}
                     />


### PR DESCRIPTION
Currently, the form doesn't clear out the source dropdown if the user toggles there is no funding source. This PR "resets" that dropdown so the data is valid.
