### PR TITLE
Update task list cypress test

### DIFF
--- a/cypress/integration/taskList.spec.js
+++ b/cypress/integration/taskList.spec.js
@@ -15,7 +15,9 @@ describe('The Task List', () => {
   });
 
   it('shows a continue link when a user clicks back until they reach the task list', () => {
-    cy.get('[data-testid="intake-start-btn"]').click();
+    cy.get('[data-testid="intake-start-btn"]')
+      .should('be.visible')
+      .click();
 
     cy.systemIntake.contactDetails.fillNonBranchingFields();
     cy.get('#IntakeForm-HasIssoNo')


### PR DESCRIPTION
We have a flakey cypress integration test for the task list. It's unclear why this test is failing, but it seems to think that the start button is "detaching" from the DOM. I don't know why it's happening considering there aren't any requests to wait for. There doesn't appear to be any updating occurring on the page either.

In order to make sure the button is on screen, I'm adding another expectation before it clicks. The hope is that the test will wait for the button to be on screen, then click.
