### PR TITLE
pass context, not logger

### DIFF
--- a/pkg/cedar/cedarldap/translated_client.go
+++ b/pkg/cedar/cedarldap/translated_client.go
@@ -1,13 +1,15 @@
 package cedarldap
 
 import (
+	"context"
 	"errors"
 	"fmt"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
 
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/apperrors"
 	apiclient "github.com/cmsgov/easi-app/pkg/cedar/cedarldap/gen/client"
@@ -37,12 +39,12 @@ func NewTranslatedClient(cedarHost string, cedarAPIKey string) TranslatedClient 
 }
 
 // FetchUserInfo fetches a user's personal details
-func (c TranslatedClient) FetchUserInfo(logger *zap.Logger, euaID string) (*models2.UserInfo, error) {
+func (c TranslatedClient) FetchUserInfo(ctx context.Context, euaID string) (*models2.UserInfo, error) {
 	params := operations.NewPersonIDParams()
 	params.ID = euaID
 	resp, err := c.client.Operations.PersonID(params, c.apiAuthHeader)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Failed to fetch person from CEDAR LDAP with error: %v", err))
+		appcontext.ZLogger(ctx).Error(fmt.Sprintf("Failed to fetch person from CEDAR LDAP with error: %v", err))
 		return nil, &apperrors.ExternalAPIError{
 			Err:       err,
 			Model:     models.Person{},

--- a/pkg/services/system_intake_action.go
+++ b/pkg/services/system_intake_action.go
@@ -67,7 +67,7 @@ func NewSubmitSystemIntake(
 	update func(context.Context, *models.SystemIntake) (*models.SystemIntake, error),
 	validateAndSubmit func(context.Context, *models.SystemIntake) (string, error),
 	createAction func(context.Context, *models.Action) (*models.Action, error),
-	fetchUserInfo func(*zap.Logger, string) (*models.UserInfo, error),
+	fetchUserInfo func(context.Context, string) (*models.UserInfo, error),
 	emailReviewer func(requester string, intakeID uuid.UUID) error,
 ) func(context.Context, *models.SystemIntake) error {
 	return func(ctx context.Context, intake *models.SystemIntake) error {
@@ -101,7 +101,7 @@ func NewSubmitSystemIntake(
 			return err
 		}
 
-		userInfo, err := fetchUserInfo(appcontext.ZLogger(ctx), appcontext.Principal(ctx).ID())
+		userInfo, err := fetchUserInfo(ctx, appcontext.Principal(ctx).ID())
 		if err != nil {
 			return err
 		}
@@ -173,7 +173,7 @@ func NewGRTReviewSystemIntake(
 	update func(c context.Context, intake *models.SystemIntake) (*models.SystemIntake, error),
 	authorize func(context.Context) (bool, error),
 	createAction func(context.Context, *models.Action) (*models.Action, error),
-	fetchUserInfo func(*zap.Logger, string) (*models.UserInfo, error),
+	fetchUserInfo func(context.Context, string) (*models.UserInfo, error),
 	sendReviewEmail func(emailText string, recipientAddress string) error,
 ) func(context.Context, *models.SystemIntake, *models.Action) error {
 	return func(ctx context.Context, intake *models.SystemIntake, action *models.Action) error {
@@ -194,7 +194,7 @@ func NewGRTReviewSystemIntake(
 			return err
 		}
 
-		requesterInfo, err := fetchUserInfo(appcontext.ZLogger(ctx), intake.EUAUserID)
+		requesterInfo, err := fetchUserInfo(ctx, intake.EUAUserID)
 		if err != nil {
 			return err
 		}
@@ -208,7 +208,7 @@ func NewGRTReviewSystemIntake(
 			}
 		}
 
-		actorInfo, err := fetchUserInfo(appcontext.ZLogger(ctx), appcontext.Principal(ctx).ID())
+		actorInfo, err := fetchUserInfo(ctx, appcontext.Principal(ctx).ID())
 		if err != nil {
 			return err
 		}

--- a/pkg/services/system_intake_action_test.go
+++ b/pkg/services/system_intake_action_test.go
@@ -82,7 +82,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 		createdAction = *action
 		return action, nil
 	}
-	fetchUserInfo := func(logger *zap.Logger, EUAUserID string) (*models.UserInfo, error) {
+	fetchUserInfo := func(_ context.Context, EUAUserID string) (*models.UserInfo, error) {
 		return &models.UserInfo{
 			CommonName: "Name",
 			Email:      "name@site.com",
@@ -149,7 +149,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	s.Run("returns error if fails to fetch user info", func() {
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusDRAFT}
 		fetchUserInfoError := errors.New("error")
-		failFetchUserInfo := func(logger *zap.Logger, EUAUserID string) (*models.UserInfo, error) {
+		failFetchUserInfo := func(_ context.Context, EUAUserID string) (*models.UserInfo, error) {
 			return nil, fetchUserInfoError
 		}
 		submitSystemIntake := NewSubmitSystemIntake(serviceConfig, authorize, update, submit, createAction, failFetchUserInfo, sendSubmitEmail)
@@ -160,7 +160,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 
 	s.Run("returns error if fetches bad user info", func() {
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusDRAFT}
-		failFetchUserInfo := func(logger *zap.Logger, EUAUserID string) (*models.UserInfo, error) {
+		failFetchUserInfo := func(_ context.Context, EUAUserID string) (*models.UserInfo, error) {
 			return &models.UserInfo{}, nil
 		}
 		submitSystemIntake := NewSubmitSystemIntake(serviceConfig, authorize, update, submit, createAction, failFetchUserInfo, sendSubmitEmail)
@@ -253,7 +253,7 @@ func (s ServicesTestSuite) TestNewGRTReviewSystemIntake() {
 	authorize := func(_ context.Context) (bool, error) {
 		return true, nil
 	}
-	fetchUserInfo := func(logger2 *zap.Logger, euaID string) (*models.UserInfo, error) {
+	fetchUserInfo := func(_ context.Context, euaID string) (*models.UserInfo, error) {
 		return &models.UserInfo{
 			Email:      "name@site.com",
 			CommonName: "NAME",
@@ -379,7 +379,7 @@ func (s ServicesTestSuite) TestNewGRTReviewSystemIntake() {
 
 	s.Run("returns error from fetching requester email", func() {
 		ctx := context.Background()
-		failFetchUserInfo := func(logger *zap.Logger, euaID string) (*models.UserInfo, error) {
+		failFetchUserInfo := func(_ context.Context, euaID string) (*models.UserInfo, error) {
 			return nil, &apperrors.ExternalAPIError{
 				Err:       errors.New("sample error"),
 				Model:     models.UserInfo{},
@@ -407,7 +407,7 @@ func (s ServicesTestSuite) TestNewGRTReviewSystemIntake() {
 
 	s.Run("returns ExternalAPIError if requester email not returned", func() {
 		ctx := context.Background()
-		failFetchUserInfo := func(logger *zap.Logger, euaID string) (*models.UserInfo, error) {
+		failFetchUserInfo := func(_ context.Context, euaID string) (*models.UserInfo, error) {
 			return &models.UserInfo{}, nil
 		}
 		reviewSystemIntake := NewGRTReviewSystemIntake(

--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -85,7 +85,7 @@ func NewUpdateSystemIntake(
 	update func(c context.Context, intake *models.SystemIntake) (*models.SystemIntake, error),
 	fetch func(c context.Context, id uuid.UUID) (*models.SystemIntake, error),
 	authorize func(context.Context, *models.SystemIntake) (bool, error),
-	fetchRequesterInfo func(*zap.Logger, string) (*models.UserInfo, error),
+	fetchRequesterInfo func(context.Context, string) (*models.UserInfo, error),
 	sendReviewEmail func(emailText string, recipientAddress string) error,
 	updateDraftIntake func(ctx context.Context, existing *models.SystemIntake, incoming *models.SystemIntake) (*models.SystemIntake, error),
 	canDecideIntake bool,
@@ -118,7 +118,7 @@ func NewUpdateSystemIntake(
 			updatedTime := config.clock.Now()
 			intake.UpdatedAt = &updatedTime
 
-			requesterInfo, err := fetchRequesterInfo(appcontext.ZLogger(ctx), existingIntake.EUAUserID)
+			requesterInfo, err := fetchRequesterInfo(ctx, existingIntake.EUAUserID)
 			if err != nil {
 				return &models.SystemIntake{}, err
 			}

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -156,7 +156,7 @@ func (s ServicesTestSuite) TestNewUpdateSystemIntake() {
 	authorize := func(ctx context.Context, intake *models.SystemIntake) (bool, error) {
 		return true, nil
 	}
-	fetchUserInfo := func(logger2 *zap.Logger, euaID string) (*models.UserInfo, error) {
+	fetchUserInfo := func(_ context.Context, euaID string) (*models.UserInfo, error) {
 		return &models.UserInfo{Email: "name@site.com"}, nil
 	}
 	reviewEmailCount := 0
@@ -241,7 +241,7 @@ func (s ServicesTestSuite) TestNewUpdateSystemIntake() {
 
 	s.Run("returns error from fetching requester email", func() {
 		ctx := context.Background()
-		failFetchEmailAddress := func(logger *zap.Logger, euaID string) (*models.UserInfo, error) {
+		failFetchEmailAddress := func(_ context.Context, euaID string) (*models.UserInfo, error) {
 			return nil, &apperrors.ExternalAPIError{
 				Err:       errors.New("sample error"),
 				Model:     models.UserInfo{},
@@ -261,7 +261,7 @@ func (s ServicesTestSuite) TestNewUpdateSystemIntake() {
 
 	s.Run("returns ExternalAPIError if requester email not returned", func() {
 		ctx := context.Background()
-		failFetchUserInfo := func(logger *zap.Logger, euaID string) (*models.UserInfo, error) {
+		failFetchUserInfo := func(_ context.Context, euaID string) (*models.UserInfo, error) {
 			return &models.UserInfo{}, nil
 		}
 		updateSystemIntake := NewUpdateSystemIntake(serviceConfig, save, fetchSubmitted, authorize, failFetchUserInfo, sendReviewEmail, updateDraftIntake, true)


### PR DESCRIPTION
# EASI-789

Changes proposed in this pull request:

- finish applying the pattern of handing around `context` for handling "cross-cutting concerns" in the CEDAR LDAP wrapper package
