### PR TITLE
add additional status to business case task list item

### DIFF
--- a/src/data/taskList.ts
+++ b/src/data/taskList.ts
@@ -63,8 +63,6 @@ export const bizCaseStatus = (
       case 'APPROVED':
       case 'CLOSED':
         return 'NOT_NEEDED';
-      case 'BIZ_CASE_DRAFT_SUBMITTED':
-        return 'BIZ_CASE_DRAFT_SUBMITTED';
       default:
         return 'CANNOT_START';
     }

--- a/src/data/taskList.ts
+++ b/src/data/taskList.ts
@@ -46,6 +46,16 @@ export const bizCaseStatus = (
   businessCase: BusinessCaseModel
   // eslint-disable-next-line consistent-return
 ) => {
+  // This is for our NEW and CURRENT intake statuses
+  // until all the old ones are deprecated
+  switch (intakeStatus) {
+    case 'BIZ_CASE_DRAFT_SUBMITTED':
+      return 'BIZ_CASE_DRAFT_SUBMITTED';
+    default:
+      break;
+  }
+
+  // START: Delete this when old statuses are deprecated
   if (businessCase === businessCaseInitialData) {
     switch (intakeStatus) {
       case 'ACCEPTED':
@@ -53,6 +63,8 @@ export const bizCaseStatus = (
       case 'APPROVED':
       case 'CLOSED':
         return 'NOT_NEEDED';
+      case 'BIZ_CASE_DRAFT_SUBMITTED':
+        return 'BIZ_CASE_DRAFT_SUBMITTED';
       default:
         return 'CANNOT_START';
     }
@@ -65,21 +77,5 @@ export const bizCaseStatus = (
     default:
       return 'CANNOT_START';
   }
-};
-
-// chooseBusinessCasePath won't return a link if the business case
-// status is NOT_NEEDED or CANNOT_START
-export const chooseBusinessCasePath = (
-  businessCaseStatus: string,
-  bizCaseId?: string
-) => {
-  switch (businessCaseStatus) {
-    case 'START':
-      return '/business/new/general-request-info';
-    case 'CONTINUE':
-    case 'COMPLETED':
-      return `/business/${bizCaseId}/general-request-info`;
-    default:
-      return null;
-  }
+  // END: Delete this when old statuses are deprecated
 };

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -11,7 +11,6 @@ import MainContent from 'components/MainContent';
 import PageWrapper from 'components/PageWrapper';
 import {
   bizCaseStatus,
-  chooseBusinessCasePath,
   chooseIntakePath,
   feedbackStatusFromIntakeStatus,
   intakeStatusFromIntake
@@ -95,15 +94,14 @@ const businessCaseLinkComponent = ({
   businessCaseStatus,
   history
 }: businessCaseLinkComponentProps) => {
-  const path = chooseBusinessCasePath(businessCaseStatus, businessCase.id);
-  // if path is null, there's nothing to render here
-  if (!path) {
-    return null;
-  }
   switch (businessCaseStatus) {
     case 'COMPLETED':
       return (
-        <UswdsLink variant="unstyled" asCustom={Link} to={path}>
+        <UswdsLink
+          variant="unstyled"
+          asCustom={Link}
+          to={`/business/${businessCase.id}/general-request-info`}
+        >
           Update the business case
         </UswdsLink>
       );
@@ -113,7 +111,7 @@ const businessCaseLinkComponent = ({
           type="button"
           onClick={() => {
             history.push({
-              pathname: `/business/new/general-request-info`,
+              pathname: '/business/new/general-request-info',
               state: {
                 systemIntakeId
               }
@@ -131,9 +129,19 @@ const businessCaseLinkComponent = ({
           className="usa-button"
           variant="unstyled"
           asCustom={Link}
-          to={path}
+          to={`/business/${businessCase.id}/general-request-info`}
         >
           Continue
+        </UswdsLink>
+      );
+    case 'BIZ_CASE_DRAFT_SUBMITTED':
+      return (
+        <UswdsLink
+          variant="unstyled"
+          asCustom={Link}
+          to={`/business/${systemIntakeId}/general-request-info`}
+        >
+          View submitted draft business case
         </UswdsLink>
       );
     default:


### PR DESCRIPTION
# EASI-764

I'm looking for feedback on this PR because I am having trouble figuring out how to maintain existing functionality with statuses in both intake and business case while we try to transition all the new statuses onto the intake.

This PR does NOT do any backend work or connect to the new actions API. That will come in another PR.

In order to verify this PR, you need to update the status of an intake to `BIZ_CASE_DRAFT_SUBMITTED`, and view the task list.
