### PR TITLE
Rename DRAFT and SUBMITTED intake statuses

### DIFF
--- a/migrations/V41__Change_Draft_Submitted_Statuses.sql
+++ b/migrations/V41__Change_Draft_Submitted_Statuses.sql
@@ -1,0 +1,2 @@
+ALTER TYPE system_intake_status RENAME VALUE 'DRAFT' to 'INTAKE_DRAFT';
+ALTER TYPE system_intake_status RENAME VALUE 'SUBMITTED' to 'INTAKE_SUBMITTED';

--- a/pkg/appvalidation/business_case.go
+++ b/pkg/appvalidation/business_case.go
@@ -27,7 +27,7 @@ func checkUniqLifecycleCosts(costs models.EstimatedLifecycleCosts) (string, stri
 
 // check the system intake status is submitted
 func checkSystemIntakeSubmitted(intake *models.SystemIntake) (string, string) {
-	if intake.Status == models.SystemIntakeStatusDRAFT {
+	if intake.Status == models.SystemIntakeStatusINTAKEDRAFT {
 		return "SystemIntake", "must have already been submitted"
 	}
 	return "", ""

--- a/pkg/appvalidation/business_case_test.go
+++ b/pkg/appvalidation/business_case_test.go
@@ -45,7 +45,7 @@ func (s AppValidateTestSuite) TestCheckUniqLifecycleCosts() {
 func (s AppValidateTestSuite) TestCheckSystemIntakeSubmitted() {
 	s.Run("returns empty strings when intake is submitted", func() {
 		submittedIntake := testhelpers.NewSystemIntake()
-		submittedIntake.Status = models.SystemIntakeStatusSUBMITTED
+		submittedIntake.Status = models.SystemIntakeStatusINTAKESUBMITTED
 		k, _ := checkSystemIntakeSubmitted(&submittedIntake)
 		s.Equal("", k)
 	})
@@ -61,7 +61,7 @@ func (s AppValidateTestSuite) TestCheckSystemIntakeSubmitted() {
 func (s AppValidateTestSuite) TestBusinessCaseForCreation() {
 	s.Run("golden path", func() {
 		submittedIntake := testhelpers.NewSystemIntake()
-		submittedIntake.Status = models.SystemIntakeStatusSUBMITTED
+		submittedIntake.Status = models.SystemIntakeStatusINTAKESUBMITTED
 		businessCase := models.BusinessCase{
 			SystemIntakeID:     submittedIntake.ID,
 			LifecycleCostLines: nil,

--- a/pkg/cedar/cedareasi/translated_client_test.go
+++ b/pkg/cedar/cedareasi/translated_client_test.go
@@ -20,7 +20,7 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 	intake := models.SystemIntake{
 		ID:                      id,
 		EUAUserID:               "FAKE",
-		Status:                  "SUBMITTED",
+		Status:                  models.SystemIntakeStatusINTAKESUBMITTED,
 		Requester:               "Fake Requester",
 		Component:               null.StringFrom("Fake Component"),
 		BusinessOwner:           null.StringFrom("Fake Business Owner"),

--- a/pkg/handlers/system_intake_test.go
+++ b/pkg/handlers/system_intake_test.go
@@ -105,7 +105,7 @@ func (s HandlerTestSuite) TestSystemIntakeHandler() {
 
 	s.Run("golden path POST passes", func() {
 		body, err := json.Marshal(map[string]string{
-			"status":    "INTAKE_DRAFT",
+			"status":    string(models.SystemIntakeStatusINTAKEDRAFT),
 			"requester": requester,
 		})
 		s.NoError(err)
@@ -126,7 +126,7 @@ func (s HandlerTestSuite) TestSystemIntakeHandler() {
 		badContext := context.Background()
 		rr := httptest.NewRecorder()
 		body, err := json.Marshal(map[string]string{
-			"status":    "INTAKE_DRAFT",
+			"status":    string(models.SystemIntakeStatusINTAKEDRAFT),
 			"requester": requester,
 		})
 		s.NoError(err)
@@ -143,7 +143,7 @@ func (s HandlerTestSuite) TestSystemIntakeHandler() {
 
 	s.Run("POST fails if a validation error is thrown", func() {
 		body, err := json.Marshal(map[string]string{
-			"status":    "INTAKE_DRAFT",
+			"status":    string(models.SystemIntakeStatusINTAKEDRAFT),
 			"requester": requester,
 		})
 		s.NoError(err)
@@ -167,7 +167,7 @@ func (s HandlerTestSuite) TestSystemIntakeHandler() {
 
 	s.Run("POST fails if system intake isn't created", func() {
 		body, err := json.Marshal(map[string]string{
-			"status":    "INTAKE_DRAFT",
+			"status":    string(models.SystemIntakeStatusINTAKEDRAFT),
 			"requester": requester,
 		})
 		s.NoError(err)
@@ -234,7 +234,7 @@ func (s HandlerTestSuite) TestSystemIntakeHandler() {
 		rr := httptest.NewRecorder()
 		body, err := json.Marshal(map[string]string{
 			"id":         id.String(),
-			"status":     "SUBMITTED",
+			"status":     string(models.SystemIntakeStatusINTAKESUBMITTED),
 			"alfabet_id": "123-345-19",
 		})
 		s.NoError(err)
@@ -259,7 +259,7 @@ func (s HandlerTestSuite) TestSystemIntakeHandler() {
 		rr := httptest.NewRecorder()
 		body, err := json.Marshal(map[string]string{
 			"id":     id.String(),
-			"status": "SUBMITTED",
+			"status": string(models.SystemIntakeStatusINTAKESUBMITTED),
 		})
 		s.NoError(err)
 		req, err := http.NewRequestWithContext(requestContext, "PUT", "/system_intake/", bytes.NewBuffer(body))
@@ -283,7 +283,7 @@ func (s HandlerTestSuite) TestSystemIntakeHandler() {
 		rr := httptest.NewRecorder()
 		body, err := json.Marshal(map[string]string{
 			"id":     id.String(),
-			"status": "SUBMITTED",
+			"status": string(models.SystemIntakeStatusINTAKESUBMITTED),
 		})
 		s.NoError(err)
 		req, err := http.NewRequestWithContext(requestContext, "PUT", "/system_intake/", bytes.NewBuffer(body))
@@ -307,7 +307,7 @@ func (s HandlerTestSuite) TestSystemIntakeHandler() {
 		rr := httptest.NewRecorder()
 		body, err := json.Marshal(map[string]string{
 			"id":     id.String(),
-			"status": "SUBMITTED",
+			"status": string(models.SystemIntakeStatusINTAKESUBMITTED),
 		})
 		s.NoError(err)
 		req, err := http.NewRequestWithContext(requestContext, "PUT", "/system_intake/", bytes.NewBuffer(body))

--- a/pkg/handlers/system_intake_test.go
+++ b/pkg/handlers/system_intake_test.go
@@ -105,7 +105,7 @@ func (s HandlerTestSuite) TestSystemIntakeHandler() {
 
 	s.Run("golden path POST passes", func() {
 		body, err := json.Marshal(map[string]string{
-			"status":    "DRAFT",
+			"status":    "INTAKE_DRAFT",
 			"requester": requester,
 		})
 		s.NoError(err)
@@ -126,7 +126,7 @@ func (s HandlerTestSuite) TestSystemIntakeHandler() {
 		badContext := context.Background()
 		rr := httptest.NewRecorder()
 		body, err := json.Marshal(map[string]string{
-			"status":    "DRAFT",
+			"status":    "INTAKE_DRAFT",
 			"requester": requester,
 		})
 		s.NoError(err)
@@ -143,7 +143,7 @@ func (s HandlerTestSuite) TestSystemIntakeHandler() {
 
 	s.Run("POST fails if a validation error is thrown", func() {
 		body, err := json.Marshal(map[string]string{
-			"status":    "DRAFT",
+			"status":    "INTAKE_DRAFT",
 			"requester": requester,
 		})
 		s.NoError(err)
@@ -167,7 +167,7 @@ func (s HandlerTestSuite) TestSystemIntakeHandler() {
 
 	s.Run("POST fails if system intake isn't created", func() {
 		body, err := json.Marshal(map[string]string{
-			"status":    "DRAFT",
+			"status":    "INTAKE_DRAFT",
 			"requester": requester,
 		})
 		s.NoError(err)

--- a/pkg/handlers/system_intake_test.go
+++ b/pkg/handlers/system_intake_test.go
@@ -38,7 +38,7 @@ func newMockCreateSystemIntake(requester string, err error) createSystemIntake {
 		newIntake := models.SystemIntake{
 			ID:        uuid.New(),
 			EUAUserID: "FAKE",
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			Requester: requester,
 		}
 		return &newIntake, err

--- a/pkg/integration/business_case_test.go
+++ b/pkg/integration/business_case_test.go
@@ -25,7 +25,7 @@ func (s IntegrationTestSuite) TestBusinessCaseEndpoints() {
 	businessCaseURL.Path = path.Join(businessCaseURL.Path, "/business_case")
 
 	intake := testhelpers.NewSystemIntake()
-	intake.Status = models.SystemIntakeStatusSUBMITTED
+	intake.Status = models.SystemIntakeStatusINTAKESUBMITTED
 	intake.EUAUserID = s.user.euaID
 
 	createdIntake, err := s.store.CreateSystemIntake(context.Background(), &intake)

--- a/pkg/integration/system_intakes_test.go
+++ b/pkg/integration/system_intakes_test.go
@@ -145,7 +145,7 @@ func (s IntegrationTestSuite) TestSystemIntakeEndpoints() {
 			EASupportRequest:        null.BoolFrom(true),
 			ExistingContract:        null.StringFrom("Test Requester"),
 			UpdatedAt:               &updatedAt,
-			Status:                  models.SystemIntakeStatusSUBMITTED,
+			Status:                  models.SystemIntakeStatusINTAKESUBMITTED,
 		}
 		body, err := json.Marshal(intake)
 		s.NoError(err)

--- a/pkg/integration/system_intakes_test.go
+++ b/pkg/integration/system_intakes_test.go
@@ -25,7 +25,7 @@ func (s IntegrationTestSuite) TestSystemIntakeEndpoints() {
 	systemIntakeURL.Path = path.Join(systemIntakeURL.Path, "/system_intake")
 
 	body, err := json.Marshal(map[string]string{
-		"status":    "INTAKE_DRAFT",
+		"status":    string(models.SystemIntakeStatusINTAKEDRAFT),
 		"requester": "TEST REQUESTER",
 	})
 	s.NoError(err)
@@ -66,7 +66,7 @@ func (s IntegrationTestSuite) TestSystemIntakeEndpoints() {
 		body, err := json.Marshal(map[string]string{
 			"id":        id.String(),
 			"requester": "TEST REQUESTER",
-			"status":    "INTAKE_DRAFT",
+			"status":    string(models.SystemIntakeStatusINTAKEDRAFT),
 		})
 		s.NoError(err)
 		req, err := http.NewRequest(http.MethodPut, systemIntakeURL.String(), bytes.NewBuffer(body))
@@ -103,7 +103,7 @@ func (s IntegrationTestSuite) TestSystemIntakeEndpoints() {
 	s.Run("PUT will succeed second time with with new data", func() {
 		body, err := json.Marshal(map[string]string{
 			"id":        id.String(),
-			"status":    "INTAKE_DRAFT",
+			"status":    string(models.SystemIntakeStatusINTAKEDRAFT),
 			"requester": "Test Requester",
 		})
 		s.NoError(err)
@@ -166,7 +166,7 @@ func (s IntegrationTestSuite) TestSystemIntakeEndpoints() {
 		}
 		body, err := json.Marshal(map[string]string{
 			"id":        id.String(),
-			"status":    "INTAKE_SUBMITTED",
+			"status":    string(models.SystemIntakeStatusINTAKESUBMITTED),
 			"requester": "Test Requester",
 		})
 		s.NoError(err)

--- a/pkg/integration/system_intakes_test.go
+++ b/pkg/integration/system_intakes_test.go
@@ -25,7 +25,7 @@ func (s IntegrationTestSuite) TestSystemIntakeEndpoints() {
 	systemIntakeURL.Path = path.Join(systemIntakeURL.Path, "/system_intake")
 
 	body, err := json.Marshal(map[string]string{
-		"status":    "DRAFT",
+		"status":    "INTAKE_DRAFT",
 		"requester": "TEST REQUESTER",
 	})
 	s.NoError(err)
@@ -66,7 +66,7 @@ func (s IntegrationTestSuite) TestSystemIntakeEndpoints() {
 		body, err := json.Marshal(map[string]string{
 			"id":        id.String(),
 			"requester": "TEST REQUESTER",
-			"status":    "DRAFT",
+			"status":    "INTAKE_DRAFT",
 		})
 		s.NoError(err)
 		req, err := http.NewRequest(http.MethodPut, systemIntakeURL.String(), bytes.NewBuffer(body))
@@ -103,7 +103,7 @@ func (s IntegrationTestSuite) TestSystemIntakeEndpoints() {
 	s.Run("PUT will succeed second time with with new data", func() {
 		body, err := json.Marshal(map[string]string{
 			"id":        id.String(),
-			"status":    "DRAFT",
+			"status":    "INTAKE_DRAFT",
 			"requester": "Test Requester",
 		})
 		s.NoError(err)
@@ -166,7 +166,7 @@ func (s IntegrationTestSuite) TestSystemIntakeEndpoints() {
 		}
 		body, err := json.Marshal(map[string]string{
 			"id":        id.String(),
-			"status":    "SUBMITTED",
+			"status":    "INTAKE_SUBMITTED",
 			"requester": "Test Requester",
 		})
 		s.NoError(err)

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -11,10 +11,10 @@ import (
 type SystemIntakeStatus string
 
 const (
-	// SystemIntakeStatusDRAFT captures enum value "DRAFT"
-	SystemIntakeStatusDRAFT SystemIntakeStatus = "DRAFT"
-	// SystemIntakeStatusSUBMITTED captures enum value "SUBMITTED"
-	SystemIntakeStatusSUBMITTED SystemIntakeStatus = "SUBMITTED"
+	// SystemIntakeStatusINTAKEDRAFT captures enum value "INTAKE_DRAFT"
+	SystemIntakeStatusINTAKEDRAFT SystemIntakeStatus = "INTAKE_DRAFT"
+	// SystemIntakeStatusINTAKESUBMITTED captures enum value "INTAKE_SUBMITTED"
+	SystemIntakeStatusINTAKESUBMITTED SystemIntakeStatus = "INTAKE_SUBMITTED"
 	// SystemIntakeStatusACCEPTED captures enum value "ACCEPTED"
 	SystemIntakeStatusACCEPTED SystemIntakeStatus = "ACCEPTED"
 	// SystemIntakeStatusNEEDBIZCASE captures enum value "NEED_BIZ_CASE"

--- a/pkg/services/business_case_test.go
+++ b/pkg/services/business_case_test.go
@@ -130,7 +130,7 @@ func (s ServicesTestSuite) TestBusinessCaseCreator() {
 	euaID := testhelpers.RandomEUAID()
 	intake := &models.SystemIntake{
 		EUAUserID: euaID,
-		Status:    models.SystemIntakeStatusSUBMITTED,
+		Status:    models.SystemIntakeStatusINTAKESUBMITTED,
 	}
 	intake, err := s.store.CreateSystemIntake(ctx, intake)
 	s.NoError(err)
@@ -258,7 +258,7 @@ func (s ServicesTestSuite) TestBusinessCaseUpdater() {
 	euaID := testhelpers.RandomEUAID()
 	intake := &models.SystemIntake{
 		EUAUserID: euaID,
-		Status:    models.SystemIntakeStatusSUBMITTED,
+		Status:    models.SystemIntakeStatusINTAKESUBMITTED,
 	}
 	_, err := s.store.CreateSystemIntake(ctx, intake)
 	s.NoError(err)

--- a/pkg/services/system_intake_action.go
+++ b/pkg/services/system_intake_action.go
@@ -79,7 +79,7 @@ func NewSubmitSystemIntake(
 			return &apperrors.UnauthorizedError{Err: err}
 		}
 
-		if intake.Status != models.SystemIntakeStatusDRAFT {
+		if intake.Status != models.SystemIntakeStatusINTAKEDRAFT {
 			err := &apperrors.ResourceConflictError{
 				Err:        errors.New("intake is not in DRAFT state"),
 				ResourceID: intake.ID.String(),
@@ -90,7 +90,7 @@ func NewSubmitSystemIntake(
 
 		updatedTime := config.clock.Now()
 		intake.UpdatedAt = &updatedTime
-		intake.Status = models.SystemIntakeStatusSUBMITTED
+		intake.Status = models.SystemIntakeStatusINTAKESUBMITTED
 
 		if intake.AlfabetID.Valid {
 			err := &apperrors.ResourceConflictError{
@@ -185,7 +185,7 @@ func NewGRTReviewSystemIntake(
 			return &apperrors.UnauthorizedError{}
 		}
 
-		if intake.Status != models.SystemIntakeStatusSUBMITTED {
+		if intake.Status != models.SystemIntakeStatusINTAKESUBMITTED {
 			err := &apperrors.ResourceConflictError{
 				Err:        errors.New("intake is not in SUBMITTED state"),
 				ResourceID: intake.ID.String(),

--- a/pkg/services/system_intake_action_test.go
+++ b/pkg/services/system_intake_action_test.go
@@ -125,7 +125,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 		s.Equal(authorizationError, err)
 	})
 
-	s.Run("returns resource conflict error if status is not DRAFT", func() {
+	s.Run("returns resource conflict error if status is not INTAKE_DRAFT", func() {
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKESUBMITTED}
 		submitSystemIntake := NewSubmitSystemIntake(serviceConfig, authorize, update, submit, createAction, fetchUserInfo, sendSubmitEmail)
 

--- a/pkg/services/system_intake_action_test.go
+++ b/pkg/services/system_intake_action_test.go
@@ -99,7 +99,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	}
 
 	s.Run("golden path submit intake", func() {
-		intake := models.SystemIntake{Status: models.SystemIntakeStatusDRAFT}
+		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		submitSystemIntake := NewSubmitSystemIntake(serviceConfig, authorize, update, submit, createAction, fetchUserInfo, sendSubmitEmail)
 		s.Equal(0, submitEmailCount)
 
@@ -114,7 +114,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	})
 
 	s.Run("returns error from authorization if authorization fails", func() {
-		intake := models.SystemIntake{Status: models.SystemIntakeStatusDRAFT}
+		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		authorizationError := errors.New("authorization failed")
 		failAuthorize := func(ctx context.Context, intake *models.SystemIntake) (bool, error) {
 			return false, authorizationError
@@ -126,7 +126,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	})
 
 	s.Run("returns resource conflict error if status is not DRAFT", func() {
-		intake := models.SystemIntake{Status: models.SystemIntakeStatusSUBMITTED}
+		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKESUBMITTED}
 		submitSystemIntake := NewSubmitSystemIntake(serviceConfig, authorize, update, submit, createAction, fetchUserInfo, sendSubmitEmail)
 
 		err := submitSystemIntake(ctx, &intake)
@@ -136,7 +136,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	})
 
 	s.Run("returns unauthorized error if authorization denied", func() {
-		intake := models.SystemIntake{Status: models.SystemIntakeStatusDRAFT}
+		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		unauthorize := func(ctx context.Context, intake *models.SystemIntake) (bool, error) {
 			return false, nil
 		}
@@ -147,7 +147,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	})
 
 	s.Run("returns error if fails to fetch user info", func() {
-		intake := models.SystemIntake{Status: models.SystemIntakeStatusDRAFT}
+		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		fetchUserInfoError := errors.New("error")
 		failFetchUserInfo := func(_ context.Context, EUAUserID string) (*models.UserInfo, error) {
 			return nil, fetchUserInfoError
@@ -159,7 +159,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	})
 
 	s.Run("returns error if fetches bad user info", func() {
-		intake := models.SystemIntake{Status: models.SystemIntakeStatusDRAFT}
+		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		failFetchUserInfo := func(_ context.Context, EUAUserID string) (*models.UserInfo, error) {
 			return &models.UserInfo{}, nil
 		}
@@ -170,7 +170,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	})
 
 	s.Run("returns error if fails to save action", func() {
-		intake := models.SystemIntake{Status: models.SystemIntakeStatusDRAFT}
+		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		failCreateAction := func(ctx context.Context, action *models.Action) (*models.Action, error) {
 			return nil, errors.New("error")
 		}
@@ -181,7 +181,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	})
 
 	s.Run("returns error when validation fails", func() {
-		intake := models.SystemIntake{Status: models.SystemIntakeStatusDRAFT}
+		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		failValidationSubmit := func(_ context.Context, intake *models.SystemIntake) (string, error) {
 			return "", &apperrors.ValidationError{
 				Err:     errors.New("validation failed on these fields: ID"),
@@ -197,7 +197,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	})
 
 	s.Run("returns error when submission fails", func() {
-		intake := models.SystemIntake{Status: models.SystemIntakeStatusDRAFT}
+		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		failValidationSubmit := func(_ context.Context, intake *models.SystemIntake) (string, error) {
 			return "", &apperrors.ExternalAPIError{
 				Err:       errors.New("CEDAR return result: unexpected failure"),
@@ -216,7 +216,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 
 	s.Run("returns error when intake has already been submitted", func() {
 		alreadySubmittedIntake := models.SystemIntake{
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			AlfabetID: null.StringFrom("394-141-0"),
 		}
 		submitSystemIntake := NewSubmitSystemIntake(serviceConfig, authorize, update, submit, createAction, fetchUserInfo, sendSubmitEmail)
@@ -227,7 +227,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 	})
 
 	s.Run("returns query error if update fails", func() {
-		intake := models.SystemIntake{Status: models.SystemIntakeStatusDRAFT}
+		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		failUpdate := func(ctx context.Context, intake *models.SystemIntake) (*models.SystemIntake, error) {
 			return &models.SystemIntake{}, errors.New("update error")
 		}
@@ -284,7 +284,7 @@ func (s ServicesTestSuite) TestNewGRTReviewSystemIntake() {
 			fetchUserInfo,
 			sendReviewEmail,
 		)
-		intake := &models.SystemIntake{Status: models.SystemIntakeStatusSUBMITTED}
+		intake := &models.SystemIntake{Status: models.SystemIntakeStatusINTAKESUBMITTED}
 		action := &models.Action{}
 		err := reviewSystemIntake(ctx, intake, action)
 
@@ -307,7 +307,7 @@ func (s ServicesTestSuite) TestNewGRTReviewSystemIntake() {
 			fetchUserInfo,
 			sendReviewEmail,
 		)
-		intake := &models.SystemIntake{Status: models.SystemIntakeStatusSUBMITTED}
+		intake := &models.SystemIntake{Status: models.SystemIntakeStatusINTAKESUBMITTED}
 		action := &models.Action{}
 		actualError := reviewSystemIntake(ctx, intake, action)
 
@@ -329,7 +329,7 @@ func (s ServicesTestSuite) TestNewGRTReviewSystemIntake() {
 			fetchUserInfo,
 			sendReviewEmail,
 		)
-		intake := &models.SystemIntake{Status: models.SystemIntakeStatusSUBMITTED}
+		intake := &models.SystemIntake{Status: models.SystemIntakeStatusINTAKESUBMITTED}
 		action := &models.Action{}
 		err := reviewSystemIntake(ctx, intake, action)
 
@@ -348,7 +348,7 @@ func (s ServicesTestSuite) TestNewGRTReviewSystemIntake() {
 			fetchUserInfo,
 			sendReviewEmail,
 		)
-		intake := &models.SystemIntake{Status: models.SystemIntakeStatusDRAFT}
+		intake := &models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		action := &models.Action{}
 		err := reviewSystemIntake(ctx, intake, action)
 
@@ -370,7 +370,7 @@ func (s ServicesTestSuite) TestNewGRTReviewSystemIntake() {
 			fetchUserInfo,
 			sendReviewEmail,
 		)
-		intake := &models.SystemIntake{Status: models.SystemIntakeStatusSUBMITTED}
+		intake := &models.SystemIntake{Status: models.SystemIntakeStatusINTAKESUBMITTED}
 		action := &models.Action{}
 		err := reviewSystemIntake(ctx, intake, action)
 
@@ -397,7 +397,7 @@ func (s ServicesTestSuite) TestNewGRTReviewSystemIntake() {
 			failFetchUserInfo,
 			sendReviewEmail,
 		)
-		intake := &models.SystemIntake{Status: models.SystemIntakeStatusSUBMITTED}
+		intake := &models.SystemIntake{Status: models.SystemIntakeStatusINTAKESUBMITTED}
 		action := &models.Action{}
 		err := reviewSystemIntake(ctx, intake, action)
 
@@ -419,7 +419,7 @@ func (s ServicesTestSuite) TestNewGRTReviewSystemIntake() {
 			failFetchUserInfo,
 			sendReviewEmail,
 		)
-		intake := &models.SystemIntake{Status: models.SystemIntakeStatusSUBMITTED}
+		intake := &models.SystemIntake{Status: models.SystemIntakeStatusINTAKESUBMITTED}
 		action := &models.Action{}
 		err := reviewSystemIntake(ctx, intake, action)
 
@@ -444,7 +444,7 @@ func (s ServicesTestSuite) TestNewGRTReviewSystemIntake() {
 			fetchUserInfo,
 			failSendReviewEmail,
 		)
-		intake := &models.SystemIntake{Status: models.SystemIntakeStatusSUBMITTED}
+		intake := &models.SystemIntake{Status: models.SystemIntakeStatusINTAKESUBMITTED}
 		action := &models.Action{}
 		err := reviewSystemIntake(ctx, intake, action)
 

--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -100,9 +100,9 @@ func NewUpdateSystemIntake(
 			}
 		}
 
-		if existingIntake.Status == models.SystemIntakeStatusDRAFT && intake.Status == models.SystemIntakeStatusDRAFT {
+		if existingIntake.Status == models.SystemIntakeStatusINTAKEDRAFT && intake.Status == models.SystemIntakeStatusINTAKEDRAFT {
 			return updateDraftIntake(ctx, existingIntake, intake)
-		} else if existingIntake.Status == models.SystemIntakeStatusSUBMITTED &&
+		} else if existingIntake.Status == models.SystemIntakeStatusINTAKESUBMITTED &&
 			(intake.Status == models.SystemIntakeStatusAPPROVED ||
 				intake.Status == models.SystemIntakeStatusACCEPTED ||
 				intake.Status == models.SystemIntakeStatusCLOSED) && canDecideIntake {

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -104,13 +104,13 @@ func (s ServicesTestSuite) TestNewCreateSystemIntake() {
 			return &models.SystemIntake{
 				EUAUserID: intake.EUAUserID,
 				Requester: requester,
-				Status:    models.SystemIntakeStatusDRAFT,
+				Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			}, nil
 		}
 		createIntake := NewCreateSystemIntake(serviceConfig, create)
 		intake, err := createIntake(ctx, &models.SystemIntake{
 			Requester: requester,
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 		})
 		s.NoError(err)
 		s.Equal(fakeEuaID, intake.EUAUserID)
@@ -123,7 +123,7 @@ func (s ServicesTestSuite) TestNewCreateSystemIntake() {
 		createIntake := NewCreateSystemIntake(serviceConfig, create)
 		intake, err := createIntake(ctx, &models.SystemIntake{
 			Requester: requester,
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 		})
 		s.IsType(&apperrors.QueryError{}, err)
 		s.Equal(&models.SystemIntake{}, intake)
@@ -134,13 +134,13 @@ func (s ServicesTestSuite) TestNewUpdateSystemIntake() {
 	logger := zap.NewNop()
 	fetch := func(ctx context.Context, id uuid.UUID) (*models.SystemIntake, error) {
 		return &models.SystemIntake{
-			Status: models.SystemIntakeStatusDRAFT,
+			Status: models.SystemIntakeStatusINTAKEDRAFT,
 		}, nil
 	}
 
 	fetchSubmitted := func(ctx context.Context, id uuid.UUID) (*models.SystemIntake, error) {
 		return &models.SystemIntake{
-			Status: models.SystemIntakeStatusSUBMITTED,
+			Status: models.SystemIntakeStatusINTAKESUBMITTED,
 		}, nil
 	}
 
@@ -175,7 +175,7 @@ func (s ServicesTestSuite) TestNewUpdateSystemIntake() {
 		updateSystemIntake := NewUpdateSystemIntake(serviceConfig, save, fetch, authorize, fetchUserInfo, sendReviewEmail, updateDraftIntake, true)
 
 		intake, err := updateSystemIntake(ctx, &models.SystemIntake{
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			Requester: requester,
 		})
 
@@ -205,7 +205,7 @@ func (s ServicesTestSuite) TestNewUpdateSystemIntake() {
 		updateSystemIntake := NewUpdateSystemIntake(serviceConfig, save, fetch, authorize, fetchUserInfo, sendReviewEmail, failUpdateDraft, true)
 
 		intake, err := updateSystemIntake(ctx, &models.SystemIntake{
-			Status: models.SystemIntakeStatusDRAFT,
+			Status: models.SystemIntakeStatusINTAKEDRAFT,
 		})
 		s.Equal(updateDraftError, err)
 		s.Equal(&models.SystemIntake{}, intake)
@@ -294,7 +294,7 @@ func (s ServicesTestSuite) TestNewUpdateSystemIntake() {
 		updateSystemIntake := NewUpdateSystemIntake(serviceConfig, save, fetchSubmitted, authorize, fetchUserInfo, sendReviewEmail, updateDraftIntake, true)
 
 		// In this case, saving a DRAFT intake against an existing SUBMITTED intake
-		intake, err := updateSystemIntake(ctx, &models.SystemIntake{Status: models.SystemIntakeStatusDRAFT})
+		intake, err := updateSystemIntake(ctx, &models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT})
 
 		s.IsType(&apperrors.ResourceConflictError{}, err)
 		s.Equal(&models.SystemIntake{}, intake)

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -293,7 +293,7 @@ func (s ServicesTestSuite) TestNewUpdateSystemIntake() {
 		ctx := context.Background()
 		updateSystemIntake := NewUpdateSystemIntake(serviceConfig, save, fetchSubmitted, authorize, fetchUserInfo, sendReviewEmail, updateDraftIntake, true)
 
-		// In this case, saving a DRAFT intake against an existing SUBMITTED intake
+		// In this case, saving a INTAKE_DRAFT intake against an existing SUBMITTED intake
 		intake, err := updateSystemIntake(ctx, &models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT})
 
 		s.IsType(&apperrors.ResourceConflictError{}, err)

--- a/pkg/storage/business_case_test.go
+++ b/pkg/storage/business_case_test.go
@@ -61,13 +61,13 @@ func (s StoreTestSuite) TestFetchBusinessCasesByEuaID() {
 
 	s.Run("golden path to fetch business cases", func() {
 		intake := testhelpers.NewSystemIntake()
-		intake.Status = models.SystemIntakeStatusSUBMITTED
+		intake.Status = models.SystemIntakeStatusINTAKESUBMITTED
 		_, err := s.store.CreateSystemIntake(ctx, &intake)
 		s.NoError(err)
 
 		intake2 := testhelpers.NewSystemIntake()
 		intake2.EUAUserID = intake.EUAUserID
-		intake2.Status = models.SystemIntakeStatusSUBMITTED
+		intake2.Status = models.SystemIntakeStatusINTAKESUBMITTED
 		_, err = s.store.CreateSystemIntake(ctx, &intake2)
 		s.NoError(err)
 
@@ -103,13 +103,13 @@ func (s StoreTestSuite) TestFetchBusinessCasesByEuaID() {
 
 	s.Run("does not fetch archived business case", func() {
 		intake := testhelpers.NewSystemIntake()
-		intake.Status = models.SystemIntakeStatusSUBMITTED
+		intake.Status = models.SystemIntakeStatusINTAKESUBMITTED
 		_, err := s.store.CreateSystemIntake(ctx, &intake)
 		s.NoError(err)
 
 		intake2 := testhelpers.NewSystemIntake()
 		intake2.EUAUserID = intake.EUAUserID
-		intake2.Status = models.SystemIntakeStatusDRAFT
+		intake2.Status = models.SystemIntakeStatusINTAKEDRAFT
 		_, err = s.store.CreateSystemIntake(ctx, &intake2)
 		s.NoError(err)
 		intake2.Status = models.SystemIntakeStatusARCHIVED

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -185,7 +185,7 @@ func (s *Store) FetchSystemIntakeByID(ctx context.Context, id uuid.UUID) (*model
 	}
 	// This should cover all statuses that might have a related business case on it.
 	// In the future submitted will also need to be checked.
-	if intake.Status != models.SystemIntakeStatusDRAFT {
+	if intake.Status != models.SystemIntakeStatusINTAKEDRAFT {
 		bizCaseID, _ := s.FetchBusinessCaseIDByIntakeID(ctx, intake.ID)
 		intake.BusinessCaseID = bizCaseID
 	}
@@ -204,7 +204,7 @@ func (s *Store) FetchSystemIntakesByEuaID(ctx context.Context, euaID string) (mo
 		return models.SystemIntakes{}, err
 	}
 	for k, intake := range intakes {
-		if intake.Status != models.SystemIntakeStatusDRAFT {
+		if intake.Status != models.SystemIntakeStatusINTAKEDRAFT {
 			bizCaseID, fetchErr := s.FetchBusinessCaseIDByIntakeID(ctx, intake.ID)
 			if fetchErr != nil {
 				return models.SystemIntakes{}, fetchErr
@@ -224,7 +224,7 @@ func (s *Store) FetchSystemIntakesNotArchived(ctx context.Context) (models.Syste
 		return models.SystemIntakes{}, err
 	}
 	for k, intake := range intakes {
-		if intake.Status != models.SystemIntakeStatusDRAFT {
+		if intake.Status != models.SystemIntakeStatusINTAKEDRAFT {
 			bizCaseID, fetchErr := s.FetchBusinessCaseIDByIntakeID(ctx, intake.ID)
 			if fetchErr != nil {
 				return models.SystemIntakes{}, fetchErr

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -25,7 +25,7 @@ func (s StoreTestSuite) TestCreateSystemIntake() {
 	s.Run("create a new system intake", func() {
 		intake := models.SystemIntake{
 			EUAUserID: testhelpers.RandomEUAID(),
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			Requester: "Test requester",
 		}
 
@@ -42,7 +42,7 @@ func (s StoreTestSuite) TestCreateSystemIntake() {
 
 	s.Run("cannot save without EUA ID", func() {
 		partialIntake := models.SystemIntake{
-			Status: models.SystemIntakeStatusDRAFT,
+			Status: models.SystemIntakeStatusINTAKEDRAFT,
 		}
 
 		_, err := s.store.CreateSystemIntake(ctx, &partialIntake)
@@ -60,7 +60,7 @@ func (s StoreTestSuite) TestCreateSystemIntake() {
 	for _, tc := range euaTests {
 		s.Run(fmt.Sprintf("cannot save with invalid EUA ID: %s", tc), func() {
 			partialIntake := models.SystemIntake{
-				Status: models.SystemIntakeStatusDRAFT,
+				Status: models.SystemIntakeStatusINTAKEDRAFT,
 			}
 			partialIntake.EUAUserID = tc
 
@@ -92,7 +92,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 	s.Run("update an existing system intake", func() {
 		intake, err := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
 			EUAUserID: testhelpers.RandomEUAID(),
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			Requester: "Test requester",
 		})
 		s.NoError(err)
@@ -109,7 +109,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 	s.Run("EUA ID will not update", func() {
 		originalIntake := models.SystemIntake{
 			EUAUserID: testhelpers.RandomEUAID(),
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			Requester: "Test requester",
 		}
 		_, err := s.store.CreateSystemIntake(ctx, &originalIntake)
@@ -118,7 +118,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		partialIntake := models.SystemIntake{
 			ID:        originalIntake.ID,
 			EUAUserID: testhelpers.RandomEUAID(),
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			Requester: "Test requester",
 		}
 		partialIntake.EUAUserID = "NEWS"
@@ -136,7 +136,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		now := time.Now()
 		originalIntake := models.SystemIntake{
 			EUAUserID: testhelpers.RandomEUAID(),
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			Requester: "Test requester",
 
 			// These fields should NOT be written during a create
@@ -179,7 +179,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 	s.Run("Update contract details information", func() {
 		originalIntake := models.SystemIntake{
 			EUAUserID: testhelpers.RandomEUAID(),
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			Requester: "Test requester",
 
 			ProcessStatus:      null.StringFrom("ABCDEF"),
@@ -242,7 +242,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 	s.Run("LifecycleID format", func() {
 		originalIntake := models.SystemIntake{
 			EUAUserID: testhelpers.RandomEUAID(),
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			Requester: "Test requester",
 		}
 
@@ -269,7 +269,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		for ix := 0; ix < 10; ix++ {
 			original := models.SystemIntake{
 				EUAUserID: testhelpers.RandomEUAID(),
-				Status:    models.SystemIntakeStatusDRAFT,
+				Status:    models.SystemIntakeStatusINTAKEDRAFT,
 				Requester: fmt.Sprintf("LCID Exhaust %d", ix),
 			}
 
@@ -291,7 +291,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		// and this should violate the db constraint of a 6-digit LCID
 		original := models.SystemIntake{
 			EUAUserID: testhelpers.RandomEUAID(),
-			Status:    models.SystemIntakeStatusDRAFT,
+			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			Requester: "LCID Exhaust 10",
 		}
 
@@ -454,7 +454,7 @@ func (s StoreTestSuite) TestFetchSystemIntakesByEuaID() {
 		id := intake.ID
 		intake2.EUAUserID = intake.EUAUserID
 		intake.Status = models.SystemIntakeStatusAPPROVED
-		intake2.Status = models.SystemIntakeStatusSUBMITTED
+		intake2.Status = models.SystemIntakeStatusINTAKESUBMITTED
 
 		bizCase := testhelpers.NewBusinessCase()
 		bizCase.SystemIntakeID = id

--- a/pkg/testhelpers/system_intake.go
+++ b/pkg/testhelpers/system_intake.go
@@ -12,7 +12,7 @@ func NewSystemIntake() models.SystemIntake {
 	return models.SystemIntake{
 		ID:                      uuid.New(),
 		EUAUserID:               RandomEUAID(),
-		Status:                  models.SystemIntakeStatusDRAFT,
+		Status:                  models.SystemIntakeStatusINTAKEDRAFT,
 		Requester:               "Test Requester",
 		Component:               null.StringFrom("Test Component"),
 		BusinessOwner:           null.StringFrom("Test Business Owner"),

--- a/src/data/systemIntake.test.ts
+++ b/src/data/systemIntake.test.ts
@@ -43,7 +43,7 @@ describe('The system intake data modifiers', () => {
         },
         contractStartDate: '',
         contractEndDate: '',
-        status: 'DRAFT',
+        status: 'INTAKE_DRAFT',
         updatedAt: null,
         submittedAt: null,
         createdAt: null,

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -12,7 +12,7 @@ export const initialSystemIntakeForm: SystemIntakeForm = {
   id: '',
   euaUserID: '',
   requestName: '',
-  status: 'DRAFT',
+  status: 'INTAKE_DRAFT',
   requester: {
     name: '',
     component: '',
@@ -137,7 +137,7 @@ export const prepareSystemIntakeForApp = (
     id: systemIntake.id || '',
     euaUserID: systemIntake.euaUserID || '',
     requestName: systemIntake.projectName || '',
-    status: systemIntake.status || 'DRAFT',
+    status: systemIntake.status || 'INTAKE_DRAFT',
     requester: {
       name: systemIntake.requester || '',
       component: systemIntake.component || '',

--- a/src/data/taskList.ts
+++ b/src/data/taskList.ts
@@ -6,7 +6,7 @@ export const intakeStatusFromIntake = (intake: SystemIntakeForm) => {
   if (intake.id === '') {
     return 'START';
   }
-  if (intake.status === 'DRAFT') {
+  if (intake.status === 'INTAKE_DRAFT') {
     return 'CONTINUE';
   }
   return 'COMPLETED';
@@ -30,7 +30,7 @@ export const chooseIntakePath = (intake: SystemIntakeForm, status: string) => {
 
 export const feedbackStatusFromIntakeStatus = (intakeStatus: string) => {
   switch (intakeStatus) {
-    case 'SUBMITTED':
+    case 'INTAKE_SUBMITTED':
       return 'SUBMITTED';
     case 'ACCEPTED':
     case 'APPROVED':

--- a/src/reducers/requestRepoReducer.test.ts
+++ b/src/reducers/requestRepoReducer.test.ts
@@ -6,7 +6,7 @@ import requestRepoReducer from './requestRepoReducer';
 describe('The request repository reducer', () => {
   const mockApiSystemIntake = {
     id: '',
-    status: 'DRAFT',
+    status: 'INTAKE_DRAFT',
     requester: '',
     component: '',
     businessOwner: '',

--- a/src/reducers/systemIntakeReducer.test.ts
+++ b/src/reducers/systemIntakeReducer.test.ts
@@ -14,7 +14,7 @@ import {
 describe('The system intake reducer', () => {
   const mockApiSystemIntake = {
     id: '',
-    status: 'DRAFT',
+    status: 'INTAKE_DRAFT',
     requester: '',
     component: '',
     businessOwner: '',

--- a/src/reducers/systemIntakesReducer.test.ts
+++ b/src/reducers/systemIntakesReducer.test.ts
@@ -28,7 +28,7 @@ describe('The system intakes reducer', () => {
   it('handles fetchSystemIntakes.SUCCESS', () => {
     const mockApiSystemIntake = {
       id: '',
-      status: 'DRAFT',
+      status: 'INTAKE_DRAFT',
       requester: '',
       component: '',
       businessOwner: '',

--- a/src/types/systemIntake.ts
+++ b/src/types/systemIntake.ts
@@ -26,13 +26,7 @@ export const closedIntakeStatuses = [
   'NO_GOVERNANCE'
 ];
 
-export const oldIntakeStatuses = [
-  'DRAFT',
-  'SUBMITTED',
-  'ACCEPTED',
-  'APPROVED',
-  'CLOSED'
-];
+export const oldIntakeStatuses = ['ACCEPTED', 'APPROVED', 'CLOSED'];
 
 export const intakeStatuses = [
   ...openIntakeStatuses,

--- a/src/views/GovernanceReviewTeam/IntakeReview/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/IntakeReview/index.test.tsx
@@ -19,7 +19,7 @@ describe('The GRT intake review view', () => {
   const mockSystemIntake = {
     id: '53d762ea-0bc8-4af0-b24d-0b5844bacea5',
     euaUserID: 'ABCD',
-    status: 'SUBMITTED',
+    status: 'INTAKE_SUBMITTED',
     requester: {
       name: 'Jane Doe',
       component: 'OIT',

--- a/src/views/GrtSystemIntakeReview/index.tsx
+++ b/src/views/GrtSystemIntakeReview/index.tsx
@@ -64,7 +64,7 @@ export const GrtSystemIntakeReview = () => {
           ) && (
             <div className="bg-gray-5 padding-top-6 padding-bottom-5">
               <div className="grid-container">
-                {systemIntake.status === 'SUBMITTED' && (
+                {systemIntake.status === 'INTAKE_SUBMITTED' && (
                   <Formik
                     initialValues={systemIntake}
                     onSubmit={values => {

--- a/src/views/Home/index.test.tsx
+++ b/src/views/Home/index.test.tsx
@@ -86,7 +86,7 @@ describe('The home page', () => {
             {
               ...initialSystemIntakeForm,
               id: '2',
-              status: 'SUBMITTED'
+              status: 'INTAKE_SUBMITTED'
             },
             {
               ...initialSystemIntakeForm,
@@ -95,7 +95,7 @@ describe('The home page', () => {
             {
               ...initialSystemIntakeForm,
               id: '4',
-              status: 'SUBMITTED',
+              status: 'INTAKE_SUBMITTED',
               businessCaseId: '1'
             }
           ]

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -49,7 +49,7 @@ const Home = ({ history }: HomeProps) => {
     const rootPath = flags.taskListLite ? '/governance-task-list' : '/system';
     return systemIntakes.map((intake: SystemIntakeForm) => {
       switch (intake.status) {
-        case 'DRAFT':
+        case 'INTAKE_DRAFT':
           return (
             <ActionBanner
               key={intake.id}
@@ -66,7 +66,7 @@ const Home = ({ history }: HomeProps) => {
               data-intakeid={intake.id}
             />
           );
-        case 'SUBMITTED':
+        case 'INTAKE_SUBMITTED':
           if (intake.businessCaseId !== null) {
             return null;
           }


### PR DESCRIPTION


<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Replaces DRAFT and SUBMITTED with INTAKE_DRAFT and INTAKE_SUBMITTED as intake statuses
