### PR TITLE
add request type form page

### DIFF
--- a/src/components/shared/RadioField/index.tsx
+++ b/src/components/shared/RadioField/index.tsx
@@ -5,6 +5,7 @@ import './index.scss';
 
 type RadioFieldProps = {
   id: string;
+  className?: string;
   inline?: boolean;
   checked?: boolean;
   label: string;
@@ -18,6 +19,7 @@ type RadioFieldProps = {
 export const RadioField = ({
   checked,
   id,
+  className,
   inline,
   label,
   name,
@@ -25,9 +27,13 @@ export const RadioField = ({
   onChange,
   value
 }: RadioFieldProps) => {
-  const radioClasses = classnames('usa-radio', {
-    'easi-radio--inline': inline
-  });
+  const radioClasses = classnames(
+    'usa-radio',
+    {
+      'easi-radio--inline': inline
+    },
+    className
+  );
 
   const radioLabelClasses = classnames('usa-radio__label', {
     'easi-radio__label--inline': inline

--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -40,6 +40,31 @@ const intake = {
     createdAt: 'Created At',
     decidedAt: 'Decided At',
     archivedAt: 'Archived At'
+  },
+  requestTypeForm: {
+    heading: 'Make a System Request',
+    subheading: 'What is this request for?',
+    info:
+      'If you are unsure or do not see an option for your use-case, mark "I\'m not sure" and someone from the Governance Team will assist you',
+    fields: {
+      addNewSystem: 'Add a new system',
+      majorChanges: 'Major changes or upgrades to an existing system',
+      recompete:
+        'Re-compete a contract without any changes to systems or services',
+      shutdown: 'Shutdown a system'
+    },
+    helpAndGuidance: {
+      majorChanges: {
+        label: 'What is a major change?',
+        para: 'A major change could be any of the following:',
+        list: [
+          'Moving a system from a physical data center to the cloud',
+          'Software platform changes',
+          'New system integrations/interconnections',
+          'Changes in Major Function Alignments or the Data Categories a system supports'
+        ]
+      }
+    }
   }
 };
 

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -22,6 +22,7 @@ import PrepareForGRB from 'views/PrepareForGRB';
 import PrepareForGRT from 'views/PrepareForGRT';
 import PrivacyPolicy from 'views/PrivacyPolicy';
 import RequestRepository from 'views/RequestRepository';
+import RequestTypeForm from 'views/RequestTypeForm';
 import Sandbox from 'views/Sandbox';
 import SystemIntake from 'views/SystemIntake';
 import TermsAndConditions from 'views/TermsAndConditions';
@@ -79,6 +80,11 @@ const AppRoutes = () => {
         exact
         path="/governance-task-list/:systemId/prepare-for-grb"
         component={PrepareForGRB}
+      />
+      <SecureRoute
+        exact
+        path="/system/request-type"
+        component={RequestTypeForm}
       />
       <SecureRoute
         exact

--- a/src/views/RequestTypeForm/index.test.tsx
+++ b/src/views/RequestTypeForm/index.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+
+import RequestTypeForm from './index';
+
+describe('The request type form page', () => {
+  it('renders without crashing', () => {
+    const mockStore = configureMockStore();
+    const store = mockStore();
+    shallow(
+      <Provider store={store}>
+        <RequestTypeForm />
+      </Provider>
+    );
+  });
+});

--- a/src/views/RequestTypeForm/index.tsx
+++ b/src/views/RequestTypeForm/index.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { Button } from '@trussworks/react-uswds';
+
+import BreadcrumbNav from 'components/BreadcrumbNav';
+import Footer from 'components/Footer';
+import Header from 'components/Header';
+import MainContent from 'components/MainContent';
+import PageWrapper from 'components/PageWrapper';
+import CollapsableLink from 'components/shared/CollapsableLink';
+import HelpText from 'components/shared/HelpText';
+import { RadioField, RadioGroup } from 'components/shared/RadioField';
+
+const RequestTypeForm = () => {
+  const [requestType, setRequestType] = useState('');
+  const { t } = useTranslation('intake');
+
+  const majorChangesExamples: string[] = t(
+    'requestTypeForm.helpAndGuidance.majorChanges.list',
+    {
+      returnObjects: true
+    }
+  );
+
+  const handleRequestTypeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRequestType(e.target.value);
+  };
+
+  return (
+    <PageWrapper>
+      <Header />
+      <MainContent className="grid-container margin-bottom-5">
+        <BreadcrumbNav className="margin-y-2">
+          <li>
+            <Link to="/">Home</Link>
+            <i className="fa fa-angle-right margin-x-05" aria-hidden />
+          </li>
+          <li aria-current="location">Make a system request</li>
+        </BreadcrumbNav>
+        <h1 className="font-heading-2xl margin-top-4">
+          {t('requestTypeForm.heading')}
+        </h1>
+        <h2>{t('requestTypeForm.subheading')}</h2>
+        <HelpText className="margin-bottom-4">
+          {t('requestTypeForm.info')}
+        </HelpText>
+        <RadioGroup>
+          <RadioField
+            id="RequestType-NewSystem"
+            className="margin-bottom-4"
+            label={t('requestTypeForm.fields.addNewSystem')}
+            name="systemType"
+            value="NEW"
+            onChange={handleRequestTypeChange}
+            checked={requestType === 'NEW'}
+          />
+          <RadioField
+            id="RequestType-MajorChangesSystem"
+            className="margin-bottom-4"
+            label={t('requestTypeForm.fields.majorChanges')}
+            name="systemType"
+            value="MAJOR_CHANGES"
+            onChange={handleRequestTypeChange}
+            checked={requestType === 'MAJOR_CHANGES'}
+          />
+          <RadioField
+            id="RequestType-RecompeteSystem"
+            className="margin-bottom-4"
+            label={t('requestTypeForm.fields.recompete')}
+            name="systemType"
+            value="RECOMPETE"
+            onChange={handleRequestTypeChange}
+            checked={requestType === 'RECOMPETE'}
+          />
+          <RadioField
+            id="RequestType-ShutdownSystem"
+            className="margin-bottom-4"
+            label={t('requestTypeForm.fields.shutdown')}
+            name="systemType"
+            value="SHUTDOWN"
+            onChange={handleRequestTypeChange}
+            checked={requestType === 'SHUTDOWN'}
+          />
+        </RadioGroup>
+        <CollapsableLink
+          id="MajorChangesAccordion"
+          label={t('requestTypeForm.helpAndGuidance.majorChanges.label')}
+        >
+          <p>{t('requestTypeForm.helpAndGuidance.majorChanges.para')}</p>
+          <ul className="line-height-body-6">
+            {majorChangesExamples.map(item => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </CollapsableLink>
+        <Button className="margin-top-5" type="submit">
+          Continue
+        </Button>
+      </MainContent>
+      <Footer />
+    </PageWrapper>
+  );
+};
+
+export default RequestTypeForm;


### PR DESCRIPTION
# EASI-824

This PR adds:
- the view of the request type form for users to select their request type
- viewable at `/system/request-type`. there was not direction on what the URL should be so i guessed. this is can be changed

This PR does **not** add:
- action on the `Continue` button click
- backend work
- front end navigation or intake creation

This is JUST the view