### PR TITLE
Remove old Business Case auth

### DIFF
--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -156,7 +156,7 @@ func (s *Server) routes(
 		services.NewFetchSystemIntakeByID(
 			serviceConfig,
 			store.FetchSystemIntakeByID,
-			services.NewAuthorizeFetchSystemIntakeByID(),
+			services.NewAuthorizeHasEASiRole(),
 		),
 		services.NewArchiveSystemIntake(
 			serviceConfig,
@@ -167,7 +167,7 @@ func (s *Server) routes(
 				store.FetchBusinessCaseByID,
 				store.UpdateBusinessCase,
 			),
-			services.NewAuthorizeArchiveSystemIntake(s.logger),
+			services.NewAuthorizeUserIsIntakeRequester(),
 			emailClient.SendWithdrawRequestEmail,
 		),
 	)
@@ -190,18 +190,18 @@ func (s *Server) routes(
 		services.NewFetchBusinessCaseByID(
 			serviceConfig,
 			store.FetchBusinessCaseByID,
-			services.NewAuthorizeFetchBusinessCaseByID(),
+			services.NewAuthorizeHasEASiRole(),
 		),
 		services.NewCreateBusinessCase(
 			serviceConfig,
 			store.FetchSystemIntakeByID,
-			services.NewAuthorizeCreateBusinessCase(s.logger),
+			services.NewAuthorizeUserIsIntakeRequester(),
 			store.CreateBusinessCase,
 		),
 		services.NewUpdateBusinessCase(
 			serviceConfig,
 			store.FetchBusinessCaseByID,
-			services.NewAuthorizeUpdateBusinessCase(s.logger),
+			services.NewAuthorizeUserIsBusinessCaseRequester(),
 			store.UpdateBusinessCase,
 			emailClient.SendBusinessCaseSubmissionEmail,
 		),
@@ -214,7 +214,7 @@ func (s *Server) routes(
 		services.NewFetchBusinessCasesByEuaID(
 			serviceConfig,
 			store.FetchBusinessCasesByEuaID,
-			services.NewAuthorizeFetchBusinessCasesByEuaID(),
+			services.NewAuthorizeHasEASiRole(),
 		),
 	)
 	api.Handle("/business_cases", businessCasesHandler.Handle())

--- a/pkg/services/business_case.go
+++ b/pkg/services/business_case.go
@@ -14,18 +14,11 @@ import (
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
-// NewAuthorizeFetchBusinessCaseByID is a service to authorize FetchBusinessCaseByID
-func NewAuthorizeFetchBusinessCaseByID() func(ctx context.Context, businessCase *models.BusinessCase) (bool, error) {
-	return func(ctx context.Context, businessCase *models.BusinessCase) (bool, error) {
-		return true, nil
-	}
-}
-
 // NewFetchBusinessCaseByID is a service to fetch the business case by id
 func NewFetchBusinessCaseByID(
 	config Config,
 	fetch func(c context.Context, id uuid.UUID) (*models.BusinessCase, error),
-	authorize func(c context.Context, b *models.BusinessCase) (bool, error),
+	authorize func(context.Context) (bool, error),
 ) func(c context.Context, id uuid.UUID) (*models.BusinessCase, error) {
 	return func(ctx context.Context, id uuid.UUID) (*models.BusinessCase, error) {
 		logger := appcontext.ZLogger(ctx)
@@ -38,7 +31,7 @@ func NewFetchBusinessCaseByID(
 				Operation: apperrors.QueryFetch,
 			}
 		}
-		ok, err := authorize(ctx, businessCase)
+		ok, err := authorize(ctx)
 		if err != nil {
 			logger.Error("failed to authorize fetch business case")
 			return &models.BusinessCase{}, err
@@ -47,43 +40,6 @@ func NewFetchBusinessCaseByID(
 			return &models.BusinessCase{}, &apperrors.UnauthorizedError{Err: err}
 		}
 		return businessCase, nil
-	}
-}
-
-// NewAuthorizeCreateBusinessCase returns a function
-// that authorizes a user for creating a business case
-func NewAuthorizeCreateBusinessCase(_ *zap.Logger) func(
-	c context.Context,
-	intake *models.SystemIntake,
-) (bool, error) {
-	return func(ctx context.Context, intake *models.SystemIntake) (bool, error) {
-		logger := appcontext.ZLogger(ctx)
-		if intake == nil {
-			logger.With(zap.Bool("Authorized", false)).
-				With(zap.String("Operation", "CreateBusinessCase")).
-				Info("intake does not exist")
-			return false, nil
-		}
-		principal := appcontext.Principal(ctx)
-		if !principal.AllowEASi() {
-			// Default to failure to authorize and create a quick audit log
-			logger.With(zap.Bool("Authorized", false)).
-				With(zap.String("Operation", "CreateBusinessCase")).
-				Info("something went wrong fetching the eua id from the context")
-			return false, nil
-		}
-		// If business case is owned by user, authorize
-		if principal.ID() == intake.EUAUserID {
-			logger.With(zap.Bool("Authorized", true)).
-				With(zap.String("Operation", "CreateBusinessCase")).
-				Info("user authorized to create business case")
-			return true, nil
-		}
-		// Default to failure to authorize and create a quick audit log
-		logger.With(zap.Bool("Authorized", false)).
-			With(zap.String("Operation", "CreateBusinessCase")).
-			Info("unauthorized attempt to create business case")
-		return false, nil
 	}
 }
 
@@ -137,21 +93,14 @@ func NewCreateBusinessCase(
 	}
 }
 
-// NewAuthorizeFetchBusinessCasesByEuaID is a service to authorize FetchBusinessCasesByEuaID
-func NewAuthorizeFetchBusinessCasesByEuaID() func(ctx context.Context, euaID string) (bool, error) {
-	return func(ctx context.Context, euaID string) (bool, error) {
-		return true, nil
-	}
-}
-
 // NewFetchBusinessCasesByEuaID is a service to fetch a list of business cases by EUA ID
 func NewFetchBusinessCasesByEuaID(
 	config Config,
 	fetch func(c context.Context, euaID string) (models.BusinessCases, error),
-	authorize func(c context.Context, euaID string) (bool, error),
+	authorize func(c context.Context) (bool, error),
 ) func(c context.Context, euaID string) (models.BusinessCases, error) {
 	return func(ctx context.Context, euaID string) (models.BusinessCases, error) {
-		ok, err := authorize(ctx, euaID)
+		ok, err := authorize(ctx)
 		if err != nil {
 			appcontext.ZLogger(ctx).Error("failed to authorize fetch system intakes")
 			return models.BusinessCases{}, err
@@ -169,43 +118,6 @@ func NewFetchBusinessCasesByEuaID(
 			}
 		}
 		return businessCases, nil
-	}
-}
-
-// NewAuthorizeUpdateBusinessCase returns a function
-// that authorizes a user for updating an existing business case
-func NewAuthorizeUpdateBusinessCase(_ *zap.Logger) func(
-	c context.Context,
-	bb *models.BusinessCase,
-) (bool, error) {
-	return func(ctx context.Context, businessCase *models.BusinessCase) (bool, error) {
-		logger := appcontext.ZLogger(ctx)
-		if businessCase == nil {
-			logger.With(zap.Bool("Authorized", false)).
-				With(zap.String("Operation", "UpdateBusinessCase")).
-				Info("business case does not exist")
-			return false, nil
-		}
-		principal := appcontext.Principal(ctx)
-		if !principal.AllowEASi() {
-			// Default to failure to authorize and create a quick audit log
-			logger.With(zap.Bool("Authorized", false)).
-				With(zap.String("Operation", "UpdateBusinessCase")).
-				Info("something went wrong fetching the eua id from the context")
-			return false, nil
-		}
-		// If intake is owned by user, authorize
-		if principal.ID() == businessCase.EUAUserID {
-			logger.With(zap.Bool("Authorized", true)).
-				With(zap.String("Operation", "UpdateBusinessCase")).
-				Info("user authorized to update business case")
-			return true, nil
-		}
-		// Default to failure to authorize and create a quick audit log
-		logger.With(zap.Bool("Authorized", false)).
-			With(zap.String("Operation", "UpdateBusinessCase")).
-			Info("unauthorized attempt to update business case")
-		return false, nil
 	}
 }
 

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -360,7 +360,7 @@ func (s ServicesTestSuite) TestSystemIntakeByIDFetcher() {
 	fakeID := uuid.New()
 	serviceConfig := NewConfig(logger, nil)
 	serviceConfig.clock = clock.NewMock()
-	authorize := func(context context.Context, intake *models.SystemIntake) (bool, error) { return true, nil }
+	authorize := func(context context.Context) (bool, error) { return true, nil }
 
 	s.Run("successfully fetches System Intake by ID without an error", func() {
 		fetch := func(ctx context.Context, id uuid.UUID) (*models.SystemIntake, error) {
@@ -385,46 +385,6 @@ func (s ServicesTestSuite) TestSystemIntakeByIDFetcher() {
 
 		s.IsType(&apperrors.QueryError{}, err)
 		s.Equal(&models.SystemIntake{}, intake)
-	})
-}
-
-func (s ServicesTestSuite) TestAuthorizeArchiveSystemIntake() {
-	logger := zap.NewNop()
-	authorizeArchiveSystemIntake := NewAuthorizeArchiveSystemIntake(logger)
-
-	s.Run("No EUA ID fails auth", func() {
-		ctx := context.Background()
-
-		ok, err := authorizeArchiveSystemIntake(ctx, &models.SystemIntake{})
-
-		s.False(ok)
-		s.IsType(&apperrors.ContextError{}, err)
-	})
-
-	s.Run("Mismatched EUA ID fails auth", func() {
-		ctx := context.Background()
-		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ZYXW", JobCodeEASi: true})
-		intake := models.SystemIntake{
-			EUAUserID: "ABCD",
-		}
-
-		ok, err := authorizeArchiveSystemIntake(ctx, &intake)
-
-		s.False(ok)
-		s.NoError(err)
-	})
-
-	s.Run("Matched EUA ID passes auth", func() {
-		ctx := context.Background()
-		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ABCD", JobCodeEASi: true})
-		intake := models.SystemIntake{
-			EUAUserID: "ABCD",
-		}
-
-		ok, err := authorizeArchiveSystemIntake(ctx, &intake)
-
-		s.True(ok)
-		s.NoError(err)
 	})
 }
 


### PR DESCRIPTION
<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Stops using specialized auth for business case
- Moves necessary auth to services/auth.go
