### PR TITLE
Remove unused cache steps for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,15 +150,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - restore_cache:
-          keys:
-            - yarn-deps-cache-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
-            - v1-node-modules-{{ checksum "yarn.lock" }}
-      - run:
-          name: Install dependencies
-          command: yarn install
       - run:
           name: Docker Hub login
           command: |
@@ -167,14 +158,6 @@ jobs:
           name: Run Cypress integration tests
           command: |
             ./scripts/run-cypress-test-docker
-      - save_cache:
-          key: yarn-deps-cache-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
-      - save_cache:
-          key: v1-node-modules-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/project/node_modules
       - store_artifacts:
           path: cypress/videos
           destination: videos


### PR DESCRIPTION
# EASI-000

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Remove unused cache steps from the integration_tests job

With the changes made by https://github.com/CMSgov/easi-app/pull/471, the `integration_tests` job doesn't currently use the yarn and node module caches that are handled via `restore_cache` and `save_cache`, and instead relies on the docker layer caching. Since these steps aren't currently being used, we can remove them and save ~ 20-25 seconds from the `integration_tests` job.
