### PR TITLE
accept historic lcid

### DIFF
--- a/migrations/V46__LCID_constraints.sql
+++ b/migrations/V46__LCID_constraints.sql
@@ -1,0 +1,3 @@
+ALTER TABLE system_intake
+    DROP CONSTRAINT lcid_check,
+    ADD CONSTRAINT lcid_check CHECK (public.system_intake.lcid ~ '^[A-Z]?[0-9]{6}$');

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -164,7 +164,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		s.Empty(partial.LifecycleNextSteps)
 
 		// Update
-		lcid := "200110" // first LCID issued on 2020-01-11
+		lcid := "H200110" // historical first LCID issued on 2020-01-11
 		content1 := "ABC"
 		content2 := "XYZ"
 		partial.LifecycleID = null.StringFrom(lcid)
@@ -263,9 +263,12 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		s.NoError(err)
 
 		fails := []string{
-			"20001",   // short
-			"2000110", // long
-			"20001A",  // non-numeric
+			"20001",    // short
+			"2000110",  // long
+			"20001A",   // non-numeric
+			"A20001",   // short with prefix
+			"A2000110", // long with prefix
+			"AA123456", // too many character prefix
 		}
 
 		for _, fail := range fails {


### PR DESCRIPTION
# EASI-868

Changes proposed in this pull request:

- update the db-enforced pattern for acceptable LCIDs... We've found on this ticket that whereas newly generated LCIDs will look like ~"YYdddN", historical ones might have a one-alpha-character prefix ~"PYYdddN" (e.g. "A220019" vs "220019")
