### PR TITLE
Integrate FE and BE pieces of the request type question

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -91,7 +91,7 @@ export const Header = ({ children }: HeaderProps) => {
               </button>
               {displayDropdown && (
                 <UserActionList id="Header-UserActionsList">
-                  <UserAction link="/governance-overview">
+                  <UserAction link="/system/request-type">
                     {t('header:addSystem')}
                   </UserAction>
                   <UserAction

--- a/src/components/shared/HelpText/index.tsx
+++ b/src/components/shared/HelpText/index.tsx
@@ -4,13 +4,18 @@ import classnames from 'classnames';
 import './index.scss';
 
 type HelpTextProps = {
+  id?: string;
   children: ReactNode;
   className?: string;
 };
 
-const HelpText = ({ children, className }: HelpTextProps) => {
+const HelpText = ({ id, children, className }: HelpTextProps) => {
   const classNames = classnames('easi-help-text', className);
-  return <div className={classNames}>{children}</div>;
+  return (
+    <div id={id} className={classNames}>
+      {children}
+    </div>
+  );
 };
 
 export default HelpText;

--- a/src/components/shared/RadioField/index.tsx
+++ b/src/components/shared/RadioField/index.tsx
@@ -60,14 +60,15 @@ export const RadioField = ({
 type RadioGroupProps = {
   children: React.ReactNode | React.ReactNodeArray;
   inline?: boolean;
-};
+} & JSX.IntrinsicElements['div'];
 
-export const RadioGroup = ({ children, inline }: RadioGroupProps) => {
+export const RadioGroup = ({ children, inline, ...props }: RadioGroupProps) => {
   const classes = classnames('easi-radio__group', {
     'easi-radio__group--inline': inline
   });
   return (
-    <div className={classes} role="radiogroup">
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <div className={classes} role="radiogroup" {...props}>
       {children}
     </div>
   );

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -13,6 +13,7 @@ export const initialSystemIntakeForm: SystemIntakeForm = {
   euaUserID: '',
   requestName: '',
   status: 'INTAKE_DRAFT',
+  requestType: 'NEW',
   requester: {
     name: '',
     component: '',
@@ -84,7 +85,7 @@ export const prepareSystemIntakeForApi = (systemIntake: SystemIntakeForm) => {
       id: systemIntake.id
     }),
     status: systemIntake.status,
-    requestType: 'NEW',
+    requestType: systemIntake.requestType,
     requester: systemIntake.requester.name,
     component: systemIntake.requester.component,
     businessOwner: systemIntake.businessOwner.name,
@@ -139,6 +140,7 @@ export const prepareSystemIntakeForApp = (
     euaUserID: systemIntake.euaUserID || '',
     requestName: systemIntake.projectName || '',
     status: systemIntake.status || 'INTAKE_DRAFT',
+    requestType: systemIntake.requestType || 'NEW',
     requester: {
       name: systemIntake.requester || '',
       component: systemIntake.component || '',

--- a/src/types/systemIntake.ts
+++ b/src/types/systemIntake.ts
@@ -34,6 +34,8 @@ export const intakeStatuses = [
 // TODO: Remove old intake statuses once they're deprecated
 export type SystemIntakeStatus = typeof intakeStatuses[number];
 
+export type RequestType = 'NEW' | 'MAJOR_CHANGES' | 'RECOMPETE' | 'SHUTDOWN';
+
 /**
  * Type for SystemIntakeForm
  *
@@ -43,6 +45,7 @@ export type SystemIntakeForm = {
   euaUserID: string;
   requestName: string;
   status: SystemIntakeStatus;
+  requestType: RequestType;
   requester: {
     name: string;
     component: string;

--- a/src/validations/systemIntakeSchema.ts
+++ b/src/validations/systemIntakeSchema.ts
@@ -135,6 +135,9 @@ const SystemIntakeValidationSchema: any = {
         })
       })
     })
+  }),
+  requestType: Yup.object().shape({
+    requestType: Yup.string().required('Tell us what your request is for')
   })
 };
 

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -84,6 +84,7 @@ const AppRoutes = () => {
       <SecureRoute
         exact
         path="/system/request-type"
+        render={({ component }: any) => component()}
         component={RequestTypeForm}
       />
       <SecureRoute

--- a/src/views/Home/WelcomeText.tsx
+++ b/src/views/Home/WelcomeText.tsx
@@ -36,7 +36,7 @@ const WelcomeText = () => {
           className="usa-button"
           asCustom={Link}
           variant="unstyled"
-          to="/governance-overview"
+          to="/system/request-type"
         >
           {t('home:startNow')}
         </UswdsLink>

--- a/src/views/RequestTypeForm/index.tsx
+++ b/src/views/RequestTypeForm/index.tsx
@@ -38,24 +38,6 @@ const RequestTypeForm = () => {
         requestType: values.requestType
       })
     );
-
-    // switch (values.requestType) {
-    //   case 'NEW':
-    //     history.push(`/governance-task-list/${systemIntake.id}`);
-    //     break;
-    //   case 'MAJOR_CHANGES':
-    //     history.push(`/governance-task-list/${systemIntake.id}`);
-    //     break;
-    //   case 'RECOMPETE':
-    //     history.push(`/governance-task-list/${systemIntake.id}`);
-    //     break;
-    //   case 'SHUTDOWN':
-    //     history.push(`/system/${systemIntake.id}/contact-details`);
-    //     break;
-    //   default:
-    //     console.warn(`Unknown request type: ${systemIntake.requestType}`);
-    //     break;
-    // }
   };
 
   return (


### PR DESCRIPTION
# EASI-824

This PR connects the FE and BE pieces of the request type question.

When visiting `/system/request-type`, a user will be able to select their request type. This form has validations for required ness.

**NOTE**: Once you select an option and hit `Continue`, an intake record will be created, **but you will not be redirected**. I'm working on a separate PR for the redirection. That piece is a little tricky so I wanted to experiment with a different idea.