### PR TITLE
lessen severity of CEDAR connection issues

### DIFF
--- a/pkg/server/health_check.go
+++ b/pkg/server/health_check.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/cedar/cedareasi"
-	"github.com/cmsgov/easi-app/pkg/cedar/cedarldap"
 	"github.com/cmsgov/easi-app/pkg/email"
 )
 
@@ -17,23 +16,12 @@ func (s Server) CheckCEDAREasiClientConnection(client cedareasi.TranslatedClient
 	s.logger.Info("Testing CEDAR EASi Connection")
 	// FetchSystems is agnostic to user, doesn't modify state,
 	// and tests that we're authorized to retrieve information
-	_, err := client.FetchSystems(appcontext.WithLogger(context.Background(), s.logger))
-	if err != nil {
-		s.logger.Error("Failed to connect to CEDAR EASi on startup", zap.Error(err))
+	// By the rubric "should someone get woken up at 2AM for this?", we have decided
+	// that transitory challenges connecting to the CEDAR API should NOT block
+	// deployment of the EASi app, nor should it be logged at `ERROR` level
+	if _, err := client.FetchSystems(appcontext.WithLogger(context.Background(), s.logger)); err != nil {
+		s.logger.Info("Non-Fatal - Failed to connect to CEDAR EASi on startup", zap.Error(err))
 	}
-}
-
-// CheckCEDARLdapClientConnection makes a call to CEDAR LDAP to test it is configured properly
-// this method will panic on failures
-func (s Server) CheckCEDARLdapClientConnection(client cedarldap.TranslatedClient) {
-	//s.logger.Info("Testing CEDAR LDAP Connection")
-	// Authenticate is agnostic to user, doesn't modify state,
-	// and tests that we're authorized to retrieve information
-	//TODO standardize this in some way that doesn't use a specific EUAID
-	//_, err := client.FetchUserEmailAddress(s.logger, "ABCD")
-	//if err != nil {
-	//	s.logger.Fatal("Failed to connect to CEDAR LDAP on startup", zap.Error(err))
-	//}
 }
 
 // CheckEmailClient sends a email to test it is configured properly

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -57,7 +57,6 @@ func (s *Server) routes(
 
 	if s.environment.Deployed() {
 		s.CheckCEDAREasiClientConnection(cedarEasiClient)
-		s.CheckCEDARLdapClientConnection(cedarLdapClient)
 	}
 
 	// set up Email Client


### PR DESCRIPTION
# EASI-975

Changes proposed in this pull request:

- Log at non-`Error` level for CEDAR instability upon startup of EASi
- Don't invoke a dead/no-op codepath
