### PR TITLE
read-side api for retrieving notes

### DIFF
--- a/pkg/handlers/notes.go
+++ b/pkg/handlers/notes.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+type fetchNotes func(context.Context, uuid.UUID) ([]*models.Note, error)
+
+// NewNotesHandler is a constructor for SystemListHandler
+func NewNotesHandler(base HandlerBase, fetch fetchNotes) NotesHandler {
+	return NotesHandler{
+		HandlerBase: base,
+		FetchNotes:  fetch,
+	}
+}
+
+// NotesHandler is the handler for interacting with admin Notes
+// associated with a SystemIntake
+type NotesHandler struct {
+	HandlerBase
+	FetchNotes fetchNotes
+}
+
+// Handle handles a web request and returns a list of systems
+func (h NotesHandler) Handle() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["intake_id"]
+		valErr := apperrors.NewValidationError(
+			errors.New("system intake failed validation"),
+			models.SystemIntake{},
+			"",
+		)
+		if id == "" {
+			valErr.WithValidation("path.intakeID", "is required")
+			h.WriteErrorResponse(r.Context(), w, &valErr)
+			return
+		}
+		uuid, err := uuid.Parse(id)
+		if err != nil {
+			valErr.WithValidation("path.intakeID", "must be UUID")
+			h.WriteErrorResponse(r.Context(), w, &valErr)
+			return
+		}
+
+		switch r.Method {
+		case "GET":
+			notes, err := h.FetchNotes(r.Context(), uuid)
+			if err != nil {
+				h.WriteErrorResponse(r.Context(), w, err)
+				return
+			}
+
+			js, err := json.Marshal(notes)
+			if err != nil {
+				h.WriteErrorResponse(r.Context(), w, err)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+
+			_, err = w.Write(js)
+			if err != nil {
+				h.WriteErrorResponse(r.Context(), w, err)
+				return
+			}
+
+		case "POST":
+			h.WriteErrorResponse(r.Context(), w, errors.New("not yet implemented"))
+			return
+		default:
+			h.WriteErrorResponse(r.Context(), w, &apperrors.MethodNotAllowedError{Method: r.Method})
+			return
+		}
+
+	}
+}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -307,6 +307,16 @@ func (s *Server) routes(
 	)
 	api.Handle("/system_intake/{intake_id}/lcid", systemIntakeLifecycleIDHandler.Handle())
 
+	notesHandler := handlers.NewNotesHandler(
+		base,
+		services.NewFetchNotes(
+			serviceConfig,
+			store.FetchNotesBySystemIntakeID,
+			services.NewAuthorizeRequireGRTJobCode(),
+		),
+	)
+	api.Handle("/system_intake/{intake_id}/notes", notesHandler.Handle())
+
 	s.router.PathPrefix("/").Handler(handlers.NewCatchAllHandler(
 		base,
 	).Handle())

--- a/pkg/services/notes.go
+++ b/pkg/services/notes.go
@@ -1,0 +1,33 @@
+package services
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+// NewFetchNotes is a service to fetch all notes
+// associated with a given SystemIntake
+func NewFetchNotes(
+	config Config,
+	fetchBySystemIntakeID func(context.Context, uuid.UUID) ([]*models.Note, error),
+	authorize func(context.Context) (bool, error),
+) func(context.Context, uuid.UUID) ([]*models.Note, error) {
+	return func(ctx context.Context, id uuid.UUID) ([]*models.Note, error) {
+		ok, err := authorize(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, &apperrors.ResourceNotFoundError{
+				Err:      errors.New("failed to authorize fetch notes"),
+				Resource: models.Note{},
+			}
+		}
+		return fetchBySystemIntakeID(ctx, id)
+	}
+}

--- a/pkg/services/notes_test.go
+++ b/pkg/services/notes_test.go
@@ -1,0 +1,104 @@
+package services
+
+import (
+	"context"
+	"errors"
+
+	"github.com/facebookgo/clock"
+	"github.com/google/uuid"
+	"github.com/guregu/null"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/models"
+	"github.com/cmsgov/easi-app/pkg/testhelpers"
+)
+
+func (s ServicesTestSuite) TestFetchNotes() {
+	cfg := NewConfig(nil, nil)
+	cfg.clock = clock.NewMock()
+
+	idError := uuid.Nil
+	idFound := uuid.New()
+	fetcher := func(_ context.Context, id uuid.UUID) ([]*models.Note, error) {
+		if id == idError {
+			return nil, errors.New("forced error")
+		}
+		if id == idFound {
+			return []*models.Note{
+				{
+					ID:             uuid.New(),
+					SystemIntakeID: id,
+					Content:        null.StringFrom("alpha"),
+				},
+				{
+					ID:             uuid.New(),
+					SystemIntakeID: id,
+					Content:        null.StringFrom("omega"),
+				},
+			}, nil
+		}
+		return nil, nil
+	}
+
+	s.Run("unhappy paths", func() {
+		errorCases := map[string]struct {
+			ctx context.Context
+			id  uuid.UUID
+			fn  func(ctx context.Context, id uuid.UUID) ([]*models.Note, error)
+		}{
+			"anonymous user": {
+				ctx: context.Background(),
+				id:  idFound,
+				fn:  NewFetchNotes(cfg, fetcher, NewAuthorizeRequireGRTJobCode()),
+			},
+			"not reviewer": {
+				ctx: appcontext.WithPrincipal(context.Background(), testhelpers.NewRequesterPrincipal()),
+				id:  idFound,
+				fn:  NewFetchNotes(cfg, fetcher, NewAuthorizeRequireGRTJobCode()),
+			},
+			"errors when talking to storage layer": {
+				ctx: appcontext.WithPrincipal(context.Background(), testhelpers.NewReviewerPrincipal()),
+				id:  idError,
+				fn:  NewFetchNotes(cfg, fetcher, NewAuthorizeRequireGRTJobCode()),
+			},
+		}
+
+		for name, tc := range errorCases {
+			s.Run(name, func() {
+				_, err := tc.fn(tc.ctx, tc.id)
+				s.Error(err)
+			})
+		}
+	})
+
+	s.Run("happy paths", func() {
+		happyCases := map[string]struct {
+			id    uuid.UUID
+			fn    func(ctx context.Context, id uuid.UUID) ([]*models.Note, error)
+			count int
+		}{
+			"zero length": {
+				id:    uuid.New(),
+				fn:    NewFetchNotes(cfg, fetcher, NewAuthorizeRequireGRTJobCode()),
+				count: 0,
+			},
+			"several results": {
+				id:    uuid.New(),
+				fn:    NewFetchNotes(cfg, fetcher, NewAuthorizeRequireGRTJobCode()),
+				count: 0,
+			},
+		}
+
+		for name, tc := range happyCases {
+			s.Run(name, func() {
+				results, err := tc.fn(
+					appcontext.WithPrincipal(context.Background(), testhelpers.NewReviewerPrincipal()),
+					tc.id,
+				)
+				s.NoError(err)
+				s.Equal(tc.count, len(results))
+			})
+		}
+	})
+
+}

--- a/pkg/testhelpers/authn.go
+++ b/pkg/testhelpers/authn.go
@@ -1,0 +1,17 @@
+package testhelpers
+
+import (
+	"github.com/cmsgov/easi-app/pkg/authn"
+)
+
+// NewRequesterPrincipal returns what represents an EASi user
+// that is NOT empowered as a Reviewer
+func NewRequesterPrincipal() authn.Principal {
+	return &authn.EUAPrincipal{EUAID: "REQ", JobCodeEASi: true, JobCodeGRT: false}
+}
+
+// NewReviewerPrincipal returns what represents an EASi user
+// that is empowered as a member of the GRT.
+func NewReviewerPrincipal() authn.Principal {
+	return &authn.EUAPrincipal{EUAID: "REV", JobCodeEASi: true, JobCodeGRT: true}
+}


### PR DESCRIPTION
# EASI-912

Changes proposed in this pull request:

- Add svc and handler layers for retrieving notes associated with a given `SystemIntake`
- Wire up so that this will be active path: `GET /system_intake/{intake_id}/notes`
