### PR TITLE
Do not wrap the text for table headers.

### DIFF
--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -164,6 +164,7 @@ const RequestRepository = () => {
                 <th
                   {...column.getHeaderProps(column.getSortByToggleProps())}
                   aria-sort={getColumnSortStatus(column)}
+                  style={{ whiteSpace: 'nowrap' }}
                 >
                   {column.render('Header')}
                   {column.isSorted && (


### PR DESCRIPTION
Changes proposed in this pull request:

- Don't wrap column headers

Old:
<img width="861" alt="Screen Shot 2020-11-04 at 8 28 31 PM" src="https://user-images.githubusercontent.com/4434681/98197844-80f35080-1edc-11eb-966d-cb2870872631.png">

New:
<img width="923" alt="Screen Shot 2020-11-04 at 8 28 44 PM" src="https://user-images.githubusercontent.com/4434681/98197856-8486d780-1edc-11eb-988e-6ca0e825f017.png">