### PR TITLE
Fix Submit Intake action type name on client

### DIFF
--- a/src/types/action.ts
+++ b/src/types/action.ts
@@ -1,5 +1,5 @@
 export type ActionType =
-  | 'SUBMIT'
+  | 'SUBMIT_INTAKE'
   | 'NOT_IT_REQUEST'
   | 'NEED_BIZ_CASE'
   | 'READY_FOR_GRT'

--- a/src/views/SystemIntake/Review/index.tsx
+++ b/src/views/SystemIntake/Review/index.tsx
@@ -63,7 +63,7 @@ const Review = ({ systemIntake }: ReviewProps) => {
         onClick={() =>
           dispatch(
             postSystemIntakeAction({
-              actionType: 'SUBMIT',
+              actionType: 'SUBMIT_INTAKE',
               intakeId: systemIntake.id
             })
           )


### PR DESCRIPTION
<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Rename SUBMIT to SUBMIT_INTAKE on the client
