### PR TITLE
API to create a note

### DIFF
--- a/pkg/handlers/notes.go
+++ b/pkg/handlers/notes.go
@@ -14,12 +14,14 @@ import (
 )
 
 type fetchNotes func(context.Context, uuid.UUID) ([]*models.Note, error)
+type createNote func(context.Context, *models.Note) (*models.Note, error)
 
 // NewNotesHandler is a constructor for SystemListHandler
-func NewNotesHandler(base HandlerBase, fetch fetchNotes) NotesHandler {
+func NewNotesHandler(base HandlerBase, fetch fetchNotes, create createNote) NotesHandler {
 	return NotesHandler{
 		HandlerBase: base,
 		FetchNotes:  fetch,
+		CreateNote:  create,
 	}
 }
 
@@ -28,6 +30,7 @@ func NewNotesHandler(base HandlerBase, fetch fetchNotes) NotesHandler {
 type NotesHandler struct {
 	HandlerBase
 	FetchNotes fetchNotes
+	CreateNote createNote
 }
 
 // Handle handles a web request and returns a list of systems
@@ -74,7 +77,45 @@ func (h NotesHandler) Handle() http.HandlerFunc {
 			}
 
 		case "POST":
-			h.WriteErrorResponse(r.Context(), w, errors.New("not yet implemented"))
+			if r.Body == nil {
+				h.WriteErrorResponse(
+					r.Context(),
+					w,
+					&apperrors.BadRequestError{Err: errors.New("empty request not allowed")},
+				)
+				return
+			}
+			defer r.Body.Close()
+
+			decoder := json.NewDecoder(r.Body)
+			note := models.Note{}
+
+			err := decoder.Decode(&note)
+			if err != nil {
+				h.WriteErrorResponse(r.Context(), w, &apperrors.BadRequestError{Err: err})
+				return
+			}
+
+			note.SystemIntakeID = uuid
+
+			createdNote, err := h.CreateNote(r.Context(), &note)
+			if err != nil {
+				h.WriteErrorResponse(r.Context(), w, err)
+				return
+			}
+
+			responseBody, err := json.Marshal(createdNote)
+			if err != nil {
+				h.WriteErrorResponse(r.Context(), w, err)
+				return
+			}
+
+			w.WriteHeader(http.StatusCreated)
+			_, err = w.Write(responseBody)
+			if err != nil {
+				h.WriteErrorResponse(r.Context(), w, err)
+				return
+			}
 			return
 		default:
 			h.WriteErrorResponse(r.Context(), w, &apperrors.MethodNotAllowedError{Method: r.Method})

--- a/pkg/handlers/notes_test.go
+++ b/pkg/handlers/notes_test.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"golang.org/x/net/context"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/authn"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+func newMockCreateNote(err error) createNote {
+	return func(context.Context, *models.Note) (*models.Note, error) {
+		return nil, err
+	}
+}
+
+func (s HandlerTestSuite) TestNoteHandler() {
+	requestContext := context.Background()
+	requestContext = appcontext.WithPrincipal(requestContext, &authn.EUAPrincipal{EUAID: "FAKE", JobCodeEASi: true})
+	id, _ := uuid.NewUUID()
+
+	s.Run("golden path POST passes", func() {
+		body, err := json.Marshal(map[string]string{
+			"content": "my note content",
+		})
+		s.NoError(err)
+		rr := httptest.NewRecorder()
+		req, reqErr := http.NewRequestWithContext(
+			requestContext,
+			"POST",
+			fmt.Sprintf("/system_intake/%s/notes", id.String()),
+			bytes.NewBuffer(body),
+		)
+		s.NoError(reqErr)
+		req = mux.SetURLVars(req, map[string]string{"intake_id": id.String()})
+		NotesHandler{
+			HandlerBase: s.base,
+			CreateNote:  newMockCreateNote(nil),
+		}.Handle()(rr, req)
+
+		s.Equal(http.StatusCreated, rr.Code)
+	})
+
+	s.Run("POST fails with empty request body", func() {
+		rr := httptest.NewRecorder()
+		req, reqErr := http.NewRequestWithContext(
+			requestContext,
+			"POST",
+			fmt.Sprintf("/system_intake/%s/notes", id.String()),
+			bytes.NewBufferString(""),
+		)
+		s.NoError(reqErr)
+		req = mux.SetURLVars(req, map[string]string{"intake_id": id.String()})
+		NotesHandler{
+			HandlerBase: s.base,
+			CreateNote:  newMockCreateNote(nil),
+		}.Handle()(rr, req)
+
+		s.Equal(http.StatusBadRequest, rr.Code)
+	})
+
+	s.Run("POST fails if a error is thrown by service", func() {
+		body, err := json.Marshal(map[string]string{
+			"content": "my note content",
+		})
+		s.NoError(err)
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(
+			requestContext,
+			"POST",
+			fmt.Sprintf("/system_intake/%s/notes", id.String()),
+			bytes.NewBuffer(body),
+		)
+		s.NoError(err)
+		req = mux.SetURLVars(req, map[string]string{"intake_id": id.String()})
+		expectedErr := apperrors.ValidationError{
+			Model:   models.Action{},
+			ModelID: "",
+			Err:     fmt.Errorf("failed validations"),
+		}
+		NotesHandler{
+			HandlerBase: s.base,
+			CreateNote:  newMockCreateNote(&expectedErr),
+		}.Handle()(rr, req)
+
+		s.Equal(http.StatusUnprocessableEntity, rr.Code)
+	})
+}

--- a/pkg/models/note.go
+++ b/pkg/models/note.go
@@ -13,7 +13,7 @@ type Note struct {
 	ID             uuid.UUID   `json:"id"`
 	SystemIntakeID uuid.UUID   `json:"systemIntakeId" db:"system_intake"`
 	CreatedAt      *time.Time  `json:"createdAt" db:"created_at"`
-	AuthorEUAID    null.String `json:"authorId" db:"eua_user_id"`
+	AuthorEUAID    string      `json:"authorId" db:"eua_user_id"`
 	AuthorName     null.String `json:"authorName" db:"author_name"`
 	Content        null.String `json:"content" db:"content"`
 }

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -364,6 +364,11 @@ func (s *Server) routes(
 			store.FetchNotesBySystemIntakeID,
 			services.NewAuthorizeRequireGRTJobCode(),
 		),
+		services.NewCreateNote(
+			serviceConfig,
+			store.CreateNote,
+			services.NewAuthorizeRequireGRTJobCode(),
+		),
 	)
 	api.Handle("/system_intake/{intake_id}/notes", notesHandler.Handle())
 

--- a/pkg/services/notes.go
+++ b/pkg/services/notes.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/apperrors"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
@@ -29,5 +30,29 @@ func NewFetchNotes(
 			}
 		}
 		return fetchBySystemIntakeID(ctx, id)
+	}
+}
+
+// NewCreateNote is a service to create and return a new note
+// associated with a given SystemIntake
+func NewCreateNote(
+	config Config,
+	create func(context.Context, *models.Note) (*models.Note, error),
+	authorize func(context.Context) (bool, error),
+) func(context.Context, *models.Note) (*models.Note, error) {
+	return func(ctx context.Context, note *models.Note) (*models.Note, error) {
+		ok, err := authorize(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, &apperrors.ResourceNotFoundError{
+				Err:      errors.New("failed to authorize create note"),
+				Resource: models.Note{},
+			}
+		}
+		note.AuthorEUAID = appcontext.Principal(ctx).ID()
+
+		return create(ctx, note)
 	}
 }

--- a/pkg/services/notes_test.go
+++ b/pkg/services/notes_test.go
@@ -102,3 +102,81 @@ func (s ServicesTestSuite) TestFetchNotes() {
 	})
 
 }
+
+func (s ServicesTestSuite) TestCreateNote() {
+	cfg := NewConfig(nil, nil)
+	cfg.clock = clock.NewMock()
+
+	noteError := models.Note{
+		ID:             uuid.Nil,
+		SystemIntakeID: uuid.New(),
+		Content:        null.StringFrom("alpha"),
+	}
+	noteCreated := models.Note{
+		ID:             uuid.New(),
+		SystemIntakeID: uuid.New(),
+		Content:        null.StringFrom("alpha"),
+	}
+	creator := func(_ context.Context, note *models.Note) (*models.Note, error) {
+		if note == &noteError {
+			return nil, errors.New("forced error")
+		}
+		if note == &noteCreated {
+			return note, nil
+		}
+		return nil, nil
+	}
+
+	s.Run("unhappy paths", func() {
+		errorCases := map[string]struct {
+			ctx  context.Context
+			note *models.Note
+			fn   func(ctx context.Context, note *models.Note) (*models.Note, error)
+		}{
+			"anonymous user": {
+				ctx:  context.Background(),
+				note: &noteCreated,
+				fn:   NewCreateNote(cfg, creator, NewAuthorizeRequireGRTJobCode()),
+			},
+			"not reviewer": {
+				ctx:  appcontext.WithPrincipal(context.Background(), testhelpers.NewRequesterPrincipal()),
+				note: &noteCreated,
+				fn:   NewCreateNote(cfg, creator, NewAuthorizeRequireGRTJobCode()),
+			},
+			"errors when talking to storage layer": {
+				ctx:  appcontext.WithPrincipal(context.Background(), testhelpers.NewReviewerPrincipal()),
+				note: &noteError,
+				fn:   NewCreateNote(cfg, creator, NewAuthorizeRequireGRTJobCode()),
+			},
+		}
+
+		for name, tc := range errorCases {
+			s.Run(name, func() {
+				_, err := tc.fn(tc.ctx, tc.note)
+				s.Error(err)
+			})
+		}
+	})
+
+	s.Run("successfully creates a note without an error", func() {
+		systemIntakeID := uuid.New()
+		content := null.StringFrom("alpha")
+		ctx := context.Background()
+		ctx = appcontext.WithPrincipal(ctx, testhelpers.NewReviewerPrincipal())
+
+		create := func(ctx context.Context, intake *models.Note) (*models.Note, error) {
+			return &models.Note{
+				SystemIntakeID: systemIntakeID,
+				Content:        content,
+			}, nil
+		}
+		createNote := NewCreateNote(cfg, create, NewAuthorizeRequireGRTJobCode())
+		note, err := createNote(ctx, &models.Note{
+			SystemIntakeID: systemIntakeID,
+			Content:        content,
+		})
+		s.NoError(err)
+		s.Equal(content, note.Content)
+	})
+
+}

--- a/pkg/storage/note_test.go
+++ b/pkg/storage/note_test.go
@@ -28,7 +28,7 @@ func (s StoreTestSuite) TestNoteRoundtrip() {
 		testCases := map[string]*models.Note{
 			"missing system intake foreign key": {
 				SystemIntakeID: uuid.Nil,
-				AuthorEUAID:    null.StringFrom(euaID),
+				AuthorEUAID:    euaID,
 			},
 			"missing author id": {
 				SystemIntakeID: intake.ID,
@@ -53,22 +53,23 @@ func (s StoreTestSuite) TestNoteRoundtrip() {
 			in := &models.Note{
 				SystemIntakeID: intake.ID,
 				// CreatedAt:      &ts,
-				AuthorEUAID: null.StringFrom(euaID),
+				AuthorEUAID: euaID,
 				AuthorName:  null.StringFrom(ts.String()),
 				Content:     null.StringFrom(ts.String()),
 			}
 
-			id, err := s.store.CreateNote(ctx, in)
+			createdNote, err := s.store.CreateNote(ctx, in)
+			id := createdNote.ID
 			s.NoError(err)
 
-			out, err := s.store.FetchNoteByID(ctx, *id)
+			out, err := s.store.FetchNoteByID(ctx, id)
 			s.NoError(err)
-			s.Equal(*id, out.ID)
+			s.Equal(id, out.ID)
 			s.Equal(in.SystemIntakeID, out.SystemIntakeID)
 			s.Equal(in.AuthorEUAID, out.AuthorEUAID)
 			s.Equal(in.AuthorName, out.AuthorName)
 			s.Equal(in.Content, out.Content)
-			notes[*id] = out
+			notes[id] = out
 		}
 
 		testCases := map[string]struct {


### PR DESCRIPTION
# EASI-913

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add an API endpoint for creating a note
- Return the entire note from the create storage function, not just the ID, to avoid making two requests per API interaction.
