### PR TITLE
update links from the home page banners

### DIFF
--- a/src/views/Home/SystemIntakeBanners.tsx
+++ b/src/views/Home/SystemIntakeBanners.tsx
@@ -26,10 +26,16 @@ const SystemIntakeBanners = () => {
   }, [dispatch, authState.isAuthenticated]);
 
   const getSystemIntakeBanners = (featureFlags: Flags) => {
-    const rootPath = featureFlags.taskListLite
-      ? '/governance-task-list'
-      : '/system';
     return systemIntakes.map((intake: SystemIntakeForm) => {
+      let rootPath = '';
+      if (intake.requestType === 'SHUTDOWN') {
+        rootPath = '/system';
+      } else {
+        rootPath = featureFlags.taskListLite
+          ? '/governance-task-list'
+          : '/system';
+      }
+
       switch (intake.status) {
         case 'INTAKE_DRAFT':
           return (


### PR DESCRIPTION
# EASI-871

Intake banners with the request types `NEW`, `MAJOR_CHAGES`, and `RECOMPETE` should link to the task list (except on prod, because the task list feature flag is off).

Intake banners with the request type `SHUTDOWN` should link directly to the intake for,
