### PR TITLE
Attach biz case ID to intake even if CLOSED

### DIFF
--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -190,7 +190,7 @@ func (s *Store) FetchSystemIntakeByID(ctx context.Context, id uuid.UUID) (*model
 		       business_case.id as business_case_id
 		FROM
 		     system_intake
-		     LEFT JOIN business_case ON business_case.system_intake = system_intake.id AND business_case.status = 'OPEN'
+		     LEFT JOIN business_case ON business_case.system_intake = system_intake.id
 		WHERE system_intake.id=$1
 `
 	err := s.db.Get(&intake, fetchSystemIntakeByIDsql, id)
@@ -217,7 +217,7 @@ func (s *Store) FetchSystemIntakesByEuaID(ctx context.Context, euaID string) (mo
 		       business_case.id as business_case_id
 		FROM
 		     system_intake
-		     LEFT JOIN business_case ON business_case.system_intake = system_intake.id AND business_case.status = 'OPEN'
+		     LEFT JOIN business_case ON business_case.system_intake = system_intake.id
 		WHERE system_intake.eua_user_id=$1 AND system_intake.status != 'WITHDRAWN'
 	`
 	err := s.db.Select(&intakes, fetchSystemIntakesByEuaIDsql, euaID)
@@ -240,7 +240,7 @@ func (s *Store) FetchSystemIntakesNotArchived(ctx context.Context) (models.Syste
 		       business_case.id as business_case_id
 		FROM
 		     system_intake
-		     LEFT JOIN business_case ON business_case.system_intake = system_intake.id AND business_case.status = 'OPEN'
+		     LEFT JOIN business_case ON business_case.system_intake = system_intake.id
 		WHERE system_intake.status != 'WITHDRAWN'
 	`
 	err := s.db.Select(&intakes, fetchSystemIntakesSQL)

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -431,7 +431,7 @@ func (s StoreTestSuite) TestFetchSystemIntakeByID() {
 		s.Nil(fetched)
 	})
 
-	s.Run("fetches OPEN biz case id if exists", func() {
+	s.Run("fetches biz case id if exists", func() {
 		intake := testhelpers.NewSystemIntake()
 		id := intake.ID
 		bizCase := testhelpers.NewBusinessCase()
@@ -503,7 +503,7 @@ func (s StoreTestSuite) TestFetchSystemIntakesByEuaID() {
 		s.Equal(models.SystemIntakes{}, fetched)
 	})
 
-	s.Run("fetches OPEN biz case IDs if they exist", func() {
+	s.Run("fetches biz case ID if it exists", func() {
 		intake := testhelpers.NewSystemIntake()
 		intake2 := testhelpers.NewSystemIntake()
 		id := intake.ID


### PR DESCRIPTION
# EASI-000

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Attaches an associated biz case ID to a system intake even if that biz case is closed
