### PR TITLE
Use text-pre-wrap to wrap text.

### DIFF
--- a/src/components/BusinessCaseReview/RequestDescriptionReview/index.tsx
+++ b/src/components/BusinessCaseReview/RequestDescriptionReview/index.tsx
@@ -21,7 +21,7 @@ const RequestDescriptionReview = ({
         <div className="margin-bottom-205 line-height-body-3">
           <DescriptionTerm term="What is your business or user need?" />
           <DescriptionDefinition
-            className="text-pre"
+            className="text-pre-wrap"
             definition={values.businessNeed}
           />
         </div>
@@ -30,7 +30,7 @@ const RequestDescriptionReview = ({
         <div className="margin-bottom-205 line-height-body-3">
           <DescriptionTerm term="How will CMS benefit from this effort?" />
           <DescriptionDefinition
-            className="text-pre"
+            className="text-pre-wrap"
             definition={values.cmsBenefit}
           />
         </div>
@@ -39,7 +39,7 @@ const RequestDescriptionReview = ({
         <div className="margin-bottom-205 line-height-body-3">
           <DescriptionTerm term="How does this effort align with organizational priorities?" />
           <DescriptionDefinition
-            className="text-pre"
+            className="text-pre-wrap"
             definition={values.priorityAlignment}
           />
         </div>
@@ -48,7 +48,7 @@ const RequestDescriptionReview = ({
         <div className="margin-bottom-205 line-height-body-3">
           <DescriptionTerm term="How will you determine whether or not this effort is successful?" />
           <DescriptionDefinition
-            className="text-pre"
+            className="text-pre-wrap"
             definition={values.successIndicators}
           />
         </div>

--- a/src/components/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/components/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -90,7 +90,7 @@ Array [
             What is your business or user need?
           </dt>
           <dd
-            className="description-definition margin-0 text-pre"
+            className="description-definition margin-0 text-pre-wrap"
           >
             Test business need
           </dd>
@@ -108,7 +108,7 @@ Array [
             How will CMS benefit from this effort?
           </dt>
           <dd
-            className="description-definition margin-0 text-pre"
+            className="description-definition margin-0 text-pre-wrap"
           >
             Test CMS benefit
           </dd>
@@ -126,7 +126,7 @@ Array [
             How does this effort align with organizational priorities?
           </dt>
           <dd
-            className="description-definition margin-0 text-pre"
+            className="description-definition margin-0 text-pre-wrap"
           >
             Test priority alignment
           </dd>
@@ -144,7 +144,7 @@ Array [
             How will you determine whether or not this effort is successful?
           </dt>
           <dd
-            className="description-definition margin-0 text-pre"
+            className="description-definition margin-0 text-pre-wrap"
           >
             Test success indicators
           </dd>
@@ -301,7 +301,7 @@ Array [
                     “As is” solution: Summary
                   </dt>
                   <dd
-                    className="description-definition margin-0 text-pre"
+                    className="description-definition margin-0 text-pre-wrap"
                   >
                     Test summary
                   </dd>
@@ -319,7 +319,7 @@ Array [
                     “As is” solution: Pros
                   </dt>
                   <dd
-                    className="description-definition margin-0 text-pre"
+                    className="description-definition margin-0 text-pre-wrap"
                   >
                     Test pros
                   </dd>
@@ -337,7 +337,7 @@ Array [
                     “As is” solution: Cons
                   </dt>
                   <dd
-                    className="description-definition margin-0 text-pre"
+                    className="description-definition margin-0 text-pre-wrap"
                   >
                     Test cons
                   </dd>
@@ -385,7 +385,7 @@ Array [
                   What is the cost savings or avoidance associated with this solution?
                 </dt>
                 <dd
-                  className="description-definition margin-0 text-pre"
+                  className="description-definition margin-0 text-pre-wrap"
                 >
                   Test cost savings
                 </dd>

--- a/src/components/SystemIntakeReview/index.tsx
+++ b/src/components/SystemIntakeReview/index.tsx
@@ -142,7 +142,7 @@ export const SystemIntakeReview = ({
           <div>
             <DescriptionTerm term="What is your business need?" />
             <DescriptionDefinition
-              className="text-pre"
+              className="text-pre-wrap"
               definition={systemIntake.businessNeed}
             />
           </div>
@@ -151,7 +151,7 @@ export const SystemIntakeReview = ({
           <div>
             <DescriptionTerm term="How are you thinking of solving it?" />
             <DescriptionDefinition
-              className="text-pre"
+              className="text-pre-wrap"
               definition={systemIntake.businessSolution}
             />
           </div>

--- a/src/views/BusinessCase/Review/AsIsSolutionReview.tsx
+++ b/src/views/BusinessCase/Review/AsIsSolutionReview.tsx
@@ -35,7 +35,7 @@ const AsIsSolutionReview = ({ solution }: ReviewProps) => (
         <div className="line-height-body-3">
           <DescriptionTerm term="“As is” solution: Summary" />
           <DescriptionDefinition
-            className="text-pre"
+            className="text-pre-wrap"
             definition={solution.summary}
           />
         </div>
@@ -44,7 +44,7 @@ const AsIsSolutionReview = ({ solution }: ReviewProps) => (
         <div className="line-height-body-3">
           <DescriptionTerm term="“As is” solution: Pros" />
           <DescriptionDefinition
-            className="text-pre"
+            className="text-pre-wrap"
             definition={solution.pros}
           />
         </div>
@@ -53,7 +53,7 @@ const AsIsSolutionReview = ({ solution }: ReviewProps) => (
         <div className="line-height-body-3">
           <DescriptionTerm term="“As is” solution: Cons" />
           <DescriptionDefinition
-            className="text-pre"
+            className="text-pre-wrap"
             definition={solution.cons}
           />
         </div>
@@ -67,7 +67,7 @@ const AsIsSolutionReview = ({ solution }: ReviewProps) => (
       <div className="line-height-body-3">
         <DescriptionTerm term="What is the cost savings or avoidance associated with this solution?" />
         <DescriptionDefinition
-          className="text-pre"
+          className="text-pre-wrap"
           definition={solution.costSavings}
         />
       </div>

--- a/src/views/BusinessCase/Review/ProposedBusinessCaseSolutionReview.tsx
+++ b/src/views/BusinessCase/Review/ProposedBusinessCaseSolutionReview.tsx
@@ -42,7 +42,7 @@ const PropsedBusinessCaseSolutionReview = ({ name, solution }: ReviewProps) => (
       <div className="line-height-body-3">
         <DescriptionTerm term={`${name}: Summary`} />
         <DescriptionDefinition
-          className="text-pre"
+          className="text-pre-wrap"
           definition={solution.summary}
         />
       </div>
@@ -51,7 +51,7 @@ const PropsedBusinessCaseSolutionReview = ({ name, solution }: ReviewProps) => (
       <div className="line-height-body-3">
         <DescriptionTerm term={`${name}: Acquisition approach`} />
         <DescriptionDefinition
-          className="text-pre"
+          className="text-pre-wrap"
           definition={solution.acquisitionApproach}
         />
       </div>
@@ -60,7 +60,7 @@ const PropsedBusinessCaseSolutionReview = ({ name, solution }: ReviewProps) => (
       <div className="line-height-body-3">
         <DescriptionTerm term="Do you need to host your solution?" />
         <DescriptionDefinition
-          className="text-pre"
+          className="text-pre-wrap"
           definition={hostingTypeMap[solution.hosting.type]}
         />
       </div>
@@ -70,7 +70,7 @@ const PropsedBusinessCaseSolutionReview = ({ name, solution }: ReviewProps) => (
         <div className="line-height-body-3">
           <DescriptionTerm term="Where are you planning to host?" />
           <DescriptionDefinition
-            className="text-pre"
+            className="text-pre-wrap"
             definition={solution.hosting.location}
           />
         </div>
@@ -78,7 +78,7 @@ const PropsedBusinessCaseSolutionReview = ({ name, solution }: ReviewProps) => (
           <div className="line-height-body-3">
             <DescriptionTerm term="What, if any, type of cloud service are you planning to use for this solution (Iaas, PaaS, SaaS, etc.)?" />
             <DescriptionDefinition
-              className="text-pre"
+              className="text-pre-wrap"
               definition={solution.hosting.cloudServiceType}
             />
           </div>
@@ -89,7 +89,7 @@ const PropsedBusinessCaseSolutionReview = ({ name, solution }: ReviewProps) => (
       <div className="line-height-body-3">
         <DescriptionTerm term="Will your solution have a User Interface?" />
         <DescriptionDefinition
-          className="text-pre"
+          className="text-pre-wrap"
           definition={yesNoMap[solution.hasUserInterface]}
         />
       </div>
@@ -98,7 +98,7 @@ const PropsedBusinessCaseSolutionReview = ({ name, solution }: ReviewProps) => (
       <div className="line-height-body-3">
         <DescriptionTerm term={`${name}: Pros`} />
         <DescriptionDefinition
-          className="text-pre"
+          className="text-pre-wrap"
           definition={solution.pros}
         />
       </div>
@@ -107,7 +107,7 @@ const PropsedBusinessCaseSolutionReview = ({ name, solution }: ReviewProps) => (
       <div className="line-height-body-3">
         <DescriptionTerm term={`${name}: Cons`} />
         <DescriptionDefinition
-          className="text-pre"
+          className="text-pre-wrap"
           definition={solution.cons}
         />
       </div>
@@ -119,7 +119,7 @@ const PropsedBusinessCaseSolutionReview = ({ name, solution }: ReviewProps) => (
       <div className="line-height-body-3">
         <DescriptionTerm term="What is the cost savings or avoidance associated with this solution?" />
         <DescriptionDefinition
-          className="text-pre"
+          className="text-pre-wrap"
           definition={solution.costSavings}
         />
       </div>

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`The GRT business case review matches the snapshot 1`] = `
           What is your business or user need?
         </dt>
         <dd
-          className="description-definition margin-0 text-pre"
+          className="description-definition margin-0 text-pre-wrap"
         >
           Mock business need
         </dd>
@@ -110,7 +110,7 @@ exports[`The GRT business case review matches the snapshot 1`] = `
           How will CMS benefit from this effort?
         </dt>
         <dd
-          className="description-definition margin-0 text-pre"
+          className="description-definition margin-0 text-pre-wrap"
         >
           Mock CMS benefit
         </dd>
@@ -128,7 +128,7 @@ exports[`The GRT business case review matches the snapshot 1`] = `
           How does this effort align with organizational priorities?
         </dt>
         <dd
-          className="description-definition margin-0 text-pre"
+          className="description-definition margin-0 text-pre-wrap"
         >
           Mock priority alignment
         </dd>
@@ -146,7 +146,7 @@ exports[`The GRT business case review matches the snapshot 1`] = `
           How will you determine whether or not this effort is successful?
         </dt>
         <dd
-          className="description-definition margin-0 text-pre"
+          className="description-definition margin-0 text-pre-wrap"
         >
           Mock success indicators
         </dd>
@@ -273,7 +273,7 @@ exports[`The GRT business case review matches the snapshot 1`] = `
                 “As is” solution: Summary
               </dt>
               <dd
-                className="description-definition margin-0 text-pre"
+                className="description-definition margin-0 text-pre-wrap"
               >
                 Mock As is solution summary
               </dd>
@@ -291,7 +291,7 @@ exports[`The GRT business case review matches the snapshot 1`] = `
                 “As is” solution: Pros
               </dt>
               <dd
-                className="description-definition margin-0 text-pre"
+                className="description-definition margin-0 text-pre-wrap"
               >
                 Mock As is solution  pros
               </dd>
@@ -309,7 +309,7 @@ exports[`The GRT business case review matches the snapshot 1`] = `
                 “As is” solution: Cons
               </dt>
               <dd
-                className="description-definition margin-0 text-pre"
+                className="description-definition margin-0 text-pre-wrap"
               >
                 Mock As is solution cons
               </dd>
@@ -352,7 +352,7 @@ exports[`The GRT business case review matches the snapshot 1`] = `
               What is the cost savings or avoidance associated with this solution?
             </dt>
             <dd
-              className="description-definition margin-0 text-pre"
+              className="description-definition margin-0 text-pre-wrap"
             >
               
             </dd>

--- a/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
@@ -188,7 +188,7 @@ Array [
               What is your business need?
             </dt>
             <dd
-              className="description-definition margin-0 text-pre"
+              className="description-definition margin-0 text-pre-wrap"
             >
               The quick brown fox jumps over the lazy dog.
             </dd>
@@ -204,7 +204,7 @@ Array [
               How are you thinking of solving it?
             </dt>
             <dd
-              className="description-definition margin-0 text-pre"
+              className="description-definition margin-0 text-pre-wrap"
             >
               The quick brown fox jumps over the lazy dog.
             </dd>


### PR DESCRIPTION
# EASI-88

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Replace 'text-pre' with 'text-pre-wrap' so the text on review screens wraps properly.