### PR TITLE
Add stubbed page for notes.

### DIFF
--- a/src/views/GovernanceReviewTeam/Notes/index.tsx
+++ b/src/views/GovernanceReviewTeam/Notes/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Notes = () => {
+  return <h1>Notes</h1>;
+};
+
+export default Notes;

--- a/src/views/GovernanceReviewTeam/index.tsx
+++ b/src/views/GovernanceReviewTeam/index.tsx
@@ -163,7 +163,6 @@ const GovernanceReviewTeam = () => {
               <li>
                 <Link
                   to={`/governance-review-team/${systemId}/actions`}
-                  aria-label={t('actions')}
                   className={getNavLinkClasses('actions')}
                 >
                   {t('actions')}
@@ -172,7 +171,6 @@ const GovernanceReviewTeam = () => {
               <li>
                 <Link
                   to={`/governance-review-team/${systemId}/notes`}
-                  aria-label={t('notes')}
                   className={getNavLinkClasses('notes')}
                 >
                   {t('notes')}

--- a/src/views/GovernanceReviewTeam/index.tsx
+++ b/src/views/GovernanceReviewTeam/index.tsx
@@ -20,6 +20,7 @@ import IssueLifecycleId from './Actions/IssueLifecycleId';
 import SubmitAction from './Actions/SubmitAction';
 import BusinessCaseReview from './BusinessCaseReview';
 import IntakeReview from './IntakeReview';
+import Notes from './Notes';
 
 import './index.scss';
 
@@ -158,13 +159,26 @@ const GovernanceReviewTeam = () => {
               </li>
             </ul>
             <hr />
-            <Link
-              to={`/governance-review-team/${systemId}/actions`}
-              aria-label={t('actions')}
-              className={getNavLinkClasses('actions')}
-            >
-              {t('actions')}
-            </Link>
+            <ul className="easi-grt__nav-list">
+              <li>
+                <Link
+                  to={`/governance-review-team/${systemId}/actions`}
+                  aria-label={t('actions')}
+                  className={getNavLinkClasses('actions')}
+                >
+                  {t('actions')}
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to={`/governance-review-team/${systemId}/notes`}
+                  aria-label={t('notes')}
+                  className={getNavLinkClasses('notes')}
+                >
+                  {t('notes')}
+                </Link>
+              </li>
+            </ul>
           </nav>
           <section className="tablet:grid-col-9">
             <Route
@@ -179,6 +193,10 @@ const GovernanceReviewTeam = () => {
             <Route
               path="/governance-review-team/:systemId/business-case"
               render={() => <BusinessCaseReview businessCase={businessCase} />}
+            />
+            <Route
+              path="/governance-review-team/:systemId/notes"
+              render={() => <Notes />}
             />
             <Route
               path="/governance-review-team/:systemId/actions"


### PR DESCRIPTION
# EASI-786

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add a new stubbed page for notes
