### PR TITLE
Update redirects after requester submits business case

### DIFF
--- a/src/i18n/en-US/businessCase.ts
+++ b/src/i18n/en-US/businessCase.ts
@@ -5,7 +5,8 @@ const businessCase = {
       subheading: 'Your reference ID is {{referenceId}}',
       improveEasi:
         'Help us improve EASi. <1>Tell us what you think of this service (opens in a new tab)</1>',
-      homeCta: 'Go back to EASi homepage'
+      homeCta: 'Go back to EASi homepage',
+      taskListCta: 'Go back to Governance Task List'
     }
   }
 };

--- a/src/reducers/businessCaseReducer.test.ts
+++ b/src/reducers/businessCaseReducer.test.ts
@@ -17,7 +17,6 @@ describe('The business case reducer', () => {
       form: businessCaseInitialData,
       isLoading: null,
       isSaving: false,
-      isSubmitting: false,
       error: null
     });
   });
@@ -33,7 +32,6 @@ describe('The business case reducer', () => {
         form: businessCaseInitialData,
         isLoading: true,
         isSaving: false,
-        isSubmitting: false,
         error: null
       });
     });
@@ -88,7 +86,6 @@ describe('The business case reducer', () => {
         form: prepareBusinessCaseForApp(mockBusinessCase),
         isLoading: null,
         isSaving: false,
-        isSubmitting: false,
         error: null
       });
     });
@@ -103,7 +100,6 @@ describe('The business case reducer', () => {
         form: businessCaseInitialData,
         isLoading: null,
         isSaving: false,
-        isSubmitting: false,
         error: 'Error Found!'
       });
     });
@@ -118,7 +114,6 @@ describe('The business case reducer', () => {
         form: businessCaseInitialData,
         isLoading: false,
         isSaving: false,
-        isSubmitting: false,
         error: null
       });
     });
@@ -135,7 +130,6 @@ describe('The business case reducer', () => {
         form: businessCaseInitialData,
         isLoading: null,
         isSaving: true,
-        isSubmitting: false,
         error: null
       });
     });
@@ -188,7 +182,6 @@ describe('The business case reducer', () => {
         form: prepareBusinessCaseForApp(mockSuccessAction.payload),
         isLoading: null,
         isSaving: false,
-        isSubmitting: false,
         error: null
       });
     });
@@ -198,7 +191,6 @@ describe('The business case reducer', () => {
         form: businessCaseInitialData,
         isLoading: false,
         isSaving: true,
-        isSubmitting: false,
         error: null
       };
       const mockFailureAction = {
@@ -210,7 +202,6 @@ describe('The business case reducer', () => {
         form: businessCaseInitialData,
         isLoading: false,
         isSaving: true,
-        isSubmitting: false,
         error: 'Error'
       });
     });
@@ -225,7 +216,6 @@ describe('The business case reducer', () => {
         form: businessCaseInitialData,
         isLoading: null,
         isSaving: false,
-        isSubmitting: false,
         error: null
       });
     });
@@ -244,7 +234,6 @@ describe('The business case reducer', () => {
         form: { ...businessCaseInitialData, ...{ id: '12345' } },
         isLoading: false,
         isSaving: false,
-        isSubmitting: false,
         error: null
       });
     });
@@ -261,7 +250,6 @@ describe('The business case reducer', () => {
         form: businessCaseInitialData,
         isLoading: null,
         isSaving: false,
-        isSubmitting: false,
         error: null
       });
     });

--- a/src/reducers/businessCaseReducer.ts
+++ b/src/reducers/businessCaseReducer.ts
@@ -17,7 +17,6 @@ const initialState: BusinessCaseState = {
   form: businessCaseInitialData,
   isLoading: null,
   isSaving: false,
-  isSubmitting: false,
   error: null
 };
 

--- a/src/types/businessCase.ts
+++ b/src/types/businessCase.ts
@@ -98,6 +98,5 @@ export type BusinessCaseState = {
   form: BusinessCaseModel;
   isLoading: boolean | null;
   isSaving: boolean;
-  isSubmitting: boolean;
   error: any;
 };

--- a/src/views/BusinessCase/Confirmation/index.tsx
+++ b/src/views/BusinessCase/Confirmation/index.tsx
@@ -2,9 +2,18 @@ import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
 
-const Confirmation = () => {
+import { useFlags } from 'contexts/flagContext';
+import { BusinessCaseModel } from 'types/businessCase';
+
+const Confirmation = ({
+  businessCase
+}: {
+  businessCase: BusinessCaseModel;
+}) => {
   const { businessCaseId } = useParams();
+  const flags = useFlags();
   const { t } = useTranslation();
+
   return (
     <div className="grid-container margin-bottom-7">
       <div>
@@ -30,10 +39,17 @@ const Confirmation = () => {
           </Trans>
         </p>
         <div>
-          <Link to="/">
-            <i className="fa fa-angle-left margin-x-05" aria-hidden />
-            {t('businessCase:submission.confirmation.homeCta')}
-          </Link>
+          {flags.taskListLite ? (
+            <Link to={`/governance-task-list/${businessCase.systemIntakeId}`}>
+              <i className="fa fa-angle-left margin-x-05" aria-hidden />
+              {t('businessCase:submission.confirmation.taskListCta')}
+            </Link>
+          ) : (
+            <Link to="/">
+              <i className="fa fa-angle-left margin-x-05" aria-hidden />
+              {t('businessCase:submission.confirmation.homeCta')}
+            </Link>
+          )}
         </div>
       </div>
     </div>

--- a/src/views/BusinessCase/index.tsx
+++ b/src/views/BusinessCase/index.tsx
@@ -15,7 +15,6 @@ import Footer from 'components/Footer';
 import Header from 'components/Header';
 import MainContent from 'components/MainContent';
 import PageWrapper from 'components/PageWrapper';
-import usePrevious from 'hooks/usePrevious';
 import { AppState } from 'reducers/rootReducer';
 import { BusinessCaseModel } from 'types/businessCase';
 import {
@@ -50,13 +49,6 @@ export const BusinessCase = () => {
   const businessCase = useSelector(
     (state: AppState) => state.businessCase.form
   );
-
-  const isSubmitting = useSelector(
-    (state: AppState) => state.businessCase.isSubmitting
-  );
-
-  const error = useSelector((state: AppState) => state.businessCase.error);
-  const prevIsSubmitting = usePrevious(isSubmitting);
 
   const dispatchSave = () => {
     const { current }: { current: FormikProps<BusinessCaseModel> } = formikRef;
@@ -97,15 +89,6 @@ export const BusinessCase = () => {
       history.replace(`/business/${businessCase.id}/${formPage}`);
     }
   }, [history, businessCase.id, formPage]);
-
-  // Handle submit
-  useEffect(() => {
-    if (prevIsSubmitting && !isSubmitting && !error) {
-      history.push(`/business/${businessCaseId}/confirmation`);
-    }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSubmitting]);
 
   return (
     <PageWrapper className="business-case">

--- a/src/views/BusinessCase/index.tsx
+++ b/src/views/BusinessCase/index.tsx
@@ -53,7 +53,7 @@ export const BusinessCase = () => {
 
   const isSubmitting = useSelector((state: AppState) => state.action.isPosting);
 
-  const error = useSelector((state: AppState) => state.businessCase.error);
+  const actionError = useSelector((state: AppState) => state.action.error);
   const prevIsSubmitting = usePrevious(isSubmitting);
 
   const dispatchSave = () => {
@@ -98,7 +98,7 @@ export const BusinessCase = () => {
 
   // Handle submit
   useEffect(() => {
-    if (prevIsSubmitting && !isSubmitting && !error) {
+    if (prevIsSubmitting && !isSubmitting && !actionError) {
       history.push(`/business/${businessCaseId}/confirmation`);
     }
 
@@ -213,7 +213,7 @@ export const BusinessCase = () => {
             />
             <SecureRoute
               path="/business/:businessCaseId/confirmation"
-              render={() => <Confirmation />}
+              render={() => <Confirmation businessCase={businessCase} />}
             />
             <SecureRoute
               path="*"

--- a/src/views/BusinessCase/index.tsx
+++ b/src/views/BusinessCase/index.tsx
@@ -15,6 +15,7 @@ import Footer from 'components/Footer';
 import Header from 'components/Header';
 import MainContent from 'components/MainContent';
 import PageWrapper from 'components/PageWrapper';
+import usePrevious from 'hooks/usePrevious';
 import { AppState } from 'reducers/rootReducer';
 import { BusinessCaseModel } from 'types/businessCase';
 import {
@@ -49,6 +50,11 @@ export const BusinessCase = () => {
   const businessCase = useSelector(
     (state: AppState) => state.businessCase.form
   );
+
+  const isSubmitting = useSelector((state: AppState) => state.action.isPosting);
+
+  const error = useSelector((state: AppState) => state.businessCase.error);
+  const prevIsSubmitting = usePrevious(isSubmitting);
 
   const dispatchSave = () => {
     const { current }: { current: FormikProps<BusinessCaseModel> } = formikRef;
@@ -89,6 +95,15 @@ export const BusinessCase = () => {
       history.replace(`/business/${businessCase.id}/${formPage}`);
     }
   }, [history, businessCase.id, formPage]);
+
+  // Handle submit
+  useEffect(() => {
+    if (prevIsSubmitting && !isSubmitting && !error) {
+      history.push(`/business/${businessCaseId}/confirmation`);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSubmitting]);
 
   return (
     <PageWrapper className="business-case">


### PR DESCRIPTION
Since the business case no longer submits (it updates intake status via action api), we need to keep track of the `isPosting` from the Action reducer. The redirect wasn't working because the component was using the deprecated `isSubmitting` from the business case.

This PR makes the old solution work. We can probably improve the redirect after submit mechanism.

NOTE: Haven't tested locally. Local environment having issues.