### PR TITLE
Update business case reducer to store payload before the request is made

### DIFF
--- a/src/reducers/businessCaseReducer.test.ts
+++ b/src/reducers/businessCaseReducer.test.ts
@@ -6,6 +6,7 @@ import {
   clearBusinessCase,
   fetchBusinessCase,
   postBusinessCase,
+  putBusinessCase,
   storeBusinessCase
 } from 'types/routines';
 
@@ -225,6 +226,46 @@ describe('The business case reducer', () => {
         form: businessCaseInitialData,
         isLoading: null,
         isSaving: false,
+        isSubmitting: false,
+        error: null
+      });
+    });
+  });
+
+  describe('putBusinessCase', () => {
+    it('handles putBusinessCase.REQUEST', () => {
+      const initialState = {
+        form: {
+          ...businessCaseInitialData,
+          id: '5e579c80-31d0-4839-b1f8-d74bfa7d5e24'
+        },
+        isLoading: null,
+        isSaving: true,
+        isSubmitting: false,
+        error: null
+      };
+      const mockRequestAction = {
+        type: putBusinessCase.REQUEST,
+        payload: {
+          ...businessCaseInitialData,
+          businessNeed: 'The quick brown fox jumps over the lazy dog',
+          cmsBenefit: 'The quick brown fox jumps over the lazy dog',
+          priorityAlignment: 'The quick brown fox jumps over the lazy dog',
+          successIndicators: 'The quick brown fox jumps over the lazy dog'
+        }
+      };
+
+      expect(businessCaseReducer(initialState, mockRequestAction)).toEqual({
+        form: {
+          ...businessCaseInitialData,
+          id: '5e579c80-31d0-4839-b1f8-d74bfa7d5e24',
+          businessNeed: 'The quick brown fox jumps over the lazy dog',
+          cmsBenefit: 'The quick brown fox jumps over the lazy dog',
+          priorityAlignment: 'The quick brown fox jumps over the lazy dog',
+          successIndicators: 'The quick brown fox jumps over the lazy dog'
+        },
+        isLoading: null,
+        isSaving: true,
         isSubmitting: false,
         error: null
       });

--- a/src/reducers/businessCaseReducer.ts
+++ b/src/reducers/businessCaseReducer.ts
@@ -72,16 +72,14 @@ function businessCaseReducer(
     case putBusinessCase.REQUEST:
       return {
         ...state,
+        form: {
+          ...state.form,
+          ...action.payload
+        },
         isSaving: true
       };
     case putBusinessCase.SUCCESS:
-      return {
-        ...state,
-        form: {
-          ...state.form,
-          ...prepareBusinessCaseForApp(action.payload)
-        }
-      };
+      return state;
     case putBusinessCase.FAILURE:
       return {
         ...state,

--- a/src/sagas/businessCaseSaga.ts
+++ b/src/sagas/businessCaseSaga.ts
@@ -57,7 +57,7 @@ function putBusinessCaseRequest(formData: BusinessCaseModel) {
 
 function* updateBusinessCase(action: Action<any>) {
   try {
-    yield put(putBusinessCase.request());
+    yield put(putBusinessCase.request(action.payload));
     const reponse = yield call(putBusinessCaseRequest, action.payload);
 
     yield put(putBusinessCase.success(reponse.data));


### PR DESCRIPTION
This PR stores the form data **before** the `PUT` business case request is made. There was a race condition between the saving of the data and the data that gets loaded onto the next page.

I am currently brainstorming other ways to avoid this (e.g. navigating to the next page after save is complete), but this is a first swing at solving our problems.


