### PR TITLE
Return intake from LCID generation to help debug deployed environments.

### DIFF
--- a/pkg/handlers/system_intakes_test.go
+++ b/pkg/handlers/system_intakes_test.go
@@ -73,7 +73,7 @@ func (s HandlerTestSuite) TestLCIDHandler() {
 				"lcidNextSteps": "fuhgeddaboutit",
 				"lcidScope": "telescope"
 			}`,
-			status: http.StatusNoContent,
+			status: http.StatusCreated,
 		},
 		"happy path generate": {
 			verb:     "POST",
@@ -83,7 +83,7 @@ func (s HandlerTestSuite) TestLCIDHandler() {
 				"lcidNextSteps": "fuhgeddaboutit",
 				"lcidScope": "telescope"
 			}`,
-			status: http.StatusNoContent,
+			status: http.StatusCreated,
 		},
 		"write error": {
 			verb:     "POST",
@@ -134,11 +134,11 @@ func (s HandlerTestSuite) TestLCIDHandler() {
 		},
 	}
 
-	fnLCID := func(c context.Context, i *models.SystemIntake) error {
+	fnLCID := func(c context.Context, i *models.SystemIntake) (*models.SystemIntake, error) {
 		if i.ID == uuid.Nil {
-			return errors.New("forced error")
+			return nil, errors.New("forced error")
 		}
-		return nil
+		return nil, nil
 	}
 	var handler http.Handler = NewSystemIntakeLifecycleIDHandler(s.base, fnLCID).Handle()
 


### PR DESCRIPTION
# EASI-891

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- When generating a lifecycle ID, return the intake with the new values
- LCID generation is working swell locally, but not working at all in impl. Trying to get more information to help the debugging process.
- Somewhere, we should probably make it a convention that a POST request returns the thing created
