### PR TITLE
Add business case final task list item

### DIFF
--- a/src/data/taskList.ts
+++ b/src/data/taskList.ts
@@ -42,3 +42,24 @@ export const businessCaseTag = (intakeStatus: string) => {
       return '';
   }
 };
+
+export const finalBusinessCaseTag = (intakeStatus: string) => {
+  switch (intakeStatus) {
+    case 'INTAKE_DRAFT':
+    case 'INTAKE_SUBMITTED':
+    case 'NEED_BIZ_CASE':
+    case 'BIZ_CASE_DRAFT':
+    case 'BIZ_CASE_DRAFT_SUBMITTED':
+      return 'CANNOT_START';
+    case 'BIZ_CASE_FINAL_SUBMITTED':
+    case 'READY_FOR_GRT':
+    case 'READY_FOR_GRB':
+      return 'COMPLETED';
+    case 'NOT_IT_REQUEST':
+    case 'WITHDRAWN':
+    case 'LCID_ISSUED':
+      return 'NOT_NEEDED';
+    default:
+      return '';
+  }
+};

--- a/src/views/GovernanceTaskList/index.test.tsx
+++ b/src/views/GovernanceTaskList/index.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
+import { Link as UswdsLink } from '@trussworks/react-uswds';
 import { mount, ReactWrapper, shallow } from 'enzyme';
 import configureMockStore from 'redux-mock-store';
 
@@ -93,7 +94,7 @@ describe('The Goveranance Task List', () => {
       ).toEqual(2);
       expect(
         component.find('ol.governance-task-list__task-list li').length
-      ).toEqual(8);
+      ).toEqual(9);
     });
   });
 
@@ -488,6 +489,45 @@ describe('The Goveranance Task List', () => {
           .find('.governance-task-list__task-tag')
           .text()
       ).toEqual('Completed');
+
+      expect(
+        component!
+          .find('[data-testid="task-list-intake-review"]')
+          .find('.governance-task-list__task-tag')
+          .text()
+      ).toEqual('Completed');
+    });
+
+    it('renders proper buttons for BIZ_CASE_FINAL_NEEDED', async () => {
+      const store = mockStore({
+        systemIntake: {
+          systemIntake: {
+            ...initialSystemIntakeForm,
+            status: 'BIZ_CASE_FINAL_NEEDED'
+          }
+        },
+        businessCase: { form: {} }
+      });
+      let component: ReactWrapper;
+
+      await act(async () => {
+        component = mount(
+          <MemoryRouter initialEntries={['/']} initialIndex={0}>
+            <Provider store={store}>
+              <GovernanceTaskList />
+            </Provider>
+          </MemoryRouter>
+        );
+      });
+
+      component!.update();
+      expect(
+        component!
+          .find('[data-testid="task-list-business-case-final"]')
+          .exists()
+      ).toEqual(true);
+
+      expect(component!.find(UswdsLink).exists()).toEqual(true);
 
       expect(
         component!

--- a/src/views/GovernanceTaskList/index.test.tsx
+++ b/src/views/GovernanceTaskList/index.test.tsx
@@ -480,7 +480,7 @@ describe('The Goveranance Task List', () => {
 
       component!.update();
       expect(
-        component!.find('[data-testid="update-biz-case-draft"]').exists()
+        component!.find('[data-testid="update-biz-case-draft-btn"]').exists()
       ).toEqual(true);
 
       expect(
@@ -521,17 +521,55 @@ describe('The Goveranance Task List', () => {
       });
 
       component!.update();
+
       expect(
         component!
           .find('[data-testid="task-list-business-case-final"]')
-          .exists()
-      ).toEqual(true);
-
-      expect(component!.find(UswdsLink).exists()).toEqual(true);
+          .find(UswdsLink)
+          .text()
+      ).toEqual('Review and Submit');
 
       expect(
         component!
-          .find('[data-testid="task-list-intake-review"]')
+          .find('[data-testid="task-list-business-case-draft"]')
+          .find('.governance-task-list__task-tag')
+          .text()
+      ).toEqual('Completed');
+    });
+
+    it('renders proper buttons for BIZ_CASE_FINAL_SUBMITTED', async () => {
+      const store = mockStore({
+        systemIntake: {
+          systemIntake: {
+            ...initialSystemIntakeForm,
+            status: 'BIZ_CASE_FINAL_SUBMITTED'
+          }
+        },
+        businessCase: { form: {} }
+      });
+      let component: ReactWrapper;
+
+      await act(async () => {
+        component = mount(
+          <MemoryRouter initialEntries={['/']} initialIndex={0}>
+            <Provider store={store}>
+              <GovernanceTaskList />
+            </Provider>
+          </MemoryRouter>
+        );
+      });
+
+      component!.update();
+      expect(
+        component!
+          .find('[data-testid="task-list-business-case-final"]')
+          .find(UswdsLink)
+          .exists()
+      ).toEqual(false);
+
+      expect(
+        component!
+          .find('[data-testid="task-list-business-case-final"]')
           .find('.governance-task-list__task-tag')
           .text()
       ).toEqual('Completed');

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -122,7 +122,7 @@ const BusinessCaseLink = ({ systemIntake }: BusinessCaseLinkProps) => {
     case 'BIZ_CASE_CHANGES_NEEDED':
       return (
         <UswdsLink
-          data-testid="update-biz-case-draft"
+          data-testid="update-biz-case-draft-btn"
           className="usa-button"
           variant="unstyled"
           asCustom={Link}
@@ -165,7 +165,10 @@ const GovernanceTaskList = () => {
   }, [dispatch, systemIntake.id, systemIntake.businessCaseId]);
 
   useEffect(() => {
-    const remainingStepsStatuses = ['BIZ_CASE_FINAL_NEEDED'];
+    const remainingStepsStatuses = [
+      'BIZ_CASE_FINAL_NEEDED',
+      'BIZ_CASE_FINAL_SUBMITTED'
+    ];
     if (remainingStepsStatuses.includes(systemIntake.status)) {
       setDisplayRemainingSteps(true);
     }

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -280,6 +280,7 @@ const GovernanceTaskList = () => {
                 start={4}
               >
                 <TaskListItem
+                  data-testid="task-list-business-case-final"
                   heading="Submit the business case for final approval"
                   description="Update the Business Case based on feedback from the review meeting and submit it to the Governance Review Board."
                   status={finalBusinessCaseTag(systemIntake.status)}

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -10,7 +10,12 @@ import Header from 'components/Header';
 import MainContent from 'components/MainContent';
 import PageWrapper from 'components/PageWrapper';
 import { isIntakeStarted } from 'data/systemIntake';
-import { businessCaseTag, initialReviewTag, intakeTag } from 'data/taskList';
+import {
+  businessCaseTag,
+  finalBusinessCaseTag,
+  initialReviewTag,
+  intakeTag
+} from 'data/taskList';
 import { AppState } from 'reducers/rootReducer';
 import {
   archiveSystemIntake,
@@ -159,6 +164,13 @@ const GovernanceTaskList = () => {
     }
   }, [dispatch, systemIntake.id, systemIntake.businessCaseId]);
 
+  useEffect(() => {
+    const remainingStepsStatuses = ['BIZ_CASE_FINAL_NEEDED'];
+    if (remainingStepsStatuses.includes(systemIntake.status)) {
+      setDisplayRemainingSteps(true);
+    }
+  }, [systemIntake.status]);
+
   const archiveIntake = () => {
     const redirect = () => {
       history.push('/', {
@@ -267,6 +279,22 @@ const GovernanceTaskList = () => {
                 className="governance-task-list__task-list governance-task-list__task-list--secondary"
                 start={4}
               >
+                <TaskListItem
+                  heading="Submit the business case for final approval"
+                  description="Update the Business Case based on feedback from the review meeting and submit it to the Governance Review Board."
+                  status={finalBusinessCaseTag(systemIntake.status)}
+                >
+                  {systemIntake.status === 'BIZ_CASE_FINAL_NEEDED' && (
+                    <UswdsLink
+                      className="usa-button"
+                      variant="unstyled"
+                      asCustom={Link}
+                      to={`/business/${systemIntake.businessCaseId}/general-request-info`}
+                    >
+                      Review and Submit
+                    </UswdsLink>
+                  )}
+                </TaskListItem>
                 <TaskListItem
                   heading="Attend the review meeting"
                   description="Discuss your draft Business Case with Governance Review Team. They will


### PR DESCRIPTION
# EASI-666

This PR adds the task list item for final submission of the requester's business case.

This task list item (#4) becomes available to the user when the intake's status is `BIZ_CASE_FINAL_NEEDED`. When the intake status is `BIZ_CASE_FINAL_NEEDED`, it displays the remaining steps to make it easier for the user.

This PR does **NOT** allow a user to submit their final business case. The `Review and Submit` button will bring them to the form, but the form will not actually submit the final business case. It will submit the draft.