### PR TITLE
Fix lcid race condition

### DIFF
--- a/src/reducers/systemIntakeReducer.ts
+++ b/src/reducers/systemIntakeReducer.ts
@@ -8,6 +8,7 @@ import {
   archiveSystemIntake,
   clearSystemIntake,
   fetchSystemIntake,
+  issueLifecycleIdForSystemIntake,
   postSystemIntake,
   reviewSystemIntake,
   saveSystemIntake,
@@ -140,6 +141,14 @@ function systemIntakeReducer(
       };
     case archiveSystemIntake.SUCCESS:
       return initialState;
+    case issueLifecycleIdForSystemIntake.SUCCESS:
+      return {
+        ...state,
+        systemIntake: {
+          ...state.systemIntake,
+          ...prepareSystemIntakeForApp(action.payload)
+        }
+      };
     default:
       return state;
   }

--- a/src/sagas/actionSaga.ts
+++ b/src/sagas/actionSaga.ts
@@ -7,7 +7,7 @@ import { updateLastActiveAt } from 'reducers/authReducer';
 import { Action } from 'types/action';
 import { postSystemIntakeAction } from 'types/routines';
 
-function postSystemIntakeActionRequest(formData: Action) {
+export function postSystemIntakeActionRequest(formData: Action) {
   return axios.post(
     `${process.env.REACT_APP_API_ADDRESS}/system_intake/${formData.intakeId}/actions`,
     formData

--- a/src/sagas/systemIntakeSaga.ts
+++ b/src/sagas/systemIntakeSaga.ts
@@ -18,6 +18,8 @@ import {
 } from 'types/routines';
 import { SystemIntakeForm } from 'types/systemIntake';
 
+import { postSystemIntakeActionRequest } from './actionSaga';
+
 function putSystemIntakeRequest(formData: SystemIntakeForm) {
   // Make API save request
   const data = prepareSystemIntakeForApi(formData);
@@ -79,6 +81,7 @@ function* getSystemIntake(action: Action<any>) {
 function* submitSystemIntakeReview(action: Action<any>) {
   try {
     yield put(reviewSystemIntake.request());
+    yield postSystemIntakeActionRequest(action);
     const response = yield call(putSystemIntakeRequest, action.payload);
     yield put(reviewSystemIntake.success(response.data));
   } catch (error) {
@@ -128,7 +131,9 @@ function postLifecycleId({ id, data }: { id: string; data: lifecycleIdData }) {
 function* issueLifecyleId(action: Action<any>) {
   try {
     yield put(issueLifecycleIdForSystemIntake.request());
-    const response = yield call(postLifecycleId, action.payload);
+    const { id, lcidPayload, actionPayload } = action.payload;
+    yield call(postSystemIntakeActionRequest, { id, ...actionPayload });
+    const response = yield call(postLifecycleId, { id, data: lcidPayload });
     yield put(issueLifecycleIdForSystemIntake.success(response.data));
   } catch (error) {
     yield put(issueLifecycleIdForSystemIntake.failure(error.message));

--- a/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
@@ -14,10 +14,7 @@ import { RadioField } from 'components/shared/RadioField';
 import TextAreaField from 'components/shared/TextAreaField';
 import TextField from 'components/shared/TextField';
 import { ActionType, SubmitLifecycleIdForm } from 'types/action';
-import {
-  issueLifecycleIdForSystemIntake,
-  postSystemIntakeAction
-} from 'types/routines';
+import { issueLifecycleIdForSystemIntake } from 'types/routines';
 import flattenErrors from 'utils/flattenErrors';
 import { lifecycleIdSchema } from 'validations/actionSchema';
 
@@ -50,19 +47,14 @@ const IssueLifecycleId = () => {
       lifecycleId
     } = values;
     const actionPayload = { actionType, intakeId: systemId, feedback };
-    dispatch(postSystemIntakeAction(actionPayload));
-
-    const lcidData = {
+    const lcidPayload = {
       lcidExpiresAt: `${expirationDateYear}-${expirationDateMonth}-${expirationDateDay}`,
       lcidNextSteps: nextSteps,
       lcidScope: scope,
       lcid: lifecycleId
     };
-    const lcidPayload = {
-      id: systemId,
-      data: lcidData
-    };
-    dispatch(issueLifecycleIdForSystemIntake(lcidPayload));
+    const payload = { id: systemId, actionPayload, lcidPayload };
+    dispatch(issueLifecycleIdForSystemIntake(payload));
 
     history.push(`/governance-review-team/${systemId}/intake-request`);
   };


### PR DESCRIPTION
# EASI-891

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Fire the action to change status first and the LCID action after
- Update the intake reducer when the LCID action finishes so user doesn't have to refresh to see new LCID and updated status

Background info:
Before this change, we were firing the action and LCID POST requests at the same time. The LCID often finished first, and returned the proper values. The action request finished second, and the save to the status of the intake would overwrite the values from the LCID response. So this PR changes the frontend code to call these API endpoints sequentially, rather than simultaneously.
