### PR TITLE
Proof of Concept for PDF download

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -101,3 +101,12 @@ CloudTamer
 DMs
 1Password
 Splunk
+PDFs
+SaaS
+DocRaptor
+PDF-UA
+3k
+4k
+Gotenberg
+UniDoc
+PDFKit

--- a/.spelling
+++ b/.spelling
@@ -110,3 +110,4 @@ PDF-UA
 Gotenberg
 UniDoc
 PDFKit
+EASI-983

--- a/docs/adr/0022-generate-pdfs-with-prince.md
+++ b/docs/adr/0022-generate-pdfs-with-prince.md
@@ -19,7 +19,7 @@ EASi does.
   develop the PDFs using the same workflows, tools, and CSS code that we
   currently use for the existing UI.
 
-**User Story:** _[ticket/issue-number]_ <!-- optional -->
+**User Story:** EASI-983
 
 ## Chosen Solution
 

--- a/docs/adr/0022-generate-pdfs-with-prince.md
+++ b/docs/adr/0022-generate-pdfs-with-prince.md
@@ -1,0 +1,116 @@
+# Generate PDFs with Prince
+
+## Background
+
+EASi needs to be able to export information in PDF format. We are looking
+specifically at exporting System Intake and Business Cases, but in the
+future we expect the range of reports to grow as the overall scope of
+EASi does.
+
+## Decision Drivers
+
+- The PDFs need to be accessible, which requires using the PDF-UA profile
+  and having appropriate tagging.
+- Most PDF tooling doesn’t have good support for accessibility features,
+  so our choices are somewhat limited.
+- The project requires hosting everything privately, which rules out any
+  SaaS options for generating PDFs (e.g. [DocRaptor](https://docraptor.com)).
+- We’d like to generate the PDF from HTML and CSS code. This allows us to
+  develop the PDFs using the same workflows, tools, and CSS code that we
+  currently use for the existing UI.
+
+**User Story:** _[ticket/issue-number]_ <!-- optional -->
+
+## Chosen Solution
+
+- We will deploy a commercial software product,
+  [Prince](https://www.princexml.com), to do the HTML-to-PDF conversion. This
+  is a command-line program that we will deploy via AWS Lambda.
+- The lambda will only be accessible from our Go backend and not via the
+  public internet. It will only have permissions to access services needed
+  for metrics and logging.
+- Our React frontend will send HTML to Go backend, which will then invoke
+  the lambda and return the resulting PDF to the user’s browser.
+
+We think this is the best solution in terms of providing highly-accessible
+PDFs, saving developer time, and building on a supported and actively
+developed tool. Hosting Prince within a private lambda function minimizes
+any potential attack surface.
+
+## Pros and Cons of the Options
+
+### [Prince](https://www.princexml.com)
+
+Mature commercial software product that converts HTML and CSS to PDF.
+
+- `+` Best HTML-to-PDF option in terms of creating accessible PDFs using
+  PDF-UA profile
+- `+` Offers [control over how PDF files are tagged](https://medium.com/@bruce_39084/making-accessible-tagged-pdfs-with-prince-ad7fd7a48711)
+- `+` Allowing us to reuse our existing code and workflow will save lots of
+  development time
+- `+` Commercially supported product with long history
+- `+` [Ready-to-go Lambda distribution](https://medium.com/@bruce_39084/setting-up-prince-on-aws-lambda-and-api-gateway-4d524dcb035b)
+- `-` Requires some infra work to setup lambda function
+- `-` Closed-source
+- `-` Annual license required (~ \$4k/year)
+- `+` Already in use by DHS and other government organizations
+
+### [Puppeteer](https://pptr.dev)
+
+Remote controlled headless Chrome allows use of Chrome’s built-in PDF
+generator via a Node module.
+
+- `+` Provides some level of PDF tagging
+- `-` Chrome’s new `--tagged-pdf` option creates a messy and cluttered
+  tag hierarchy that can't be customized
+- `-` Requires some infra work to setup lambda function
+- `+` Open Source
+- `+` Free
+
+### [UniDoc](https://www.unidoc.io) - DOCX
+
+- `-` DOCX isn’t as desirable as PDF
+- `-` It isn’t clear if DOCX fulfills our accessibility requirements
+- `-` Can't reuse any of our existing application UI for presentation
+- `+` Runs in the Go process (doesn’t require additional infra)
+- `+` Open Source
+- `-` Costs \$3k
+
+### [React-PDF](https://react-pdf.org) (and [PDFKit](http://pdfkit.org))
+
+JavaScript library, all code runs within frontend application
+
+- `-` [Does not support generating accessible PDFs](https://github.com/foliojs/pdfkit/issues/1062)
+  (no support for tagging)
+- `+` Doesn’t require additional infrastructure
+- `+` Open source
+- `+` Free
+
+### [Gotenberg](https://thecodingmachine.github.io/gotenberg/)
+
+Docker-based service that created PDFs from various document formats
+
+- `-` Doesn’t support generating tagged PDFs
+- `-` Docker image isn’t immediately compatible with running on Lambda
+- `+` Open source
+- `+` Free
+
+### [Microsoft Print-To-PDF](https://www.onmsft.com/how-to/how-to-print-to-pdf-in-windows-10)
+
+Component of Windows 10 that allows any Windows application to create PDFs
+
+- `-` Creates inaccessible PDFs by embedding images of the webpage
+- `-` Not intuitive for users (using “print” to download a file)
+- `-` May not be installed by default
+- `+` Free
+- `+` Works with any Windows application
+
+### [UniDoc](https://www.unidoc.io) - PDF
+
+Go library for generating PDFs
+
+- `-` Doesn’t support creating tagged PDFs
+- `-` Can't reuse any of our existing application UI for presentation
+- `+` Runs in the Go process (doesn’t require additional infra)
+- `+` Open source
+- `-` Costs \$3k a year

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -26,8 +26,6 @@ This log lists the architectural decisions for the CMS EASi application.
 - [ADR-0019](0019-use-1password-for-sharing-secrets.md) - Use 1Password for sharing secrets
 - [ADR-0020](0020-do-not-implement-state-machine.md) - Do not implement state machine to handle transitions in Services
 - [ADR-0021](0021-audit-logging.md) - Audit Logging
-- [ADR-0021](0021-namespace-code-by-process.md) - Namespace Code by Process
 - [ADR-0022](0022-generate-pdfs-with-prince.md) - Generate PDFs with Prince
-- [ADR-0022](0022-use-graphql.md) - *[short title of solved problem and solution]*
 
 <!-- adrlogstop -->

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -26,5 +26,8 @@ This log lists the architectural decisions for the CMS EASi application.
 - [ADR-0019](0019-use-1password-for-sharing-secrets.md) - Use 1Password for sharing secrets
 - [ADR-0020](0020-do-not-implement-state-machine.md) - Do not implement state machine to handle transitions in Services
 - [ADR-0021](0021-audit-logging.md) - Audit Logging
+- [ADR-0021](0021-namespace-code-by-process.md) - Namespace Code by Process
+- [ADR-0022](0022-generate-pdfs-with-prince.md) - Generate PDFs with Prince
+- [ADR-0022](0022-use-graphql.md) - *[short title of solved problem and solution]*
 
 <!-- adrlogstop -->

--- a/lambda/prince/index.js
+++ b/lambda/prince/index.js
@@ -1,0 +1,85 @@
+const { execFile } = require('child_process');
+
+function tinyMultipartParser(data) {
+  // assume first line is boundary
+  const lines = data.split('\r\n');
+  const boundary = lines[0];
+  const endboundary = `${boundary}--`;
+  const boundaries = lines.filter(l => l === boundary).length;
+
+  if (boundaries !== 1) {
+    throw new Error(`Unexpected boundaries ${boundaries}`);
+  }
+  const endboundaries = lines.filter(l => l === endboundary).length;
+
+  if (endboundaries !== 1) {
+    throw new Error(`Unexpected end boundaries ${boundaries}`);
+  }
+
+  const output = [];
+  let inBody = false;
+  lines.forEach(line => {
+    if (line.trim() === '' && !inBody) {
+      inBody = true;
+      return;
+    }
+    if (
+      !inBody &&
+      line.match(/^content-type: /i) &&
+      !line.match(/text\/html/)
+    ) {
+      throw new Error('not html');
+    }
+    if (line.indexOf(boundary) > -1) return;
+    if (inBody) output.push(line);
+  });
+  return output.join('\n');
+}
+
+function handler(event, context, done) {
+  if (!event || !event.body) {
+    return done(new Error('No data.'));
+  }
+  let { body } = event;
+  if (event.isBase64Encoded) {
+    body = Buffer.from(body, 'base64').toString('ascii');
+  }
+  const html = tinyMultipartParser(body);
+  const opts = {
+    timeout: 10 * 1000,
+    maxbuffer: 10 * 1024 * 1024,
+    encoding: 'buffer'
+  };
+
+  const princeCallback = (err, stdout, stderr) => {
+    if (err) {
+      return done(err);
+    }
+
+    const m = stderr.toString().match(/prince:\s+error:\s+([^\n]+)/);
+    if (err === null && m) {
+      return done(new Error(m[1]));
+    }
+
+    return done(null, {
+      isBase64Encoded: true,
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/pdf' },
+      body: stdout.toString('base64')
+    });
+  };
+
+  const child = execFile(
+    './prince',
+    ['-', '--output=-', '--pdf-profile=PDF/UA-1'],
+    opts,
+    princeCallback
+  );
+  child.stdin.write(html);
+  child.stdin.end();
+  return null;
+}
+
+module.exports = {
+  handler
+};

--- a/pkg/handlers/pdf.go
+++ b/pkg/handlers/pdf.go
@@ -1,0 +1,99 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"os"
+)
+
+// PDFHandler handles PDFs
+type PDFHandler struct {
+	HandlerBase
+}
+
+// NewPDFHandler returns a new PDFHandler
+func NewPDFHandler() *PDFHandler {
+	return &PDFHandler{}
+}
+
+// Handle returns an http.HandlerFunc
+func (h PDFHandler) Handle() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		type GenerateRequest struct {
+			HTML     string `json:"html"`
+			Filename string `json:"filename"`
+		}
+
+		var data GenerateRequest
+
+		body, readErr := ioutil.ReadAll(r.Body)
+		if readErr != nil {
+			h.WriteErrorResponse(r.Context(), w, readErr)
+			return
+		}
+
+		parseErr := json.Unmarshal(body, &data)
+		if parseErr != nil {
+			h.WriteErrorResponse(r.Context(), w, parseErr)
+			return
+		}
+
+		postBody := new(bytes.Buffer)
+		writer := multipart.NewWriter(postBody)
+
+		header := make(textproto.MIMEHeader)
+		header.Set("Content-Disposition", `form-data; name="file"; filename="input.html"`)
+		header.Set("Content-Type", "text/html")
+
+		part, partErr := writer.CreatePart(header)
+		if partErr != nil {
+			h.WriteErrorResponse(r.Context(), w, partErr)
+			return
+		}
+		if _, partWriteErr := part.Write([]byte(data.HTML)); partWriteErr != nil {
+			h.WriteErrorResponse(r.Context(), w, partWriteErr)
+			return
+		}
+
+		if closeErr := writer.Close(); closeErr != nil {
+			h.WriteErrorResponse(r.Context(), w, closeErr)
+			return
+		}
+
+		// TODO This should use the logger
+		fmt.Println("making request to lambda")
+
+		uri := os.Getenv("PDF_GENERATOR_LAMBDA_URL")
+
+		client := &http.Client{}
+		request, reqErr := http.NewRequest("POST", uri, postBody)
+		if reqErr != nil {
+			h.WriteErrorResponse(r.Context(), w, reqErr)
+			return
+		}
+		request.Header.Add("Content-Type", "text/html")
+
+		response, respErr := client.Do(request)
+		if respErr != nil {
+			h.WriteErrorResponse(r.Context(), w, respErr)
+			return
+		}
+
+		// If we were sending the response to a non-XHR, these headers would be necessary
+		//
+		// w.Header().Set("Content-Length", response.Header.Get("Content-Length"))
+		// w.Header().Set("Content-Disposition", "attachment; filename=generated.pdf")
+		// w.Header().Set("Content-Type", "application/pdf")
+
+		if _, copyErr := io.Copy(w, response.Body); copyErr != nil {
+			h.WriteErrorResponse(r.Context(), w, copyErr)
+			return
+		}
+	}
+}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -96,7 +96,7 @@ func (s *Server) routes(
 
 	switch flagConfig.Source {
 	case appconfig.FlagSourceLocal:
-		defaultFlags := flags.FlagValues{"taskListLite": "true", "sandbox": "true"}
+		defaultFlags := flags.FlagValues{"taskListLite": "true", "sandbox": "true", "pdfExport": "true"}
 		flagClient = flags.NewLocalClient(defaultFlags)
 
 	case appconfig.FlagSourceLaunchDarkly:

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -459,4 +459,7 @@ func (s *Server) routes(
 	s.router.PathPrefix("/").Handler(handlers.NewCatchAllHandler(
 		base,
 	).Handle())
+
+	api.Handle("/pdf/generate", handlers.NewPDFHandler().Handle())
+
 }

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -43,9 +43,8 @@ function generatePDF(filename: string, content: string) {
       const blob = new Blob([response.data], { type: 'application/pdf' });
       downloadBlob(filename, blob);
     })
-    .catch(error => {
+    .catch(() => {
       // TODO add error handling: display a modal if things fail?
-      console.debug(error);
     });
 }
 
@@ -67,8 +66,8 @@ const downloadPDF = (title: string, filename: string): void => {
     .then(stylesheets => {
       styleBlocks.concat(stylesheets.map(response => response.data));
     })
-    .catch(error => {
-      console.debug(error);
+    .catch(() => {
+      // TODO add error handling: display a modal if things fail?
     });
 
   const markupToRender = `<html lang="en">

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import axios from 'axios';
+
+import { useFlags } from 'contexts/flagContext';
+
+type PDFExportProps = {
+  filename: string;
+  title: string;
+};
+
+function downloadBlob(filename: string, blob: Blob) {
+  // This approach to downloading files works fine in the tests I've done in Chrome
+  // with PDF files that are < 100kB. For larger files we might need to
+  // instead redirect the browser to a URL that returns the file. That
+  // approach is complicated by using JWTs for auth.
+  //
+  // TODO test this in various browsers. Some reports say this might not work
+  // properly in Firefox and that firing a MouseEvent is required instead.
+  const blobUrl = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = blobUrl;
+  link.download = filename;
+
+  // This downloads the file to the user's machine.
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+function generatePDF(filename: string, content: string) {
+  axios
+    .request({
+      url: `${process.env.REACT_APP_API_ADDRESS}/pdf/generate`,
+      responseType: 'blob',
+      method: 'POST',
+      data: {
+        html: content,
+        filename: 'input.html'
+      }
+    })
+    .then(response => {
+      const blob = new Blob([response.data], { type: 'application/pdf' });
+      downloadBlob(filename, blob);
+    })
+    .catch(error => {
+      // TODO add error handling: display a modal if things fail?
+      console.debug(error);
+    });
+}
+
+const downloadPDF = (title: string, filename: string): void => {
+  // Collect any stylesheets that are linked to. These are used in production.
+  const stylesheetRequests = Array.prototype.slice
+    .apply(document.styleSheets)
+    .filter(stylesheet =>
+      stylesheet.href ? axios.get(stylesheet.href) : null
+    );
+
+  // Also grab any inline styles, used predominantly in development.
+  const styleBlocks = Array.prototype.slice
+    .apply(document.querySelectorAll('style'))
+    .map(node => node.innerText);
+
+  // Combine external and inline styles
+  Promise.all(stylesheetRequests)
+    .then(stylesheets => {
+      styleBlocks.concat(stylesheets.map(response => response.data));
+    })
+    .catch(error => {
+      console.debug(error);
+    });
+
+  const markupToRender = `<html lang="en">
+        <head>
+          <title>${escape(title)}</title>
+          <style>
+            ${styleBlocks.join('\n\n')}
+          </style>
+        </head>
+        ${document.body.outerHTML} 
+      </html>`;
+
+  generatePDF(filename, markupToRender);
+};
+
+// PDFExport adds a "Download PDF" button to the screen. When this button is clicked,
+// the HTML content of the *entire current page* is sent to the server and converted
+// to PDF format. This is required because the style rules for the page are inlined
+// into the document source. Style changes will need to be made using print styles.
+//
+// An additional benefit to this design is that is pushes us to have decent print
+// stylesheets for the application, whether or not we are expecting users to export
+// that part to PDF.
+const PDFExport = ({ title, filename }: PDFExportProps) => {
+  const flags = useFlags();
+
+  return flags.pdfExport ? (
+    <button
+      className="easi-no-print"
+      type="button"
+      onClick={() => downloadPDF(title, filename)}
+    >
+      Download PDF
+    </button>
+  ) : null;
+};
+
+export default PDFExport;

--- a/src/contexts/flagContext.test.tsx
+++ b/src/contexts/flagContext.test.tsx
@@ -24,7 +24,8 @@ it('loads flags into the provider', async () => {
   const getMock = mockedAxios.get.mockResolvedValue({
     data: {
       sandbox: true,
-      taskListLite: true
+      taskListLite: true,
+      pdfExport: true
     }
   });
 
@@ -40,7 +41,9 @@ it('loads flags into the provider', async () => {
   wrapper.update();
 
   const printer = wrapper.find(FlagPrinter);
-  expect(printer.text()).toEqual(`{"sandbox":true,"taskListLite":true}`);
+  expect(printer.text()).toEqual(
+    `{"pdfExport":true,"sandbox":true,"taskListLite":true}`
+  );
   expect(mockedAxios.get.mock.calls).toEqual([[flagsURL]]);
 });
 
@@ -61,6 +64,8 @@ it('uses the defaults when flags fail to load', async () => {
   wrapper.update();
 
   const printer = wrapper.find(FlagPrinter);
-  expect(printer.text()).toEqual(`{"sandbox":false,"taskListLite":false}`);
+  expect(printer.text()).toEqual(
+    `{"pdfExport":false,"sandbox":false,"taskListLite":false}`
+  );
   expect(mockedAxios.get.mock.calls).toEqual([[flagsURL]]);
 });

--- a/src/contexts/flagContext.tsx
+++ b/src/contexts/flagContext.tsx
@@ -6,7 +6,8 @@ import { Flags, FlagsState } from 'types/flags';
 const initialState: FlagsState = {
   flags: {
     taskListLite: false,
-    sandbox: false
+    sandbox: false,
+    pdfExport: false
   },
   isLoaded: false
 };

--- a/src/index.scss
+++ b/src/index.scss
@@ -32,7 +32,12 @@
 // Custom USWDS
 @import './stylesheets/custom.scss';
 
-html, body, #root {
+// Print styles (used for PDF generation)
+@import './stylesheets/print.scss';
+
+html,
+body,
+#root {
   height: 100%;
   min-height: 100%;
 }

--- a/src/stylesheets/print.scss
+++ b/src/stylesheets/print.scss
@@ -1,0 +1,29 @@
+@media print {
+  header.usa-header,
+  footer.usa-footer,
+  nav.easi-breadcrumb-nav,
+  .easi-no-print,
+  .skipnav,
+  noscript {
+    display: none;
+  }
+
+  .easi-review-row {
+    display: flex;
+    & > div {
+      flex: 1;
+      margin-bottom: 1.25rem;
+    }
+  }
+
+  hr.system-intake__hr {
+    opacity: 1;
+    border-bottom: solid 5px black;
+  }
+
+  h1 {
+    border-bottom: solid 5px #009bc3;
+    padding-bottom: 1rem;
+    margin-bottom: 3rem;
+  }
+}

--- a/src/types/flags.ts
+++ b/src/types/flags.ts
@@ -1,6 +1,7 @@
 export type Flags = {
   taskListLite: Boolean;
   sandbox: Boolean;
+  pdfExport: Boolean;
 };
 
 export type FlagsState = {

--- a/src/views/GrtSystemIntakeReview/index.tsx
+++ b/src/views/GrtSystemIntakeReview/index.tsx
@@ -10,6 +10,7 @@ import Footer from 'components/Footer';
 import Header from 'components/Header';
 import MainContent from 'components/MainContent';
 import PageWrapper from 'components/PageWrapper';
+import PDFExport from 'components/PDFExport';
 import Alert from 'components/shared/Alert';
 import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
@@ -58,6 +59,7 @@ export const GrtSystemIntakeReview = () => {
                 now={DateTime.local()}
               />
             )}
+            <PDFExport filename="system-intake.pdf" />
           </div>
         </div>
         {!isLoading &&
@@ -65,7 +67,7 @@ export const GrtSystemIntakeReview = () => {
           ['local', 'dev', 'impl'].includes(
             process.env.REACT_APP_APP_ENV || ''
           ) && (
-            <div className="bg-gray-5 padding-top-6 padding-bottom-5">
+            <div className="bg-gray-5 padding-top-6 padding-bottom-5 easi-no-print">
               <div className="grid-container">
                 {systemIntake.status === 'INTAKE_SUBMITTED' && (
                   <Formik

--- a/src/views/SystemIntake/ViewOnly/index.tsx
+++ b/src/views/SystemIntake/ViewOnly/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import axios from 'axios';
 import { DateTime } from 'luxon';
 
 import SystemIntakeReview from 'components/SystemIntakeReview';
@@ -7,11 +8,66 @@ import { SystemIntakeForm } from 'types/systemIntake';
 type SystemIntakeViewOnlyProps = {
   systemIntake: SystemIntakeForm;
 };
-const SystemIntakeView = ({ systemIntake }: SystemIntakeViewOnlyProps) => (
-  <>
-    <h1>Review your Intake Request</h1>
-    <SystemIntakeReview systemIntake={systemIntake} now={DateTime.local()} />
-  </>
-);
+
+function downloadFile(filename: string, content: string) {
+  axios
+    .request({
+      url: `${process.env.REACT_APP_API_ADDRESS}/pdf/generate`,
+      responseType: 'blob',
+      method: 'POST',
+      data: {
+        html: content,
+        filename
+      }
+    })
+    .then(response => {
+      // This approach works fine in the tests I've done in Chrome
+      // With PDF files that are < 100kB. For larger files we might need to
+      // instead redirect the browser to a URL that returns the file. That
+      // approach is complicated by using JWTs for auth.
+      const blobUrl = URL.createObjectURL(
+        new Blob([response.data], { type: 'application/pdf' })
+      );
+
+      const link = document.createElement('a');
+
+      link.href = blobUrl;
+
+      // TODO generate a useful filename here
+      link.download = 'generated.pdf';
+
+      // This downloads the file
+      // TODO test this in various browsers. Some reports say this might not work
+      // properly in Firefox and that firing a MouseEvent is required instead.
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    })
+    .catch(error => {
+      // TODO add error handling: display a modal if things fail?
+      console.debug(error);
+    });
+}
+
+const SystemIntakeView = ({ systemIntake }: SystemIntakeViewOnlyProps) => {
+  const download = (): void => {
+    downloadFile('intake.html', document.documentElement.outerHTML);
+  };
+
+  return (
+    <>
+      <div>
+        <h1>Review your Intake Request</h1>
+        <SystemIntakeReview
+          systemIntake={systemIntake}
+          now={DateTime.local()}
+        />
+      </div>
+      <button className="easi-no-print" type="button" onClick={download}>
+        Download PDF
+      </button>
+    </>
+  );
+};
 
 export default SystemIntakeView;

--- a/src/views/SystemIntake/ViewOnly/index.tsx
+++ b/src/views/SystemIntake/ViewOnly/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import axios from 'axios';
 import { DateTime } from 'luxon';
 
+import PDFExport from 'components/PDFExport';
 import SystemIntakeReview from 'components/SystemIntakeReview';
 import { SystemIntakeForm } from 'types/systemIntake';
 
@@ -9,63 +9,12 @@ type SystemIntakeViewOnlyProps = {
   systemIntake: SystemIntakeForm;
 };
 
-function downloadFile(filename: string, content: string) {
-  axios
-    .request({
-      url: `${process.env.REACT_APP_API_ADDRESS}/pdf/generate`,
-      responseType: 'blob',
-      method: 'POST',
-      data: {
-        html: content,
-        filename
-      }
-    })
-    .then(response => {
-      // This approach works fine in the tests I've done in Chrome
-      // With PDF files that are < 100kB. For larger files we might need to
-      // instead redirect the browser to a URL that returns the file. That
-      // approach is complicated by using JWTs for auth.
-      const blobUrl = URL.createObjectURL(
-        new Blob([response.data], { type: 'application/pdf' })
-      );
-
-      const link = document.createElement('a');
-
-      link.href = blobUrl;
-
-      // TODO generate a useful filename here
-      link.download = 'generated.pdf';
-
-      // This downloads the file
-      // TODO test this in various browsers. Some reports say this might not work
-      // properly in Firefox and that firing a MouseEvent is required instead.
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    })
-    .catch(error => {
-      // TODO add error handling: display a modal if things fail?
-      console.debug(error);
-    });
-}
-
 const SystemIntakeView = ({ systemIntake }: SystemIntakeViewOnlyProps) => {
-  const download = (): void => {
-    downloadFile('intake.html', document.documentElement.outerHTML);
-  };
-
   return (
     <>
-      <div>
-        <h1>Review your Intake Request</h1>
-        <SystemIntakeReview
-          systemIntake={systemIntake}
-          now={DateTime.local()}
-        />
-      </div>
-      <button className="easi-no-print" type="button" onClick={download}>
-        Download PDF
-      </button>
+      <h1>Review your Intake Request</h1>
+      <SystemIntakeReview systemIntake={systemIntake} now={DateTime.local()} />
+      <PDFExport filename="system-intake.pdf" />
     </>
   );
 };


### PR DESCRIPTION
# EASI-983

The backend needs to have the `PDF_GENERATOR_LAMBDA_URL` environment variable set. Ping me in Slack and I'll give you a value to use in the short term.

Changes proposed in this pull request:

- Add a `/pdf/generate` endpoint that accepts the HTML of a page and passes it to a Lambda function.
- This Lambda function converts the HTML to a PDF using [Prince](https://www.princexml.com)
- The resulting PDF is returned to the frontend, where it is then downloaded to the user's computer.

Please check out the included ADR to see more of the background that went into this particular solution.

Here is an example PDF that is created through this process: [generated.pdf](https://github.com/CMSgov/easi-app/files/5538358/generated.pdf)

