### PR TITLE
Rejection API

### DIFF
--- a/migrations/V56__Update_Intake_For_Rejection.sql
+++ b/migrations/V56__Update_Intake_For_Rejection.sql
@@ -1,0 +1,5 @@
+ALTER TABLE system_intake ADD COLUMN rejection_reason text;
+ALTER TABLE system_intake ADD COLUMN decision_next_steps text;
+UPDATE system_intake
+    SET decision_next_steps = lcid_next_steps
+    WHERE lcid_next_steps IS NOT NULL;

--- a/migrations/V57__Add_Reject_Action_Type.sql
+++ b/migrations/V57__Add_Reject_Action_Type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE action_type ADD VALUE 'REJECT';

--- a/pkg/handlers/system_intake.go
+++ b/pkg/handlers/system_intake.go
@@ -302,7 +302,7 @@ func (h SystemIntakeLifecycleIDHandler) Handle() http.HandlerFunc {
 				valErr.WithValidation("body.lcidNextSteps", "is required")
 				valFail = true
 			} else {
-				intake.LifecycleNextSteps = null.StringFrom(fields.NextSteps)
+				intake.DecisionNextSteps = null.StringFrom(fields.NextSteps)
 			}
 
 			if valFail {

--- a/pkg/models/action.go
+++ b/pkg/models/action.go
@@ -38,6 +38,8 @@ const (
 	ActionTypePROVIDEFEEDBACKBIZCASEFINAL ActionType = "PROVIDE_GRT_FEEDBACK_BIZ_CASE_FINAL"
 	// ActionTypeNOGOVERNANCENEEDED captures enum value NO_GOVERNANCE_NEEDED
 	ActionTypeNOGOVERNANCENEEDED ActionType = "NO_GOVERNANCE_NEEDED"
+	// ActionTypeREJECT captures enum value REJECTED
+	ActionTypeREJECT ActionType = "REJECT"
 )
 
 // Action is the model for an action on a system intake

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -48,6 +48,8 @@ const (
 	SystemIntakeStatusBIZCASEFINALNEEDED SystemIntakeStatus = "BIZ_CASE_FINAL_NEEDED"
 	// SystemIntakeStatusNOGOVERNANCE captures enum value "NO_GOVERNANCE"
 	SystemIntakeStatusNOGOVERNANCE SystemIntakeStatus = "NO_GOVERNANCE"
+	// SystemIntakeStatusNOTAPPROVED captures enum value "NOT_APPROVED"
+	SystemIntakeStatusNOTAPPROVED SystemIntakeStatus = "NOT_APPROVED"
 
 	// SystemIntakeRequestTypeNEW captures enum value of "NEW"
 	SystemIntakeRequestTypeNEW SystemIntakeRequestType = "NEW"

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -107,7 +107,9 @@ type SystemIntake struct {
 	LifecycleID             null.String             `json:"lcid" db:"lcid"`
 	LifecycleExpiresAt      *time.Time              `json:"lcidExpiresAt" db:"lcid_expires_at"`
 	LifecycleScope          null.String             `json:"lcidScope" db:"lcid_scope"`
-	LifecycleNextSteps      null.String             `json:"lcidNextSteps" db:"lcid_next_steps"`
+	LifecycleNextSteps      null.String             `json:"lifecycleNextSteps" db:"lcid_next_steps"`
+	DecisionNextSteps       null.String             `json:"decisionNextSteps" db:"decision_next_steps"`
+	RejectionReason         null.String             `json:"rejectionReason" db:"rejection_reason"`
 }
 
 // SystemIntakes is a list of System Intakes

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -441,6 +441,17 @@ func (s *Server) routes(
 	)
 	api.Handle("/system_intake/{intake_id}/lcid", systemIntakeLifecycleIDHandler.Handle())
 
+	systemIntakeRejectionHandler := handlers.NewSystemIntakeRejectionHandler(
+		base,
+		services.NewUpdateRejectionFields(
+			serviceConfig,
+			services.NewAuthorizeRequireGRTJobCode(),
+			store.FetchSystemIntakeByID,
+			store.UpdateSystemIntake,
+		),
+	)
+	api.Handle("/system_intake/{intake_id}/reject", systemIntakeRejectionHandler.Handle())
+
 	notesHandler := handlers.NewNotesHandler(
 		base,
 		services.NewFetchNotes(

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -424,6 +424,21 @@ func (s *Server) routes(
 						store.UpdateBusinessCase,
 					),
 				),
+				models.ActionTypeREJECT: services.NewTakeActionUpdateStatus(
+					serviceConfig,
+					models.SystemIntakeStatusNOTAPPROVED,
+					store.UpdateSystemIntake,
+					services.NewAuthorizeRequireGRTJobCode(),
+					store.CreateAction,
+					cedarLDAPClient.FetchUserInfo,
+					emailClient.SendSystemIntakeReviewEmail,
+					true,
+					services.NewCloseBusinessCase(
+						serviceConfig,
+						store.FetchBusinessCaseByID,
+						store.UpdateBusinessCase,
+					),
+				),
 			},
 		),
 	)

--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -322,7 +322,7 @@ func NewUpdateLifecycleFields(
 		existing.LifecycleID = intake.LifecycleID
 		existing.LifecycleExpiresAt = intake.LifecycleExpiresAt
 		existing.LifecycleScope = intake.LifecycleScope
-		existing.LifecycleNextSteps = intake.LifecycleNextSteps
+		existing.DecisionNextSteps = intake.DecisionNextSteps
 
 		// if a LCID wasn't passed in, we generate one
 		if existing.LifecycleID.ValueOrZero() == "" {

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -482,7 +482,7 @@ func (s ServicesTestSuite) TestUpdateLifecycleFields() {
 		ID:                 uuid.New(),
 		LifecycleID:        lifecycleID,
 		LifecycleExpiresAt: expiresAt,
-		LifecycleNextSteps: nextSteps,
+		DecisionNextSteps:  nextSteps,
 		LifecycleScope:     scope,
 	}
 
@@ -497,7 +497,7 @@ func (s ServicesTestSuite) TestUpdateLifecycleFields() {
 		if !i.LifecycleExpiresAt.Equal(today) {
 			return nil, errors.New("incorrect date")
 		}
-		if !i.LifecycleNextSteps.Equal(input.LifecycleNextSteps) {
+		if !i.DecisionNextSteps.Equal(input.DecisionNextSteps) {
 			return nil, errors.New("incorrect next")
 		}
 		if !i.LifecycleScope.Equal(input.LifecycleScope) {
@@ -514,7 +514,7 @@ func (s ServicesTestSuite) TestUpdateLifecycleFields() {
 		s.NoError(err)
 		s.Equal(intake.LifecycleID, lifecycleID)
 		s.Equal(intake.LifecycleExpiresAt, expiresAt)
-		s.Equal(intake.LifecycleNextSteps, nextSteps)
+		s.Equal(intake.DecisionNextSteps, nextSteps)
 		s.Equal(intake.LifecycleScope, scope)
 	})
 
@@ -526,7 +526,7 @@ func (s ServicesTestSuite) TestUpdateLifecycleFields() {
 		s.NoError(err)
 		s.NotEqual(intake.LifecycleID, "")
 		s.Equal(intake.LifecycleExpiresAt, expiresAt)
-		s.Equal(intake.LifecycleNextSteps, nextSteps)
+		s.Equal(intake.DecisionNextSteps, nextSteps)
 		s.Equal(intake.LifecycleScope, scope)
 	})
 

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -569,3 +569,73 @@ func (s ServicesTestSuite) TestUpdateLifecycleFields() {
 		})
 	}
 }
+
+func (s ServicesTestSuite) TestUpdateRejectionFields() {
+	today := time.Now()
+	nextSteps := null.StringFrom(fmt.Sprintf("next %s", today))
+	reason := null.StringFrom(fmt.Sprintf("reason %s", today))
+
+	input := &models.SystemIntake{
+		ID:                uuid.New(),
+		DecisionNextSteps: nextSteps,
+		RejectionReason:   reason,
+	}
+
+	fnAuthorize := func(context.Context) (bool, error) { return true, nil }
+	fnFetch := func(c context.Context, id uuid.UUID) (*models.SystemIntake, error) {
+		return &models.SystemIntake{ID: id}, nil
+	}
+	fnUpdate := func(c context.Context, i *models.SystemIntake) (*models.SystemIntake, error) {
+		if !i.DecisionNextSteps.Equal(input.DecisionNextSteps) {
+			return nil, errors.New("incorrect next")
+		}
+		if !i.LifecycleScope.Equal(input.LifecycleScope) {
+			return nil, errors.New("incorrect scope")
+		}
+		return i, nil
+	}
+	cfg := Config{clock: clock.NewMock()}
+	happy := NewUpdateRejectionFields(cfg, fnAuthorize, fnFetch, fnUpdate)
+
+	s.Run("happy path", func() {
+		intake, err := happy(context.Background(), input)
+		s.NoError(err)
+		s.Equal(intake.DecisionNextSteps, nextSteps)
+		s.Equal(intake.RejectionReason, reason)
+	})
+
+	// build the error-generating pieces
+	fnAuthorizeErr := func(context.Context) (bool, error) { return false, errors.New("auth error") }
+	fnAuthorizeFail := func(context.Context) (bool, error) { return false, nil }
+	fnFetchErr := func(c context.Context, id uuid.UUID) (*models.SystemIntake, error) {
+		return nil, errors.New("fetch error")
+	}
+	fnUpdateErr := func(c context.Context, i *models.SystemIntake) (*models.SystemIntake, error) {
+		return nil, errors.New("update error")
+	}
+
+	// build the table-driven test of error cases for unhappy path
+	testCases := map[string]struct {
+		fn func(context.Context, *models.SystemIntake) (*models.SystemIntake, error)
+	}{
+		"error path fetch": {
+			fn: NewUpdateRejectionFields(cfg, fnAuthorize, fnFetchErr, fnUpdate),
+		},
+		"error path auth": {
+			fn: NewUpdateRejectionFields(cfg, fnAuthorizeErr, fnFetch, fnUpdate),
+		},
+		"error path auth fail": {
+			fn: NewUpdateRejectionFields(cfg, fnAuthorizeFail, fnFetch, fnUpdate),
+		},
+		"error path update": {
+			fn: NewUpdateRejectionFields(cfg, fnAuthorize, fnFetch, fnUpdateErr),
+		},
+	}
+
+	for expectedErr, tc := range testCases {
+		s.Run(expectedErr, func() {
+			_, err := tc.fn(context.Background(), input)
+			s.Error(err)
+		})
+	}
+}

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -161,7 +161,8 @@ func (s *Store) UpdateSystemIntake(ctx context.Context, intake *models.SystemInt
 			lcid = :lcid,
 			lcid_expires_at = :lcid_expires_at,
 			lcid_scope = :lcid_scope,
-			decision_next_steps = :decision_next_steps
+			decision_next_steps = :decision_next_steps,
+			rejection_reason = :rejection_reason
 		WHERE system_intake.id = :id
 	`
 	_, err := s.db.NamedExec(

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -161,7 +161,7 @@ func (s *Store) UpdateSystemIntake(ctx context.Context, intake *models.SystemInt
 			lcid = :lcid,
 			lcid_expires_at = :lcid_expires_at,
 			lcid_scope = :lcid_scope,
-			lcid_next_steps = :lcid_next_steps
+			decision_next_steps = :decision_next_steps
 		WHERE system_intake.id = :id
 	`
 	_, err := s.db.NamedExec(

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -151,7 +151,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 			LifecycleID:        null.StringFrom("ABCDEF"),
 			LifecycleExpiresAt: &now,
 			LifecycleScope:     null.StringFrom("ABCDEF"),
-			LifecycleNextSteps: null.StringFrom("ABCDEF"),
+			DecisionNextSteps:  null.StringFrom("ABCDEF"),
 		}
 		_, err := s.store.CreateSystemIntake(ctx, &originalIntake)
 		s.NoError(err)
@@ -161,7 +161,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		s.Empty(partial.LifecycleID)
 		s.Empty(partial.LifecycleExpiresAt)
 		s.Empty(partial.LifecycleScope)
-		s.Empty(partial.LifecycleNextSteps)
+		s.Empty(partial.DecisionNextSteps)
 
 		// Update
 		lcid := "H200110" // historical first LCID issued on 2020-01-11
@@ -170,7 +170,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		partial.LifecycleID = null.StringFrom(lcid)
 		partial.LifecycleExpiresAt = &now
 		partial.LifecycleScope = null.StringFrom(content1)
-		partial.LifecycleNextSteps = null.StringFrom(content2)
+		partial.DecisionNextSteps = null.StringFrom(content2)
 
 		_, err = s.store.UpdateSystemIntake(ctx, partial)
 		s.NoError(err, "failed to update system intake")
@@ -181,7 +181,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		s.Equal(lcid, updated.LifecycleID.String)
 		s.NotEmpty(updated.LifecycleExpiresAt)
 		s.Equal(content1, updated.LifecycleScope.String)
-		s.Equal(content2, updated.LifecycleNextSteps.String)
+		s.Equal(content2, updated.DecisionNextSteps.String)
 	})
 
 	s.Run("Update contract details information", func() {


### PR DESCRIPTION
# EASI-893

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add an API endpoint to reject an intake request
- There is one field that is shared between the lifecycle ID and the reject, so I made it more generic. But happy to have two fields if folks see a reason to keep them separate.
- There will be a follow-up PR to remove the old db column once the "rename" PR is deployed to prod.
