### PR TITLE
update auth reducer to include name and eua id

### DIFF
--- a/src/reducers/authReducer.test.ts
+++ b/src/reducers/authReducer.test.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon';
 
 import authReducer, {
-  setUserGroups,
+  setUser,
   updateLastActiveAt,
   updateLastRenewAt
 } from './authReducer';
@@ -11,8 +11,10 @@ describe('The auth reducer', () => {
     expect(authReducer(undefined, { type: 'TEST', payload: {} })).toEqual({
       lastActiveAt: expect.any(Number),
       lastRenewAt: expect.any(Number),
+      name: '',
+      euaId: '',
       groups: [],
-      userGroupsSet: false
+      isUserSet: false
     });
   });
 
@@ -20,8 +22,10 @@ describe('The auth reducer', () => {
     const initialReducer = {
       lastActiveAt: 0,
       lastRenewAt: 0,
+      name: '',
+      euaId: '',
       groups: [],
-      userGroupsSet: false
+      isUserSet: false
     };
     const now = DateTime.local();
 
@@ -34,8 +38,10 @@ describe('The auth reducer', () => {
     const initialReducer = {
       lastActiveAt: 0,
       lastRenewAt: 0,
+      name: '',
+      euaId: '',
       groups: [],
-      userGroupsSet: false
+      isUserSet: false
     };
     const now = DateTime.local();
 
@@ -44,17 +50,25 @@ describe('The auth reducer', () => {
     ).toEqual(now);
   });
 
-  it('handles setUserGroups', () => {
+  it('sets user info', () => {
     const initialReducer = {
       lastActiveAt: 0,
       lastRenewAt: 0,
+      name: '',
+      euaId: '',
       groups: [],
-      userGroupsSet: false
+      isUserSet: false
     };
-    const mockAction = setUserGroups(['my-test-group']);
+    const mockAction = setUser({
+      name: 'Jane Smith',
+      euaId: 'ABCD',
+      groups: ['my-test-group']
+    });
 
     const newState = authReducer(initialReducer, mockAction);
+    expect(newState.name).toEqual('Jane Smith');
+    expect(newState.euaId).toEqual('ABCD');
     expect(newState.groups).toEqual(['my-test-group']);
-    expect(newState.userGroupsSet).toEqual(true);
+    expect(newState.isUserSet).toEqual(true);
   });
 });

--- a/src/reducers/authReducer.ts
+++ b/src/reducers/authReducer.ts
@@ -6,8 +6,10 @@ const newTimeStamp = () => Date.now();
 type authReducerState = {
   lastActiveAt: number;
   lastRenewAt: number;
+  name: string;
+  euaId: string;
   groups: Array<string>;
-  userGroupsSet: boolean;
+  isUserSet: boolean;
 };
 
 const UPDATE_LAST_ACTIVE_AT = 'AUTH_REDUCER_UPDATE_LAST_ACTIVE_AT';
@@ -32,17 +34,19 @@ export const updateLastRenewAt = (lastRenewAt: DateTime) => {
   };
 };
 
-const SET_USER_GROUPS = 'AUTH_REDUCER_SET_USER_GROUPS';
-export const setUserGroups = (groups: Array<string>) => ({
-  type: SET_USER_GROUPS,
-  payload: { groups }
+const SET_USER = 'AUTH_REDUCER_SET_USER';
+export const setUser = (user: any) => ({
+  type: SET_USER,
+  payload: user
 });
 
 const initialState: authReducerState = {
   lastActiveAt: newTimeStamp(),
   lastRenewAt: newTimeStamp(),
+  name: '',
+  euaId: '',
   groups: [],
-  userGroupsSet: false
+  isUserSet: false
 };
 
 function authReducer(
@@ -60,11 +64,11 @@ function authReducer(
         ...state,
         lastRenewAt: action.payload.lastRenewAt
       };
-    case SET_USER_GROUPS:
+    case SET_USER:
       return {
         ...state,
-        groups: action.payload.groups,
-        userGroupsSet: true
+        ...action.payload,
+        isUserSet: true
       };
     default:
       return state;

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -33,9 +33,7 @@ import './index.scss';
 const AppRoutes = () => {
   const flags = useFlags();
   const userGroups = useSelector((state: AppState) => state.auth.groups);
-  const userGroupsSet = useSelector(
-    (state: AppState) => state.auth.userGroupsSet
-  );
+  const isUserSet = useSelector((state: AppState) => state.auth.isUserSet);
 
   return (
     <Switch>
@@ -54,7 +52,7 @@ const AppRoutes = () => {
           component={GovernanceTaskList}
         />
       )}
-      {userGroupsSet && user.isGrtReviewer(userGroups) && (
+      {isUserSet && user.isGrtReviewer(userGroups) && (
         <SecureRoute
           path="/governance-review-team/:systemId/:activePage"
           component={GovernanceReviewTeam}

--- a/src/views/Home/index.test.tsx
+++ b/src/views/Home/index.test.tsx
@@ -30,7 +30,7 @@ jest.mock('@okta/okta-react', () => ({
 describe('The home page', () => {
   describe('not a grt review user', () => {
     const mockAuthReducer = {
-      userGroupsSet: true,
+      isUserSet: true,
       groups: []
     };
 
@@ -127,7 +127,7 @@ describe('The home page', () => {
 
   describe('is a grt reviewer', () => {
     const mockAuthReducer = {
-      userGroupsSet: true,
+      isUserSet: true,
       groups: ['EASI_D_GOVTEAM']
     };
 

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -37,15 +37,13 @@ const Banners = () => {
 const Home = () => {
   const { authState } = useOktaAuth();
   const userGroups = useSelector((state: AppState) => state.auth.groups);
-  const userGroupsSet = useSelector(
-    (state: AppState) => state.auth.userGroupsSet
-  );
+  const isUserSet = useSelector((state: AppState) => state.auth.isUserSet);
 
   return (
     <PageWrapper>
       <Header />
       <MainContent className="grid-container margin-bottom-5">
-        {userGroupsSet &&
+        {isUserSet &&
           (user.isGrtReviewer(userGroups) ? (
             <RequestRepository />
           ) : (

--- a/src/views/UserInfoWrapper/index.tsx
+++ b/src/views/UserInfoWrapper/index.tsx
@@ -25,20 +25,20 @@ const UserInfoWrapper = ({ children }: UserInfoWrapperProps) => {
       euaId: '',
       groups: []
     };
-    if (accessToken) {
-      const token = accessToken.value;
-      const decodedBearerToken = JSON.parse(atob(token.split('.')[1]));
-      user.groups = (decodedBearerToken && decodedBearerToken.groups) || [];
-    }
+    if (accessToken && idToken) {
+      const accessTokenValue = accessToken.value;
+      const decodedBearerToken = JSON.parse(
+        atob(accessTokenValue.split('.')[1])
+      );
 
-    if (idToken) {
-      const token = idToken.value;
-      const decodedIdToken = JSON.parse(atob(token.split('.')[1]));
+      const idTokenValue = idToken.value;
+      const decodedIdToken = JSON.parse(atob(idTokenValue.split('.')[1]));
+
       user.name = (decodedIdToken && decodedIdToken.name) || '';
       user.euaId = (decodedIdToken && decodedIdToken.preferred_username) || '';
+      user.groups = (decodedBearerToken && decodedBearerToken.groups) || [];
+      dispatch(setUser(user));
     }
-
-    dispatch(setUser(user));
   };
 
   useEffect(() => {

--- a/src/views/UserInfoWrapper/index.tsx
+++ b/src/views/UserInfoWrapper/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useOktaAuth } from '@okta/okta-react';
 
-import { setUserGroups } from 'reducers/authReducer';
+import { setUser } from 'reducers/authReducer';
 
 type UserInfoWrapperProps = {
   children: React.ReactNode;
@@ -15,12 +15,30 @@ const UserInfoWrapper = ({ children }: UserInfoWrapperProps) => {
   const storeUserInfo = async () => {
     const tokenManager = await authService.getTokenManager();
     const accessToken = await tokenManager.get('accessToken');
+    const idToken = await tokenManager.get('idToken');
+    const user: {
+      name: string;
+      euaId: string;
+      groups: string[];
+    } = {
+      name: '',
+      euaId: '',
+      groups: []
+    };
     if (accessToken) {
       const token = accessToken.value;
       const decodedBearerToken = JSON.parse(atob(token.split('.')[1]));
-      const groups = (decodedBearerToken && decodedBearerToken.groups) || [];
-      dispatch(setUserGroups(groups));
+      user.groups = (decodedBearerToken && decodedBearerToken.groups) || [];
     }
+
+    if (idToken) {
+      const token = idToken.value;
+      const decodedIdToken = JSON.parse(atob(token.split('.')[1]));
+      user.name = (decodedIdToken && decodedIdToken.name) || '';
+      user.euaId = (decodedIdToken && decodedIdToken.preferred_username) || '';
+    }
+
+    dispatch(setUser(user));
   };
 
   useEffect(() => {


### PR DESCRIPTION
For notes, we need to pass in the user's name from the id token since it's not included in the access token that's passed to validate the API request.

We're currently only setting `groups` in the `authReducer`. Since we need at least the user's name, I thought this might be a good time to add in the user's EUA ID to the reducer as well.

In addition to adding these values into the reducer, there's a bit of renaming too.

