### PR TITLE
Add functionality to create notes

### DIFF
--- a/src/i18n/en-US/governanceReviewTeam.ts
+++ b/src/i18n/en-US/governanceReviewTeam.ts
@@ -101,7 +101,11 @@ const governanceReviewTeam = {
       closedTableCaption: 'Table of closed requests'
     }
   },
-  notes: 'Admin team notes',
+  notes: {
+    heading: 'Admin team notes',
+    addNote: 'Add a note',
+    addNoteCta: 'Add note'
+  },
   aria: {
     openIntake: 'Open intake request',
     openBusiness: 'Open business case',

--- a/src/reducers/systemIntakeReducer.test.ts
+++ b/src/reducers/systemIntakeReducer.test.ts
@@ -6,6 +6,7 @@ import systemIntakeReducer from 'reducers/systemIntakeReducer';
 import {
   clearSystemIntake,
   fetchSystemIntake,
+  postIntakeNote,
   postSystemIntake,
   saveSystemIntake,
   storeSystemIntake
@@ -41,7 +42,8 @@ describe('The system intake reducer', () => {
       isLoading: null,
       isSaving: false,
       isNewIntakeCreated: null,
-      error: null
+      error: null,
+      notes: []
     });
   });
 
@@ -57,7 +59,8 @@ describe('The system intake reducer', () => {
         isLoading: true,
         isSaving: false,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       });
     });
 
@@ -78,7 +81,8 @@ describe('The system intake reducer', () => {
         isLoading: null,
         isSaving: false,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       });
     });
 
@@ -93,7 +97,8 @@ describe('The system intake reducer', () => {
         isLoading: false,
         isSaving: false,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       });
     });
   });
@@ -120,7 +125,8 @@ describe('The system intake reducer', () => {
         isLoading: false,
         isSaving: false,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       });
     });
     it('handles storeSystemIntake.FAILURE', () => {
@@ -134,7 +140,8 @@ describe('The system intake reducer', () => {
         isLoading: null,
         isSaving: false,
         isNewIntakeCreated: null,
-        error: 'Error'
+        error: 'Error',
+        notes: []
       });
     });
     it('handles storeSystemIntake.FULFILL', () => {
@@ -148,7 +155,8 @@ describe('The system intake reducer', () => {
         isLoading: false,
         isSaving: false,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       });
     });
   });
@@ -165,7 +173,8 @@ describe('The system intake reducer', () => {
         isLoading: null,
         isSaving: true,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       });
     });
     it('handles postSystemIntake.SUCCESS', () => {
@@ -179,7 +188,8 @@ describe('The system intake reducer', () => {
         isLoading: null,
         isSaving: false,
         isNewIntakeCreated: true,
-        error: null
+        error: null,
+        notes: []
       });
     });
 
@@ -189,7 +199,8 @@ describe('The system intake reducer', () => {
         isLoading: false,
         isSaving: true,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       };
       const mockFailureAction = {
         type: postSystemIntake.FAILURE,
@@ -201,7 +212,8 @@ describe('The system intake reducer', () => {
         isLoading: false,
         isSaving: true,
         isNewIntakeCreated: false,
-        error: 'Error'
+        error: 'Error',
+        notes: []
       });
     });
 
@@ -216,7 +228,8 @@ describe('The system intake reducer', () => {
         isLoading: null,
         isSaving: false,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       });
     });
   });
@@ -233,7 +246,8 @@ describe('The system intake reducer', () => {
         isLoading: null,
         isSaving: true,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       });
     });
     it('handles saveSystemIntake.SUCCESS', () => {
@@ -247,7 +261,8 @@ describe('The system intake reducer', () => {
         isLoading: null,
         isSaving: false,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       });
     });
 
@@ -257,7 +272,8 @@ describe('The system intake reducer', () => {
         isLoading: false,
         isSaving: true,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       };
       const mockFailureAction = {
         type: saveSystemIntake.FAILURE,
@@ -269,7 +285,8 @@ describe('The system intake reducer', () => {
         isLoading: false,
         isSaving: true,
         isNewIntakeCreated: null,
-        error: 'Error'
+        error: 'Error',
+        notes: []
       });
     });
 
@@ -279,7 +296,8 @@ describe('The system intake reducer', () => {
         isLoading: false,
         isSaving: true,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       };
 
       const mockFulfillAction = {
@@ -292,7 +310,8 @@ describe('The system intake reducer', () => {
         isLoading: false,
         isSaving: false,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
       });
     });
   });
@@ -309,7 +328,94 @@ describe('The system intake reducer', () => {
         isLoading: null,
         isSaving: false,
         isNewIntakeCreated: null,
-        error: null
+        error: null,
+        notes: []
+      });
+    });
+  });
+
+  describe('postIntakeNote', () => {
+    it('adds successfully created note to the reducer', () => {
+      const mockPostAction = {
+        type: postIntakeNote.SUCCESS,
+        payload: {
+          id: '12345',
+          authorName: 'John Brown',
+          authorId: 'ABCD',
+          content: 'Test Note 1',
+          systemIntakeId: 'test-uuid-note-1'
+        }
+      };
+
+      expect(systemIntakeReducer(undefined, mockPostAction)).toEqual({
+        systemIntake: initialSystemIntakeForm,
+        isLoading: null,
+        isSaving: false,
+        isNewIntakeCreated: null,
+        error: null,
+        notes: [
+          {
+            id: '12345',
+            authorName: 'John Brown',
+            authorId: 'ABCD',
+            content: 'Test Note 1',
+            systemIntakeId: 'test-uuid-note-1'
+          }
+        ]
+      });
+    });
+
+    it('appends successfully created note to the reducer', () => {
+      const initialState = {
+        systemIntake: initialSystemIntakeForm,
+        isLoading: null,
+        isSaving: false,
+        isNewIntakeCreated: null,
+        error: null,
+        notes: [
+          {
+            id: '12345',
+            authorName: 'John Brown',
+            authorId: 'ABCD',
+            content: 'Test Note 1',
+            systemIntakeId: 'test-uuid-note-1'
+          }
+        ]
+      };
+
+      const mockPostAction = {
+        type: postIntakeNote.SUCCESS,
+        payload: {
+          id: '67890',
+          authorName: 'Lisa Brown',
+          authorId: 'EFGH',
+          content: 'Test Note 2',
+          systemIntakeId: 'test-uuid-note-2'
+        }
+      };
+
+      expect(systemIntakeReducer(initialState, mockPostAction)).toEqual({
+        systemIntake: initialSystemIntakeForm,
+        isLoading: null,
+        isSaving: false,
+        isNewIntakeCreated: null,
+        error: null,
+        notes: [
+          {
+            id: '12345',
+            authorName: 'John Brown',
+            authorId: 'ABCD',
+            content: 'Test Note 1',
+            systemIntakeId: 'test-uuid-note-1'
+          },
+          {
+            id: '67890',
+            authorName: 'Lisa Brown',
+            authorId: 'EFGH',
+            content: 'Test Note 2',
+            systemIntakeId: 'test-uuid-note-2'
+          }
+        ]
       });
     });
   });

--- a/src/reducers/systemIntakeReducer.test.ts
+++ b/src/reducers/systemIntakeReducer.test.ts
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon';
+
 import {
   initialSystemIntakeForm,
   prepareSystemIntakeForApp
@@ -335,6 +337,16 @@ describe('The system intake reducer', () => {
   });
 
   describe('postIntakeNote', () => {
+    let dateSpy: jest.SpyInstance;
+    beforeAll(() => {
+      // September 30, 2020
+      dateSpy = jest.spyOn(Date, 'now').mockImplementation(() => 1601449200000);
+    });
+
+    afterAll(() => {
+      dateSpy.mockRestore();
+    });
+
     it('adds successfully created note to the reducer', () => {
       const mockPostAction = {
         type: postIntakeNote.SUCCESS,
@@ -343,7 +355,8 @@ describe('The system intake reducer', () => {
           authorName: 'John Brown',
           authorId: 'ABCD',
           content: 'Test Note 1',
-          systemIntakeId: 'test-uuid-note-1'
+          systemIntakeId: 'test-uuid-note-1',
+          createdAt: '2020-11-17 08:13:18.936399+00'
         }
       };
 
@@ -359,7 +372,8 @@ describe('The system intake reducer', () => {
             authorName: 'John Brown',
             authorId: 'ABCD',
             content: 'Test Note 1',
-            systemIntakeId: 'test-uuid-note-1'
+            systemIntakeId: 'test-uuid-note-1',
+            createdAt: DateTime.fromISO('2020-11-17 08:13:18.936399+00')
           }
         ]
       });
@@ -378,7 +392,8 @@ describe('The system intake reducer', () => {
             authorName: 'John Brown',
             authorId: 'ABCD',
             content: 'Test Note 1',
-            systemIntakeId: 'test-uuid-note-1'
+            systemIntakeId: 'test-uuid-note-1',
+            createdAt: DateTime.fromISO('2020-11-17 08:13:18.936399+00')
           }
         ]
       };
@@ -390,7 +405,8 @@ describe('The system intake reducer', () => {
           authorName: 'Lisa Brown',
           authorId: 'EFGH',
           content: 'Test Note 2',
-          systemIntakeId: 'test-uuid-note-2'
+          systemIntakeId: 'test-uuid-note-2',
+          createdAt: '2020-11-17 08:13:18.936399+00'
         }
       };
 
@@ -406,14 +422,16 @@ describe('The system intake reducer', () => {
             authorName: 'John Brown',
             authorId: 'ABCD',
             content: 'Test Note 1',
-            systemIntakeId: 'test-uuid-note-1'
+            systemIntakeId: 'test-uuid-note-1',
+            createdAt: DateTime.fromISO('2020-11-17 08:13:18.936399+00')
           },
           {
             id: '67890',
             authorName: 'Lisa Brown',
             authorId: 'EFGH',
             content: 'Test Note 2',
-            systemIntakeId: 'test-uuid-note-2'
+            systemIntakeId: 'test-uuid-note-2',
+            createdAt: DateTime.fromISO('2020-11-17 08:13:18.936399+00')
           }
         ]
       });

--- a/src/reducers/systemIntakeReducer.ts
+++ b/src/reducers/systemIntakeReducer.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import { Action } from 'redux-actions';
 
 import {
@@ -154,7 +155,13 @@ function systemIntakeReducer(
     case postIntakeNote.SUCCESS:
       return {
         ...state,
-        notes: [...state.notes, action.payload]
+        notes: [
+          ...state.notes,
+          {
+            ...action.payload,
+            createdAt: DateTime.fromISO(action.payload.createdAt)
+          }
+        ]
       };
     default:
       return state;

--- a/src/reducers/systemIntakeReducer.ts
+++ b/src/reducers/systemIntakeReducer.ts
@@ -9,6 +9,7 @@ import {
   clearSystemIntake,
   fetchSystemIntake,
   issueLifecycleIdForSystemIntake,
+  postIntakeNote,
   postSystemIntake,
   reviewSystemIntake,
   saveSystemIntake,
@@ -21,7 +22,8 @@ const initialState: SystemIntakeState = {
   isLoading: null,
   isSaving: false,
   isNewIntakeCreated: null,
-  error: null
+  error: null,
+  notes: []
 };
 
 function systemIntakeReducer(
@@ -148,6 +150,11 @@ function systemIntakeReducer(
           ...state.systemIntake,
           ...prepareSystemIntakeForApp(action.payload)
         }
+      };
+    case postIntakeNote.SUCCESS:
+      return {
+        ...state,
+        notes: [...state.notes, action.payload]
       };
     default:
       return state;

--- a/src/sagas/systemIntakeSaga.ts
+++ b/src/sagas/systemIntakeSaga.ts
@@ -12,6 +12,7 @@ import {
   archiveSystemIntake,
   fetchSystemIntake,
   issueLifecycleIdForSystemIntake,
+  postIntakeNote,
   postSystemIntake,
   reviewSystemIntake,
   saveSystemIntake
@@ -142,6 +143,36 @@ function* issueLifecyleId(action: Action<any>) {
   }
 }
 
+type NoteRequestBody = {
+  intakeId: string;
+  content: string;
+  authorId: string;
+  authorName: string;
+};
+
+function postIntakeNoteRequest(data: NoteRequestBody) {
+  const { content, authorId, authorName, intakeId } = data;
+  return axios.post(
+    `${process.env.REACT_APP_API_ADDRESS}/system_intake/${intakeId}/notes`,
+    {
+      authorId,
+      authorName,
+      content
+    }
+  );
+}
+function* createIntakeNote(action: Action<any>) {
+  try {
+    yield put(postIntakeNote.request());
+    const response = yield call(postIntakeNoteRequest, action.payload);
+    yield put(postIntakeNote.success(response.data));
+  } catch (error) {
+    yield put(postIntakeNote.failure(error.message));
+  } finally {
+    yield put(postIntakeNote.fulfill());
+  }
+}
+
 export default function* systemIntakeSaga() {
   yield takeLatest(fetchSystemIntake.TRIGGER, getSystemIntake);
   yield takeLatest(saveSystemIntake.TRIGGER, putSystemIntake);
@@ -149,4 +180,5 @@ export default function* systemIntakeSaga() {
   yield takeLatest(reviewSystemIntake.TRIGGER, submitSystemIntakeReview);
   yield takeLatest(archiveSystemIntake.TRIGGER, deleteSystemIntake);
   yield takeLatest(issueLifecycleIdForSystemIntake.TRIGGER, issueLifecyleId);
+  yield takeLatest(postIntakeNote.TRIGGER, createIntakeNote);
 }

--- a/src/types/routines.ts
+++ b/src/types/routines.ts
@@ -16,6 +16,7 @@ export const archiveSystemIntake = createRoutine('ARCHIVE_SYSTEM_INTAKE');
 export const issueLifecycleIdForSystemIntake = createRoutine(
   'ISSUE_LIFECYCLE_ID_FOR_SYSTEM_INTAKE'
 );
+export const postIntakeNote = createRoutine('POST_INTAKE_NOTE');
 
 // SystemShorts routines
 export const fetchSystemShorts = createRoutine('FETCH_SYSTEM_SHORTS');

--- a/src/types/systemIntake.ts
+++ b/src/types/systemIntake.ts
@@ -107,6 +107,15 @@ export type ContractDetailsForm = {
   };
 };
 
+export type IntakeNote = {
+  id: string;
+  authorName: string;
+  authorId: string;
+  content: string;
+  systemIntakeId: string;
+  createdAt: DateTime;
+};
+
 // Redux store type for a system intake
 export type SystemIntakeState = {
   systemIntake: SystemIntakeForm;
@@ -114,7 +123,7 @@ export type SystemIntakeState = {
   isSaving: boolean;
   isNewIntakeCreated: boolean | null;
   error?: any;
-  notes: any[];
+  notes: IntakeNote[];
 };
 
 // Redux store type for systems

--- a/src/types/systemIntake.ts
+++ b/src/types/systemIntake.ts
@@ -114,6 +114,7 @@ export type SystemIntakeState = {
   isSaving: boolean;
   isNewIntakeCreated: boolean | null;
   error?: any;
+  notes: any[];
 };
 
 // Redux store type for systems

--- a/src/views/GovernanceReviewTeam/Notes/index.tsx
+++ b/src/views/GovernanceReviewTeam/Notes/index.tsx
@@ -1,13 +1,40 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 import { Button } from '@trussworks/react-uswds';
-import { Field, Form, Formik, FormikProps } from 'formik';
+import { Field, Form, Formik, FormikHelpers, FormikProps } from 'formik';
 
 import FieldGroup from 'components/shared/FieldGroup';
 import Label from 'components/shared/Label';
 import TextAreaField from 'components/shared/TextAreaField';
+import { AppState } from 'reducers/rootReducer';
+import { postIntakeNote } from 'types/routines';
+
+type NoteForm = {
+  note: string;
+};
 
 const Notes = () => {
-  const onSubmit = () => {};
+  const dispatch = useDispatch();
+  const { systemId } = useParams<{ systemId: string }>();
+  const authState = useSelector((state: AppState) => state.auth);
+  const { t } = useTranslation('governanceReviewTeam');
+
+  const onSubmit = async (
+    values: NoteForm,
+    { resetForm }: FormikHelpers<NoteForm>
+  ) => {
+    await dispatch(
+      postIntakeNote({
+        intakeId: systemId,
+        authorName: authState.name,
+        authorId: authState.euaId,
+        content: values.note
+      })
+    );
+    await resetForm();
+  };
 
   const initialValues = {
     note: ''
@@ -15,15 +42,17 @@ const Notes = () => {
 
   return (
     <>
-      <h1>Admin team notes</h1>
+      <h1>{t('notes.heading')}</h1>
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
-        {(formikProps: FormikProps<any>) => {
+        {(formikProps: FormikProps<NoteForm>) => {
           const { values } = formikProps;
           return (
             <div className="tablet:grid-col-9 margin-bottom-7">
               <Form>
                 <FieldGroup>
-                  <Label htmlFor="GovernanceReviewTeam-Note">Add a note</Label>
+                  <Label htmlFor="GovernanceReviewTeam-Note">
+                    {t('notes.addNote')}
+                  </Label>
                   <Field
                     as={TextAreaField}
                     id="GovernanceReviewTeam-Note"
@@ -37,7 +66,7 @@ const Notes = () => {
                   type="submit"
                   disabled={!values.note}
                 >
-                  Add note
+                  {t('notes.addNoteCta')}
                 </Button>
               </Form>
             </div>

--- a/src/views/GovernanceReviewTeam/index.tsx
+++ b/src/views/GovernanceReviewTeam/index.tsx
@@ -173,7 +173,7 @@ const GovernanceReviewTeam = () => {
                   to={`/governance-review-team/${systemId}/notes`}
                   className={getNavLinkClasses('notes')}
                 >
-                  {t('notes')}
+                  {t('notes.heading')}
                 </Link>
               </li>
             </ul>


### PR DESCRIPTION
# EASI-911

This PR hooks up the "Add note" button to create a note. This PR **does not** implement any way to view created notes on the UI.

Two ways to verify notes have been created are to:
1. View the note in the DB
2. View the note in the Redux Dev Tools

Viewing created notes will be handled in a separate ticket/story.

As far as ticket management goes, I will probably finish the list/view of the notes before setting this ticket to "Review"
