### PR TITLE
Only show open requests in table

### DIFF
--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -54,8 +54,6 @@ const (
 	SystemIntakeStatusNOTAPPROVED SystemIntakeStatus = "NOT_APPROVED"
 	// SystemIntakeStatusNOGOVERNANCE captures enum value "NO_GOVERNANCE"
 	SystemIntakeStatusNOGOVERNANCE SystemIntakeStatus = "NO_GOVERNANCE"
-	// SystemIntakeStatusNOTAPPROVED captures enum value "NOT_APPROVED"
-	SystemIntakeStatusNOTAPPROVED SystemIntakeStatus = "NOT_APPROVED"
 
 	// SystemIntakeRequestTypeNEW captures enum value of "NEW"
 	SystemIntakeRequestTypeNEW SystemIntakeRequestType = "NEW"

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -62,7 +62,7 @@ const RequestRepository = () => {
   );
 
   useEffect(() => {
-    dispatch(fetchSystemIntakes());
+    dispatch(fetchSystemIntakes({ status: 'open' }));
   }, [dispatch]);
 
   const systemIntakes = useSelector(

--- a/src/sagas/systemIntakesSaga.ts
+++ b/src/sagas/systemIntakesSaga.ts
@@ -1,18 +1,25 @@
 import axios from 'axios';
 import { DateTime } from 'luxon';
+import { Action } from 'redux-actions';
 import { call, put, takeLatest } from 'redux-saga/effects';
 
 import { updateLastActiveAt } from 'reducers/authReducer';
 import { fetchSystemIntakes } from 'types/routines';
 
-function getSystemIntakesRequest() {
-  return axios.get(`${process.env.REACT_APP_API_ADDRESS}/system_intakes`);
+function getSystemIntakesRequest(status: string | null) {
+  let route = `${process.env.REACT_APP_API_ADDRESS}/system_intakes`;
+  if (status) {
+    route = `${route}?status=${status}`;
+  }
+  return axios.get(route);
 }
 
-function* getSystemIntakes() {
+function* getSystemIntakes(action: Action<any>) {
+  const { payload } = action;
+  const status = payload && payload.status;
   try {
     yield put(fetchSystemIntakes.request());
-    const response = yield call(getSystemIntakesRequest);
+    const response = yield call(getSystemIntakesRequest, status);
     yield put(fetchSystemIntakes.success(response.data));
   } catch (error) {
     yield put(fetchSystemIntakes.failure(error.message));


### PR DESCRIPTION
# EASI-963

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add a filter to the saga for fetching intakes
- Use it for the open requests table
