### PR TITLE
nullable euaID

### DIFF
--- a/migrations/V58__Intake_EUA_Drop_Not_Null.sql
+++ b/migrations/V58__Intake_EUA_Drop_Not_Null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE system_intake ALTER eua_user_id DROP NOT NULL;

--- a/pkg/cedar/cedareasi/translated_client.go
+++ b/pkg/cedar/cedareasi/translated_client.go
@@ -83,7 +83,7 @@ func ValidateSystemIntakeForCedar(ctx context.Context, intake *models.SystemInta
 	if validate.RequireUUID(intake.ID) {
 		expectedError.WithValidation("ID", validationMessage)
 	}
-	if validate.RequireString(intake.EUAUserID) {
+	if validate.RequireString(intake.EUAUserID.ValueOrZero()) {
 		expectedError.WithValidation("EUAUserID", validationMessage)
 	}
 	if validate.RequireString(intake.Requester) {
@@ -155,13 +155,14 @@ func submitSystemIntake(ctx context.Context, validatedIntake *models.SystemIntak
 	id := validatedIntake.ID.String()
 	submissionTime := validatedIntake.SubmittedAt.String()
 	params := apioperations.NewIntakegovernancePOST4Params()
+	euaID := validatedIntake.EUAUserID.ValueOrZero()
 	governanceIntake := apimodels.GovernanceIntake{
 		BusinessNeeds:           &validatedIntake.BusinessNeed.String,
 		BusinessOwner:           &validatedIntake.BusinessOwner.String,
 		BusinessOwnerComponent:  &validatedIntake.BusinessOwnerComponent.String,
 		EaCollaborator:          validatedIntake.EACollaborator.String,
 		EaSupportRequest:        &validatedIntake.EASupportRequest.Bool,
-		EuaUserID:               &validatedIntake.EUAUserID,
+		EuaUserID:               &euaID,
 		ExistingContract:        &validatedIntake.ExistingContract.String,
 		ExistingFunding:         &validatedIntake.ExistingFunding.Bool,
 		FundingNumber:           validatedIntake.FundingNumber.String,

--- a/pkg/cedar/cedareasi/translated_client_test.go
+++ b/pkg/cedar/cedareasi/translated_client_test.go
@@ -19,7 +19,7 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 	id := uuid.New()
 	intake := models.SystemIntake{
 		ID:                      id,
-		EUAUserID:               "FAKE",
+		EUAUserID:               null.StringFrom("FAKE"),
 		Status:                  models.SystemIntakeStatusINTAKESUBMITTED,
 		Requester:               "Fake Requester",
 		Component:               null.StringFrom("Fake Component"),
@@ -126,7 +126,7 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 	})
 
 	s.Run("An intake without a required string fails", func() {
-		intake.EUAUserID = ""
+		intake.EUAUserID = null.StringFrom("")
 		err := ValidateSystemIntakeForCedar(ctx, &intake)
 		s.IsType(&apperrors.ValidationError{}, err)
 		expectedErrString := fmt.Sprintf(
@@ -136,7 +136,7 @@ func (s CedarEasiTestSuite) TestValidateSystemIntakeForCedar() {
 		s.EqualError(err, expectedErrString)
 
 		// Reset intake fields
-		intake.EUAUserID = "FAKE"
+		intake.EUAUserID = null.StringFrom("FAKE")
 	})
 
 	s.Run("An intake without a required id fails", func() {

--- a/pkg/handlers/system_intake.go
+++ b/pkg/handlers/system_intake.go
@@ -153,7 +153,7 @@ func (h SystemIntakeHandler) Handle() http.HandlerFunc {
 					})
 				return
 			}
-			intake.EUAUserID = principal.ID()
+			intake.EUAUserID = null.StringFrom(principal.ID())
 
 			updatedIntake, err := h.UpdateSystemIntake(r.Context(), &intake)
 			if err != nil {

--- a/pkg/handlers/system_intake_test.go
+++ b/pkg/handlers/system_intake_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/guregu/null"
 	"golang.org/x/net/context"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
@@ -27,7 +28,7 @@ func newMockFetchSystemIntakeByID(err error) fetchSystemIntakeByID {
 	return func(context context.Context, id uuid.UUID) (*models.SystemIntake, error) {
 		intake := models.SystemIntake{
 			ID:        id,
-			EUAUserID: "FAKE",
+			EUAUserID: null.StringFrom("FAKE"),
 		}
 		return &intake, err
 	}
@@ -37,7 +38,7 @@ func newMockCreateSystemIntake(requester string, err error) createSystemIntake {
 	return func(ctx context.Context, intake *models.SystemIntake) (*models.SystemIntake, error) {
 		newIntake := models.SystemIntake{
 			ID:        uuid.New(),
-			EUAUserID: "FAKE",
+			EUAUserID: null.StringFrom("FAKE"),
 			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 			Requester: requester,
 		}

--- a/pkg/integration/business_case_test.go
+++ b/pkg/integration/business_case_test.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"path"
 
+	"github.com/guregu/null"
+
 	"github.com/cmsgov/easi-app/pkg/models"
 	"github.com/cmsgov/easi-app/pkg/testhelpers"
 )
@@ -24,7 +26,7 @@ func (s IntegrationTestSuite) TestBusinessCaseEndpoints() {
 
 	intake := testhelpers.NewSystemIntake()
 	intake.Status = models.SystemIntakeStatusINTAKESUBMITTED
-	intake.EUAUserID = s.user.euaID
+	intake.EUAUserID = null.StringFrom(s.user.euaID)
 
 	createdIntake, err := s.store.CreateSystemIntake(context.Background(), &intake)
 	s.NoError(err)

--- a/pkg/integration/system_intakes_test.go
+++ b/pkg/integration/system_intakes_test.go
@@ -133,7 +133,7 @@ func (s IntegrationTestSuite) TestSystemIntakeEndpoints() {
 		updatedAt := time.Now().UTC()
 		intake := models.SystemIntake{
 			ID:                      id,
-			EUAUserID:               "FAKE",
+			EUAUserID:               null.StringFrom("FAKE"),
 			Requester:               "Test Requester",
 			Component:               null.StringFrom("Test Requester"),
 			BusinessOwner:           null.StringFrom("Test Requester"),

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -73,7 +73,7 @@ const (
 // SystemIntake is the model for the system intake form
 type SystemIntake struct {
 	ID                      uuid.UUID               `json:"id"`
-	EUAUserID               string                  `json:"euaUserId" db:"eua_user_id"`
+	EUAUserID               null.String             `json:"euaUserId" db:"eua_user_id"`
 	Status                  SystemIntakeStatus      `json:"status"`
 	RequestType             SystemIntakeRequestType `json:"requestType" db:"request_type"`
 	Requester               string                  `json:"requester"`

--- a/pkg/services/action.go
+++ b/pkg/services/action.go
@@ -260,7 +260,7 @@ func NewTakeActionUpdateStatus(
 			return &apperrors.UnauthorizedError{}
 		}
 
-		requesterInfo, err := fetchUserInfo(ctx, intake.EUAUserID)
+		requesterInfo, err := fetchUserInfo(ctx, intake.EUAUserID.ValueOrZero())
 		if err != nil {
 			return err
 		}

--- a/pkg/services/auth.go
+++ b/pkg/services/auth.go
@@ -24,7 +24,7 @@ func NewAuthorizeUserIsIntakeRequester() func(
 		}
 
 		// If intake is owned by user, authorize
-		if principal.ID() == intake.EUAUserID {
+		if principal.ID() == intake.EUAUserID.ValueOrZero() {
 			return true, nil
 		}
 		// Default to failure to authorize and create a quick audit log

--- a/pkg/services/auth_test.go
+++ b/pkg/services/auth_test.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 
+	"github.com/guregu/null"
+
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/authn"
 	"github.com/cmsgov/easi-app/pkg/models"
@@ -26,7 +28,7 @@ func (s ServicesTestSuite) TestAuthorizeUserIsIntakeRequester() {
 		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ZYXW", JobCodeEASi: true})
 
 		intake := models.SystemIntake{
-			EUAUserID: "ABCD",
+			EUAUserID: null.StringFrom("ABCD"),
 		}
 
 		ok, err := authorizeSaveSystemIntake(ctx, &intake)
@@ -40,7 +42,7 @@ func (s ServicesTestSuite) TestAuthorizeUserIsIntakeRequester() {
 		ctx = appcontext.WithPrincipal(ctx, &authn.EUAPrincipal{EUAID: "ABCD", JobCodeEASi: true})
 
 		intake := models.SystemIntake{
-			EUAUserID: "ABCD",
+			EUAUserID: null.StringFrom("ABCD"),
 		}
 
 		ok, err := authorizeSaveSystemIntake(ctx, &intake)

--- a/pkg/services/business_case_test.go
+++ b/pkg/services/business_case_test.go
@@ -85,7 +85,7 @@ func (s ServicesTestSuite) TestBusinessCaseCreator() {
 	logger := zap.NewNop()
 	serviceConfig := NewConfig(logger, nil)
 	serviceConfig.clock = clock.NewMock()
-	euaID := testhelpers.RandomEUAID()
+	euaID := testhelpers.RandomEUAIDNull()
 	intake := &models.SystemIntake{
 		EUAUserID:   euaID,
 		Status:      models.SystemIntakeStatusINTAKESUBMITTED,
@@ -95,7 +95,7 @@ func (s ServicesTestSuite) TestBusinessCaseCreator() {
 	s.NoError(err)
 
 	input := models.BusinessCase{
-		EUAUserID:      euaID,
+		EUAUserID:      euaID.ValueOrZero(),
 		SystemIntakeID: intake.ID,
 	}
 	fetch := func(ctx context.Context, id uuid.UUID) (*models.SystemIntake, error) {
@@ -103,7 +103,7 @@ func (s ServicesTestSuite) TestBusinessCaseCreator() {
 	}
 	create := func(ctx context.Context, businessCase *models.BusinessCase) (*models.BusinessCase, error) {
 		return &models.BusinessCase{
-			EUAUserID: euaID,
+			EUAUserID: euaID.ValueOrZero(),
 		}, nil
 	}
 	authorize := func(ctx context.Context, intake *models.SystemIntake) (bool, error) {
@@ -128,7 +128,7 @@ func (s ServicesTestSuite) TestBusinessCaseCreator() {
 		businessCase, err := createBusinessCase(ctx, &input)
 		s.NoError(err)
 
-		s.Equal(euaID, businessCase.EUAUserID)
+		s.Equal(euaID.ValueOrZero(), businessCase.EUAUserID)
 	})
 
 	s.Run("returns query error when create fails", func() {
@@ -221,7 +221,7 @@ func (s ServicesTestSuite) TestBusinessCaseUpdater() {
 	logger := zap.NewNop()
 	serviceConfig := NewConfig(logger, nil)
 	serviceConfig.clock = clock.NewMock()
-	euaID := testhelpers.RandomEUAID()
+	euaID := testhelpers.RandomEUAIDNull()
 	intake := &models.SystemIntake{
 		EUAUserID:   euaID,
 		Status:      models.SystemIntakeStatusINTAKESUBMITTED,

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -29,7 +29,7 @@ func (s ServicesTestSuite) TestFetchSystemIntakes() {
 
 	fnByID := func(ctx context.Context, euaID string) (models.SystemIntakes, error) {
 		return models.SystemIntakes{
-			models.SystemIntake{EUAUserID: euaID},
+			models.SystemIntake{EUAUserID: null.StringFrom(euaID)},
 		}, nil
 	}
 	fnByIDFail := func(ctx context.Context, euaID string) (models.SystemIntakes, error) {
@@ -38,8 +38,8 @@ func (s ServicesTestSuite) TestFetchSystemIntakes() {
 
 	fnAll := func(ctx context.Context) (models.SystemIntakes, error) {
 		return models.SystemIntakes{
-			models.SystemIntake{EUAUserID: reviewerID},
-			models.SystemIntake{EUAUserID: requesterID},
+			models.SystemIntake{EUAUserID: null.StringFrom(reviewerID)},
+			models.SystemIntake{EUAUserID: null.StringFrom(requesterID)},
 		}, nil
 	}
 	fnAllFail := func(ctx context.Context) (models.SystemIntakes, error) { return nil, errors.New("forced error") }
@@ -146,7 +146,7 @@ func (s ServicesTestSuite) TestNewCreateSystemIntake() {
 			Status:    models.SystemIntakeStatusINTAKEDRAFT,
 		})
 		s.NoError(err)
-		s.Equal(fakeEuaID, intake.EUAUserID)
+		s.Equal(fakeEuaID, intake.EUAUserID.ValueOrZero())
 	})
 
 	s.Run("returns query error when create fails", func() {

--- a/pkg/storage/business_case_test.go
+++ b/pkg/storage/business_case_test.go
@@ -57,11 +57,11 @@ func (s StoreTestSuite) TestFetchBusinessCasesByEuaID() {
 		s.NoError(err)
 
 		businessCase := testhelpers.NewBusinessCase()
-		businessCase.EUAUserID = intake.EUAUserID
+		businessCase.EUAUserID = intake.EUAUserID.ValueOrZero()
 		businessCase.SystemIntakeID = intake.ID
 
 		businessCase2 := testhelpers.NewBusinessCase()
-		businessCase2.EUAUserID = intake.EUAUserID
+		businessCase2.EUAUserID = intake.EUAUserID.ValueOrZero()
 		businessCase2.SystemIntakeID = intake2.ID
 
 		_, err = s.store.CreateBusinessCase(ctx, &businessCase)
@@ -175,7 +175,7 @@ func (s StoreTestSuite) TestUpdateBusinessCase() {
 	intake := testhelpers.NewSystemIntake()
 	_, err := s.store.CreateSystemIntake(ctx, &intake)
 	s.NoError(err)
-	euaID := intake.EUAUserID
+	euaID := intake.EUAUserID.ValueOrZero()
 	businessCaseOriginal := testhelpers.NewBusinessCase()
 	businessCaseOriginal.EUAUserID = euaID
 	businessCaseOriginal.SystemIntakeID = intake.ID

--- a/pkg/storage/note_test.go
+++ b/pkg/storage/note_test.go
@@ -18,7 +18,7 @@ func (s StoreTestSuite) TestNoteRoundtrip() {
 	intake, err := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
 		Status:      models.SystemIntakeStatusINTAKEDRAFT,
 		RequestType: models.SystemIntakeRequestTypeNEW,
-		EUAUserID:   euaID,
+		EUAUserID:   null.StringFrom(euaID),
 	})
 	s.NoError(err)
 

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -107,7 +107,7 @@ func (s *Store) CreateSystemIntake(ctx context.Context, intake *models.SystemInt
 	if err != nil {
 		appcontext.ZLogger(ctx).Error(
 			fmt.Sprintf("Failed to create system intake with error %s", err),
-			zap.String("user", intake.EUAUserID),
+			zap.String("user", intake.EUAUserID.ValueOrZero()),
 		)
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (s *Store) UpdateSystemIntake(ctx context.Context, intake *models.SystemInt
 		appcontext.ZLogger(ctx).Error(
 			fmt.Sprintf("Failed to update system intake %s", err),
 			zap.String("id", intake.ID.String()),
-			zap.String("user", intake.EUAUserID),
+			zap.String("user", intake.EUAUserID.ValueOrZero()),
 		)
 		return nil, err
 	}

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -24,7 +24,7 @@ func (s StoreTestSuite) TestCreateSystemIntake() {
 
 	s.Run("create a new system intake", func() {
 		intake := models.SystemIntake{
-			EUAUserID:   testhelpers.RandomEUAID(),
+			EUAUserID:   testhelpers.RandomEUAIDNull(),
 			Status:      models.SystemIntakeStatusINTAKEDRAFT,
 			RequestType: models.SystemIntakeRequestTypeNEW,
 			Requester:   "Test requester",
@@ -41,18 +41,6 @@ func (s StoreTestSuite) TestCreateSystemIntake() {
 		s.False(created.ID == uuid.Nil)
 	})
 
-	s.Run("cannot save without EUA ID", func() {
-		partialIntake := models.SystemIntake{
-			Status:      models.SystemIntakeStatusINTAKEDRAFT,
-			RequestType: models.SystemIntakeRequestTypeNEW,
-		}
-
-		_, err := s.store.CreateSystemIntake(ctx, &partialIntake)
-
-		s.Error(err)
-		s.Equal("pq: new row for relation \"system_intake\" violates check constraint \"eua_id_check\"", err.Error())
-	})
-
 	euaTests := []string{
 		"f",
 		"F",
@@ -65,7 +53,7 @@ func (s StoreTestSuite) TestCreateSystemIntake() {
 				Status:      models.SystemIntakeStatusINTAKEDRAFT,
 				RequestType: models.SystemIntakeRequestTypeNEW,
 			}
-			partialIntake.EUAUserID = tc
+			partialIntake.EUAUserID = null.StringFrom(tc)
 
 			_, err := s.store.CreateSystemIntake(ctx, &partialIntake)
 
@@ -76,7 +64,7 @@ func (s StoreTestSuite) TestCreateSystemIntake() {
 
 	s.Run("cannot create with invalid status", func() {
 		partialIntake := models.SystemIntake{
-			EUAUserID:   testhelpers.RandomEUAID(),
+			EUAUserID:   testhelpers.RandomEUAIDNull(),
 			Status:      "fakeStatus",
 			RequestType: models.SystemIntakeRequestTypeNEW,
 			Requester:   "Test requester",
@@ -95,7 +83,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 
 	s.Run("update an existing system intake", func() {
 		intake, err := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
-			EUAUserID:   testhelpers.RandomEUAID(),
+			EUAUserID:   testhelpers.RandomEUAIDNull(),
 			Status:      models.SystemIntakeStatusINTAKEDRAFT,
 			RequestType: models.SystemIntakeRequestTypeNEW,
 			Requester:   "Test requester",
@@ -113,7 +101,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 
 	s.Run("EUA ID will not update", func() {
 		originalIntake := models.SystemIntake{
-			EUAUserID:   testhelpers.RandomEUAID(),
+			EUAUserID:   testhelpers.RandomEUAIDNull(),
 			Status:      models.SystemIntakeStatusINTAKEDRAFT,
 			RequestType: models.SystemIntakeRequestTypeNEW,
 			Requester:   "Test requester",
@@ -123,12 +111,12 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		originalEUA := originalIntake.EUAUserID
 		partialIntake := models.SystemIntake{
 			ID:          originalIntake.ID,
-			EUAUserID:   testhelpers.RandomEUAID(),
+			EUAUserID:   testhelpers.RandomEUAIDNull(),
 			Status:      models.SystemIntakeStatusINTAKEDRAFT,
 			RequestType: models.SystemIntakeRequestTypeNEW,
 			Requester:   "Test requester",
 		}
-		partialIntake.EUAUserID = "NEWS"
+		partialIntake.EUAUserID = null.StringFrom("NEWS")
 
 		_, err = s.store.UpdateSystemIntake(ctx, &partialIntake)
 		s.NoError(err, "failed to update system intake")
@@ -142,7 +130,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 	s.Run("Lifecycle fields only upon update", func() {
 		now := time.Now()
 		originalIntake := models.SystemIntake{
-			EUAUserID:   testhelpers.RandomEUAID(),
+			EUAUserID:   testhelpers.RandomEUAIDNull(),
 			Status:      models.SystemIntakeStatusINTAKEDRAFT,
 			RequestType: models.SystemIntakeRequestTypeNEW,
 			Requester:   "Test requester",
@@ -186,7 +174,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 
 	s.Run("Rejection fields only upon update", func() {
 		originalIntake := models.SystemIntake{
-			EUAUserID:   testhelpers.RandomEUAID(),
+			EUAUserID:   testhelpers.RandomEUAIDNull(),
 			Status:      models.SystemIntakeStatusINTAKEDRAFT,
 			RequestType: models.SystemIntakeRequestTypeNEW,
 			Requester:   "Test requester",
@@ -221,7 +209,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 
 	s.Run("Update contract details information", func() {
 		originalIntake := models.SystemIntake{
-			EUAUserID:   testhelpers.RandomEUAID(),
+			EUAUserID:   testhelpers.RandomEUAIDNull(),
 			Status:      models.SystemIntakeStatusINTAKEDRAFT,
 			RequestType: models.SystemIntakeRequestTypeNEW,
 			Requester:   "Test requester",
@@ -285,7 +273,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 
 	s.Run("LifecycleID format", func() {
 		originalIntake := models.SystemIntake{
-			EUAUserID:   testhelpers.RandomEUAID(),
+			EUAUserID:   testhelpers.RandomEUAIDNull(),
 			Status:      models.SystemIntakeStatusINTAKEDRAFT,
 			RequestType: models.SystemIntakeRequestTypeNEW,
 			Requester:   "Test requester",
@@ -316,7 +304,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 	s.Run("exhaust lifecycleID generation", func() {
 		for ix := 0; ix < 10; ix++ {
 			original := models.SystemIntake{
-				EUAUserID:   testhelpers.RandomEUAID(),
+				EUAUserID:   testhelpers.RandomEUAIDNull(),
 				Status:      models.SystemIntakeStatusINTAKEDRAFT,
 				RequestType: models.SystemIntakeRequestTypeNEW,
 				Requester:   fmt.Sprintf("LCID Exhaust %d", ix),
@@ -339,7 +327,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		// the 11th attempt should generate an LCID that looks like "2136510" (~"YYddd10"),
 		// and this should violate the db constraint of a 6-digit LCID
 		original := models.SystemIntake{
-			EUAUserID:   testhelpers.RandomEUAID(),
+			EUAUserID:   testhelpers.RandomEUAIDNull(),
 			Status:      models.SystemIntakeStatusINTAKEDRAFT,
 			RequestType: models.SystemIntakeRequestTypeNEW,
 			Requester:   "LCID Exhaust 10",
@@ -363,7 +351,7 @@ func (s StoreTestSuite) TestUpdateSystemIntake() {
 		t1 := clock.NewMock().Now().UTC()
 		t2 := clock.NewMock().Now().UTC()
 		original := models.SystemIntake{
-			EUAUserID:   testhelpers.RandomEUAID(),
+			EUAUserID:   testhelpers.RandomEUAIDNull(),
 			Status:      models.SystemIntakeStatusINTAKEDRAFT,
 			RequestType: models.SystemIntakeRequestTypeNEW,
 
@@ -503,7 +491,7 @@ func (s StoreTestSuite) TestFetchSystemIntakesByEuaID() {
 		err = tx.Commit()
 		s.NoError(err)
 
-		fetched, err := s.store.FetchSystemIntakesByEuaID(ctx, intake.EUAUserID)
+		fetched, err := s.store.FetchSystemIntakesByEuaID(ctx, intake.EUAUserID.ValueOrZero())
 
 		s.NoError(err, "failed to fetch system intakes")
 		s.Len(fetched, 2)
@@ -523,7 +511,7 @@ func (s StoreTestSuite) TestFetchSystemIntakesByEuaID() {
 		err = tx.Commit()
 		s.NoError(err)
 
-		fetched, err := s.store.FetchSystemIntakesByEuaID(ctx, intake.EUAUserID)
+		fetched, err := s.store.FetchSystemIntakesByEuaID(ctx, intake.EUAUserID.ValueOrZero())
 
 		s.NoError(err, "failed to fetch system intakes")
 		s.Len(fetched, 1)
@@ -557,7 +545,7 @@ func (s StoreTestSuite) TestFetchSystemIntakesByEuaID() {
 		err = tx.Commit()
 		s.NoError(err)
 
-		fetched, err := s.store.FetchSystemIntakesByEuaID(ctx, intake.EUAUserID)
+		fetched, err := s.store.FetchSystemIntakesByEuaID(ctx, intake.EUAUserID.ValueOrZero())
 
 		s.NoError(err, "failed to fetch system intakes")
 		s.Len(fetched, 2)

--- a/pkg/testhelpers/rand.go
+++ b/pkg/testhelpers/rand.go
@@ -3,6 +3,8 @@ package testhelpers
 import (
 	"math/rand"
 	"time"
+
+	"github.com/guregu/null"
 )
 
 // RandomEUAID returns a random EUA ID for testing
@@ -16,4 +18,10 @@ func RandomEUAID() string {
 		b[i] = letter[rand.Intn(len(letter))]
 	}
 	return string(b)
+}
+
+// RandomEUAIDNull returns a random EUA ID for testing,
+// in the form of a null.String
+func RandomEUAIDNull() null.String {
+	return null.StringFrom(RandomEUAID())
 }

--- a/pkg/testhelpers/system_intake.go
+++ b/pkg/testhelpers/system_intake.go
@@ -11,7 +11,7 @@ import (
 func NewSystemIntake() models.SystemIntake {
 	return models.SystemIntake{
 		ID:                      uuid.New(),
-		EUAUserID:               RandomEUAID(),
+		EUAUserID:               null.StringFrom(RandomEUAID()),
 		Status:                  models.SystemIntakeStatusINTAKEDRAFT,
 		RequestType:             models.SystemIntakeRequestTypeNEW,
 		Requester:               "Test Requester",


### PR DESCRIPTION
# EASI-972

Changes proposed in this pull request:

- Remove the db constraint that a SystemIntake has an EUA_ID (to support backfill data that doesn't have EUA_ID available)
