### PR TITLE
updates tags to display not needed for recompete

### DIFF
--- a/src/data/taskList.ts
+++ b/src/data/taskList.ts
@@ -34,6 +34,9 @@ export const initialReviewTag = (intakeStatus: string): TagEnum => {
 
 export const businessCaseTag = (intake: SystemIntakeForm): TagEnum => {
   if (intake.requestType === 'RECOMPETE') {
+    if (intake.status === 'LCID_ISSUED') {
+      return 'NOT_NEEDED';
+    }
     return 'CANNOT_START';
   }
 
@@ -56,6 +59,9 @@ export const businessCaseTag = (intake: SystemIntakeForm): TagEnum => {
 
 export const finalBusinessCaseTag = (intake: SystemIntakeForm) => {
   if (intake.requestType === 'RECOMPETE') {
+    if (intake.status === 'LCID_ISSUED') {
+      return 'NOT_NEEDED';
+    }
     return 'CANNOT_START';
   }
 
@@ -83,6 +89,9 @@ export const finalBusinessCaseTag = (intake: SystemIntakeForm) => {
 // Task List Item: Attend GRB Meeting
 export const attendGrbMeetingTag = (intake: SystemIntakeForm): TagEnum => {
   if (intake.requestType === 'RECOMPETE') {
+    if (intake.status === 'LCID_ISSUED') {
+      return 'NOT_NEEDED';
+    }
     return 'CANNOT_START';
   }
 
@@ -103,6 +112,9 @@ export const attendGrbMeetingTag = (intake: SystemIntakeForm): TagEnum => {
 // Task List Item: Decision
 export const decisionTag = (intake: SystemIntakeForm): TagEnum => {
   if (intake.requestType === 'RECOMPETE') {
+    if (intake.status === 'LCID_ISSUED') {
+      return '';
+    }
     return 'CANNOT_START';
   }
 

--- a/src/views/GovernanceTaskList/index.test.tsx
+++ b/src/views/GovernanceTaskList/index.test.tsx
@@ -64,18 +64,19 @@ describe('The Goveranance Task List', () => {
   });
 
   describe('Recompetes', () => {
-    const mockStore = configureMockStore();
-    const store = mockStore({
-      systemIntake: {
-        systemIntake: {
-          ...initialSystemIntakeForm,
-          requestName: 'Easy Access to System Information',
-          requestType: 'RECOMPETE'
-        }
-      },
-      businessCase: { form: {} }
-    });
     it('displays "for recompete in title', async () => {
+      const mockStore = configureMockStore();
+      const store = mockStore({
+        systemIntake: {
+          systemIntake: {
+            ...initialSystemIntakeForm,
+            requestName: 'Easy Access to System Information',
+            requestType: 'RECOMPETE'
+          }
+        },
+        businessCase: { form: {} }
+      });
+
       let component: ReactWrapper;
       await act(async () => {
         component = mount(
@@ -94,6 +95,18 @@ describe('The Goveranance Task List', () => {
     });
 
     it('displays not applicable steps as cannot start', async () => {
+      const mockStore = configureMockStore();
+      const store = mockStore({
+        systemIntake: {
+          systemIntake: {
+            ...initialSystemIntakeForm,
+            requestName: 'Easy Access to System Information',
+            requestType: 'RECOMPETE'
+          }
+        },
+        businessCase: { form: {} }
+      });
+
       let component: ReactWrapper;
       await act(async () => {
         component = mount(
@@ -133,6 +146,74 @@ describe('The Goveranance Task List', () => {
           .find('.governance-task-list__task-tag')
           .text()
       ).toEqual('Cannot start yet');
+    });
+
+    it('displays steps 3, 4, and 5 as not needed once issued LCID', async () => {
+      const mockStore = configureMockStore();
+      const store = mockStore({
+        systemIntake: {
+          systemIntake: {
+            ...initialSystemIntakeForm,
+            requestName: 'Easy Access to System Information',
+            requestType: 'RECOMPETE',
+            status: 'LCID_ISSUED'
+          }
+        },
+        businessCase: { form: {} }
+      });
+
+      let component: ReactWrapper;
+      await act(async () => {
+        component = mount(
+          <MemoryRouter initialEntries={['/']} initialIndex={0}>
+            <Provider store={store}>
+              <GovernanceTaskList />
+            </Provider>
+          </MemoryRouter>
+        );
+      });
+      component!.update();
+      expect(
+        component!
+          .find('[data-testid="task-list-intake-form"]')
+          .find('.governance-task-list__task-tag')
+          .text()
+      ).toEqual('Completed');
+
+      expect(
+        component!
+          .find('[data-testid="task-list-intake-review"]')
+          .find('.governance-task-list__task-tag')
+          .text()
+      ).toEqual('Completed');
+
+      expect(
+        component!
+          .find('[data-testid="task-list-business-case-draft"]')
+          .find('.governance-task-list__task-tag')
+          .text()
+      ).toEqual('Not needed');
+
+      expect(
+        component!
+          .find('[data-testid="task-list-business-case-final"]')
+          .find('.governance-task-list__task-tag')
+          .text()
+      ).toEqual('Not needed');
+
+      expect(
+        component!
+          .find('[data-testid="task-list-grb-meeting"]')
+          .find('.governance-task-list__task-tag')
+          .text()
+      ).toEqual('Not needed');
+
+      expect(
+        component!
+          .find('[data-testid="task-list-decision"]')
+          .find('.governance-task-list__task-tag')
+          .exists()
+      ).toEqual(false);
     });
   });
 


### PR DESCRIPTION
For a **RECOMPETE** request:

Once a reviewer has made an action to issue an LCID (status: `LCID_ISSUED`):
- Step 3, 4, 5 should turn from `Cannot start yet` to `Not needed`
- Step 6 doesn't have a tag/status