### PR TITLE
Add endpoint to store completed file upload metadata

### DIFF
--- a/migrations/V58__Add_File_Uploads_Table.sql
+++ b/migrations/V58__Add_File_Uploads_Table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE files (
+    id uuid primary key not null,
+    file_type text not null,
+    bucket text not null,
+    file_key text not null,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    virus_scanned boolean,
+    virus_clean boolean,
+)

--- a/migrations/V58__Add_File_Uploads_Table.sql
+++ b/migrations/V58__Add_File_Uploads_Table.sql
@@ -6,5 +6,5 @@ CREATE TABLE files (
     created_at timestamp with time zone,
     updated_at timestamp with time zone,
     virus_scanned boolean,
-    virus_clean boolean,
-)
+    virus_clean boolean
+);

--- a/pkg/handlers/file_uploads.go
+++ b/pkg/handlers/file_uploads.go
@@ -3,19 +3,25 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 
+	"github.com/cmsgov/easi-app/pkg/apperrors"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 // CreateFileUploadURL is our handler for creating pre-signed S3 upload URLs
 type CreateFileUploadURL func(ctx context.Context) (*models.PreSignedURL, error)
 
+// CreateUploadedFile is a handler for storing file upload metadata
+type CreateUploadedFile func(ctx context.Context, file *models.UploadedFile) (*models.UploadedFile, error)
+
 // NewFileUploadHandler is a constructor for FileUploadHandler
-func NewFileUploadHandler(base HandlerBase, createURL CreateFileUploadURL) FileUploadHandler {
+func NewFileUploadHandler(base HandlerBase, createURL CreateFileUploadURL, createFile CreateUploadedFile) FileUploadHandler {
 	return FileUploadHandler{
 		HandlerBase:         base,
 		CreateFileUploadURL: createURL,
+		CreateUploadedFile:  createFile,
 	}
 }
 
@@ -24,6 +30,7 @@ func NewFileUploadHandler(base HandlerBase, createURL CreateFileUploadURL) FileU
 type FileUploadHandler struct {
 	HandlerBase
 	CreateFileUploadURL CreateFileUploadURL
+	CreateUploadedFile  CreateUploadedFile
 }
 
 // Handle handles a request for file uploading
@@ -50,6 +57,47 @@ func (h FileUploadHandler) Handle() http.HandlerFunc {
 				return
 			}
 			return
+		case "PUT":
+			h.putHandler(w, r)
+			return
 		}
+	}
+}
+
+func (h FileUploadHandler) putHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Body == nil {
+		h.WriteErrorResponse(
+			r.Context(),
+			w,
+			&apperrors.BadRequestError{Err: errors.New("empty request not allowed")},
+		)
+		return
+	}
+	defer r.Body.Close()
+
+	var file models.UploadedFile
+	err := json.NewDecoder(r.Body).Decode(&file)
+	if err != nil {
+		h.WriteErrorResponse(r.Context(), w, &apperrors.BadRequestError{Err: err})
+		return
+	}
+
+	savedFile, err := h.CreateUploadedFile(r.Context(), &file)
+	if err != nil {
+		h.WriteErrorResponse(r.Context(), w, err)
+		return
+	}
+
+	responseBody, err := json.Marshal(savedFile)
+	if err != nil {
+		h.WriteErrorResponse(r.Context(), w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	_, err = w.Write(responseBody)
+	if err != nil {
+		h.WriteErrorResponse(r.Context(), w, err)
+		return
 	}
 }

--- a/pkg/handlers/file_uploads.go
+++ b/pkg/handlers/file_uploads.go
@@ -38,33 +38,36 @@ func (h FileUploadHandler) Handle() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case "POST":
-			url, err := h.CreateFileUploadURL(r.Context())
-			if err != nil {
-				h.WriteErrorResponse(r.Context(), w, err)
-				return
-			}
-
-			responseBody, err := json.Marshal(url)
-			if err != nil {
-				h.WriteErrorResponse(r.Context(), w, err)
-				return
-			}
-
-			w.WriteHeader(http.StatusCreated)
-			_, err = w.Write(responseBody)
-			if err != nil {
-				h.WriteErrorResponse(r.Context(), w, err)
-				return
-			}
-			return
-		case "PUT":
-			h.putHandler(w, r)
+			h.createFileMetadata(w, r)
 			return
 		}
 	}
 }
 
-func (h FileUploadHandler) putHandler(w http.ResponseWriter, r *http.Request) {
+// GeneratePresignedURL is our handler that handles generating pre-signed URLs
+func (h FileUploadHandler) GeneratePresignedURL(w http.ResponseWriter, r *http.Request) {
+	url, err := h.CreateFileUploadURL(r.Context())
+	if err != nil {
+		h.WriteErrorResponse(r.Context(), w, err)
+		return
+	}
+
+	responseBody, err := json.Marshal(url)
+	if err != nil {
+		h.WriteErrorResponse(r.Context(), w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	_, err = w.Write(responseBody)
+	if err != nil {
+		h.WriteErrorResponse(r.Context(), w, err)
+		return
+	}
+	return
+}
+
+func (h FileUploadHandler) createFileMetadata(w http.ResponseWriter, r *http.Request) {
 	if r.Body == nil {
 		h.WriteErrorResponse(
 			r.Context(),

--- a/pkg/models/file_uploads.go
+++ b/pkg/models/file_uploads.go
@@ -18,7 +18,7 @@ type UploadedFile struct {
 	ID           uuid.UUID   `json:"id"`
 	FileType     null.String `json:"fileType" db:"file_type"`
 	Bucket       null.String `json:"bucket" db:"bucket"`
-	Key          null.String `json:"key" db:"key"`
+	Key          null.String `json:"fileKey" db:"file_key"`
 	CreatedAt    *time.Time  `json:"createdAt" db:"created_at"`
 	UpdatedAt    *time.Time  `json:"updatedAt" db:"updated_at"`
 	VirusScanned null.Bool   `json:"virusScanned" db:"virus_scanned"`

--- a/pkg/models/file_uploads.go
+++ b/pkg/models/file_uploads.go
@@ -1,7 +1,26 @@
 package models
 
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/guregu/null"
+)
+
 //PreSignedURL is the model to return S3 pre-signed URLs
 type PreSignedURL struct {
 	URL      string `json:"URL"`
 	Filename string `json:"filename"`
+}
+
+// UploadedFile is the representation of stored files uploaded to S3
+type UploadedFile struct {
+	ID           uuid.UUID   `json:"id"`
+	FileType     null.String `json:"fileType" db:"file_type"`
+	Bucket       null.String `json:"bucket" db:"bucket"`
+	Key          null.String `json:"key" db:"key"`
+	CreatedAt    *time.Time  `json:"createdAt" db:"created_at"`
+	UpdatedAt    *time.Time  `json:"updatedAt" db:"updated_at"`
+	VirusScanned null.Bool   `json:"virusScanned" db:"virus_scanned"`
+	VirusClean   null.Bool   `json:"virusClean" db:"virus_clean"`
 }

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -487,8 +487,15 @@ func (s *Server) routes(
 	// File Upload Handlers
 	fileUploadHandler := handlers.NewFileUploadHandler(
 		base,
-		services.NewCreateFileUploadURL(serviceConfig, s3Client),
-		services.NewCreateUploadedFile(serviceConfig, store.CreateUploadedFile),
+		services.NewCreateFileUploadURL(
+			serviceConfig,
+			services.NewAuthorizeRequireGRTJobCode(),
+			s3Client,
+		),
+		services.NewCreateUploadedFile(
+			serviceConfig,
+			services.NewAuthorizeRequireGRTJobCode(),
+			store.CreateUploadedFile),
 	)
 	api.Handle("/file_uploads", fileUploadHandler.Handle())
 

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -492,6 +492,9 @@ func (s *Server) routes(
 	)
 	api.Handle("/file_uploads", fileUploadHandler.Handle())
 
+	api.HandleFunc("/file_uploads/presignedurl", fileUploadHandler.GeneratePresignedURL).
+		Methods("POST")
+
 	s.router.PathPrefix("/").Handler(handlers.NewCatchAllHandler(
 		base,
 	).Handle())

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -488,6 +488,7 @@ func (s *Server) routes(
 	fileUploadHandler := handlers.NewFileUploadHandler(
 		base,
 		services.NewCreateFileUploadURL(serviceConfig, s3Client),
+		services.NewCreateUploadedFile(serviceConfig, store.CreateUploadedFile),
 	)
 	api.Handle("/file_uploads", fileUploadHandler.Handle())
 

--- a/pkg/services/file_uploads.go
+++ b/pkg/services/file_uploads.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"errors"
 
+	"github.com/cmsgov/easi-app/pkg/apperrors"
 	"github.com/cmsgov/easi-app/pkg/handlers"
 	"github.com/cmsgov/easi-app/pkg/models"
 	"github.com/cmsgov/easi-app/pkg/upload"
@@ -11,9 +13,24 @@ import (
 // createFunc is a function that saves uploaded file metadata
 type createFunc func(context.Context, *models.UploadedFile) (*models.UploadedFile, error)
 
+// authFunc is a function that deals with auth
+type authFunc func(context.Context) (bool, error)
+
 // NewCreateFileUploadURL is a service to create a file upload URL via a pre-signed URL in S3
-func NewCreateFileUploadURL(config Config, s3client upload.S3Client) handlers.CreateFileUploadURL {
+func NewCreateFileUploadURL(config Config, authorize authFunc, s3client upload.S3Client) handlers.CreateFileUploadURL {
 	return func(ctx context.Context) (*models.PreSignedURL, error) {
+		ok, err := authorize(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if !ok {
+			return nil, &apperrors.ResourceNotFoundError{
+				Err:      errors.New("failed to authorize pre-signed url generation"),
+				Resource: models.PreSignedURL{},
+			}
+		}
+
 		url, err := s3client.NewPutPresignedURL()
 		if err != nil {
 			return nil, err
@@ -23,8 +40,20 @@ func NewCreateFileUploadURL(config Config, s3client upload.S3Client) handlers.Cr
 }
 
 // NewCreateUploadedFile returns a function that saves the metadata of an uploaded file
-func NewCreateUploadedFile(config Config, create createFunc) handlers.CreateUploadedFile {
+func NewCreateUploadedFile(config Config, authorize authFunc, create createFunc) handlers.CreateUploadedFile {
 	return func(ctx context.Context, file *models.UploadedFile) (*models.UploadedFile, error) {
+		ok, err := authorize(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if !ok {
+			return nil, &apperrors.ResourceNotFoundError{
+				Err:      errors.New("failed to authorize save uploaded file metadata"),
+				Resource: models.PreSignedURL{},
+			}
+		}
+
 		return create(ctx, file)
 	}
 }

--- a/pkg/services/file_uploads.go
+++ b/pkg/services/file_uploads.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/cmsgov/easi-app/pkg/apperrors"
-	"github.com/cmsgov/easi-app/pkg/handlers"
 	"github.com/cmsgov/easi-app/pkg/models"
 	"github.com/cmsgov/easi-app/pkg/upload"
 )
@@ -17,7 +16,7 @@ type createFunc func(context.Context, *models.UploadedFile) (*models.UploadedFil
 type authFunc func(context.Context) (bool, error)
 
 // NewCreateFileUploadURL is a service to create a file upload URL via a pre-signed URL in S3
-func NewCreateFileUploadURL(config Config, authorize authFunc, s3client upload.S3Client) handlers.CreateFileUploadURL {
+func NewCreateFileUploadURL(config Config, authorize authFunc, s3client upload.S3Client) func(ctx context.Context) (*models.PreSignedURL, error) {
 	return func(ctx context.Context) (*models.PreSignedURL, error) {
 		ok, err := authorize(ctx)
 		if err != nil {
@@ -40,7 +39,7 @@ func NewCreateFileUploadURL(config Config, authorize authFunc, s3client upload.S
 }
 
 // NewCreateUploadedFile returns a function that saves the metadata of an uploaded file
-func NewCreateUploadedFile(config Config, authorize authFunc, create createFunc) handlers.CreateUploadedFile {
+func NewCreateUploadedFile(config Config, authorize authFunc, create createFunc) func(ctx context.Context, file *models.UploadedFile) (*models.UploadedFile, error) {
 	return func(ctx context.Context, file *models.UploadedFile) (*models.UploadedFile, error) {
 		ok, err := authorize(ctx)
 		if err != nil {

--- a/pkg/services/file_uploads.go
+++ b/pkg/services/file_uploads.go
@@ -8,8 +8,8 @@ import (
 	"github.com/cmsgov/easi-app/pkg/upload"
 )
 
-//PreSignedURLReturn is the return type of these functions
-type PreSignedURLReturn func(context.Context) (*models.PreSignedURL, error)
+// createFunc is a function that saves uploaded file metadata
+type createFunc func(context.Context, *models.UploadedFile) (*models.UploadedFile, error)
 
 // NewCreateFileUploadURL is a service to create a file upload URL via a pre-signed URL in S3
 func NewCreateFileUploadURL(config Config, s3client upload.S3Client) handlers.CreateFileUploadURL {
@@ -19,5 +19,12 @@ func NewCreateFileUploadURL(config Config, s3client upload.S3Client) handlers.Cr
 			return nil, err
 		}
 		return url, nil
+	}
+}
+
+// NewCreateUploadedFile returns a function that saves the metadata of an uploaded file
+func NewCreateUploadedFile(config Config, create createFunc) handlers.CreateUploadedFile {
+	return func(ctx context.Context, file *models.UploadedFile) (*models.UploadedFile, error) {
+		return create(ctx, file)
 	}
 }

--- a/pkg/storage/file_uploads.go
+++ b/pkg/storage/file_uploads.go
@@ -1,0 +1,71 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+// CreateUploadedFile stores metadata for files uploaded to S3
+func (s *Store) CreateUploadedFile(ctx context.Context, file *models.UploadedFile) (*models.UploadedFile, error) {
+	file.ID = uuid.New()
+	createAt := s.clock.Now()
+	file.CreatedAt = &createAt
+	file.UpdatedAt = &createAt
+	const createUploadedFileSQL = `INSERT INTO files (
+                         id,
+                         file_type,
+                         bucket, key,
+                         created_at,
+                         updated_at,
+                         virus_scanned,
+                         virus_clean
+                 )
+                 VALUES (
+                         :id,
+                         :file_type,
+                         :bucket,
+                         :key,
+                         :created_at,
+                         :updated_at,
+                         :virus_scanned,
+                         :virus_clean
+                 )`
+	_, err := s.db.NamedExec(createUploadedFileSQL, file)
+	if err != nil {
+		appcontext.ZLogger(ctx).Error(
+			fmt.Sprintf("Failed to create file upload with error %s", err),
+		)
+		return nil, err
+	}
+	return s.FetchUploadedFileByID(ctx, file.ID)
+}
+
+// FetchUploadedFileByID retrieves the metadata for a file uploaded to S3
+func (s *Store) FetchUploadedFileByID(ctx context.Context, id uuid.UUID) (*models.UploadedFile, error) {
+	var file models.UploadedFile
+
+	err := s.db.Get(&file, "SELECT * FROM files WHERE id=$1", id)
+	if err != nil {
+		appcontext.ZLogger(ctx).Error(
+			fmt.Sprintf("Failed to fetch file %s", err),
+			zap.String("id", id.String()),
+		)
+
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, &apperrors.ResourceNotFoundError{Err: err, Resource: models.UploadedFile{}}
+		}
+
+		return nil, err
+	}
+
+	return &file, nil
+}

--- a/pkg/storage/file_uploads.go
+++ b/pkg/storage/file_uploads.go
@@ -23,7 +23,8 @@ func (s *Store) CreateUploadedFile(ctx context.Context, file *models.UploadedFil
 	const createUploadedFileSQL = `INSERT INTO files (
                          id,
                          file_type,
-                         bucket, key,
+                         bucket,
+                         file_key,
                          created_at,
                          updated_at,
                          virus_scanned,
@@ -33,7 +34,7 @@ func (s *Store) CreateUploadedFile(ctx context.Context, file *models.UploadedFil
                          :id,
                          :file_type,
                          :bucket,
-                         :key,
+                         :file_key,
                          :created_at,
                          :updated_at,
                          :virus_scanned,


### PR DESCRIPTION
# EASI-945

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Adds the endpoint to store the metadata around uploaded file
- Adds db migration for creating the table
