### PR TITLE
Add validations for GRT and GRB Dates

### DIFF
--- a/src/validations/systemIntakeSchema.ts
+++ b/src/validations/systemIntakeSchema.ts
@@ -143,56 +143,51 @@ const SystemIntakeValidationSchema: any = {
 
 export default SystemIntakeValidationSchema;
 
-export const DateValidationSchema: any = Yup.object().shape({
-  grtDate: Yup.mixed().test({
-    name: 'grtDate',
-    // exclusive: true,
-    // params: { ['grtDateDay', 'grtDateMonth', 'grtDateYear'] },
-    message: 'Please enter a complete GRT date',
-    test: ({
-      grtDateDay,
-      grtDateMonth,
-      grtDateYear
-    }: {
-      grtDateDay: any;
-      grtDateMonth: any;
-      grtDateYear: any;
-    }) => {
-      console.log('grtDateDay ', grtDateDay);
-      console.log('grtDateMonth ', grtDateMonth);
-      console.log('grtDateYear ', grtDateYear);
-
-      if (
-        grtDateDay === undefined &&
-        grtDateMonth === undefined &&
-        grtDateYear === undefined
-      ) {
-        console.log('Got here A');
-        return true;
-      }
-
-      if (
-        grtDateDay !== undefined &&
-        grtDateMonth !== undefined &&
-        grtDateYear !== undefined
-      ) {
-        console.log('got here B');
-        return true;
-      }
-
-      return false;
-    }
-  })
-  // grtDateDay: Yup.number().when(['grtDateMonth', 'grtDateYear'], {
-  //   is: (grtDateMonth: any, grtDateYear: any) => grtDateMonth || grtDateYear,
-  //   then: (s: any) => s.required('The day is required')
-  // }),
-  // grtDateMonth: Yup.string().when(['grtDateDay', 'grtDateYear'], {
-  //   is: (grtDateDay: any, grtDateYear: any) => grtDateDay || grtDateYear,
-  //   then: (s: any) => s.required('The month is required')
-  // }),
-  // grtDateYear: Yup.string().when(['grtDateDay', 'grtDateMonth'], {
-  //   is: true,
-  //   then: (s: any) => s.required('The year is required')
-  // })
-});
+export const DateValidationSchema: any = Yup.object().shape(
+  {
+    grtDateDay: Yup.string().when(['grtDateMonth', 'grtDateYear'], {
+      is: (grtDateMonth: string, grtDateYear: string) => {
+        return grtDateMonth || grtDateYear;
+      },
+      then: Yup.string().required('The day is required')
+    }),
+    grtDateMonth: Yup.string().when(['grtDateDay', 'grtDateYear'], {
+      is: (grtDateDay: string, grtDateYear: string) => {
+        return grtDateDay || grtDateYear;
+      },
+      then: Yup.string().required('The month is required')
+    }),
+    grtDateYear: Yup.string().when(['grtDateDay', 'grtDateMonth'], {
+      is: (grtDateDay: string, grtDateMonth: string) => {
+        return grtDateDay || grtDateMonth;
+      },
+      then: Yup.string().required('The year is required')
+    }),
+    grbDateDay: Yup.string().when(['grbDateMonth', 'grbDateYear'], {
+      is: (grbDateMonth: string, grbDateYear: string) => {
+        return grbDateMonth || grbDateYear;
+      },
+      then: Yup.string().required('The day is required')
+    }),
+    grbDateMonth: Yup.string().when(['grbDateDay', 'grbDateYear'], {
+      is: (grbDateDay: string, grbDateYear: string) => {
+        return grbDateDay || grbDateYear;
+      },
+      then: Yup.string().required('The month is required')
+    }),
+    grbDateYear: Yup.string().when(['grbDateDay', 'grbDateMonth'], {
+      is: (grbDateDay: string, grbDateMonth: string) => {
+        return grbDateDay || grbDateMonth;
+      },
+      then: Yup.string().required('The year is required')
+    })
+  },
+  [
+    ['grtDateDay', 'grtDateMonth'],
+    ['grtDateDay', 'grtDateYear'],
+    ['grtDateMonth', 'grtDateYear'],
+    ['grbDateDay', 'grbDateMonth'],
+    ['grbDateDay', 'grbDateYear'],
+    ['grbDateMonth', 'grbDateYear']
+  ]
+);

--- a/src/validations/systemIntakeSchema.ts
+++ b/src/validations/systemIntakeSchema.ts
@@ -142,3 +142,57 @@ const SystemIntakeValidationSchema: any = {
 };
 
 export default SystemIntakeValidationSchema;
+
+export const DateValidationSchema: any = Yup.object().shape({
+  grtDate: Yup.mixed().test({
+    name: 'grtDate',
+    // exclusive: true,
+    // params: { ['grtDateDay', 'grtDateMonth', 'grtDateYear'] },
+    message: 'Please enter a complete GRT date',
+    test: ({
+      grtDateDay,
+      grtDateMonth,
+      grtDateYear
+    }: {
+      grtDateDay: any;
+      grtDateMonth: any;
+      grtDateYear: any;
+    }) => {
+      console.log('grtDateDay ', grtDateDay);
+      console.log('grtDateMonth ', grtDateMonth);
+      console.log('grtDateYear ', grtDateYear);
+
+      if (
+        grtDateDay === undefined &&
+        grtDateMonth === undefined &&
+        grtDateYear === undefined
+      ) {
+        console.log('Got here A');
+        return true;
+      }
+
+      if (
+        grtDateDay !== undefined &&
+        grtDateMonth !== undefined &&
+        grtDateYear !== undefined
+      ) {
+        console.log('got here B');
+        return true;
+      }
+
+      return false;
+    }
+  })
+  // grtDateDay: Yup.number().when(['grtDateMonth', 'grtDateYear'], {
+  //   is: (grtDateMonth: any, grtDateYear: any) => grtDateMonth || grtDateYear,
+  //   then: (s: any) => s.required('The day is required')
+  // }),
+  // grtDateMonth: Yup.string().when(['grtDateDay', 'grtDateYear'], {
+  //   is: (grtDateDay: any, grtDateYear: any) => grtDateDay || grtDateYear,
+  //   then: (s: any) => s.required('The month is required')
+  // }),
+  // grtDateYear: Yup.string().when(['grtDateDay', 'grtDateMonth'], {
+  //   is: true,
+  //   then: (s: any) => s.required('The year is required')
+  // })
+});

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -71,7 +71,7 @@ const AppRoutes = () => {
       {isUserSet && user.isGrtReviewer(userGroups) && (
         <SecureRoute
           path="/governance-review-team/:systemId/:activePage"
-          component={GovernanceReviewTeam}
+          render={() => <GovernanceReviewTeam />}
         />
       )}
       <SecureRoute

--- a/src/views/GovernanceReviewTeam/Dates/index.tsx
+++ b/src/views/GovernanceReviewTeam/Dates/index.tsx
@@ -15,6 +15,7 @@ import { AppState } from 'reducers/rootReducer';
 import { saveSystemIntake } from 'types/routines';
 import { SubmitDatesForm, SystemIntakeForm } from 'types/systemIntake';
 import flattenErrors from 'utils/flattenErrors';
+import { DateValidationSchema } from 'validations/systemIntakeSchema';
 
 const Dates = ({ systemIntake }: { systemIntake: SystemIntakeForm }) => {
   const { systemId } = useParams();
@@ -77,13 +78,14 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntakeForm }) => {
     <Formik
       initialValues={initialValues}
       onSubmit={onSubmit}
-      // validationSchema={lifecycleIdSchema}
+      validationSchema={DateValidationSchema}
       validateOnBlur={false}
-      validateOnChange={false}
+      validateOnChange
       validateOnMount={false}
     >
       {(formikProps: FormikProps<SubmitDatesForm>) => {
         const { errors } = formikProps;
+        console.log('errors ', errors);
         const flatErrors = flattenErrors(errors);
         return (
           <>

--- a/src/views/GovernanceReviewTeam/Dates/index.tsx
+++ b/src/views/GovernanceReviewTeam/Dates/index.tsx
@@ -80,12 +80,11 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntakeForm }) => {
       onSubmit={onSubmit}
       validationSchema={DateValidationSchema}
       validateOnBlur={false}
-      validateOnChange
+      validateOnChange={false}
       validateOnMount={false}
     >
       {(formikProps: FormikProps<SubmitDatesForm>) => {
         const { errors } = formikProps;
-        console.log('errors ', errors);
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -111,11 +110,20 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntakeForm }) => {
             <div className="tablet:grid-col-9 margin-bottom-7">
               <Form>
                 {/* GRT Date Fields */}
-                <FieldGroup>
+                <FieldGroup
+                  error={
+                    !!flatErrors.grtDateMonth ||
+                    !!flatErrors.grtDateDay ||
+                    !!flatErrors.grtDateYear
+                  }
+                >
                   <fieldset className="usa-fieldset margin-top-4">
                     <legend className="usa-label margin-bottom-1">
                       {t('governanceReviewTeam:dates.grtDate.label')}
                     </legend>
+                    <FieldErrorMsg>{flatErrors.grtDateMonth}</FieldErrorMsg>
+                    <FieldErrorMsg>{flatErrors.grtDateDay}</FieldErrorMsg>
+                    <FieldErrorMsg>{flatErrors.grtDateYear}</FieldErrorMsg>
                     <div
                       className="usa-memorable-date"
                       style={{ marginTop: '-2rem' }}
@@ -124,7 +132,6 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntakeForm }) => {
                         <Label htmlFor="Dates-GrtDateMonth">
                           {t('general:date.month')}
                         </Label>
-                        <FieldErrorMsg>{flatErrors.grtDateMonth}</FieldErrorMsg>
                         <Field
                           as={TextField}
                           error={!!flatErrors.grtDateMonth}
@@ -137,7 +144,6 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntakeForm }) => {
                         <Label htmlFor="Dates-GrtDateDay">
                           {t('general:date.day')}
                         </Label>
-                        <FieldErrorMsg>{flatErrors.grtDateDay}</FieldErrorMsg>
                         <Field
                           as={TextField}
                           error={!!flatErrors.grtDateDay}
@@ -150,7 +156,6 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntakeForm }) => {
                         <Label htmlFor="Dates-GrtDateYear">
                           {t('general:date.year')}
                         </Label>
-                        <FieldErrorMsg>{flatErrors.grtDateYear}</FieldErrorMsg>
                         <Field
                           as={TextField}
                           error={!!flatErrors.grtDateYear}
@@ -164,11 +169,20 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntakeForm }) => {
                 </FieldGroup>
                 {/* End GRT Date Fields */}
                 {/* GRB Date Fields */}
-                <FieldGroup>
+                <FieldGroup
+                  error={
+                    !!flatErrors.grbDateMonth ||
+                    !!flatErrors.grbDateDay ||
+                    !!flatErrors.grbDateYear
+                  }
+                >
                   <fieldset className="usa-fieldset margin-top-4">
                     <legend className="usa-label margin-bottom-1">
                       {t('governanceReviewTeam:dates.grbDate.label')}
                     </legend>
+                    <FieldErrorMsg>{flatErrors.grbDateMonth}</FieldErrorMsg>
+                    <FieldErrorMsg>{flatErrors.grbDateDay}</FieldErrorMsg>
+                    <FieldErrorMsg>{flatErrors.grbDateYear}</FieldErrorMsg>
                     <div
                       className="usa-memorable-date"
                       style={{ marginTop: '-2rem' }}
@@ -177,7 +191,6 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntakeForm }) => {
                         <Label htmlFor="Dates-GrbDateMonth">
                           {t('general:date.month')}
                         </Label>
-                        <FieldErrorMsg>{flatErrors.grbDateMonth}</FieldErrorMsg>
                         <Field
                           as={TextField}
                           error={!!flatErrors.grbDateMonth}
@@ -190,7 +203,6 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntakeForm }) => {
                         <Label htmlFor="Dates-GrbDateDay">
                           {t('general:date.day')}
                         </Label>
-                        <FieldErrorMsg>{flatErrors.grbDateDay}</FieldErrorMsg>
                         <Field
                           as={TextField}
                           error={!!flatErrors.grbDateDay}
@@ -203,7 +215,6 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntakeForm }) => {
                         <Label htmlFor="Dates-GrbDateYear">
                           {t('general:date.year')}
                         </Label>
-                        <FieldErrorMsg>{flatErrors.grbDateYear}</FieldErrorMsg>
                         <Field
                           as={TextField}
                           error={!!flatErrors.grbDateYear}


### PR DESCRIPTION
# EASI-1018

This PR adds validations for the GRT and GRB dates in the reviewer track.

We decided that in order to save, one of the following criteria must be met:
- the date must be **fully** filled out
- the date must be empty

Examples:
- [ ] GRT and GRB dates are fully empty should save without any validation errors
- [ ] GRT OR GRB date is fully filled out and should save without any validation errors
- [ ] GRT month is the only field filled out. The GRT day and year should have validation errors, and no errors for GRB
- [ ] GRB month is the only field filled out. The GRB day and year should have validation errors, and no errors for GRT

There are other permutations, but the general idea is the dates must be fully filled out or not filled at all.


In order to test, you need the GRT job code and visit:
`http://localhost:3000/governance-review-team/:systemId/dates`

Those are the date fields you need to fill out.