### PR TITLE
update frontend model to include new lcid fields

### DIFF
--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -69,6 +69,11 @@ export const initialSystemIntakeForm: SystemIntakeForm = {
   createdAt: null,
   archivedAt: null,
   lcid: '',
+  lcidExpiration: null,
+  lcidScope: '',
+  lifecycleNextSteps: '',
+  decisionNextSteps: '',
+  rejectionReason: '',
   grtDate: null,
   grbDate: null
 };
@@ -216,6 +221,13 @@ export const prepareSystemIntakeForApp = (
       ? DateTime.fromISO(systemIntake.archivedAt)
       : null,
     lcid: systemIntake.lcid || '',
+    lcidExpiration: systemIntake.lcidExpiresAt
+      ? DateTime.fromISO(systemIntake.lcidExpiresAt)
+      : null,
+    lcidScope: systemIntake.lcidScope || '',
+    lifecycleNextSteps: systemIntake.lifecycleNextSteps || '',
+    decisionNextSteps: systemIntake.decisionNextSteps || '',
+    rejectionReason: systemIntake.rejectionReason || '',
     grtDate: systemIntake.grtDate
       ? DateTime.fromISO(systemIntake.grtDate)
       : null,

--- a/src/types/systemIntake.ts
+++ b/src/types/systemIntake.ts
@@ -79,6 +79,11 @@ export type SystemIntakeForm = {
   createdAt: DateTime | null;
   archivedAt: DateTime | null;
   lcid: string;
+  lcidExpiration: DateTime | null;
+  lcidScope: string;
+  lifecycleNextSteps: string;
+  decisionNextSteps: string;
+  rejectionReason: string;
   grtDate: DateTime | null;
   grbDate: DateTime | null;
 } & ContractDetailsForm;


### PR DESCRIPTION
# EASI-780

In order to create the decision (approved/rejected) pages, we need to have the data from the API:

This PR adds the following data to our frontend intake model:
- Lifecycle ID Expiration
- Lifecycle ID Scope
- Lifecycle Next Steps
- Decision Next Steps
- Rejection Reason

It's not 100% clear how these should be presented, but all of these attributes are supported on the API already, so I'm guessing we'll use them in one way or another.
