### PR TITLE
fix action types

### DIFF
--- a/src/types/action.ts
+++ b/src/types/action.ts
@@ -17,6 +17,18 @@ export type ActionType =
   | 'ISSUE_LCID'
   | 'REJECT';
 
+/**
+ * Type for the POST Action request payload
+ */
+export type CreateActionPayload = {
+  intakeId: string;
+  actionType: ActionType;
+  feedback?: string;
+};
+
+/**
+ * Type for the GET Action request payload
+ */
 export type Action = {
   id: string;
   createdAt: DateTime;
@@ -27,6 +39,9 @@ export type Action = {
   feedback?: string;
 };
 
+/**
+ * Type for Action Reducer State
+ */
 export type ActionState = {
   isPosting: boolean;
   error?: any;

--- a/src/types/routines.ts
+++ b/src/types/routines.ts
@@ -1,6 +1,6 @@
 import { createRoutine } from 'redux-saga-routines';
 
-import { Action } from 'types/action';
+import { CreateActionPayload } from 'types/action';
 
 // SystemIntakes routines
 export const fetchSystemIntakes = createRoutine('FETCH_SYSTEM_INTAKES');
@@ -36,5 +36,5 @@ export const fetchRequestRepoIntakes = createRoutine(
 );
 
 // Action routines
-export const postAction = createRoutine<Action>('POST_ACTION');
+export const postAction = createRoutine<CreateActionPayload>('POST_ACTION');
 export const fetchActions = createRoutine('FETCH_ACTIONS');

--- a/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
@@ -13,13 +13,17 @@ import Label from 'components/shared/Label';
 import { RadioField } from 'components/shared/RadioField';
 import TextAreaField from 'components/shared/TextAreaField';
 import TextField from 'components/shared/TextField';
-import { ActionType, SubmitLifecycleIdForm } from 'types/action';
+import {
+  ActionType,
+  CreateActionPayload,
+  SubmitLifecycleIdForm
+} from 'types/action';
 import { issueLifecycleIdForSystemIntake } from 'types/routines';
 import flattenErrors from 'utils/flattenErrors';
 import { lifecycleIdSchema } from 'validations/actionSchema';
 
 const IssueLifecycleId = () => {
-  const { systemId } = useParams();
+  const { systemId } = useParams<{ systemId: string }>();
   const dispatch = useDispatch();
   const history = useHistory();
   const { t } = useTranslation('action');
@@ -46,7 +50,11 @@ const IssueLifecycleId = () => {
       scope,
       lifecycleId
     } = values;
-    const actionPayload = { actionType, intakeId: systemId, feedback };
+    const actionPayload: CreateActionPayload = {
+      actionType,
+      intakeId: systemId,
+      feedback
+    };
     const lcidPayload = {
       lcidExpiresAt: `${expirationDateYear}-${expirationDateMonth}-${expirationDateDay}`,
       lcidNextSteps: nextSteps,
@@ -118,7 +126,7 @@ const IssueLifecycleId = () => {
                       label={t('issueLCID.lcid.new')}
                       onChange={() => {
                         setFieldValue('newLifecycleId', true);
-                        setFieldValue('lifecycleId', null);
+                        setFieldValue('lifecycleId', '');
                       }}
                       value
                     />

--- a/src/views/GovernanceReviewTeam/Actions/RejectIntake.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/RejectIntake.tsx
@@ -17,7 +17,7 @@ import flattenErrors from 'utils/flattenErrors';
 import { rejectIntakeSchema } from 'validations/actionSchema';
 
 const RejectIntake = () => {
-  const { systemId } = useParams();
+  const { systemId } = useParams<{ systemId: string }>();
   const dispatch = useDispatch();
   const history = useHistory();
   const { t } = useTranslation('action');

--- a/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
@@ -10,7 +10,7 @@ import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import Label from 'components/shared/Label';
 import TextAreaField from 'components/shared/TextAreaField';
-import { Action, ActionForm, ActionType } from 'types/action';
+import { ActionForm, ActionType, CreateActionPayload } from 'types/action';
 import { postAction } from 'types/routines';
 import flattenErrors from 'utils/flattenErrors';
 import { actionSchema } from 'validations/actionSchema';
@@ -21,14 +21,14 @@ type SubmitActionProps = {
 };
 
 const SubmitAction = ({ action, actionName }: SubmitActionProps) => {
-  const { systemId } = useParams();
+  const { systemId } = useParams<{ systemId: string }>();
   const { t } = useTranslation('action');
   const history = useHistory();
   const dispatch = useDispatch();
 
   const dispatchSave = (values: ActionForm) => {
     const { feedback } = values;
-    const payload: Action = {
+    const payload: CreateActionPayload = {
       intakeId: systemId,
       actionType: action,
       feedback


### PR DESCRIPTION
This PR fixes a few of the non-breaking Typescript errors we were having.

Going forward, we should have separate types for request payloads and response payloads. That's what I did in this PR for Actions. Hopefully this clears up confusion on how to use the types. We should probably also document our types so it's more clear on which to use.