### PR TITLE
Add closed request table to GRT review home page

### DIFF
--- a/pkg/models/action.go
+++ b/pkg/models/action.go
@@ -45,13 +45,13 @@ const (
 
 // Action is the model for an action on a system intake
 type Action struct {
-	ID             uuid.UUID  `json:"id"`
-	IntakeID       *uuid.UUID `db:"intake_id"`
-	BusinessCaseID *uuid.UUID `db:"business_case_id"`
-	ActionType     ActionType `json:"actionType" db:"action_type"`
-	ActorName      string     `json:"actorName" db:"actor_name"`
-	ActorEmail     string     `json:"actorEmail" db:"actor_email"`
-	ActorEUAUserID string     `json:"actorEuaUserId" db:"actor_eua_user_id"`
-	Feedback       null.String
-	CreatedAt      *time.Time `json:"createdAt" db:"created_at"`
+	ID             uuid.UUID   `json:"id"`
+	IntakeID       *uuid.UUID  `db:"intake_id"`
+	BusinessCaseID *uuid.UUID  `db:"business_case_id"`
+	ActionType     ActionType  `json:"actionType" db:"action_type"`
+	ActorName      string      `json:"actorName" db:"actor_name"`
+	ActorEmail     string      `json:"actorEmail" db:"actor_email"`
+	ActorEUAUserID string      `json:"actorEuaUserId" db:"actor_eua_user_id"`
+	Feedback       null.String `json:"feedback"`
+	CreatedAt      *time.Time  `json:"createdAt" db:"created_at"`
 }

--- a/pkg/storage/action.go
+++ b/pkg/storage/action.go
@@ -26,6 +26,7 @@ func (s *Store) CreateAction(ctx context.Context, action *models.Action) (*model
 		    actor_email,
 		    actor_eua_user_id,
 			intake_id,
+			feedback,
 			created_at
 		)
 		VALUES (
@@ -35,6 +36,7 @@ func (s *Store) CreateAction(ctx context.Context, action *models.Action) (*model
 		    :actor_email,
 			:actor_eua_user_id,
 		    :intake_id,
+			:feedback,
 		    :created_at
 		)`
 	_, err := s.db.NamedExec(

--- a/pkg/storage/action_test.go
+++ b/pkg/storage/action_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/guregu/null"
 
 	"github.com/cmsgov/easi-app/pkg/models"
 	"github.com/cmsgov/easi-app/pkg/testhelpers"
@@ -25,6 +26,7 @@ func (s StoreTestSuite) TestCreateAction() {
 			ActorName:      "name",
 			ActorEmail:     "email@site.com",
 			ActorEUAUserID: testhelpers.RandomEUAID(),
+			Feedback:       null.StringFrom("feedback"),
 		}
 
 		created, err := s.store.CreateAction(ctx, &action)
@@ -32,6 +34,7 @@ func (s StoreTestSuite) TestCreateAction() {
 		s.NotNil(created)
 		s.Equal(action.ID, created.ID)
 		s.Equal(action.ActionType, created.ActionType)
+		s.Equal("feedback", created.Feedback.String)
 		epochTime := time.Unix(0, 0)
 		s.Equal(created.CreatedAt, &epochTime)
 		s.False(created.ID == uuid.Nil)

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { CSVLink } from 'react-csv';
 import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { useSortBy, useTable } from 'react-table';
 import { Table } from '@trussworks/react-uswds';
@@ -10,19 +9,23 @@ import { DateTime } from 'luxon';
 
 import BreadcrumbNav from 'components/BreadcrumbNav';
 import { convertIntakeToCSV } from 'data/systemIntake';
-import { AppState } from 'reducers/rootReducer';
-import { fetchSystemIntakes } from 'types/routines';
 import { SystemIntakeForm } from 'types/systemIntake';
 
 import csvHeaderMap from './csvHeaderMap';
 
 import './index.scss';
 
-const RequestRepository = () => {
+type RequestRepositoryProps = {
+  openIntakes: SystemIntakeForm[];
+  closedIntakes: SystemIntakeForm[];
+};
+const RequestRepository = ({
+  openIntakes,
+  closedIntakes
+}: RequestRepositoryProps) => {
   type TableTypes = 'open' | 'closed';
   const [activeTable, setActiveTable] = useState<TableTypes>('open');
   const { t } = useTranslation('governanceReviewTeam');
-  const dispatch = useDispatch();
 
   const columns: any = useMemo(
     () => [
@@ -65,16 +68,12 @@ const RequestRepository = () => {
     [t]
   );
 
-  useEffect(() => {
-    dispatch(fetchSystemIntakes({ status: 'open' }));
-  }, [dispatch]);
-
-  const systemIntakes = useSelector(
-    (state: AppState) => state.systemIntakes.systemIntakes
-  );
-
   const data = useMemo(() => {
-    return systemIntakes.map(intake => {
+    const tableData = {
+      open: openIntakes,
+      closed: closedIntakes
+    };
+    return tableData[activeTable].map(intake => {
       const statusEnum = intake.status;
       let statusTranslation = '';
 
@@ -94,7 +93,7 @@ const RequestRepository = () => {
         requestType: t(`intake:requestTypeMap.${intake.requestType}`)
       };
     });
-  }, [systemIntakes, t]);
+  }, [activeTable, closedIntakes, openIntakes, t]);
 
   const {
     getTableProps,
@@ -193,6 +192,7 @@ const RequestRepository = () => {
               type="button"
               className="easi-request-repo__tab-btn"
               onClick={() => setActiveTable('closed')}
+              data-testid="view-closed-intakes-btn"
             >
               Closed Requests
             </button>

--- a/src/i18n/en-US/governanceReviewTeam.ts
+++ b/src/i18n/en-US/governanceReviewTeam.ts
@@ -88,8 +88,10 @@ const governanceReviewTeam = {
   },
   requestRepository: {
     header: 'Requests',
-    requestCount_open: 'There are {{count}} open requests',
-    requestCount_closed: 'There are {{count}} closed requests',
+    requestCount_open: 'There is {{count}} open request',
+    requestCount_open_plural: 'There are {{count}} open requests',
+    requestCount_closed: 'There is {{count}} closed request',
+    requestCount_closed_plural: 'There are {{count}} closed requests',
     table: {
       requestType: 'Type of request',
       submissionDate: {

--- a/src/reducers/systemIntakesReducer.test.ts
+++ b/src/reducers/systemIntakesReducer.test.ts
@@ -6,12 +6,14 @@ import systemIntakesReducer from './systemIntakesReducer';
 describe('The system intakes reducer', () => {
   it('returns the initial state', () => {
     expect(systemIntakesReducer(undefined, {})).toEqual({
-      systemIntakes: [],
+      openIntakes: [],
+      closedIntakes: [],
       error: null,
       isLoading: null,
       loadedTimestamp: null
     });
   });
+
   it('handles fetchSystemIntakes.REQUEST', () => {
     const mockRequestAction = {
       type: fetchSystemIntakes.REQUEST,
@@ -19,12 +21,14 @@ describe('The system intakes reducer', () => {
     };
 
     expect(systemIntakesReducer(undefined, mockRequestAction)).toEqual({
-      systemIntakes: [],
+      openIntakes: [],
+      closedIntakes: [],
       error: null,
       isLoading: true,
       loadedTimestamp: null
     });
   });
+
   it('handles fetchSystemIntakes.SUCCESS', () => {
     const mockApiSystemIntake = {
       id: '',
@@ -54,9 +58,84 @@ describe('The system intakes reducer', () => {
     };
 
     expect(
-      systemIntakesReducer(undefined, mockSuccessAction).systemIntakes
+      systemIntakesReducer(undefined, mockSuccessAction).openIntakes
     ).toMatchObject([prepareSystemIntakeForApp(mockApiSystemIntake)]);
   });
+
+  it('fetchSystemIntakes.SUCCESS differentiates open and closed intakes', () => {
+    const mockApiSystemIntake = {
+      id: '',
+      status: 'INTAKE_DRAFT',
+      requester: '',
+      component: '',
+      businessOwner: '',
+      businessOwnerComponent: '',
+      productManager: '',
+      productManagerComponent: '',
+      isso: '',
+      trbCollaborator: '',
+      oitSecurityCollaborator: '',
+      eaCollaborator: '',
+      projectName: '',
+      existingFunding: null,
+      fundingNUmber: '',
+      businessNeed: '',
+      solution: '',
+      processStatus: '',
+      eaSupportRequest: null,
+      existingContract: ''
+    };
+    const mockSuccessAction = {
+      type: fetchSystemIntakes.SUCCESS,
+      payload: [
+        {
+          ...mockApiSystemIntake,
+          status: 'INTAKE_SUBMITTED'
+        },
+        {
+          ...mockApiSystemIntake,
+          status: 'LCID_ISSUED'
+        },
+        {
+          ...mockApiSystemIntake,
+          status: 'WITHDRAWN'
+        },
+        {
+          ...mockApiSystemIntake,
+          status: 'NEED_BIZ_CASE'
+        },
+        {
+          ...mockApiSystemIntake,
+          status: 'BIZ_CASE_FINAL_NEEDED'
+        },
+        {
+          ...mockApiSystemIntake,
+          status: 'READY_FOR_GRT'
+        },
+        {
+          ...mockApiSystemIntake,
+          status: 'NOT_APPROVED'
+        },
+        {
+          ...mockApiSystemIntake,
+          status: 'NO_GOVERNANCE'
+        },
+        {
+          ...mockApiSystemIntake,
+          status: 'NOT_IT_REQUEST'
+        }
+      ]
+    };
+
+    expect(
+      systemIntakesReducer(undefined, mockSuccessAction).openIntakes.length
+    ).toEqual(4);
+
+    expect(
+      systemIntakesReducer(undefined, mockSuccessAction).closedIntakes.length
+    ).toEqual(5);
+  });
+
   it('handles fetchSystemIntakes.FAILURE', () => {
     const mockFailureAction = {
       type: fetchSystemIntakes.FAILURE,
@@ -64,12 +143,14 @@ describe('The system intakes reducer', () => {
     };
 
     expect(systemIntakesReducer(undefined, mockFailureAction)).toEqual({
-      systemIntakes: [],
+      openIntakes: [],
+      closedIntakes: [],
       error: 'Error',
       isLoading: null,
       loadedTimestamp: null
     });
   });
+
   it('handles fetchSystemIntakes.FULFILL', () => {
     const mockFulfillAction = {
       type: fetchSystemIntakes.FULFILL,
@@ -77,7 +158,8 @@ describe('The system intakes reducer', () => {
     };
 
     expect(systemIntakesReducer(undefined, mockFulfillAction)).toEqual({
-      systemIntakes: [],
+      openIntakes: [],
+      closedIntakes: [],
       error: null,
       isLoading: false,
       loadedTimestamp: null

--- a/src/reducers/systemIntakesReducer.ts
+++ b/src/reducers/systemIntakesReducer.ts
@@ -3,10 +3,12 @@ import { Action } from 'redux-actions';
 
 import { prepareSystemIntakeForApp } from 'data/systemIntake';
 import { fetchSystemIntakes } from 'types/routines';
-import { SystemIntakesState } from 'types/systemIntake';
+import { SystemIntakeForm, SystemIntakesState } from 'types/systemIntake';
+import { isIntakeClosed, isIntakeOpen } from 'utils/systemIntake';
 
 const initialState: SystemIntakesState = {
-  systemIntakes: [],
+  openIntakes: [],
+  closedIntakes: [],
   isLoading: null,
   loadedTimestamp: null,
   error: null
@@ -16,6 +18,8 @@ function systemIntakesReducer(
   state = initialState,
   action: Action<any>
 ): SystemIntakesState {
+  const openIntakes: SystemIntakeForm[] = [];
+  const closedIntakes: SystemIntakeForm[] = [];
   switch (action.type) {
     case fetchSystemIntakes.REQUEST:
       return {
@@ -23,11 +27,17 @@ function systemIntakesReducer(
         isLoading: true
       };
     case fetchSystemIntakes.SUCCESS:
+      action.payload.forEach((intake: any) => {
+        if (isIntakeOpen(intake.status)) {
+          openIntakes.push(prepareSystemIntakeForApp(intake));
+        } else if (isIntakeClosed(intake.status)) {
+          closedIntakes.push(prepareSystemIntakeForApp(intake));
+        }
+      });
       return {
         ...state,
-        systemIntakes: action.payload.map((intake: any) =>
-          prepareSystemIntakeForApp(intake)
-        ),
+        openIntakes,
+        closedIntakes,
         loadedTimestamp: DateTime.local()
       };
     case fetchSystemIntakes.FAILURE:

--- a/src/types/systemIntake.ts
+++ b/src/types/systemIntake.ts
@@ -130,7 +130,8 @@ export type SystemIntakeState = {
 
 // Redux store type for systems
 export type SystemIntakesState = {
-  systemIntakes: SystemIntakeForm[];
+  openIntakes: SystemIntakeForm[];
+  closedIntakes: SystemIntakeForm[];
   isLoading: boolean | null;
   loadedTimestamp: DateTime | null;
   error: string | null;

--- a/src/views/Home/SystemIntakeBanners.tsx
+++ b/src/views/Home/SystemIntakeBanners.tsx
@@ -1,30 +1,19 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { useOktaAuth } from '@okta/okta-react';
 
 import ActionBanner from 'components/shared/ActionBanner';
 import { useFlags } from 'contexts/flagContext';
-import { AppState } from 'reducers/rootReducer';
-import { fetchSystemIntakes } from 'types/routines';
 import { SystemIntakeForm } from 'types/systemIntake';
 
-const SystemIntakeBanners = () => {
-  const { authState } = useOktaAuth();
-  const dispatch = useDispatch();
-  const systemIntakes = useSelector(
-    (state: AppState) => state.systemIntakes.systemIntakes
-  );
+type SystemIntakeBannersProps = {
+  intakes: SystemIntakeForm[];
+};
+
+const SystemIntakeBanners = ({ intakes }: SystemIntakeBannersProps) => {
   const flags = useFlags();
   const history = useHistory();
   const { t } = useTranslation('intake');
-
-  useEffect(() => {
-    if (authState.isAuthenticated) {
-      dispatch(fetchSystemIntakes());
-    }
-  }, [dispatch, authState.isAuthenticated]);
 
   const statusMap: { [key: string]: { title: string; description: string } } = {
     INTAKE_DRAFT: {
@@ -91,7 +80,7 @@ const SystemIntakeBanners = () => {
 
   return (
     <>
-      {systemIntakes.map((intake: SystemIntakeForm) => {
+      {intakes.map((intake: SystemIntakeForm) => {
         let rootPath = '';
         if (intake.requestType === 'SHUTDOWN') {
           rootPath = '/system';

--- a/src/views/Home/index.test.tsx
+++ b/src/views/Home/index.test.tsx
@@ -54,7 +54,8 @@ describe('The home page', () => {
         const store = mockStore({
           auth: mockAuthReducer,
           systemIntakes: {
-            systemIntakes: []
+            openIntakes: [],
+            closedIntakes: []
           },
           businessCases: {
             businessCases: []
@@ -84,7 +85,7 @@ describe('The home page', () => {
         const store = mockStore({
           auth: mockAuthReducer,
           systemIntakes: {
-            systemIntakes: [
+            openIntakes: [
               {
                 ...initialSystemIntakeForm,
                 id: '1'
@@ -104,7 +105,8 @@ describe('The home page', () => {
                 status: 'NEED_BIZ_CASE',
                 businessCaseId: '1'
               }
-            ]
+            ],
+            closeIntakes: []
           }
         });
         let component: any;
@@ -132,7 +134,7 @@ describe('The home page', () => {
     };
 
     const mockSystemIntakes = {
-      systemIntakes: [
+      openIntakes: [
         {
           ...initialSystemIntakeForm,
           id: '1'
@@ -151,6 +153,13 @@ describe('The home page', () => {
           id: '4',
           status: 'INTAKE_SUBMITTED',
           businessCaseId: '1'
+        }
+      ],
+      closedIntakes: [
+        {
+          ...initialSystemIntakeForm,
+          id: '4',
+          status: 'WITHDRAWN'
         }
       ]
     };
@@ -190,12 +199,24 @@ describe('The home page', () => {
       expect(shallowComponent).not.toThrow();
     });
 
-    it('renders the table', async () => {
+    it('renders the open requests table', async () => {
       const homePage = mountComponent();
 
       await act(async () => {
         homePage.update();
         expect(homePage.text()).toContain('There are 4 open requests');
+      });
+    });
+
+    it('renders the closed requests table', async () => {
+      const homePage = mountComponent();
+
+      homePage
+        .find('[data-testid="view-closed-intakes-btn"]')
+        .simulate('click');
+      await act(async () => {
+        homePage.update();
+        expect(homePage.text()).toContain('There is 1 closed request');
       });
     });
 

--- a/src/views/Home/index.test.tsx
+++ b/src/views/Home/index.test.tsx
@@ -204,7 +204,7 @@ describe('The home page', () => {
 
       await act(async () => {
         homePage.update();
-        expect(homePage.text()).toContain('There are 4 open requests');
+        expect(homePage.text()).toContain('There are 2 open requests');
       });
     });
 

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, withRouter } from 'react-router-dom';
 import { useOktaAuth } from '@okta/okta-react';
 
@@ -9,6 +9,8 @@ import MainContent from 'components/MainContent';
 import PageWrapper from 'components/PageWrapper';
 import RequestRepository from 'components/RequestRepository';
 import { AppState } from 'reducers/rootReducer';
+import { fetchSystemIntakes } from 'types/routines';
+import { SystemIntakeForm } from 'types/systemIntake';
 import user from 'utils/user';
 
 import SystemIntakeBanners from './SystemIntakeBanners';
@@ -16,7 +18,10 @@ import WelcomeText from './WelcomeText';
 
 import './index.scss';
 
-const Banners = () => {
+type BannersProps = {
+  intakes: SystemIntakeForm[];
+};
+const Banners = ({ intakes }: BannersProps) => {
   const location = useLocation<any>();
 
   return (
@@ -29,15 +34,28 @@ const Banners = () => {
           </p>
         </div>
       )}
-      <SystemIntakeBanners />
+      <SystemIntakeBanners intakes={intakes} />
     </div>
   );
 };
 
 const Home = () => {
+  const dispatch = useDispatch();
   const { authState } = useOktaAuth();
   const userGroups = useSelector((state: AppState) => state.auth.groups);
   const isUserSet = useSelector((state: AppState) => state.auth.isUserSet);
+  const openIntakes = useSelector(
+    (state: AppState) => state.systemIntakes.openIntakes
+  );
+  const closedIntakes = useSelector(
+    (state: AppState) => state.systemIntakes.closedIntakes
+  );
+
+  useEffect(() => {
+    if (authState.isAuthenticated) {
+      dispatch(fetchSystemIntakes());
+    }
+  }, [dispatch, authState.isAuthenticated]);
 
   return (
     <PageWrapper>
@@ -45,10 +63,13 @@ const Home = () => {
       <MainContent className="grid-container margin-bottom-5">
         {isUserSet &&
           (user.isGrtReviewer(userGroups) ? (
-            <RequestRepository />
+            <RequestRepository
+              openIntakes={openIntakes}
+              closedIntakes={closedIntakes}
+            />
           ) : (
             <>
-              <Banners />
+              <Banners intakes={openIntakes} />
               <WelcomeText />
             </>
           ))}

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -64,7 +64,9 @@ const Home = () => {
         {isUserSet &&
           (user.isGrtReviewer(userGroups) ? (
             <RequestRepository
-              openIntakes={openIntakes}
+              openIntakes={openIntakes.filter(
+                intake => intake.status !== 'INTAKE_DRAFT'
+              )}
               closedIntakes={closedIntakes}
             />
           ) : (


### PR DESCRIPTION
# EASI-865

- updates `systemIntake` reducers to have `openIntakes` and `closedIntakes` instead of just `systemIntakes`
    - this allows us to make a single network request and have both open and closed intakes
- move up the dispatch action creator to fetch intakes up one level to the home page
    - previously we were fetching intakes from the banners and the request repository component. they both use the same data and appear on the same view
