### PR TITLE
Add generation of download pre-signed urls

### DIFF
--- a/pkg/handlers/file_uploads.go
+++ b/pkg/handlers/file_uploads.go
@@ -25,13 +25,13 @@ type FetchUploadedFile func(ctx context.Context, id uuid.UUID) (*models.Uploaded
 // NewFileUploadHandler is a constructor for FileUploadHandler
 func NewFileUploadHandler(
 	base HandlerBase,
-	createURL CreateFileUploadURL,
+	createUploadURL CreateFileUploadURL,
 	createFile CreateUploadedFile,
 	fetchFile FetchUploadedFile,
 ) FileUploadHandler {
 	return FileUploadHandler{
 		HandlerBase:         base,
-		CreateFileUploadURL: createURL,
+		CreateFileUploadURL: createUploadURL,
 		CreateUploadedFile:  createFile,
 		FetchUploadedFile:   fetchFile,
 	}
@@ -61,8 +61,8 @@ func (h FileUploadHandler) Handle() http.HandlerFunc {
 	}
 }
 
-// GeneratePresignedURL is our handler that handles generating pre-signed URLs
-func (h FileUploadHandler) GeneratePresignedURL(w http.ResponseWriter, r *http.Request) {
+// GenerateUploadPresignedURL is our handler that handles generating pre-signed URLs
+func (h FileUploadHandler) GenerateUploadPresignedURL(w http.ResponseWriter, r *http.Request) {
 	url, err := h.CreateFileUploadURL(r.Context())
 	if err != nil {
 		h.WriteErrorResponse(r.Context(), w, err)

--- a/pkg/handlers/file_uploads.go
+++ b/pkg/handlers/file_uploads.go
@@ -16,6 +16,9 @@ import (
 // CreateFileUploadURL is our handler for creating pre-signed S3 upload URLs
 type CreateFileUploadURL func(ctx context.Context) (*models.PreSignedURL, error)
 
+// CreateFileDownloadURL is a handler for creating pre-signed S3 download URLs
+type CreateFileDownloadURL func(ctx context.Context, key string) (*models.PreSignedURL, error)
+
 // CreateUploadedFile is a handler for storing file upload metadata
 type CreateUploadedFile func(ctx context.Context, file *models.UploadedFile) (*models.UploadedFile, error)
 
@@ -26,14 +29,16 @@ type FetchUploadedFile func(ctx context.Context, id uuid.UUID) (*models.Uploaded
 func NewFileUploadHandler(
 	base HandlerBase,
 	createUploadURL CreateFileUploadURL,
+	createFileDownloadURL CreateFileDownloadURL,
 	createFile CreateUploadedFile,
 	fetchFile FetchUploadedFile,
 ) FileUploadHandler {
 	return FileUploadHandler{
-		HandlerBase:         base,
-		CreateFileUploadURL: createUploadURL,
-		CreateUploadedFile:  createFile,
-		FetchUploadedFile:   fetchFile,
+		HandlerBase:           base,
+		CreateFileUploadURL:   createUploadURL,
+		CreateFileDownloadURL: createFileDownloadURL,
+		CreateUploadedFile:    createFile,
+		FetchUploadedFile:     fetchFile,
 	}
 }
 
@@ -41,9 +46,10 @@ func NewFileUploadHandler(
 // to file uploads
 type FileUploadHandler struct {
 	HandlerBase
-	CreateFileUploadURL CreateFileUploadURL
-	CreateUploadedFile  CreateUploadedFile
-	FetchUploadedFile   FetchUploadedFile
+	CreateFileUploadURL   CreateFileUploadURL
+	CreateFileDownloadURL CreateFileDownloadURL
+	CreateUploadedFile    CreateUploadedFile
+	FetchUploadedFile     FetchUploadedFile
 }
 
 // Handle handles a request for file uploading
@@ -61,9 +67,38 @@ func (h FileUploadHandler) Handle() http.HandlerFunc {
 	}
 }
 
-// GenerateUploadPresignedURL is our handler that handles generating pre-signed URLs
+// GenerateUploadPresignedURL is our handler that handles generating pre-signed URLs for file uploading
 func (h FileUploadHandler) GenerateUploadPresignedURL(w http.ResponseWriter, r *http.Request) {
 	url, err := h.CreateFileUploadURL(r.Context())
+	if err != nil {
+		h.WriteErrorResponse(r.Context(), w, err)
+		return
+	}
+
+	responseBody, err := json.Marshal(url)
+	if err != nil {
+		h.WriteErrorResponse(r.Context(), w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	_, err = w.Write(responseBody)
+	if err != nil {
+		h.WriteErrorResponse(r.Context(), w, err)
+		return
+	}
+	return
+}
+
+// GenerateDownloadPresignedURL handles generating pre-signed URLs for file downloading
+func (h FileUploadHandler) GenerateDownloadPresignedURL(w http.ResponseWriter, r *http.Request) {
+	fileID, err := requireFileUploadID(mux.Vars(r))
+	if err != nil {
+		h.WriteErrorResponse(r.Context(), w, err)
+		return
+	}
+
+	url, err := h.CreateFileDownloadURL(r.Context(), fileID.String())
 	if err != nil {
 		h.WriteErrorResponse(r.Context(), w, err)
 		return

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -492,6 +492,11 @@ func (s *Server) routes(
 			services.NewAuthorizeRequireGRTJobCode(),
 			s3Client,
 		),
+		services.NewCreateFileDownloadURL(
+			serviceConfig,
+			services.NewAuthorizeRequireGRTJobCode(),
+			s3Client,
+		),
 		services.NewCreateUploadedFile(
 			serviceConfig,
 			services.NewAuthorizeRequireGRTJobCode(),
@@ -503,10 +508,13 @@ func (s *Server) routes(
 	)
 	api.Handle("/file_uploads", fileUploadHandler.Handle())
 
+	api.HandleFunc("/file_uploads/upload_url", fileUploadHandler.GenerateUploadPresignedURL).
+		Methods("POST")
+
 	api.HandleFunc("/file_uploads/{file_id}", fileUploadHandler.FetchFileMetadata).
 		Methods("GET")
 
-	api.HandleFunc("/file_uploads/presignedurl", fileUploadHandler.GenerateUploadPresignedURL).
+	api.HandleFunc("/file_uploads/{file_id}/download_url", fileUploadHandler.GenerateDownloadPresignedURL).
 		Methods("POST")
 
 	s.router.PathPrefix("/").Handler(handlers.NewCatchAllHandler(

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -506,7 +506,7 @@ func (s *Server) routes(
 	api.HandleFunc("/file_uploads/{file_id}", fileUploadHandler.FetchFileMetadata).
 		Methods("GET")
 
-	api.HandleFunc("/file_uploads/presignedurl", fileUploadHandler.GeneratePresignedURL).
+	api.HandleFunc("/file_uploads/presignedurl", fileUploadHandler.GenerateUploadPresignedURL).
 		Methods("POST")
 
 	s.router.PathPrefix("/").Handler(handlers.NewCatchAllHandler(

--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -52,3 +52,22 @@ func (c S3Client) NewPutPresignedURL() (*models.PreSignedURL, error) {
 
 	return &result, nil
 }
+
+// NewGetPresignedURL returns a pre-signed URL used for GET-ing objects
+func (c S3Client) NewGetPresignedURL(key string) (*models.PreSignedURL, error) {
+	objectInput := &s3.GetObjectInput{
+		Bucket: aws.String(c.config.Bucket),
+		Key:    aws.String(key),
+	}
+	req, _ := c.client.GetObjectRequest(objectInput)
+
+	url, err := req.Presign(15 * time.Minute)
+	if err != nil {
+		return &models.PreSignedURL{}, err
+	}
+
+	result := models.PreSignedURL{URL: url, Filename: key}
+
+	return &result, nil
+
+}


### PR DESCRIPTION
# EASI-1036

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Adds the ability to generate pre-signed URLs for S3 GET requests. This lets us go direct to S3 for downloading after auth.
