### PR TITLE
use proper statuses for backfill

### DIFF
--- a/cmd/backfill/main.go
+++ b/cmd/backfill/main.go
@@ -117,7 +117,7 @@ func upload(host string, auth string, item *entry) error {
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("expected 204; got %d; body %s", resp.StatusCode, content)
+		return fmt.Errorf("%s; expected 204; got %d; body %s", item.Intake.ID.String(), resp.StatusCode, content)
 	}
 	fmt.Fprintf(os.Stdout, "uploaded: %s\n", item.Intake.ID.String())
 	return nil

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -574,7 +574,9 @@ func (s *Server) routes(
 		base,
 		services.NewBackfill(
 			serviceConfig,
+			store.FetchSystemIntakeByID,
 			store.CreateSystemIntake,
+			store.UpdateSystemIntake,
 			store.CreateNote,
 			services.NewAuthorizeHasEASiRole(),
 		),

--- a/pkg/services/backfill.go
+++ b/pkg/services/backfill.go
@@ -33,8 +33,9 @@ func NewBackfill(
 
 		// invariant data for all backfill (maybe do this in transport layer, for de-normalizing fields?)
 		intake.RequestType = models.SystemIntakeRequestTypeNEW // TODO: correct RequestType?
-		if intake.Status == "" {
-			intake.Status = models.SystemIntakeStatusCLOSED // TODO: correct Status?
+		intake.Status = models.SystemIntakeStatusNOTAPPROVED
+		if intake.LifecycleID.ValueOrZero() != "" {
+			intake.Status = models.SystemIntakeStatusLCIDISSUED
 		}
 		if _, err = createIntake(ctx, &intake); err != nil {
 			return err

--- a/pkg/services/backfill.go
+++ b/pkg/services/backfill.go
@@ -6,8 +6,9 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/google/uuid"
 
+	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/apperrors"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
@@ -15,7 +16,9 @@ import (
 // NewBackfill imports historical data into EASi
 func NewBackfill(
 	config Config,
+	fetchIntake func(ctx context.Context, id uuid.UUID) (*models.SystemIntake, error),
 	createIntake func(c context.Context, intake *models.SystemIntake) (*models.SystemIntake, error),
+	updateIntake func(ctx context.Context, intake *models.SystemIntake) (*models.SystemIntake, error),
 	createNote func(c context.Context, note *models.Note) (*models.Note, error),
 	authorize func(context.Context) (bool, error),
 ) func(context.Context, models.SystemIntake, []models.Note) error {
@@ -39,6 +42,32 @@ func NewBackfill(
 		}
 		if _, err = createIntake(ctx, &intake); err != nil {
 			return err
+		}
+
+		// this "mutate" section gets around the fact that LCID fields don't get saved on a CREATE operation
+		mutate, err := fetchIntake(ctx, intake.ID)
+		if err != nil {
+			return err
+		}
+
+		hasUpdate := false
+		if intake.LifecycleID.ValueOrZero() != "" {
+			hasUpdate = true
+			mutate.LifecycleID = intake.LifecycleID
+		}
+		if intake.LifecycleExpiresAt != nil {
+			hasUpdate = true
+			mutate.LifecycleExpiresAt = intake.LifecycleExpiresAt
+		}
+		if intake.LifecycleScope.ValueOrZero() != "" {
+			hasUpdate = true
+			mutate.LifecycleScope = intake.LifecycleScope
+		}
+
+		if hasUpdate {
+			if _, err = updateIntake(ctx, mutate); err != nil {
+				return err
+			}
 		}
 
 		for _, note := range notes {


### PR DESCRIPTION
# EASI-972

Changes proposed in this pull request:

- Use the correct statuses, inferred from the state of whether or not an LCID is present
