### PR TITLE
add decomission banner

### DIFF
--- a/src/components/shared/ActionBanner/index.tsx
+++ b/src/components/shared/ActionBanner/index.tsx
@@ -34,7 +34,7 @@ const ActionBanner = ({
         <div className="action-banner__icon">
           <i className="fa fa-clock-o fa-3x" />
         </div>
-        <span className="action-banner__text">
+        <span className="action-banner__text margin-right-2">
           <h2>{title}</h2>
           <p>{helpfulText}</p>
         </span>

--- a/src/views/Home/SystemIntakeBanners.tsx
+++ b/src/views/Home/SystemIntakeBanners.tsx
@@ -120,7 +120,6 @@ const SystemIntakeBanners = () => {
               }
               requestType={intake.requestType}
               data-intakeid={intake.id}
-              buttonUnstyled={intake.status === 'INTAKE_SUBMITTED'}
             />
           );
         }

--- a/src/views/Home/SystemIntakeBanners.tsx
+++ b/src/views/Home/SystemIntakeBanners.tsx
@@ -91,13 +91,39 @@ const SystemIntakeBanners = () => {
   return (
     <>
       {intakes.map((intake: SystemIntakeForm) => {
-        let rootPath = '';
-        if (intake.requestType === 'SHUTDOWN') {
-          rootPath = '/system';
-        } else {
-          rootPath = flags.taskListLite ? '/governance-task-list' : '/system';
-        }
         const status = statusMap[intake.status];
+        const rootPath = flags.taskListLite
+          ? '/governance-task-list'
+          : '/system';
+
+        if (intake.requestType === 'SHUTDOWN') {
+          return (
+            <ActionBanner
+              key={intake.id}
+              title={
+                intake.requestName
+                  ? `${intake.requestName}: ${status.title}`
+                  : status.title
+              }
+              helpfulText={status.description}
+              onClick={() => {
+                const link =
+                  intake.status === 'INTAKE_SUBMITTED'
+                    ? `/system/${intake.id}/view`
+                    : `/system/${intake.id}`;
+                history.push(link);
+              }}
+              label={
+                intake.status === 'INTAKE_SUBMITTED'
+                  ? 'View submitted intake request'
+                  : 'Go to intake request'
+              }
+              requestType={intake.requestType}
+              data-intakeid={intake.id}
+              buttonUnstyled={intake.status === 'INTAKE_SUBMITTED'}
+            />
+          );
+        }
 
         return (
           <ActionBanner


### PR DESCRIPTION
# EASI-1028

This PR adds decommission banners.
`INTAKE_DRAFT` -> `View intake request`
`INTAKE_SUBMITTED` -> `View submitted intake request` (link)

As far as decisions go, no idea yet; TBD
