### PR TITLE
Add flags for prototypes and file uploads

### DIFF
--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -101,7 +101,7 @@ func (s *Server) routes(
 
 	switch flagConfig.Source {
 	case appconfig.FlagSourceLocal:
-		defaultFlags := flags.FlagValues{"taskListLite": "true", "sandbox": "true", "pdfExport": "true"}
+		defaultFlags := flags.FlagValues{"taskListLite": "true", "sandbox": "true", "pdfExport": "true", "prototype508": "true", "fileUploads": "true", "prototypeTRB": "true"}
 		flagClient = flags.NewLocalClient(defaultFlags)
 
 	case appconfig.FlagSourceLaunchDarkly:

--- a/src/contexts/flagContext.test.tsx
+++ b/src/contexts/flagContext.test.tsx
@@ -65,7 +65,14 @@ it('uses the defaults when flags fail to load', async () => {
 
   const printer = wrapper.find(FlagPrinter);
   expect(printer.text()).toEqual(
-    `{"pdfExport":false,"sandbox":false,"taskListLite":false}`
+    JSON.stringify({
+      fileUploads: false,
+      pdfExport: false,
+      prototype508: false,
+      prototypeTRB: false,
+      sandbox: false,
+      taskListLite: false
+    })
   );
   expect(mockedAxios.get.mock.calls).toEqual([[flagsURL]]);
 });

--- a/src/contexts/flagContext.tsx
+++ b/src/contexts/flagContext.tsx
@@ -7,7 +7,10 @@ const initialState: FlagsState = {
   flags: {
     taskListLite: false,
     sandbox: false,
-    pdfExport: false
+    pdfExport: false,
+    prototype508: false,
+    prototypeTRB: false,
+    fileUploads: false
   },
   isLoaded: false
 };

--- a/src/types/flags.ts
+++ b/src/types/flags.ts
@@ -2,6 +2,9 @@ export type Flags = {
   taskListLite: Boolean;
   sandbox: Boolean;
   pdfExport: Boolean;
+  prototype508: Boolean;
+  prototypeTRB: Boolean;
+  fileUploads: Boolean;
 };
 
 export type FlagsState = {


### PR DESCRIPTION
# Add flags for prototypes and file uploads

Changes proposed in this pull request:

- Adds three new feature flags: `prototype508`, `prototypeTRB`, and `fileUploads`.
- These flags have already been configured in Launch Darkly
- If you aren't connecting to LD from your dev machine to load flags (`export FLAG_SOURCE=LOCAL`), the defaults have these new flags enabled.
