### PR TITLE
fix ld flags

### DIFF
--- a/src/contexts/flagContext.tsx
+++ b/src/contexts/flagContext.tsx
@@ -5,7 +5,7 @@ import { Flags, FlagsState } from 'types/flags';
 
 const initialState: FlagsState = {
   flags: {
-    taskListLite: true,
+    taskListLite: false,
     sandbox: false,
     pdfExport: false
   },

--- a/src/contexts/flagContext.tsx
+++ b/src/contexts/flagContext.tsx
@@ -5,7 +5,7 @@ import { Flags, FlagsState } from 'types/flags';
 
 const initialState: FlagsState = {
   flags: {
-    taskListLite: false,
+    taskListLite: true,
     sandbox: false,
     pdfExport: false
   },
@@ -27,7 +27,13 @@ export const FlagProvider = ({ children }: FlagProviderProps) => {
         const response = await axios.get(
           `${process.env.REACT_APP_API_ADDRESS}/flags`
         );
-        setFlagState({ flags: response.data, isLoaded: true });
+        setFlagState(prevState => ({
+          flags: {
+            ...prevState.flags,
+            ...response.data
+          },
+          isLoaded: true
+        }));
       } catch (error) {
         setFlagState(state => ({ ...state, isLoaded: true }));
         if (process.env.NODE_ENV !== 'test') {


### PR DESCRIPTION
Currently, I'm in a situation where `/flags` endpoint is returning `{}`, which is causing some errors. So instead of just replacing the current context with the new, I am spreading the new flags from the API over the existing flags.
