### PR TITLE
Clear confirmation text after page is refreshed

### DIFF
--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useLocation, withRouter } from 'react-router-dom';
+import { useHistory, useLocation, withRouter } from 'react-router-dom';
 import { useOktaAuth } from '@okta/okta-react';
 
 import Footer from 'components/Footer';
@@ -17,15 +17,28 @@ import WelcomeText from './WelcomeText';
 import './index.scss';
 
 const Banners = () => {
+  const history = useHistory();
   const location = useLocation<any>();
+  const [confirmationText, setIsConfirmationText] = useState('');
+
+  useEffect(() => {
+    if (location.state && location.state.confirmationText) {
+      setIsConfirmationText(location.state.confirmationText);
+      history.replace({
+        pathname: '/',
+        state: {}
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="margin-y-6">
-      {location.state && location.state.confirmationText && (
+      {confirmationText && (
         <div className="border-05 border-green">
           <div className="fa fa-check fa-2x display-inline-block text-middle text-green margin-left-1 margin-right-2" />
           <p className="display-inline-block text-middle margin-y-105">
-            {location.state.confirmationText}
+            {confirmationText}
           </p>
         </div>
       )}

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -37,7 +37,10 @@ const Banners = () => {
       {confirmationText && (
         <div className="border-05 border-green">
           <div className="fa fa-check fa-2x display-inline-block text-middle text-green margin-left-1 margin-right-2" />
-          <p className="display-inline-block text-middle margin-y-105">
+          <p
+            role="alert"
+            className="display-inline-block text-middle margin-y-105"
+          >
             {confirmationText}
           </p>
         </div>


### PR DESCRIPTION
While implementing some accessibility work for the intake withdrawal confirmation, I came across a bug that needed to be fixed.

To reproduce on `master`:
1. Go to intake task list
2. Withdraw it via button in the side nav
3. Confirm
4. App should redirect you to the home page with the confirmation message.
5. BUG: Refresh and the confirmation text stays and doesn't disappear.

This will be misleading for all users so it's important to have it only show up when necessary.

In this PR, the confirmation text should disappear when the page is refreshed.