### PR TITLE
Add local S3 testing workflows

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -111,3 +111,4 @@ Gotenberg
 UniDoc
 PDFKit
 EASI-983
+minio

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ environments.
 
 | File | Description |
 | ---- | ----------- |
-| docker-compose.yml | Base configuration for `db` and `db_migrate` service |
+| docker-compose.yml | Base configuration for `db`, `db_migrate`, and `minio` service |
 | docker-compose.override.yml | Additional configuration for running `db` and `db_migrate` locally. Intended to simplify the use case where someone uses docker-compose only to run `db` and `db_migrate` |
 | docker-compose.circleci.yml | Additional configuration for running all services in CircleCI |
 | docker-compose.local.yml | Additional configuration for running all services locally |
@@ -349,6 +349,23 @@ air
 
 It's not currently set up to run with docker.
 You can edit the config [here](.air.conf)
+
+### Setup: Minio
+
+[MinIO](https://min.io/) is an S3 compatible object store.
+It ships as a Docker container and accepts normal AWS S3
+API requests. This allows us to test file uploading functionality
+in our local development environments without needing to interact
+with CMS AWS accounts.
+
+The container is configured as part of our `docker-compose.yml` and
+should be running when you `docker-compose up`. You'll need to set
+two environment variables locally in your `.envrc.local` file:
+
+```bash
+export MINIO_ACCESS_KEY='minioadmin'
+export MINIO_SECRET_KEY='minioadmin'
+```
 
 ## Build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,18 @@ services:
     volumes:
       - s3-data:/data
     entrypoint: minio server /data
+  minio_mc:
+    image: minio/mc:latest
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host rm local;
+      /usr/bin/mc config host add --quiet --api s3v4 local http://minio:9000 minioadmin minioadmin;
+      /usr/bin/mc rb --force local/easi-app-file-uploads/;
+      /usr/bin/mc mb --quiet local/easi-app-file-uploads/;
+      /usr/bin/mc policy set public local/easi-app-file-uploads;
+      "
 
 volumes:
   s3-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,14 @@ services:
       - FLYWAY_URL=jdbc:postgresql://db/postgres
     depends_on:
       - db
+  minio:
+    restart: always
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"
+    volumes:
+      - s3-data:/data
+    entrypoint: minio server /data
+
+volumes:
+  s3-data:

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -150,6 +150,12 @@ const EmailTemplateDirectoryKey = "EMAIL_TEMPLATE_DIR"
 // AWSS3FileUploadBucket is the key for the bucket we upload files to
 const AWSS3FileUploadBucket = "AWS_S3_FILE_UPLOAD_BUCKET"
 
+// LocalMinioS3AccessKey is a key used for local access to minio
+const LocalMinioS3AccessKey = "MINIO_ACCESS_KEY"
+
+// LocalMinioS3SecretKey is the secret key used for local access to minio
+const LocalMinioS3SecretKey = "MINIO_SECRET_KEY"
+
 // AWSRegion is the key for the region we establish a session to for AWS services
 const AWSRegion = "AWS_REGION"
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -72,8 +72,9 @@ func (s Server) NewS3Config() upload.Config {
 	s.checkRequiredConfig(appconfig.AWSRegion)
 
 	return upload.Config{
-		Bucket: s.Config.GetString(appconfig.AWSS3FileUploadBucket),
-		Region: s.Config.GetString(appconfig.AWSRegion),
+		Bucket:  s.Config.GetString(appconfig.AWSS3FileUploadBucket),
+		Region:  s.Config.GetString(appconfig.AWSRegion),
+		IsLocal: false,
 	}
 }
 

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -93,6 +93,10 @@ func (s *Server) routes(
 
 	// set up S3 client
 	s3Config := s.NewS3Config()
+	if s.environment.Local() {
+		s3Config.IsLocal = true
+	}
+
 	s3Client := upload.NewS3Client(s3Config)
 
 	// set up FlagClient


### PR DESCRIPTION
# EASI-1015

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Adds [MinIO](https://min.io) container for local S3 development
- Changes AWS credentials to use local minio when we detect we're local

We needed a way to test local interactions with S3 without having to interact with any CMS AWS accounts. [MinIO](https://min.io) is an S3 compatible server that is packaged in a Docker container and accepts API/SDK interaction in the same way that regular AWS S3 does. This lets us swap out calls to AWS to the local container when we are in our local environments.

Up for suggestions as this adds a new piece of local dev infrastructure, although nothing in code really changes except for the client session setup.
