### PR TITLE
Use LaunchDarkly for CEDAR conditional

### DIFF
--- a/pkg/flags/client.go
+++ b/pkg/flags/client.go
@@ -51,12 +51,13 @@ func (c LocalFlagClient) Flags(user ld.User) FlagValues {
 }
 
 // NewLaunchDarklyClient returns a client backed by Launch Darkly
-func NewLaunchDarklyClient(config Config) (*LaunchDarklyClient, error) {
-	ldClient, err := ld.MakeClient(config.Key, config.Timeout)
-	if err != nil {
-		return nil, err
-	}
-	return &LaunchDarklyClient{client: ldClient}, nil
+func NewLaunchDarklyClient(config Config) (*ld.LDClient, error) {
+	return ld.MakeClient(config.Key, config.Timeout)
+}
+
+// WrapLaunchDarklyClient returns a client that fulfils the flags.FlagClient interface
+func WrapLaunchDarklyClient(c *ld.LDClient) *LaunchDarklyClient {
+	return &LaunchDarklyClient{client: c}
 }
 
 // NewLocalClient returns a client backed by local values

--- a/pkg/integration/cedar_test.go
+++ b/pkg/integration/cedar_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	ld "gopkg.in/launchdarkly/go-server-sdk.v4"
+
 	"github.com/cmsgov/easi-app/pkg/cedar/cedareasi"
 	"github.com/cmsgov/easi-app/pkg/handlers"
 	"github.com/cmsgov/easi-app/pkg/models"
@@ -26,9 +28,14 @@ func (s *IntegrationTestSuite) TestCEDARConnection() {
 	s.NoError(err)
 	rr := httptest.NewRecorder()
 
+	ldClient, err := ld.MakeCustomClient("fake", ld.Config{Offline: true}, 0)
+	s.NoError(err)
+
 	cedarEasiClient := cedareasi.NewTranslatedClient(
 		s.config.GetString("CEDAR_API_URL"),
 		s.config.GetString("CEDAR_API_KEY"),
+		ldClient,
+		ld.NewAnonymousUser("fake"),
 	)
 
 	handlers.NewSystemsListHandler(

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"time"
 
 	_ "github.com/lib/pq" // pq is required to get the postgres driver into sqlx
 	"go.uber.org/zap"
@@ -41,30 +42,52 @@ func (s *Server) routes(
 	)
 	s.router.HandleFunc("/api/v1/healthcheck", healthCheckHandler.Handle())
 
-	// check we have all of the configs for CEDAR clients
-	if s.environment.Deployed() {
-		s.NewCEDARClientCheck()
+	// set up Feature Flagging utilities
+	flagUser := ld.NewAnonymousUser(s.Config.GetString("LD_ENV_USER"))
+	flagConfig := s.NewFlagConfig()
+	var flagClient flags.FlagClient
+
+	// we default to an OFFLINE client for non-deployed environments
+	ldClient, err := ld.MakeCustomClient("fake_offline_key", ld.Config{Offline: true}, 5*time.Second)
+	if err != nil {
+		s.logger.Fatal("Failed to create LaunchDarkly client", zap.Error(err))
+	}
+
+	switch flagConfig.Source {
+	case appconfig.FlagSourceLocal:
+		defaultFlags := flags.FlagValues{"taskListLite": "true", "sandbox": "true", "pdfExport": "true", "prototype508": "true", "fileUploads": "true", "prototypeTRB": "true"}
+		flagClient = flags.NewLocalClient(defaultFlags)
+
+	case appconfig.FlagSourceLaunchDarkly:
+		client, clientErr := flags.NewLaunchDarklyClient(flagConfig)
+		if clientErr != nil {
+			s.logger.Fatal("Failed to connect to create flag client", zap.Error(clientErr))
+		}
+		ldClient = client
+		flagClient = flags.WrapLaunchDarklyClient(ldClient)
 	}
 
 	// set up CEDAR client
-	var cedarEasiClient cedareasi.Client
-	connectedCedarEasiClient := cedareasi.NewTranslatedClient(
-		s.Config.GetString("CEDAR_API_URL"),
-		s.Config.GetString("CEDAR_API_KEY"),
-	)
-	if s.environment.Deployed() {
-		s.CheckCEDAREasiClientConnection(connectedCedarEasiClient)
-	}
-	if s.environment.Local() || s.environment.Test() {
-		cedarEasiClient = local.NewCedarEasiClient(s.logger)
-	} else {
-		cedarEasiClient = connectedCedarEasiClient
+	cedarEasiClient := local.NewCedarEasiClient(s.logger)
+	if !(s.environment.Local() || s.environment.Test()) {
+		// check we have all of the configs for CEDAR clients
+		s.NewCEDARClientCheck()
+
+		cedarEasiClient := cedareasi.NewTranslatedClient(
+			s.Config.GetString(appconfig.CEDARAPIURL),
+			s.Config.GetString(appconfig.CEDARAPIKey),
+			ldClient,
+			flagUser,
+		)
+		if s.environment.Deployed() {
+			s.CheckCEDAREasiClientConnection(cedarEasiClient)
+		}
 	}
 
 	var cedarLDAPClient cedarldap.Client
 	cedarLDAPClient = cedarldap.NewTranslatedClient(
-		s.Config.GetString("CEDAR_API_URL"),
-		s.Config.GetString("CEDAR_API_KEY"),
+		s.Config.GetString(appconfig.CEDARAPIURL),
+		s.Config.GetString(appconfig.CEDARAPIKey),
 	)
 	if s.environment.Local() || s.environment.Test() {
 		cedarLDAPClient = local.NewCedarLdapClient(s.logger)
@@ -94,25 +117,6 @@ func (s *Server) routes(
 	// set up S3 client
 	s3Config := s.NewS3Config()
 	s3Client := upload.NewS3Client(s3Config)
-
-	// set up FlagClient
-	flagConfig := s.NewFlagConfig()
-	var flagClient flags.FlagClient
-
-	switch flagConfig.Source {
-	case appconfig.FlagSourceLocal:
-		defaultFlags := flags.FlagValues{"taskListLite": "true", "sandbox": "true", "pdfExport": "true", "prototype508": "true", "fileUploads": "true", "prototypeTRB": "true"}
-		flagClient = flags.NewLocalClient(defaultFlags)
-
-	case appconfig.FlagSourceLaunchDarkly:
-		client, clientErr := flags.NewLaunchDarklyClient(flagConfig)
-		if clientErr != nil {
-			s.logger.Fatal("Failed to connect to create flag client", zap.Error(clientErr))
-		}
-		flagClient = client
-	}
-
-	flagUser := ld.NewAnonymousUser(s.Config.GetString("LD_ENV_USER"))
 
 	// API base path is versioned
 	api := s.router.PathPrefix("/api/v1").Subrouter()

--- a/pkg/services/action.go
+++ b/pkg/services/action.go
@@ -113,16 +113,6 @@ func NewSubmitSystemIntake(
 		if validateAndSubmitErr != nil {
 			return validateAndSubmitErr
 		}
-		// TODO: we are not submitting to CEDAR right now - EASI-1025
-		// if alfabetID == "" {
-		// 	return &apperrors.ExternalAPIError{
-		// 		Err:       errors.New("submission was not successful"),
-		// 		Model:     intake,
-		// 		ModelID:   intake.ID.String(),
-		// 		Operation: apperrors.Submit,
-		// 		Source:    "CEDAR EASi",
-		// 	}
-		// }
 		intake.AlfabetID = null.StringFrom(alfabetID)
 
 		err = saveAction(ctx, action)


### PR DESCRIPTION
# EASI-834

Changes proposed in this pull request:

- Reorders some LD and CEDAR client initializations
- Actually use the LD client for choosing whether or not to emit to CEDAR
- Move the quality check for non-empty AlfabetID (e.g. `ExternalAPIError`) to live in the `cedareasi` client, since it is conditional on whether or not we are actually emitting downstream
- This does not substantively change the use of `flags.NewLocalClient` in non-deployed environments, to support current front-end behaviors (see ES-39 for more info)
