### PR TITLE
Nelz backfill drop

### DIFF
--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -184,6 +184,11 @@ func (s *Server) routes(
 			services.NewAuthorizeUserIsIntakeRequester(),
 			emailClient.SendWithdrawRequestEmail,
 		),
+		services.NewDeleteSystemIntakeByID(
+			serviceConfig,
+			store.DeleteSystemIntakeByID,
+			services.NewAuthorizeRequireGRTJobCode(),
+		),
 	)
 	api.Handle("/system_intake/{intake_id}", systemIntakeHandler.Handle())
 	api.Handle("/system_intake", systemIntakeHandler.Handle())

--- a/pkg/services/backfill.go
+++ b/pkg/services/backfill.go
@@ -63,6 +63,10 @@ func NewBackfill(
 			hasUpdate = true
 			mutate.LifecycleScope = intake.LifecycleScope
 		}
+		if intake.SubmittedAt != nil {
+			hasUpdate = true
+			mutate.SubmittedAt = intake.SubmittedAt
+		}
 
 		if hasUpdate {
 			if _, err = updateIntake(ctx, mutate); err != nil {

--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -394,3 +394,22 @@ func NewUpdateRejectionFields(
 		return updated, nil
 	}
 }
+
+// NewDeleteSystemIntakeByID is a service to remove the system intake by intake id
+// TODO: this should be remove quickly - EASI-974
+func NewDeleteSystemIntakeByID(
+	config Config,
+	delete func(c context.Context, id uuid.UUID) error,
+	authorize func(context.Context) (bool, error),
+) func(context.Context, uuid.UUID) error {
+	return func(ctx context.Context, id uuid.UUID) error {
+		ok, err := authorize(ctx)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return &apperrors.UnauthorizedError{Err: err}
+		}
+		return delete(ctx, id)
+	}
+}

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -359,3 +359,33 @@ func (s *Store) FetchSystemIntakeMetrics(ctx context.Context, startTime time.Tim
 
 	return metrics, nil
 }
+
+// DeleteSystemIntakeByID removes an Intake, along with any associated Notes
+// TODO: this should be remove quickly - EASI-974
+func (s *Store) DeleteSystemIntakeByID(ctx context.Context, id uuid.UUID) error {
+	_, err := s.db.Exec(
+		`DELETE from note n WHERE n.system_intake=$1`,
+		id.String(),
+	)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		appcontext.ZLogger(ctx).Error(
+			fmt.Sprintf("Failed to delete notes"),
+			zap.Error(err),
+			zap.String("id", id.String()),
+		)
+		return err
+	}
+	_, err = s.db.Exec(
+		`DELETE from system_intake i WHERE i.id=$1`,
+		id.String(),
+	)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		appcontext.ZLogger(ctx).Error(
+			fmt.Sprintf("Failed to delete system_intake"),
+			zap.Error(err),
+			zap.String("id", id.String()),
+		)
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
# EASI-974

Changes proposed in this pull request:

- Given the correct input to the executable, optionally send an API command to remove the given SystemIntakes by ID
- Server-side code to facilitate deleting the SystemIntake and associated Notes. This is fairly quick & dirty code that is expected to be removed quickly, but it has been tested to work locally.
- Also spotted that `submitted_at` still wasn't updating, and added the code necessary