### PR TITLE
add decommission banner stuff

### DIFF
--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -154,6 +154,7 @@ func GetStatusesByFilter(filter SystemIntakeStatusFilter) ([]SystemIntakeStatus,
 			SystemIntakeStatusBIZCASEFINALSUBMITTED,
 			SystemIntakeStatusREADYFORGRT,
 			SystemIntakeStatusREADYFORGRB,
+			SystemIntakeStatusSHUTDOWNINPROGRESS,
 		}, nil
 	case SystemIntakeStatusFilterCLOSED:
 		return []SystemIntakeStatus{
@@ -162,6 +163,7 @@ func GetStatusesByFilter(filter SystemIntakeStatusFilter) ([]SystemIntakeStatus,
 			SystemIntakeStatusNOTITREQUEST,
 			SystemIntakeStatusNOTAPPROVED,
 			SystemIntakeStatusNOGOVERNANCE,
+			SystemIntakeStatusSHUTDOWNCOMPLETE,
 		}, nil
 	default:
 		return []SystemIntakeStatus{}, errors.New("unexpected system intake status filter name")

--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -42,7 +42,8 @@ const intake = {
       prepareGrt: 'Prepare for GRT',
       prepareGrb: 'Prepare for GRB',
       decisionReceived: 'Decision received',
-      requestWithdrawn: 'Request withdrawn'
+      requestWithdrawn: 'Request withdrawn',
+      decommissioning: 'Decommission in progress'
     },
     description: {
       intakeIncomplete:
@@ -54,7 +55,9 @@ const intake = {
       bizCaseIncomplete:
         'Your Business Case is incomplete, please submit it when you are ready so that we can move you to the next step.',
       bizCaseSubmitted:
-        'Your Business Case has been submitted for review. The Governance Admin team will get back to you about the next step.'
+        'Your Business Case has been submitted for review. The Governance Admin team will get back to you about the next step.',
+      decommissioning:
+        'Follow the decommission guide, complete steps relevant to your system and submit it back to ITgovernance@cms.hhs.gov to officially complete the decommissioning of your system.'
     }
   },
   requestTypeMap: {

--- a/src/views/Home/SystemIntakeBanners.tsx
+++ b/src/views/Home/SystemIntakeBanners.tsx
@@ -79,8 +79,8 @@ const SystemIntakeBanners = () => {
       description: t('banner.description.checkNextStep')
     },
     SHUTDOWN_IN_PROGRESS: {
-      title: t('banner.title.responseRecevied'),
-      description: t('banner.description.checkNextStep')
+      title: t('banner.title.decommissioning'),
+      description: t('banner.description.decommissioning')
     },
     SHUTDOWN_COMPLETE: {
       title: t('banner.title.responseRecevied'),
@@ -101,6 +101,16 @@ const SystemIntakeBanners = () => {
           : '/system';
 
         if (intake.requestType === 'SHUTDOWN') {
+          // Current implementation a banner doesn't appear for completed shutdown
+          // because the entire flow is handled via email. Nothing to display.
+          if (
+            ['SHUTDOWN_COMPLETE', 'NO_GOVERNANCE', 'NOT_IT_REQUEST'].includes(
+              intake.status
+            )
+          ) {
+            return <React.Fragment key={intake.id} />;
+          }
+
           return (
             <ActionBanner
               key={intake.id}
@@ -111,14 +121,18 @@ const SystemIntakeBanners = () => {
               }
               helpfulText={status.description}
               onClick={() => {
-                const link =
-                  intake.status === 'INTAKE_SUBMITTED'
-                    ? `/system/${intake.id}/view`
-                    : `/system/${intake.id}`;
+                const link = [
+                  'INTAKE_SUBMITTED',
+                  'SHUTDOWN_IN_PROGRESS'
+                ].includes(intake.status)
+                  ? `/system/${intake.id}/view`
+                  : `/system/${intake.id}`;
                 history.push(link);
               }}
               label={
-                intake.status === 'INTAKE_SUBMITTED'
+                ['INTAKE_SUBMITTED', 'SHUTDOWN_IN_PROGRESS'].includes(
+                  intake.status
+                )
                   ? 'View submitted intake request'
                   : 'Go to intake request'
               }


### PR DESCRIPTION
There's a lot to test for this. I'll try my best to give some rough steps

1. Create a shutdown/decommission request
2. VERIFY: Before submitting verify the requester banner state that an intake draft is incomplete.
3. Submit the request
4: VERIFY: Requester banner state is intake submitted; awaiting response.

5. Switch to a reviewer and do the action of sending an email.
6. Switch to a requester, check that the banner state is now decommission in progress

7. Switch to a reviewer, check that the statuses change accordingly for each of the action radio options
8. As a requester, I shouldn't see any banners for shutdown/decommission requests once the request is closed. This flow is mostly communicated via email. The only banners a requester should see for shutdown/decommission are for intake draft, intake submitted, and shutdown in progress.

Also it's probably worth verifying that the open/closed tables have the appropriate requests.
