### PR TITLE
EASI-834 use proper client in deployed envs

### DIFF
--- a/pkg/server/health_check.go
+++ b/pkg/server/health_check.go
@@ -12,7 +12,7 @@ import (
 
 // CheckCEDAREasiClientConnection makes a call to CEDAR Easi to test it is configured properly
 // this method will panic on failures
-func (s Server) CheckCEDAREasiClientConnection(client cedareasi.TranslatedClient) {
+func (s Server) CheckCEDAREasiClientConnection(client cedareasi.Client) {
 	s.logger.Info("Testing CEDAR EASi Connection")
 	// FetchSystems is agnostic to user, doesn't modify state,
 	// and tests that we're authorized to retrieve information

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -68,12 +68,12 @@ func (s *Server) routes(
 	}
 
 	// set up CEDAR client
-	cedarEasiClient := local.NewCedarEasiClient(s.logger)
+	var cedarEasiClient cedareasi.Client = local.NewCedarEasiClient(s.logger)
 	if !(s.environment.Local() || s.environment.Test()) {
 		// check we have all of the configs for CEDAR clients
 		s.NewCEDARClientCheck()
 
-		cedarEasiClient := cedareasi.NewTranslatedClient(
+		cedarEasiClient = cedareasi.NewTranslatedClient(
 			s.Config.GetString(appconfig.CEDARAPIURL),
 			s.Config.GetString(appconfig.CEDARAPIKey),
 			ldClient,


### PR DESCRIPTION
# EASI-834

Changes proposed in this pull request:

- my previous PR in this area had a bug where we accidentally had ALL environments using the Mock version of the CEDAR EASi client, regardless of configuration values; this change ensures we use the intended client in deployed environments