### PR TITLE
clean up process.env typescript error hack

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,7 +54,7 @@ axios.interceptors.request.use(
     if (
       newConfig &&
       newConfig.url &&
-      newConfig.url.includes(process.env.REACT_APP_API_ADDRESS || ' ') &&
+      newConfig.url.includes(process.env.REACT_APP_API_ADDRESS as string) &&
       window.localStorage['okta-token-storage']
     ) {
       const json = JSON.parse(window.localStorage['okta-token-storage']);

--- a/src/views/BusinessCase/index.tsx
+++ b/src/views/BusinessCase/index.tsx
@@ -111,7 +111,7 @@ export const BusinessCase = () => {
       <MainContent className="margin-bottom-5">
         <div className="grid-container">
           {!['local', 'dev', 'impl'].includes(
-            process.env.REACT_APP_APP_ENV || ''
+            process.env.REACT_APP_APP_ENV as string
           ) && (
             <BreadcrumbNav className="margin-y-2">
               <li>
@@ -122,7 +122,7 @@ export const BusinessCase = () => {
             </BreadcrumbNav>
           )}
           {['local', 'dev', 'impl'].includes(
-            process.env.REACT_APP_APP_ENV || ''
+            process.env.REACT_APP_APP_ENV as string
           ) && (
             <BreadcrumbNav className="margin-y-2">
               <li>

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -94,7 +94,7 @@ export const SystemIntake = () => {
       <Header />
       <MainContent className="grid-container margin-bottom-5">
         {!['local', 'dev', 'impl'].includes(
-          process.env.REACT_APP_APP_ENV || ''
+          process.env.REACT_APP_APP_ENV as string
         ) && (
           <BreadcrumbNav className="margin-y-2">
             <li>
@@ -105,7 +105,7 @@ export const SystemIntake = () => {
           </BreadcrumbNav>
         )}
         {['local', 'dev', 'impl'].includes(
-          process.env.REACT_APP_APP_ENV || ''
+          process.env.REACT_APP_APP_ENV as string
         ) && (
           <BreadcrumbNav className="margin-y-2">
             <li>


### PR DESCRIPTION
There've been a few instances in this project where we've done `process.env.SOME_VAR  || ''` to hack our way past some Typescript errors. I thought this might be a good time to fix it.

`process.env` is typed as
```
export interface ProcessEnv {
    [key: string]: string | undefined
}`
```

Since environment variables can be `undefined`, the Typescript compiler throws some errors for some methods. The main violator in this application is `Array.prototype.includes()`. `Array.prototype.includes()` expects a `string`, which is why we get the error below:

`Argument of type 'string | undefined' is not assignable to parameter of type 'string'`

However, the following statements don't throw errors. There's some debate within the Typescript community whether the type definition is too narrow.
```
[].includes(undefined)
// false

[].includes(null)
// false
```

In this PR, I am choosing to tell the Typescript compiler that the `process.env.SOME_VAR` is a `string` to avoid that error at build time. Even if the variable were `undefined` at run time, it wont error (see example above). I think having the environment variable be it's "true" defined value (CircleCI/`.envrc`) is better off than us giving it a default value to avoid compilation errors.