### PR TITLE
add request type to the grt review header

### DIFF
--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -12,6 +12,7 @@ import BreadcrumbNav from 'components/BreadcrumbNav';
 import { convertIntakeToCSV } from 'data/systemIntake';
 import { AppState } from 'reducers/rootReducer';
 import { fetchSystemIntakes } from 'types/routines';
+import { translateRequestType } from 'utils/systemIntake';
 
 import csvHeaderMap from './csvHeaderMap';
 
@@ -160,7 +161,7 @@ const RequestRepository = () => {
       return {
         ...intake,
         status: statusTranslation,
-        requestType: t(`intake:requestTypeMap.${intake.requestType}`)
+        requestType: translateRequestType(intake.requestType)
       };
     });
   }, [systemIntakes, t]);

--- a/src/components/shared/ActionBanner/index.test.tsx
+++ b/src/components/shared/ActionBanner/index.test.tsx
@@ -11,6 +11,7 @@ describe('The Action Banner component', () => {
         helpfulText="Testing this form helps you receive a CMS IT LifeCycle ID so that you can start a new system or project."
         label="Finish CMS TEST"
         onClick={() => {}}
+        requestType="NEW"
       />
     );
   });
@@ -22,6 +23,7 @@ describe('The Action Banner component', () => {
         helpfulText="Testing this form helps you receive a CMS IT LifeCycle ID so that you can start a new system or project."
         label="Finish CMS TEST"
         onClick={() => {}}
+        requestType="NEW"
       />
     );
     expect(component.find('button').length).toEqual(1);
@@ -35,6 +37,7 @@ describe('The Action Banner component', () => {
         title="TEST"
         helpfulText="Testing this form helps you receive a CMS IT LifeCycle ID so that you can start a new system or project."
         label="Finish CMS TEST"
+        requestType="NEW"
       />
     );
     expect(component.find('button').length).toEqual(0);

--- a/src/components/shared/ActionBanner/index.tsx
+++ b/src/components/shared/ActionBanner/index.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Button } from '@trussworks/react-uswds';
+
+import { RequestType } from 'types/systemIntake';
+import { translateRequestType } from 'utils/systemIntake';
 
 import './index.scss';
 
 type ActionBannerProps = {
   title: string;
-  requestType: string;
+  requestType: RequestType;
   helpfulText: string;
   label: any;
   buttonUnstyled?: boolean;
@@ -22,13 +24,11 @@ const ActionBanner = ({
   onClick,
   ...remainingProps
 }: ActionBannerProps) => {
-  const { t } = useTranslation('intake');
-
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
     <div className="action-banner usa-alert" {...remainingProps}>
       <span className="text-base-dark font-body-3xs">
-        {t(`requestTypeMap.${requestType}`)}
+        {translateRequestType(requestType)}
       </span>
       <div className="action-banner__content">
         <div className="action-banner__icon">

--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -60,11 +60,11 @@ const intake = {
         'Follow the decommission guide, complete steps relevant to your system and submit it back to ITgovernance@cms.hhs.gov to officially complete the decommissioning of your system.'
     }
   },
-  requestTypeMap: {
-    NEW: 'Add a new system',
-    RECOMPETE: 'Re-compete',
-    MAJOR_CHANGES: 'Major change or upgrade',
-    SHUTDOWN: 'Decommission a system'
+  requestType: {
+    new: 'Add a new system',
+    recompete: 'Re-compete',
+    majorChanges: 'Major change or upgrade',
+    shutdown: 'Decommission a system'
   },
 
   csvHeadings: {

--- a/src/utils/systemIntake.ts
+++ b/src/utils/systemIntake.ts
@@ -1,4 +1,11 @@
-import { closedIntakeStatuses, openIntakeStatuses } from 'types/systemIntake';
+import i18next from 'i18next';
+
+import {
+  closedIntakeStatuses,
+  openIntakeStatuses,
+  RequestType
+} from 'types/systemIntake';
+
 /**
  * Checks whenther an intake is closed
  * @param status - the intake's status
@@ -13,4 +20,22 @@ export const isIntakeClosed = (status: string) => {
  */
 export const isIntakeOpen = (status: string) => {
   return openIntakeStatuses.includes(status);
+};
+
+/**
+ * Translate the API enum to a human readable string
+ */
+export const translateRequestType = (requestType: RequestType) => {
+  switch (requestType) {
+    case 'NEW':
+      return i18next.t('intake:requestType.new');
+    case 'RECOMPETE':
+      return i18next.t('intake:requestType.recompete');
+    case 'MAJOR_CHANGES':
+      return i18next.t('intake:requestType.majorChanges');
+    case 'SHUTDOWN':
+      return i18next.t('intake:requestType.shutdown');
+    default:
+      return '';
+  }
 };

--- a/src/views/GovernanceReviewTeam/index.tsx
+++ b/src/views/GovernanceReviewTeam/index.tsx
@@ -13,7 +13,11 @@ import PageWrapper from 'components/PageWrapper';
 import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
 import { AppState } from 'reducers/rootReducer';
 import { fetchBusinessCase, fetchSystemIntake } from 'types/routines';
-import { isIntakeClosed, isIntakeOpen } from 'utils/systemIntake';
+import {
+  isIntakeClosed,
+  isIntakeOpen,
+  translateRequestType
+} from 'utils/systemIntake';
 
 import ChooseAction from './Actions/ChooseAction';
 import IssueLifecycleId from './Actions/IssueLifecycleId';
@@ -100,7 +104,7 @@ const GovernanceReviewTeam = () => {
                 </div>
                 <div className="easi-grt__description-group">
                   <dt>{t('intake:fields.requestFor')}</dt>
-                  <dd>N/A</dd>
+                  <dd>{translateRequestType(systemIntake.requestType)}</dd>
                 </div>
               </div>
             </dl>


### PR DESCRIPTION
# EASI-1072

Previously, the GRT reviewer header had the request type hardcoded as `N/A` because that field didn't exist yet.

Now we're adding the request type in.

- move enum out of the i18n file so we can have a generic i18n key
- add util for translating the request type from enum to human readable value
- replace all use cases of the previous i18n key
- add request type to GRT reviewer header