### PR TITLE
Avoid waf

### DIFF
--- a/pkg/handlers/pdf.go
+++ b/pkg/handlers/pdf.go
@@ -23,7 +23,7 @@ func NewPDFHandler(invoker invokeLambdaFunc) *PDFHandler {
 }
 
 type requestPayload struct {
-	HTML string `json:"html"`
+	HTML []byte `json:"html"` // automatically decode base64
 }
 
 // Handle returns an http.HandlerFunc
@@ -43,7 +43,7 @@ func (h PDFHandler) Handle() http.HandlerFunc {
 			return
 		}
 
-		result, generateErr := h.invokeLambda(r.Context(), generateRequest.HTML)
+		result, generateErr := h.invokeLambda(r.Context(), string(generateRequest.HTML))
 		if generateErr != nil {
 			h.WriteErrorResponse(r.Context(), w, generateErr)
 			return

--- a/src/components/BusinessCaseReview/index.tsx
+++ b/src/components/BusinessCaseReview/index.tsx
@@ -12,9 +12,10 @@ type BusinessCaseReviewProps = {
 };
 
 const BusinessCaseReview = ({ values }: BusinessCaseReviewProps) => {
+  const filename = `Business case for ${values.requestName}.pdf`;
   return (
     <>
-      <PDFExport title="test business case" filename="bizcase.pdf">
+      <PDFExport title="Business Case" filename={filename}>
         <div className="grid-container">
           <h2 className="font-heading-xl">General request information</h2>
           <GeneralRequestInfoReview

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -96,7 +96,11 @@ const downloadRefAsPDF = (
 // PDFExport adds a "Download PDF" button to the screen. When this button is clicked,
 // the HTML content of child elements is sent to the server and converted
 // to PDF format.
-const PDFExport = ({ title, filename, children }: PDFExportProps) => {
+const PDFExport = ({
+  title,
+  filename,
+  children
+}: PDFExportProps): JSX.Element => {
   const flags = useFlags();
 
   const divEl = useRef<HTMLDivElement>(null);
@@ -114,7 +118,7 @@ const PDFExport = ({ title, filename, children }: PDFExportProps) => {
       </button>
     </div>
   ) : (
-    children
+    <>{children}</>
   );
 };
 

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -37,7 +37,7 @@ function generatePDF(filename: string, content: string) {
       responseType: 'blob',
       method: 'POST',
       data: {
-        html: content,
+        html: btoa(content),
         filename: 'input.html'
       }
     })

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -58,9 +58,8 @@ const downloadRefAsPDF = (
   // Collect any stylesheets that are linked to. These are used in production.
   const stylesheetRequests = Array.prototype.slice
     .apply(document.styleSheets)
-    .filter(stylesheet =>
-      stylesheet.href ? axios.get(stylesheet.href) : null
-    );
+    .filter(stylesheet => stylesheet.href)
+    .map(stylesheet => axios.get(stylesheet.href));
 
   // Also grab any inline styles, used predominantly in development.
   const styleBlocks = Array.prototype.slice

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -70,12 +70,8 @@ const downloadRefAsPDF = (
   Promise.all(stylesheetRequests)
     .then(stylesheets => {
       stylesheets.forEach(response => styleBlocks.push(response.data));
-    })
-    .catch(() => {
-      // TODO add error handling: display a modal if things fail?
-    });
 
-  const markupToRender = `<html lang="en">
+      const markupToRender = `<html lang="en">
         <head>
           <title>${escape(title)}</title>
           <style>
@@ -90,7 +86,11 @@ const downloadRefAsPDF = (
         </body>
       </html>`;
 
-  generatePDF(filename, markupToRender);
+      generatePDF(filename, markupToRender);
+    })
+    .catch(() => {
+      // TODO add error handling: display a modal if things fail?
+    });
 };
 
 // PDFExport adds a "Download PDF" button to the screen. When this button is clicked,

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -69,7 +69,7 @@ const downloadRefAsPDF = (
   // Combine external and inline styles
   Promise.all(stylesheetRequests)
     .then(stylesheets => {
-      styleBlocks.concat(stylesheets.map(response => response.data));
+      stylesheets.forEach(response => styleBlocks.push(response.data));
     })
     .catch(() => {
       // TODO add error handling: display a modal if things fail?

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -58,7 +58,10 @@ const downloadRefAsPDF = (
   // Collect any stylesheets that are linked to. These are used in production.
   const stylesheetRequests = Array.prototype.slice
     .apply(document.styleSheets)
-    .filter(stylesheet => stylesheet.href)
+    .filter(
+      // don't load google fonts stylesheets
+      stylesheet => stylesheet.href && !stylesheet.href.startsWith('http')
+    )
     .map(stylesheet => axios.get(stylesheet.href));
 
   // Also grab any inline styles, used predominantly in development.

--- a/src/views/SystemIntake/ViewOnly/index.tsx
+++ b/src/views/SystemIntake/ViewOnly/index.tsx
@@ -10,10 +10,11 @@ type SystemIntakeViewOnlyProps = {
 };
 
 const SystemIntakeView = ({ systemIntake }: SystemIntakeViewOnlyProps) => {
+  const filename = `System intake for ${systemIntake.requestName}.pdf`;
   return (
     <>
       <h1>Review your Intake Request</h1>
-      <PDFExport title="system intake" filename="system-intake.pdf">
+      <PDFExport title="System Intake" filename={filename}>
         <SystemIntakeReview
           systemIntake={systemIntake}
           now={DateTime.local()}


### PR DESCRIPTION
# EASI-532

Changes proposed in this pull request:

- Base64 encode the HTML that we're sending to the backend to avoid tripping a WAF rule
- Fix a bug that was preventing the content of stylesheets to be harvested
