### PR TITLE
Update GRT/GRB reviewer date validations

### DIFF
--- a/src/validations/systemIntakeSchema.ts
+++ b/src/validations/systemIntakeSchema.ts
@@ -206,7 +206,32 @@ export const DateValidationSchema: any = Yup.object().shape(
         return grbDateDay || grbDateMonth;
       },
       then: Yup.string().required('The year is required')
-    })
+    }),
+    validGrbDate: Yup.string().when(
+      ['grbDateDay', 'grbDateMonth', 'grbDateYear'],
+      {
+        is: (grbDateDay: string, grbDateMonth: string, grbDateYear: string) => {
+          if (grbDateDay && grbDateMonth && grbDateYear) {
+            if (
+              DateTime.fromObject({
+                month: Number(grbDateMonth) || 0,
+                day: Number(grbDateDay) || 0,
+                year: Number(grbDateYear) || 0
+              }).isValid
+            ) {
+              return true;
+            }
+            return false;
+          }
+          return true;
+        },
+        otherwise: Yup.string().test(
+          'validateGrbDate',
+          'GRB Date: Please enter a valid date',
+          () => false
+        )
+      }
+    )
   },
   [
     ['grtDateDay', 'grtDateMonth'],

--- a/src/validations/systemIntakeSchema.ts
+++ b/src/validations/systemIntakeSchema.ts
@@ -168,7 +168,9 @@ export const DateValidationSchema: any = Yup.object().shape(
       ['grtDateDay', 'grtDateMonth', 'grtDateYear'],
       {
         is: (grtDateDay: string, grtDateMonth: string, grtDateYear: string) => {
+          // Only check for a valid date if monday, date, and year a filled
           if (grtDateDay && grtDateMonth && grtDateYear) {
+            // If the date is valid, it passes the validation
             if (
               DateTime.fromObject({
                 month: Number(grtDateMonth) || 0,
@@ -180,6 +182,7 @@ export const DateValidationSchema: any = Yup.object().shape(
             }
             return false;
           }
+          // If month, day, and year aren't ALL filled, don't run the validation
           return true;
         },
         otherwise: Yup.string().test(
@@ -211,7 +214,9 @@ export const DateValidationSchema: any = Yup.object().shape(
       ['grbDateDay', 'grbDateMonth', 'grbDateYear'],
       {
         is: (grbDateDay: string, grbDateMonth: string, grbDateYear: string) => {
+          // Only check for a valid date if monday, date, and year a filled
           if (grbDateDay && grbDateMonth && grbDateYear) {
+            // If the date is valid, it passes the validation
             if (
               DateTime.fromObject({
                 month: Number(grbDateMonth) || 0,
@@ -223,6 +228,7 @@ export const DateValidationSchema: any = Yup.object().shape(
             }
             return false;
           }
+          // If month, day, and year aren't ALL filled, don't run the validation
           return true;
         },
         otherwise: Yup.string().test(

--- a/src/validations/systemIntakeSchema.ts
+++ b/src/validations/systemIntakeSchema.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import * as Yup from 'yup';
 
 import cmsGovernanceTeams from 'constants/enums/cmsGovernanceTeams';
@@ -163,6 +164,31 @@ export const DateValidationSchema: any = Yup.object().shape(
       },
       then: Yup.string().required('The year is required')
     }),
+    validGrtDate: Yup.string().when(
+      ['grtDateDay', 'grtDateMonth', 'grtDateYear'],
+      {
+        is: (grtDateDay: string, grtDateMonth: string, grtDateYear: string) => {
+          if (grtDateDay && grtDateMonth && grtDateYear) {
+            if (
+              DateTime.fromObject({
+                month: Number(grtDateMonth) || 0,
+                day: Number(grtDateDay) || 0,
+                year: Number(grtDateYear) || 0
+              }).isValid
+            ) {
+              return true;
+            }
+            return false;
+          }
+          return true;
+        },
+        otherwise: Yup.string().test(
+          'validateGrtDate',
+          'GRT Date: Please enter a valid date',
+          () => false
+        )
+      }
+    ),
     grbDateDay: Yup.string().when(['grbDateMonth', 'grbDateYear'], {
       is: (grbDateMonth: string, grbDateYear: string) => {
         return grbDateMonth || grbDateYear;

--- a/src/views/GovernanceReviewTeam/Dates/index.tsx
+++ b/src/views/GovernanceReviewTeam/Dates/index.tsx
@@ -19,7 +19,7 @@ import flattenErrors from 'utils/flattenErrors';
 import { DateValidationSchema } from 'validations/systemIntakeSchema';
 
 const Dates = ({ systemIntake }: { systemIntake: SystemIntakeForm }) => {
-  const { systemId } = useParams();
+  const { systemId } = useParams<{ systemId: string }>();
   const dispatch = useDispatch();
   const history = useHistory();
   const { t } = useTranslation();


### PR DESCRIPTION
# EASI-1073

In the bug, we discovered that invalid dates were able to be created.
e.g. Month = 53, Date = 53.

This PR fixes that, it's a little bit messy and there _might_ be a few edge case, but it _works_
I tested for the following cases. Please feel free to do me a favor and verify them too.

- [ ] ALL dates empty: It should save because we've established that the fields are "all or nothing" for each date
- [ ] Fill out GRT or GRB date partially and it should complain that certain fields are missing
- [ ] Fill out GRT or GRB date partially WITH out of range values. It should only complain about the missing date fields.
- [ ] Fill out GRT or GRB date COMPLETELY, but with a value that's out of range. (e.g. month is 13 or day is 45). It should complain that the date is not valid.
    - There are some "edge cases". I'm not completely sure if they are edge cases. For example, year can be any number. We are relying on `luxon` to create a valid date based on it's month, day, and year. We check the `DateTime` with `.isValid` (from `luxon`). Date validity is checked by `luxon`.
- [ ] Fill out GRT or GRB date COMPLETELY, with out of range values. It should complain that the date is not valid.



tl;dr; Date validity is ONLY checked when ALL fields (month, date, year) are filled. Otherwise, the validation is making sure that the fields are filled. Each date is "all or nothing" (e.g. month, date, year filled, or nothing at all)
