### PR TITLE
add trim to all validated fields

### DIFF
--- a/src/validations/actionSchema.ts
+++ b/src/validations/actionSchema.ts
@@ -6,24 +6,38 @@ export const actionSchema = Yup.object().shape({
 
 export const lifecycleIdSchema = Yup.object().shape({
   lifecycleId: Yup.string()
+    .trim()
     .nullable()
     .length(7),
   expirationDateDay: Yup.string()
+    .trim()
     .length(2)
     .required('Please include a day'),
   expirationDateMonth: Yup.string()
+    .trim()
     .length(2)
     .required('Please include a month'),
   expirationDateYear: Yup.string()
+    .trim()
     .length(4)
     .required('Please include a year'),
-  scope: Yup.string().required('Please include a scope'),
-  nextSteps: Yup.string(),
-  feedback: Yup.string().required('Please fill out email')
+  scope: Yup.string()
+    .trim()
+    .required('Please include a scope'),
+  nextSteps: Yup.string().trim(),
+  feedback: Yup.string()
+    .trim()
+    .required('Please fill out email')
 });
 
 export const rejectIntakeSchema = Yup.object().shape({
-  nextSteps: Yup.string().required('Please include next steps'),
-  reason: Yup.string().required('Please include a reason'),
-  feedback: Yup.string().required('Please fill out email')
+  nextSteps: Yup.string()
+    .trim()
+    .required('Please include next steps'),
+  reason: Yup.string()
+    .trim()
+    .required('Please include a reason'),
+  feedback: Yup.string()
+    .trim()
+    .required('Please fill out email')
 });

--- a/src/validations/businessCaseSchema.ts
+++ b/src/validations/businessCaseSchema.ts
@@ -4,10 +4,15 @@ import * as Yup from 'yup';
 const phoneNumberRegex = /( *-*[0-9] *?){10,}/;
 export const BusinessCaseFinalValidationSchema = {
   generalRequestInfo: Yup.object().shape({
-    requestName: Yup.string().required('Enter the Project Name'),
+    requestName: Yup.string()
+      .trim()
+      .required('Enter the Project Name'),
     requester: Yup.object().shape({
-      name: Yup.string().required("Enter the Requester's name"),
+      name: Yup.string()
+        .trim()
+        .required("Enter the Requester's name"),
       phoneNumber: Yup.string()
+        .trim()
         .matches(
           phoneNumberRegex,
           'Enter the requester’s phone number like 123456789 or 123-456-789'
@@ -17,73 +22,105 @@ export const BusinessCaseFinalValidationSchema = {
         )
     }),
     businessOwner: Yup.object().shape({
-      name: Yup.string().required("Enter the Business Owner's name")
+      name: Yup.string()
+        .trim()
+        .required("Enter the Business Owner's name")
     })
   }),
   requestDescription: Yup.object().shape({
-    businessNeed: Yup.string().required(
-      'Tell us what the business or user need is'
-    ),
-    cmsBenefit: Yup.string().required(
-      'Tell us how CMS will benefit from this effort'
-    ),
-    priorityAlignment: Yup.string().required(
-      'Tell us how this effort aligns with organizational priorities'
-    ),
-    successIndicators: Yup.string().required(
-      'Tell us how you will determine whethere or not this effort is successful'
-    )
+    businessNeed: Yup.string()
+      .trim()
+      .required('Tell us what the business or user need is'),
+    cmsBenefit: Yup.string()
+      .trim()
+      .required('Tell us how CMS will benefit from this effort'),
+    priorityAlignment: Yup.string()
+      .trim()
+      .required(
+        'Tell us how this effort aligns with organizational priorities'
+      ),
+    successIndicators: Yup.string()
+      .trim()
+      .required(
+        'Tell us how you will determine whethere or not this effort is successful'
+      )
   }),
   asIsSolution: Yup.object().shape({
     asIsSolution: Yup.object().shape({
-      title: Yup.string().required('Enter a title for the "As is" solution'),
-      summary: Yup.string().required('Tell us about the "As is" solution'),
-      pros: Yup.string().required('Tell us about the pros of "As is" solution'),
-      cons: Yup.string().required('Tell us about the cons of "As is" solution'),
+      title: Yup.string()
+        .trim()
+        .required('Enter a title for the "As is" solution'),
+      summary: Yup.string()
+        .trim()
+        .required('Tell us about the "As is" solution'),
+      pros: Yup.string()
+        .trim()
+        .required('Tell us about the pros of "As is" solution'),
+      cons: Yup.string()
+        .trim()
+        .required('Tell us about the cons of "As is" solution'),
       estimatedLifecycleCost: Yup.object().shape({
         year1: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 1'),
-            cost: Yup.string().required('Enter the cost for Year 1')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 1')
           })
         ),
         year2: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 2'),
-            cost: Yup.string().required('Enter the cost for Year 2')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 2')
           })
         ),
         year3: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 3'),
-            cost: Yup.string().required('Enter the cost for Year 3')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 3')
           })
         ),
         year4: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 4'),
-            cost: Yup.string().required('Enter the cost for Year 4')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 4')
           })
         ),
         year5: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 5'),
-            cost: Yup.string().required('Enter the cost for Year 5')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 5')
           })
         )
       }),
-      costSavings: Yup.string().required(
-        'Tell us about the cost savings or avoidance associated with this solution'
-      )
+      costSavings: Yup.string()
+        .trim()
+        .required(
+          'Tell us about the cost savings or avoidance associated with this solution'
+        )
     })
   }),
   preferredSolution: Yup.object().shape({
     preferredSolution: Yup.object().shape({
-      title: Yup.string().required('Enter a title for the Preferred solution'),
-      summary: Yup.string().required('Tell us about the Preferred solution'),
-      acquisitionApproach: Yup.string().required(
-        'Tell us about the acquisition approach for the Preferred solution'
-      ),
+      title: Yup.string()
+        .trim()
+        .required('Enter a title for the Preferred solution'),
+      summary: Yup.string()
+        .trim()
+        .required('Tell us about the Preferred solution'),
+      acquisitionApproach: Yup.string()
+        .trim()
+        .required(
+          'Tell us about the acquisition approach for the Preferred solution'
+        ),
       security: Yup.object().shape({
         isApproved: Yup.boolean()
           .nullable()
@@ -104,80 +141,96 @@ export const BusinessCaseFinalValidationSchema = {
         location: Yup.string()
           .when('type', {
             is: 'cloud',
-            then: Yup.string().required(
-              'Tell us where Preferred solution will be hosted'
-            )
+            then: Yup.string()
+              .trim()
+              .required('Tell us where Preferred solution will be hosted')
           })
           .when('type', {
             is: 'dataCenter',
-            then: Yup.string().required(
-              'Tell us where Preferred solution will be hosted'
-            )
+            then: Yup.string()
+              .trim()
+              .required('Tell us where Preferred solution will be hosted')
           }),
         cloudServiceType: Yup.string().when('type', {
           is: 'cloud',
-          then: Yup.string().required(
-            'Tell us about the cloud service that will be used for the Preferred solution'
-          )
+          then: Yup.string()
+            .trim()
+            .required(
+              'Tell us about the cloud service that will be used for the Preferred solution'
+            )
         })
       }),
       hasUserInterface: Yup.string().required(
         'Tell us whether the Preferred solution will have user interface'
       ),
-      pros: Yup.string().required(
-        'Tell us about the pros of Preferred solution'
-      ),
-      cons: Yup.string().required(
-        'Tell us about the cons of Preferred solution'
-      ),
+      pros: Yup.string()
+        .trim()
+        .required('Tell us about the pros of Preferred solution'),
+      cons: Yup.string()
+        .trim()
+        .required('Tell us about the cons of Preferred solution'),
       estimatedLifecycleCost: Yup.object().shape({
         year1: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 1'),
-            cost: Yup.string().required('Enter the cost for Year 1')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 1')
           })
         ),
         year2: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 2'),
-            cost: Yup.string().required('Enter the cost for Year 2')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 2')
           })
         ),
         year3: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 3'),
-            cost: Yup.string().required('Enter the cost for Year 3')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 3')
           })
         ),
         year4: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 4'),
-            cost: Yup.string().required('Enter the cost for Year 4')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 4')
           })
         ),
         year5: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 5'),
-            cost: Yup.string().required('Enter the cost for Year 5')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 5')
           })
         )
       }),
-      costSavings: Yup.string().required(
-        'Tell us about the cost savings or avoidance associated with this solution'
-      )
+      costSavings: Yup.string()
+        .trim()
+        .required(
+          'Tell us about the cost savings or avoidance associated with this solution'
+        )
     })
   }),
   alternativeA: Yup.object().shape({
     alternativeA: Yup.object().shape({
-      title: Yup.string().required(
-        'Enter a title for the Alternative A solution'
-      ),
-      summary: Yup.string().required(
-        'Tell us about the Alternative A solution'
-      ),
-      acquisitionApproach: Yup.string().required(
-        'Tell us about the acquisition approach for the Alternative A solution'
-      ),
+      title: Yup.string()
+        .trim()
+        .required('Enter a title for the Alternative A solution'),
+      summary: Yup.string()
+        .trim()
+        .required('Tell us about the Alternative A solution'),
+      acquisitionApproach: Yup.string()
+        .trim()
+        .required(
+          'Tell us about the acquisition approach for the Alternative A solution'
+        ),
       security: Yup.object().shape({
         isApproved: Yup.boolean()
           .nullable()
@@ -192,86 +245,102 @@ export const BusinessCaseFinalValidationSchema = {
         })
       }),
       hosting: Yup.object().shape({
-        type: Yup.string().required(
-          'Tell us how Alternative A solution will be hosted'
-        ),
+        type: Yup.string()
+          .trim()
+          .required('Tell us how Alternative A solution will be hosted'),
         location: Yup.string()
           .when('type', {
             is: 'cloud',
-            then: Yup.string().required(
-              'Tell us where Alternative A solution will be hosted'
-            )
+            then: Yup.string()
+              .trim()
+              .required('Tell us where Alternative A solution will be hosted')
           })
           .when('type', {
             is: 'dataCenter',
-            then: Yup.string().required(
-              'Tell us where Alternative A solution will be hosted'
-            )
+            then: Yup.string()
+              .trim()
+              .required('Tell us where Alternative A solution will be hosted')
           }),
         cloudServiceType: Yup.string().when('type', {
           is: 'cloud',
-          then: Yup.string().required(
-            'Tell us about the cloud service that will be used for the Alternative A solution'
-          )
+          then: Yup.string()
+            .trim()
+            .required(
+              'Tell us about the cloud service that will be used for the Alternative A solution'
+            )
         })
       }),
       hasUserInterface: Yup.string().required(
         'Tell us whether the Alternative A solution will have user interface'
       ),
-      pros: Yup.string().required(
-        'Tell us about the pros of Alternative A solution'
-      ),
-      cons: Yup.string().required(
-        'Tell us about the cons of Alternative A solution'
-      ),
+      pros: Yup.string()
+        .trim()
+        .required('Tell us about the pros of Alternative A solution'),
+      cons: Yup.string()
+        .trim()
+        .required('Tell us about the cons of Alternative A solution'),
       estimatedLifecycleCost: Yup.object().shape({
         year1: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 1'),
-            cost: Yup.string().required('Enter the cost for Year 1')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 1')
           })
         ),
         year2: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 2'),
-            cost: Yup.string().required('Enter the cost for Year 2')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 2')
           })
         ),
         year3: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 3'),
-            cost: Yup.string().required('Enter the cost for Year 3')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 3')
           })
         ),
         year4: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 4'),
-            cost: Yup.string().required('Enter the cost for Year 4')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 4')
           })
         ),
         year5: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 5'),
-            cost: Yup.string().required('Enter the cost for Year 5')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 5')
           })
         )
       }),
-      costSavings: Yup.string().required(
-        'Tell us about the cost savings or avoidance associated with this solution'
-      )
+      costSavings: Yup.string()
+        .trim()
+        .required(
+          'Tell us about the cost savings or avoidance associated with this solution'
+        )
     })
   }),
   alternativeB: Yup.object().shape({
     alternativeB: Yup.object().shape({
-      title: Yup.string().required(
-        'Enter a title for the Alternative B solution'
-      ),
-      summary: Yup.string().required(
-        'Tell us about the Alternative B solution'
-      ),
-      acquisitionApproach: Yup.string().required(
-        'Tell us about the acquisition approach for the Alternative B solution'
-      ),
+      title: Yup.string()
+        .trim()
+        .required('Enter a title for the Alternative B solution'),
+      summary: Yup.string()
+        .trim()
+        .required('Tell us about the Alternative B solution'),
+      acquisitionApproach: Yup.string()
+        .trim()
+        .required(
+          'Tell us about the acquisition approach for the Alternative B solution'
+        ),
       security: Yup.object().shape({
         isApproved: Yup.boolean()
           .nullable()
@@ -292,67 +361,81 @@ export const BusinessCaseFinalValidationSchema = {
         location: Yup.string()
           .when('type', {
             is: 'cloud',
-            then: Yup.string().required(
-              'Tell us where Alternative B solution will be hosted'
-            )
+            then: Yup.string()
+              .trim()
+              .required('Tell us where Alternative B solution will be hosted')
           })
           .when('type', {
             is: 'dataCenter',
-            then: Yup.string().required(
-              'Tell us where Alternative B solution will be hosted'
-            )
+            then: Yup.string()
+              .trim()
+              .required('Tell us where Alternative B solution will be hosted')
           }),
         cloudServiceType: Yup.string().when('type', {
           is: 'cloud',
-          then: Yup.string().required(
-            'Tell us about the cloud service that will be used for the Alternative B solution'
-          )
+          then: Yup.string()
+            .trim()
+            .required(
+              'Tell us about the cloud service that will be used for the Alternative B solution'
+            )
         })
       }),
       hasUserInterface: Yup.string().required(
         'Tell us whether the Alternative B solution will have user interface'
       ),
-      pros: Yup.string().required(
-        'Tell us about the pros of Alternative B solution'
-      ),
-      cons: Yup.string().required(
-        'Tell us about the cons of Alternative B solution'
-      ),
+      pros: Yup.string()
+        .trim()
+        .required('Tell us about the pros of Alternative B solution'),
+      cons: Yup.string()
+        .trim()
+        .required('Tell us about the cons of Alternative B solution'),
       estimatedLifecycleCost: Yup.object().shape({
         year1: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 1'),
-            cost: Yup.string().required('Enter the cost for Year 1')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 1')
           })
         ),
         year2: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 2'),
-            cost: Yup.string().required('Enter the cost for Year 2')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 2')
           })
         ),
         year3: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 3'),
-            cost: Yup.string().required('Enter the cost for Year 3')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 3')
           })
         ),
         year4: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 4'),
-            cost: Yup.string().required('Enter the cost for Year 4')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 4')
           })
         ),
         year5: Yup.array().of(
           Yup.object().shape({
             phase: Yup.string().required('Select the type of phase for Year 5'),
-            cost: Yup.string().required('Enter the cost for Year 5')
+            cost: Yup.string()
+              .trim()
+              .required('Enter the cost for Year 5')
           })
         )
       }),
-      costSavings: Yup.string().required(
-        'Tell us about the cost savings or avoidance associated with this solution'
-      )
+      costSavings: Yup.string()
+        .trim()
+        .required(
+          'Tell us about the cost savings or avoidance associated with this solution'
+        )
     })
   })
 };

--- a/src/validations/systemIntakeSchema.ts
+++ b/src/validations/systemIntakeSchema.ts
@@ -6,17 +6,21 @@ const governanceTeamNames = cmsGovernanceTeams.map(team => team.value);
 const SystemIntakeValidationSchema: any = {
   contactDetails: Yup.object().shape({
     requester: Yup.object().shape({
-      name: Yup.string().required('Enter a name for this request'),
+      name: Yup.string()
+        .trim()
+        .required('Enter a name for this request'),
       component: Yup.string().required("Select the Requester's component")
     }),
     businessOwner: Yup.object().shape({
-      name: Yup.string().required("Enter the Business or Product Owner's name"),
+      name: Yup.string()
+        .trim()
+        .required("Enter the Business or Product Owner's name"),
       component: Yup.string().required('Select a Business Owner Component')
     }),
     productManager: Yup.object().shape({
-      name: Yup.string().required(
-        'Enter the CMS Project/Product Manager or Lead name'
-      ),
+      name: Yup.string()
+        .trim()
+        .required('Enter the CMS Project/Product Manager or Lead name'),
       component: Yup.string().required(
         'Select a project/ product manager, or Lead Component'
       )
@@ -27,7 +31,9 @@ const SystemIntakeValidationSchema: any = {
         .required('Select Yes or No to indicate if you have an ISSO'),
       name: Yup.string().when('isPresent', {
         is: true,
-        then: Yup.string().required('Tell us the name of your ISSO')
+        then: Yup.string()
+          .trim()
+          .required('Tell us the name of your ISSO')
       })
     }),
     governanceTeams: Yup.object().shape({
@@ -44,21 +50,27 @@ const SystemIntakeValidationSchema: any = {
               collaborator: Yup.string()
                 .when('name', {
                   is: 'Technical Review Board',
-                  then: Yup.string().required(
-                    "Tell us the name of the person you've been working with from the Technical Review Board"
-                  )
+                  then: Yup.string()
+                    .trim()
+                    .required(
+                      "Tell us the name of the person you've been working with from the Technical Review Board"
+                    )
                 })
                 .when('name', {
                   is: "OIT's Security and Privacy Group",
-                  then: Yup.string().required(
-                    "Tell us the name of the person you've been working with from OIT's Security and Privacy Group"
-                  )
+                  then: Yup.string()
+                    .trim()
+                    .required(
+                      "Tell us the name of the person you've been working with from OIT's Security and Privacy Group"
+                    )
                 })
                 .when('name', {
                   is: 'Enterprise Architecture',
-                  then: Yup.string().required(
-                    "Tell us the name of the person you've been working with from Enterprise Architecture"
-                  )
+                  then: Yup.string()
+                    .trim()
+                    .required(
+                      "Tell us the name of the person you've been working with from Enterprise Architecture"
+                    )
                 })
             })
           )
@@ -66,11 +78,15 @@ const SystemIntakeValidationSchema: any = {
     })
   }),
   requestDetails: Yup.object().shape({
-    requestName: Yup.string().required('Enter the Project Name'),
-    businessNeed: Yup.string().required('Tell us about your request'),
-    businessSolution: Yup.string().required(
-      'Tell us how you think of solving your business need'
-    ),
+    requestName: Yup.string()
+      .trim()
+      .required('Enter the Project Name'),
+    businessNeed: Yup.string()
+      .trim()
+      .required('Tell us about your request'),
+    businessSolution: Yup.string()
+      .trim()
+      .required('Tell us how you think of solving your business need'),
     needsEaSupport: Yup.boolean()
       .nullable()
       .required('Tell us if you need Enterprise Architecture (EA) support')
@@ -84,6 +100,7 @@ const SystemIntakeValidationSchema: any = {
       fundingNumber: Yup.string().when('isFunded', {
         is: true,
         then: Yup.string()
+          .trim()
           .length(6, 'Funding number must be exactly 6 digits')
           .matches(/^\d+$/, 'Fuding number can only contain digits')
           .required(
@@ -101,9 +118,11 @@ const SystemIntakeValidationSchema: any = {
       ),
       expectedIncreaseAmount: Yup.string().when('isExpectingIncrease', {
         is: 'YES',
-        then: Yup.string().required(
-          'Tell us approximately how much do you expect the cost to increase'
-        )
+        then: Yup.string()
+          .trim()
+          .required(
+            'Tell us approximately how much do you expect the cost to increase'
+          )
       })
     }),
     contract: Yup.object().shape({
@@ -112,32 +131,44 @@ const SystemIntakeValidationSchema: any = {
       ),
       contractor: Yup.string().when('hasContract', {
         is: val => ['HAVE_CONTRACT', 'IN_PROGRESS'].includes(val),
-        then: Yup.string().required(
-          'Tell us whether you have selected a contractor(s)'
-        )
+        then: Yup.string()
+          .trim()
+          .required('Tell us whether you have selected a contractor(s)')
       }),
       vehicle: Yup.string().when('hasContract', {
         is: val => ['HAVE_CONTRACT', 'IN_PROGRESS'].includes(val),
-        then: Yup.string().required('Tell us about the contract vehicle')
+        then: Yup.string()
+          .trim()
+          .required('Tell us about the contract vehicle')
       }),
       startDate: Yup.mixed().when('hasContract', {
         is: val => ['HAVE_CONTRACT', 'IN_PROGRESS'].includes(val),
         then: Yup.object().shape({
-          month: Yup.string().required('Tell us the contract start month'),
-          year: Yup.string().required('Tell us the contract start year')
+          month: Yup.string()
+            .trim()
+            .required('Tell us the contract start month'),
+          year: Yup.string()
+            .trim()
+            .required('Tell us the contract start year')
         })
       }),
       endDate: Yup.mixed().when('hasContract', {
         is: val => ['HAVE_CONTRACT', 'IN_PROGRESS'].includes(val),
         then: Yup.object().shape({
-          month: Yup.string().required('Tell us the contract end month'),
-          year: Yup.string().required('Tell us the contract end year')
+          month: Yup.string()
+            .trim()
+            .required('Tell us the contract end month'),
+          year: Yup.string()
+            .trim()
+            .required('Tell us the contract end year')
         })
       })
     })
   }),
   requestType: Yup.object().shape({
-    requestType: Yup.string().required('Tell us what your request is for')
+    requestType: Yup.string()
+      .trim()
+      .required('Tell us what your request is for')
   })
 };
 
@@ -149,37 +180,49 @@ export const DateValidationSchema: any = Yup.object().shape(
       is: (grtDateMonth: string, grtDateYear: string) => {
         return grtDateMonth || grtDateYear;
       },
-      then: Yup.string().required('The day is required')
+      then: Yup.string()
+        .trim()
+        .required('The day is required')
     }),
     grtDateMonth: Yup.string().when(['grtDateDay', 'grtDateYear'], {
       is: (grtDateDay: string, grtDateYear: string) => {
         return grtDateDay || grtDateYear;
       },
-      then: Yup.string().required('The month is required')
+      then: Yup.string()
+        .trim()
+        .required('The month is required')
     }),
     grtDateYear: Yup.string().when(['grtDateDay', 'grtDateMonth'], {
       is: (grtDateDay: string, grtDateMonth: string) => {
         return grtDateDay || grtDateMonth;
       },
-      then: Yup.string().required('The year is required')
+      then: Yup.string()
+        .trim()
+        .required('The year is required')
     }),
     grbDateDay: Yup.string().when(['grbDateMonth', 'grbDateYear'], {
       is: (grbDateMonth: string, grbDateYear: string) => {
         return grbDateMonth || grbDateYear;
       },
-      then: Yup.string().required('The day is required')
+      then: Yup.string()
+        .trim()
+        .required('The day is required')
     }),
     grbDateMonth: Yup.string().when(['grbDateDay', 'grbDateYear'], {
       is: (grbDateDay: string, grbDateYear: string) => {
         return grbDateDay || grbDateYear;
       },
-      then: Yup.string().required('The month is required')
+      then: Yup.string()
+        .trim()
+        .required('The month is required')
     }),
     grbDateYear: Yup.string().when(['grbDateDay', 'grbDateMonth'], {
       is: (grbDateDay: string, grbDateMonth: string) => {
         return grbDateDay || grbDateMonth;
       },
-      then: Yup.string().required('The year is required')
+      then: Yup.string()
+        .trim()
+        .required('The year is required')
     })
   },
   [


### PR DESCRIPTION
# EASI-1075

This PR trims all text/textarea input values before validating them. This PR DOES NOT alter any user input. If a user has any whitespace, those will be preserved. Whitespace with text will pass validation, but ONLY whitespace will fail.

In the example below, `CMS Business/Product Owner's Name` only has whitespace, it fails validation. `CMS Project/Product Manager, or lead` has whitespace, but it also has text, so it passes validation.

If we want to remove leading/trailing whitespace, let's create a story for that and have a discussion how/when/where it should happen.

![trim-example-gif](https://user-images.githubusercontent.com/8367504/102401904-da00da80-3f98-11eb-804c-acfedc52cfc0.gif)
