### PR TITLE
add intake submission confirmation page

### DIFF
--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -10,9 +10,15 @@ const intake = {
     status: 'Status',
     fundingNumber: 'Funding number'
   },
-
+  submission: {
+    confirmation: {
+      heading: 'Your Intake Request has been submitted',
+      subheading: 'Your reference ID is {{referenceId}}',
+      homeCta: 'Go back to EASi homepage',
+      taskListCta: 'Go back to Governance Task List'
+    }
+  },
   lifecycleId: 'Lifecycle ID',
-
   statusMap: {
     INTAKE_DRAFT: 'N/A',
     INTAKE_SUBMITTED: 'Intake request received',

--- a/src/views/SystemIntake/Confirmation/index.tsx
+++ b/src/views/SystemIntake/Confirmation/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router-dom';
+
+import { ImproveEasiSurvey } from 'components/Survey';
+import { useFlags } from 'contexts/flagContext';
+
+const Confirmation = () => {
+  const { systemId } = useParams<{ systemId: string }>();
+  const flags = useFlags();
+  const { t } = useTranslation('intake');
+
+  return (
+    <div className="grid-container margin-bottom-7">
+      <div>
+        <h1 className="font-heading-xl margin-top-4">
+          {t('submission.confirmation.heading')}
+        </h1>
+        <h2 className="margin-bottom-8 text-normal">
+          {t('submission.confirmation.subheading', {
+            referenceId: systemId
+          })}
+        </h2>
+        <ImproveEasiSurvey />
+        <div>
+          {flags.taskListLite ? (
+            <Link to={`/governance-task-list/${systemId}`}>
+              <i className="fa fa-angle-left margin-x-05" aria-hidden />
+              {t('submission.confirmation.taskListCta')}
+            </Link>
+          ) : (
+            <Link to="/">
+              <i className="fa fa-angle-left margin-x-05" aria-hidden />
+              {t('submission.confirmation.homeCta')}
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Confirmation;


### PR DESCRIPTION
After the requester submits their intake. They should be redirected to a confirmation page that displays their intake request id.
