### PR TITLE
Use document origin instead of protocol to filter stylesheets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     restart: always
     image: minio/minio:latest
     ports:
-      - "9000:9000"
+      - '9000:9000'
     entrypoint: minio server /data
   minio_mc:
     image: minio/mc:latest
@@ -29,3 +29,12 @@ services:
       /usr/bin/mc mb --quiet local/easi-app-file-uploads/;
       /usr/bin/mc policy set public local/easi-app-file-uploads;
       "
+  lambda:
+    image: lambci/lambda:go1.x
+    ports:
+      - 9001:9001
+    environment:
+      - DOCKER_LAMBDA_STAY_OPEN=1
+      - LICENSE_KEY=
+    volumes:
+      - ./../easi-infra-modules/lambda/prince/build:/var/task:ro,delegated

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "i18next": "^19.8.3",
     "i18next-browser-languagedetector": "^5.0.0",
     "istanbul-lib-coverage": "^3.0.0",
+    "js-base64": "^3.6.0",
     "lodash": "^4.17.15",
     "luxon": "^1.22.0",
     "no-scroll": "^2.1.1",

--- a/src/components/BusinessCaseReview/index.scss
+++ b/src/components/BusinessCaseReview/index.scss
@@ -1,0 +1,8 @@
+.easi-pdf-export .easi-pdf-export__controls {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 75rem;
+  margin-top: 3rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+}

--- a/src/components/BusinessCaseReview/index.tsx
+++ b/src/components/BusinessCaseReview/index.tsx
@@ -7,6 +7,8 @@ import AlternativeAnalysisReview from './AlternativeAnalysisReview';
 import GeneralRequestInfoReview from './GeneralRequestInfoReview';
 import RequestDescriptionReview from './RequestDescriptionReview';
 
+import './index.scss';
+
 type BusinessCaseReviewProps = {
   values: BusinessCaseModel;
 };
@@ -15,7 +17,11 @@ const BusinessCaseReview = ({ values }: BusinessCaseReviewProps) => {
   const filename = `Business case for ${values.requestName}.pdf`;
   return (
     <>
-      <PDFExport title="Business Case" filename={filename}>
+      <PDFExport
+        title="Business Case"
+        filename={filename}
+        label="Download Business Case as PDF"
+      >
         <div className="grid-container">
           <h2 className="font-heading-xl">General request information</h2>
           <GeneralRequestInfoReview

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -56,11 +56,12 @@ const downloadRefAsPDF = (
   ref: React.Ref<HTMLDivElement>
 ): void => {
   // Collect any stylesheets that are linked to. These are used in production.
+  const { origin } = document.location;
   const stylesheetRequests = Array.prototype.slice
     .apply(document.styleSheets)
     .filter(
       // don't load google fonts stylesheets
-      stylesheet => stylesheet.href && !stylesheet.href.startsWith('http')
+      stylesheet => stylesheet.href && stylesheet.href.startsWith(origin)
     )
     .map(stylesheet => axios.get(stylesheet.href));
 

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -1,13 +1,17 @@
 import React, { useRef } from 'react';
 import axios from 'axios';
+import { Base64 } from 'js-base64';
 import escape from 'lodash';
 
 import { useFlags } from 'contexts/flagContext';
+
+import downloadSVG from './download.svg';
 
 type PDFExportProps = {
   filename: string;
   title: string;
   children: React.ReactNode;
+  label?: string;
 };
 
 function downloadBlob(filename: string, blob: Blob) {
@@ -37,7 +41,7 @@ function generatePDF(filename: string, content: string) {
       responseType: 'blob',
       method: 'POST',
       data: {
-        html: btoa(content),
+        html: Base64.encode(content),
         filename: 'input.html'
       }
     })
@@ -92,7 +96,8 @@ const downloadRefAsPDF = (
 
       generatePDF(filename, markupToRender);
     })
-    .catch(() => {
+    .catch(e => {
+      console.error(e);
       // TODO add error handling: display a modal if things fail?
     });
 };
@@ -100,11 +105,7 @@ const downloadRefAsPDF = (
 // PDFExport adds a "Download PDF" button to the screen. When this button is clicked,
 // the HTML content of child elements is sent to the server and converted
 // to PDF format.
-const PDFExport = ({
-  title,
-  filename,
-  children
-}: PDFExportProps): JSX.Element => {
+const PDFExport = ({ title, filename, children, label }: PDFExportProps) => {
   const flags = useFlags();
 
   const divEl = useRef<HTMLDivElement>(null);
@@ -113,13 +114,21 @@ const PDFExport = ({
     <div className="easi-pdf-export" ref={divEl}>
       {children}
 
-      <button
-        className="easi-no-print"
-        type="button"
-        onClick={() => downloadRefAsPDF(title, filename, divEl)}
-      >
-        Download PDF
-      </button>
+      <div className="easi-pdf-export__controls">
+        <button
+          className="usa-button usa-button--unstyled easi-no-print"
+          type="button"
+          onClick={() => downloadRefAsPDF(title, filename, divEl)}
+        >
+          <img
+            src={downloadSVG}
+            alt=""
+            aria-hidden="true"
+            className="margin-right-1"
+          />
+          {label || 'Download PDF'}
+        </button>
+      </div>
     </div>
   ) : (
     <>{children}</>

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -49,8 +49,9 @@ function generatePDF(filename: string, content: string) {
       const blob = new Blob([response.data], { type: 'application/pdf' });
       downloadBlob(filename, blob);
     })
-    .catch(() => {
+    .catch(e => {
       // TODO add error handling: display a modal if things fail?
+      console.error(e); // eslint-disable-line
     });
 }
 
@@ -97,7 +98,7 @@ const downloadRefAsPDF = (
       generatePDF(filename, markupToRender);
     })
     .catch(e => {
-      console.error(e);
+      console.error(e); // eslint-disable-line
       // TODO add error handling: display a modal if things fail?
     });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9478,6 +9478,11 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.3.tgz#7afdb9b57aa7717e15d370b66e8f36a9cb835dc3"
   integrity sha512-fiUvdfCaAXoQTHdKMgTvg6IkecXDcVz6V5rlftUTclF9IKBjMizvSdQaCl/z/6TApDeby5NL+axYou3i0mu1Pg==
 
+js-base64@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.6.0.tgz#773e1de628f4f298d65a7e9842c50244751f5756"
+  integrity sha512-wVdUBYQeY2gY73RIlPrysvpYx+2vheGo8Y1SNQv/BzHToWpAZzJU7Z6uheKMAe+GLSBig5/Ps2nxg/8tRB73xg==
+
 js-cookie@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"


### PR DESCRIPTION
# EASI-532

Changes proposed in this pull request:

- Use a stylesheet's origin to determine if it should be included when generating a PDF.
