### PR TITLE
Update ecs-manager revision to 19 in DEV

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,12 +386,12 @@ jobs:
       - run:
           name: Run migrations
           command: |
-            ./scripts/deploy_service "easi-app-db-migrate" "18" "easi-db-migrate"
-            ./scripts/db_lambda_invoke "dev-ecs-manager" "18" "easi-app-db-migrate"
+            ./scripts/deploy_service "easi-app-db-migrate" "19" "easi-db-migrate"
+            ./scripts/db_lambda_invoke "dev-ecs-manager" "19" "easi-app-db-migrate"
       - run:
           name: Deploy ECS service
           command: |
-            ./scripts/deploy_service "easi-app" "18" "easi-backend"
+            ./scripts/deploy_service "easi-app" "19" "easi-backend"
             ./scripts/healthcheck
       - run:
           name: Build static assets and release to S3


### PR DESCRIPTION
# EASI-1069

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Update ecs-manager revision to 19 in DEV
 
CircleCI will now invoke the latest lambda revision, which has the default Waiter timeout settings.