### PR TITLE
add "view submitted request" to task list item 1 for every status

### DIFF
--- a/src/views/GovernanceTaskList/TaskListCta.tsx
+++ b/src/views/GovernanceTaskList/TaskListCta.tsx
@@ -44,7 +44,15 @@ export const IntakeDraftCta = ({ intake }: { intake: SystemIntakeForm }) => {
         </UswdsLink>
       );
     default:
-      return <></>;
+      return (
+        <UswdsLink
+          data-testid="intake-view-link"
+          asCustom={Link}
+          to={`/system/${intake.id}/view`}
+        >
+          View Submitted Request Form
+        </UswdsLink>
+      );
   }
 };
 

--- a/src/views/GovernanceTaskList/index.test.tsx
+++ b/src/views/GovernanceTaskList/index.test.tsx
@@ -404,6 +404,10 @@ describe('The Goveranance Task List', () => {
 
       component!.update();
       expect(
+        component!.find('[data-testid="intake-view-link"]').exists()
+      ).toEqual(true);
+
+      expect(
         component!.find('[data-testid="start-biz-case-btn"]').exists()
       ).toEqual(true);
 
@@ -452,6 +456,10 @@ describe('The Goveranance Task List', () => {
       });
 
       component!.update();
+      expect(
+        component!.find('[data-testid="intake-view-link"]').exists()
+      ).toEqual(true);
+
       expect(
         component!.find('[data-testid="continue-biz-case-btn"]').exists()
       ).toEqual(true);
@@ -502,6 +510,10 @@ describe('The Goveranance Task List', () => {
 
       component!.update();
       expect(
+        component!.find('[data-testid="intake-view-link"]').exists()
+      ).toEqual(true);
+
+      expect(
         component!.find('[data-testid="view-biz-case-link"]').exists()
       ).toEqual(true);
 
@@ -551,6 +563,10 @@ describe('The Goveranance Task List', () => {
 
       component!.update();
       expect(
+        component!.find('[data-testid="intake-view-link"]').exists()
+      ).toEqual(true);
+
+      expect(
         component!.find('[data-testid="update-biz-case-draft-btn"]').exists()
       ).toEqual(true);
 
@@ -599,6 +615,9 @@ describe('The Goveranance Task List', () => {
       });
 
       component!.update();
+      expect(
+        component!.find('[data-testid="intake-view-link"]').exists()
+      ).toEqual(true);
 
       expect(
         component!.find('[data-testid="prepare-for-grt-cta"]').exists()
@@ -674,6 +693,9 @@ describe('The Goveranance Task List', () => {
       });
 
       component!.update();
+      expect(
+        component!.find('[data-testid="intake-view-link"]').exists()
+      ).toEqual(true);
 
       expect(
         component!
@@ -735,6 +757,10 @@ describe('The Goveranance Task List', () => {
 
       component!.update();
       expect(
+        component!.find('[data-testid="intake-view-link"]').exists()
+      ).toEqual(true);
+
+      expect(
         component!
           .find('[data-testid="task-list-business-case-final"]')
           .find(UswdsLink)
@@ -793,6 +819,9 @@ describe('The Goveranance Task List', () => {
       });
 
       component!.update();
+      expect(
+        component!.find('[data-testid="intake-view-link"]').exists()
+      ).toEqual(true);
 
       expect(
         component!.find('[data-testid="prepare-for-grb-btn"]').exists()
@@ -857,6 +886,9 @@ describe('The Goveranance Task List', () => {
       });
 
       component!.update();
+      expect(
+        component!.find('[data-testid="intake-view-link"]').exists()
+      ).toEqual(true);
 
       expect(component!.find('[data-testid="decision-cta"]').exists()).toEqual(
         true


### PR DESCRIPTION
This PR ensures that a user can still view their submitted intake on task list item 1, no matter where they are in the governance process.

- added tests too to make sure that link is visible.
