### PR TITLE
EASI-1069 Update ecs-manager revision to 7 in IMPL, PROD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - run:
           name: Restart ECS app service
           command: |
-            ./scripts/deploy_service "easi-app" "6" ""
+            ./scripts/deploy_service "easi-app" "7" ""
 
   build_db_migrate_image:
     docker:
@@ -502,12 +502,12 @@ jobs:
       - run:
           name: Run migrations
           command: |
-            ./scripts/deploy_service "easi-app-db-migrate" "6" "easi-db-migrate"
-            ./scripts/db_lambda_invoke "prod-ecs-manager" "6" "easi-app-db-migrate"
+            ./scripts/deploy_service "easi-app-db-migrate" "7" "easi-db-migrate"
+            ./scripts/db_lambda_invoke "prod-ecs-manager" "7" "easi-app-db-migrate"
       - run:
           name: Deploy ECS service
           command: |
-            ./scripts/deploy_service "easi-app" "6" "easi-backend"
+            ./scripts/deploy_service "easi-app" "7" "easi-backend"
             ./scripts/healthcheck
       - run:
           name: Build static assets and release to S3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: Restart ECS app service
           command: |
-            ./scripts/deploy_service "easi-app" "6" ""
+            ./scripts/deploy_service "easi-app" "7" ""
 
   restart_prod_ecs_app_service:
     docker:
@@ -444,12 +444,12 @@ jobs:
       - run:
           name: Run migrations
           command: |
-            ./scripts/deploy_service "easi-app-db-migrate" "6" "easi-db-migrate"
-            ./scripts/db_lambda_invoke "impl-ecs-manager" "6" "easi-app-db-migrate"
+            ./scripts/deploy_service "easi-app-db-migrate" "7" "easi-db-migrate"
+            ./scripts/db_lambda_invoke "impl-ecs-manager" "7" "easi-app-db-migrate"
       - run:
           name: Deploy ECS service
           command: |
-            ./scripts/deploy_service "easi-app" "6" "easi-backend"
+            ./scripts/deploy_service "easi-app" "7" "easi-backend"
             ./scripts/healthcheck
       - run:
           name: Build static assets and release to S3


### PR DESCRIPTION
# EASI-1069

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Follow-on to https://github.com/CMSgov/easi-app/pull/665.

Changes proposed in this pull request:

- Update ecs-manager revision to 7 in IMPL, PROD

CircleCI will now invoke the latest lambda revision, which has the default Waiter timeout settings.
