### PR TITLE
ES-249 enable per-user flag targeting on server-side

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-# EASI-000
+# ES-000
 
 <!--
     If applicable, insert the Jira story number in the markdown header above

--- a/pkg/flags/client_test.go
+++ b/pkg/flags/client_test.go
@@ -1,0 +1,58 @@
+package flags
+
+import (
+	"context"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/authn"
+)
+
+func TestPrincipal(t *testing.T) {
+	testCases := map[string]struct {
+		ctx  context.Context
+		anon bool
+	}{
+		"anonymous": {
+			context.Background(),
+			true,
+		},
+		"disempowered": {
+			appcontext.WithPrincipal(
+				context.Background(),
+				&authn.EUAPrincipal{EUAID: "WEAK"},
+			),
+			true,
+		},
+		"submitter": {
+			appcontext.WithPrincipal(
+				context.Background(),
+				&authn.EUAPrincipal{EUAID: "EASi", JobCodeEASi: true},
+			),
+			false,
+		},
+		"reviewer": {
+			appcontext.WithPrincipal(
+				context.Background(),
+				&authn.EUAPrincipal{EUAID: "BOSS", JobCodeGRT: true},
+			),
+			false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			base := appcontext.Principal(tc.ctx)
+
+			lduser := Principal(tc.ctx)
+
+			assert.Equal(t, tc.anon, lduser.GetAnonymous())
+			assert.NotEqual(t, base.ID(), lduser.GetKey())
+			assert.Equal(t, len(lduser.GetKey()), sha256.Size*2)
+			// t.Logf("key: %s\n", lduser.GetKey())
+		})
+	}
+}

--- a/pkg/integration/cedar_test.go
+++ b/pkg/integration/cedar_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
 
 	"github.com/cmsgov/easi-app/pkg/cedar/cedareasi"
@@ -27,7 +26,6 @@ func (s *IntegrationTestSuite) TestCEDARConnection() {
 		s.config.GetString("CEDAR_API_URL"),
 		s.config.GetString("CEDAR_API_KEY"),
 		ldClient,
-		lduser.NewAnonymousUser("fake"),
 	)
 
 	ctx, cxl := context.WithTimeout(context.Background(), time.Second*2)

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -81,7 +81,6 @@ func (s *Server) routes(
 			s.Config.GetString(appconfig.CEDARAPIURL),
 			s.Config.GetString(appconfig.CEDARAPIKey),
 			ldClient,
-			flagUser,
 		)
 		if s.environment.Deployed() {
 			s.CheckCEDAREasiClientConnection(cedarEasiClient)


### PR DESCRIPTION
# ES-249

Changes proposed in this pull request:

- in talks with Jimil, it's okay to do per-user targeting of functionality via LaunchDarkly, as long as we're not using raw EUA IDs as identifiers within LD
- build the LD User object with a key derived from the EUAID by a one-way cryptographic hash
- pass this user object in when doing flag evaluations that that features can be turned on/off per individual user
- this functionality is probably only going to be used in pre-PROD testing environments for the near future
