### PR TITLE
ES-246 template points to scylla project

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-# EASI-000
+# ES-000
 
 <!--
     If applicable, insert the Jira story number in the markdown header above


### PR DESCRIPTION
# ES-246

Changes proposed in this pull request:

- by default, point the PRs to the Scylla project ("ES" as ticket prefix)
