### PR TITLE
ES-249 LaunchDarkly targeting and simplified init

### DIFF
--- a/pkg/flags/client.go
+++ b/pkg/flags/client.go
@@ -10,7 +10,6 @@ import (
 
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
-	"gopkg.in/launchdarkly/go-server-sdk.v5/interfaces/flagstate"
 
 	"github.com/cmsgov/easi-app/pkg/appconfig"
 )
@@ -22,54 +21,14 @@ type Config struct {
 	Timeout time.Duration
 }
 
-// FlagValues is the struct for our keys and values from LD
-type FlagValues map[string]interface{}
-
-// FlagClient provides a way to retrieve the set of flags
-type FlagClient interface {
-	Flags(user lduser.User) FlagValues
-}
-
-// LaunchDarklyClient is backed by the LaunchDarkly service and requires
-// network access.
-type LaunchDarklyClient struct {
-	client *ld.LDClient
-}
-
-// Flags returns the flags from Launch Darkly
-func (c LaunchDarklyClient) Flags(user lduser.User) FlagValues {
-	currentFlags := FlagValues{}
-	state := c.client.AllFlagsState(user, flagstate.OptionClientSideOnly())
-	valuesMap := state.ToValuesMap()
-	for k, v := range valuesMap {
-		currentFlags[k] = v
-	}
-	return currentFlags
-}
-
-// LocalFlagClient returns a set of flags specified locally
-type LocalFlagClient struct {
-	flags FlagValues
-}
-
-// Flags returns all flags
-func (c LocalFlagClient) Flags(user lduser.User) FlagValues {
-	return c.flags
-}
-
 // NewLaunchDarklyClient returns a client backed by Launch Darkly
 func NewLaunchDarklyClient(config Config) (*ld.LDClient, error) {
-	return ld.MakeClient(config.Key, config.Timeout)
-}
+	if config.Source == appconfig.FlagSourceLaunchDarkly {
+		return ld.MakeClient(config.Key, config.Timeout)
+	}
 
-// WrapLaunchDarklyClient returns a client that fulfils the flags.FlagClient interface
-func WrapLaunchDarklyClient(c *ld.LDClient) *LaunchDarklyClient {
-	return &LaunchDarklyClient{client: c}
-}
-
-// NewLocalClient returns a client backed by local values
-func NewLocalClient(flags FlagValues) *LocalFlagClient {
-	return &LocalFlagClient{flags: flags}
+	// we default to an OFFLINE client for non-deployed environments
+	return ld.MakeCustomClient("fake_offline_key", ld.Config{Offline: true}, 5*time.Second)
 }
 
 // Principal builds the LaunchDarkly user object for the

--- a/pkg/flags/client_test.go
+++ b/pkg/flags/client_test.go
@@ -1,0 +1,58 @@
+package flags
+
+import (
+	"context"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/authn"
+)
+
+func TestPrincipal(t *testing.T) {
+	testCases := map[string]struct {
+		ctx  context.Context
+		anon bool
+	}{
+		"anonymous": {
+			context.Background(),
+			true,
+		},
+		"disempowered": {
+			appcontext.WithPrincipal(
+				context.Background(),
+				&authn.EUAPrincipal{EUAID: "WEAK"},
+			),
+			true,
+		},
+		"submitter": {
+			appcontext.WithPrincipal(
+				context.Background(),
+				&authn.EUAPrincipal{EUAID: "EASi", JobCodeEASi: true},
+			),
+			false,
+		},
+		"reviewer": {
+			appcontext.WithPrincipal(
+				context.Background(),
+				&authn.EUAPrincipal{EUAID: "BOSS", JobCodeGRT: true},
+			),
+			false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			base := appcontext.Principal(tc.ctx)
+
+			lduser := Principal(tc.ctx)
+
+			assert.Equal(t, tc.anon, lduser.GetAnonymous())
+			assert.NotEqual(t, base.ID(), lduser.GetKey())
+			assert.Equal(t, len(lduser.GetKey()), sha256.Size*2)
+			// t.Logf("key: %s\n", lduser.GetKey())
+		})
+	}
+}

--- a/pkg/integration/cedar_test.go
+++ b/pkg/integration/cedar_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
 
 	"github.com/cmsgov/easi-app/pkg/cedar/cedareasi"
@@ -27,7 +26,6 @@ func (s *IntegrationTestSuite) TestCEDARConnection() {
 		s.config.GetString("CEDAR_API_URL"),
 		s.config.GetString("CEDAR_API_KEY"),
 		ldClient,
-		lduser.NewAnonymousUser("fake"),
 	)
 
 	ctx, cxl := context.WithTimeout(context.Background(), time.Second*2)

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -81,7 +81,6 @@ func (s *Server) routes(
 			s.Config.GetString(appconfig.CEDARAPIURL),
 			s.Config.GetString(appconfig.CEDARAPIKey),
 			ldClient,
-			flagUser,
 		)
 		if s.environment.Deployed() {
 			s.CheckCEDAREasiClientConnection(cedarEasiClient)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -3,22 +3,21 @@ package services
 import (
 	"github.com/facebookgo/clock"
 	"go.uber.org/zap"
-
-	"github.com/cmsgov/easi-app/pkg/flags"
+	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
 )
 
 // NewConfig returns a Config for services
-func NewConfig(logger *zap.Logger, flagClient flags.FlagClient) Config {
+func NewConfig(logger *zap.Logger, ldc *ld.LDClient) Config {
 	return Config{
-		clock:      clock.New(),
-		logger:     logger,
-		flagClient: flagClient,
+		clock:    clock.New(),
+		logger:   logger,
+		ldClient: ldc,
 	}
 }
 
 // Config holds common configured object for services
 type Config struct {
-	clock      clock.Clock
-	logger     *zap.Logger
-	flagClient flags.FlagClient
+	clock    clock.Clock
+	logger   *zap.Logger
+	ldClient *ld.LDClient
 }


### PR DESCRIPTION
# ES-249

Changes proposed in this pull request:

- in talks with Jimil, it's okay to do per-user targeting of functionality via LaunchDarkly, as long as we're not using raw EUA IDs as identifiers within LD, so we build the LD User object with a key derived from the EUAID by a one-way cryptographic hash
- pass this user object in when doing flag evaluations that that features can be turned on/off per individual user
- simplify the init of the LaunchDarkly client at start-up time
- make the LD Client usable by functions created in the `services` package (by way of the `Config` type)
