### PR TITLE
remove no spreading props eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,7 @@
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md#how-to-use
     "no-use-before-define": "off",
     "@typescript-eslint/no-use-before-define": ["error"],
-   
+
     // We mostly use functional components anyhow
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-default-props.md
     "react/require-default-props": "off",
@@ -67,7 +67,8 @@
           ["^.+\\.s?css$"]
         ]
       }
-    ]
+    ],
+    "react/jsx-props-no-spreading": "off"
   },
   "settings": {
     "import/resolver": {

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -234,7 +234,6 @@ const RequestRepository = () => {
     return intakes.map(intake => convertIntakeToCSV(intake));
   };
 
-  /* eslint-disable react/jsx-props-no-spreading */
   return (
     <>
       <div className="display-flex flex-justify flex-wrap margin-y-2">

--- a/src/components/shared/ActionBanner/index.tsx
+++ b/src/components/shared/ActionBanner/index.tsx
@@ -25,7 +25,6 @@ const ActionBanner = ({
   ...remainingProps
 }: ActionBannerProps) => {
   return (
-    // eslint-disable-next-line react/jsx-props-no-spreading
     <div className="action-banner usa-alert" {...remainingProps}>
       <span className="text-base-dark font-body-3xs">
         {translateRequestType(requestType)}

--- a/src/components/shared/DateInput/index.tsx
+++ b/src/components/shared/DateInput/index.tsx
@@ -37,7 +37,6 @@ const DateInputMonth = ({
       inputMode="numeric"
       value={value}
       onChange={onChange}
-      // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     />
   );
@@ -70,7 +69,6 @@ const DateInputDay = ({
       inputMode="numeric"
       value={value}
       onChange={onChange}
-      // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     />
   );
@@ -104,7 +102,6 @@ const DateInputYear = ({
       inputMode="numeric"
       value={value}
       onChange={onChange}
-      // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     />
   );

--- a/src/components/shared/DropdownField/index.tsx
+++ b/src/components/shared/DropdownField/index.tsx
@@ -40,7 +40,6 @@ export const DropdownField = ({
       onBlur={onBlur}
       id={id}
       value={value}
-      // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     >
       {children}

--- a/src/components/shared/RadioField/index.tsx
+++ b/src/components/shared/RadioField/index.tsx
@@ -50,7 +50,6 @@ export const RadioField = ({
         onChange={onChange}
         type="radio"
         value={value}
-        // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
       />
       <label className={radioLabelClasses} htmlFor={id}>
@@ -70,7 +69,6 @@ export const RadioGroup = ({ children, inline, ...props }: RadioGroupProps) => {
     'easi-radio__group--inline': inline
   });
   return (
-    // eslint-disable-next-line react/jsx-props-no-spreading
     <div className={classes} role="radiogroup" {...props}>
       {children}
     </div>

--- a/src/components/shared/SearchBar/index.tsx
+++ b/src/components/shared/SearchBar/index.tsx
@@ -50,7 +50,6 @@ const SearchBar = ({
 
   const renderSuggestionsContainer = ({ containerProps, children }: any) => {
     return (
-      // eslint-disable-next-line react/jsx-props-no-spreading
       <div {...containerProps}>
         {children}
         {searchValue.trim().length >= 2 &&

--- a/src/components/shared/TextAreaField/index.test.tsx
+++ b/src/components/shared/TextAreaField/index.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 

--- a/src/components/shared/TextAreaField/index.tsx
+++ b/src/components/shared/TextAreaField/index.tsx
@@ -47,7 +47,6 @@ const TextAreaField = ({
         onBlur={onBlur}
         value={value}
         maxLength={maxLength}
-        // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
       />
     </>

--- a/src/components/shared/TextField/index.test.tsx
+++ b/src/components/shared/TextField/index.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 

--- a/src/components/shared/TextField/index.tsx
+++ b/src/components/shared/TextField/index.tsx
@@ -54,7 +54,6 @@ const TextField = ({
       type="text"
       value={value}
       maxLength={maxLength}
-      // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     />
   );

--- a/src/views/DocumentPrototype/index.tsx
+++ b/src/views/DocumentPrototype/index.tsx
@@ -141,7 +141,6 @@ const DocumentPrototype = () => {
     });
   };
 
-  /* eslint-disable react/jsx-props-no-spreading */
   return (
     <PageWrapper className="system-intake">
       <Header />


### PR DESCRIPTION
We are consistently disabling the eslint rule that prevents prop spreading. It is most commonly used when we want to apply `aria-*` attributes. It doesn't make sense to explicitly write out each ARIA or HTML attribute.

We have `eslint-disable-next-line react/jsx-props-no-spreading` littered throughout the codebase and I think it's time to put that rule to rest because we are consistently disabling it.