### PR TITLE
Add USWDS design tokens to app

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -6,6 +6,7 @@ module.exports = {
       plugin: sassResourcesLoader,
       options: {
         resources: [
+          './src/stylesheets/_uswdsUtilities.scss',
           './src/stylesheets/_colors.scss',
           './src/stylesheets/_variables.scss'
         ]

--- a/src/stylesheets/_uswdsUtilities.scss
+++ b/src/stylesheets/_uswdsUtilities.scss
@@ -1,0 +1,10 @@
+@import '~uswds/src/stylesheets/theme/uswds-theme-general';
+@import '~uswds/src/stylesheets/theme/uswds-theme-typography';
+@import '~uswds/src/stylesheets/theme/uswds-theme-spacing';
+@import '~uswds/src/stylesheets/theme/uswds-theme-color';
+@import '~uswds/src/stylesheets/theme/uswds-theme-utilities';
+
+// Disable showing updates and notifications logs
+$theme-show-notifications: false;
+
+@import '~uswds/src/stylesheets/packages/required';


### PR DESCRIPTION
I went down a rabbit hole while configuring storybook and I'm fixing two small things in this PR.

1. Add USWDS design tokens
    - Traditionally we've used the USWDS class names.
    - I imported some of the variables from USWDS so we can use them in our CSS. For example: `color: color('primary-vivid')` or mixin with `@include u-text('primary-vivid')`. There's a lot more we can do, so reference the [documentation](https://designsystem.digital.gov/) if there are any questions.
    - Not sure if I got all the files, but this is a good start. I haven't heard any complaints in the past, so I think we should be good.

2. Disable USWDS changelogs.
    - super annoying; finally turning them off