### PR TITLE
Adjust padding of PDF link to align on all screens.

### DIFF
--- a/src/components/BusinessCaseReview/index.scss
+++ b/src/components/BusinessCaseReview/index.scss
@@ -3,6 +3,5 @@
   margin-right: auto;
   max-width: 75rem;
   margin-top: 3rem;
-  padding-left: 2rem;
   padding-right: 2rem;
 }

--- a/src/views/BusinessCase/Review/index.scss
+++ b/src/views/BusinessCase/Review/index.scss
@@ -6,3 +6,7 @@
     margin-bottom: 3rem;
   }
 }
+
+.business-case-review .easi-pdf-export__controls {
+  padding-left: 2rem;
+}

--- a/src/views/BusinessCase/Review/index.tsx
+++ b/src/views/BusinessCase/Review/index.tsx
@@ -25,7 +25,7 @@ const Review = ({ businessCase }: ReviewProps) => {
       : 'SUBMIT_BIZ_CASE';
 
   return (
-    <div>
+    <div className="business-case-review">
       <div className="grid-container">
         <h1 className="font-heading-xl margin-top-4">
           Check your answers before sending

--- a/src/views/BusinessCase/ViewOnly/index.tsx
+++ b/src/views/BusinessCase/ViewOnly/index.tsx
@@ -12,7 +12,9 @@ const BusinessCaseView = ({ businessCase }: BusinessCaseViewOnlyProps) => (
     <div className="grid-container">
       <h1>Review your Business Case</h1>
     </div>
-    <BusinessCaseReview values={businessCase} />
+    <div className="business-case-review">
+      <BusinessCaseReview values={businessCase} />
+    </div>
   </>
 );
 

--- a/src/views/GovernanceReviewTeam/IntakeReview/index.tsx
+++ b/src/views/GovernanceReviewTeam/IntakeReview/index.tsx
@@ -21,7 +21,11 @@ const IntakeReview = ({ systemIntake, now }: IntakeReviewProps) => {
   return (
     <div>
       <h1 className="margin-top-0">{t('general:intake')}</h1>
-      <PDFExport title="System Intake" filename={filename}>
+      <PDFExport
+        title="System Intake"
+        filename={filename}
+        label="Download System Intake as PDF"
+      >
         <SystemIntakeReview systemIntake={systemIntake} now={now} />
       </PDFExport>
       <UswdsLink

--- a/src/views/SystemIntake/ViewOnly/index.tsx
+++ b/src/views/SystemIntake/ViewOnly/index.tsx
@@ -14,7 +14,11 @@ const SystemIntakeView = ({ systemIntake }: SystemIntakeViewOnlyProps) => {
   return (
     <>
       <h1>Review your Intake Request</h1>
-      <PDFExport title="System Intake" filename={filename}>
+      <PDFExport
+        title="System Intake"
+        filename={filename}
+        label="Download System Intake as PDF"
+      >
         <SystemIntakeReview
           systemIntake={systemIntake}
           now={DateTime.local()}


### PR DESCRIPTION
# ES-247

Changes proposed in this pull request:

- Adjust the padding of the PDF download link so that it lines up with the left margin of various screens. I added a wrapper div so that we could target the button in a few cases where that page's layout required some adjustments to the general styles.
- Updated the system intake PDF download links to "Download System Intake as PDF" from the generic "Download PDF"

Here are some screenshots of various pages after this PR is applied:

![Screen Shot 2021-01-12 at 4 51 11 PM](https://user-images.githubusercontent.com/3331/104384561-48cd4700-54f7-11eb-9659-0f2091cced48.png)
![Screen Shot 2021-01-12 at 4 50 20 PM](https://user-images.githubusercontent.com/3331/104384565-4965dd80-54f7-11eb-9f34-90220a7455ee.png)
![Screen Shot 2021-01-12 at 4 48 46 PM](https://user-images.githubusercontent.com/3331/104384567-4965dd80-54f7-11eb-9941-3020f099acc1.png)
![Screen Shot 2021-01-12 at 5 02 37 PM](https://user-images.githubusercontent.com/3331/104385145-4fa88980-54f8-11eb-9920-20f7600ba897.png)
![Screen Shot 2021-01-12 at 5 02 28 PM](https://user-images.githubusercontent.com/3331/104385147-4fa88980-54f8-11eb-9994-e8fdd2f83751.png)
