### PR TITLE
ES-255 initial system sketch

### DIFF
--- a/pkg/models/system.go
+++ b/pkg/models/system.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// System represents something that may be tested for 508 compliance
+// TODO: if we are using the `SystemFromIntake` strategy, the "db" field tags would be unecessary;
+// but if we are trying to read the System type straight from sqlx we WOULD need the "db" field tags
+type System struct {
+	IntakeID    uuid.UUID  `json:"intakeId" db:"id"` // TODO: is this actually necessary, if LCID is really the identifier?
+	LCID        string     `json:"lcid" db:"lcid"`
+	CreatedAt   *time.Time `json:"createdAt" db:"created_at"`
+	UpdatedAt   *time.Time `json:"updatedAt" db:"updated_at"`
+	IssuedAt    *time.Time `json:"issuedAt" db:"decided_at"`
+	ExpiresAt   *time.Time `json:"expiresAt" db:"lcid_expires_at"`
+	ProjectName string     `json:"projectName" db:"project_name"`
+	OwnerID     string     `json:"ownerId" db:"eua_user_id"`
+	OwnerName   string     `json:"ownerName" db:"requester"` // TODO: wouldn't really be necessary at DB layer if we had performant access to LDAP
+}
+
+// SystemFromIntake builds a System type from its constituent SystemIntake
+func SystemFromIntake(intake *SystemIntake) *System {
+	return &System{
+		IntakeID:    intake.ID,
+		LCID:        intake.LifecycleID.ValueOrZero(),
+		CreatedAt:   intake.CreatedAt,
+		UpdatedAt:   intake.UpdatedAt,
+		IssuedAt:    intake.DecidedAt,
+		ExpiresAt:   intake.LifecycleExpiresAt,
+		ProjectName: intake.ProjectName.ValueOrZero(),
+		OwnerID:     intake.EUAUserID.ValueOrZero(),
+		OwnerName:   intake.Requester,
+	}
+}

--- a/pkg/storage/system.go
+++ b/pkg/storage/system.go
@@ -1,0 +1,64 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+// FetchSystemByLCID uses the Lifecycle ID as the unique identifier for a given System
+func (s *Store) FetchSystemByLCID(ctx context.Context, lcid string) (*models.System, error) {
+	// TODO: this code would emulate the behavior outlined in `ListSystems(...)`
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+// ListSystems retrieves a collection of Systems, which are a subset of all SystemIntakes that
+// have been "decided" and issued an LCID.
+func (s *Store) ListSystems(ctx context.Context) ([]*models.System, error) {
+	sqlComplete := false
+	if sqlComplete {
+		// if we can achieve all the filtering necessary via SQL, we can then just rely
+		// on "db" field tags in the System type to hydrate via the subset of columns that
+		// are needed
+		systems := []*models.System{}
+		err := s.db.Select(
+			&systems,
+			`select * from system_intake where status = LCID_ISSUED and NOT EMPTY lcid`,
+		)
+		if err != nil {
+			appcontext.ZLogger(ctx).Error(fmt.Sprintf("Failed to fetch system intakes %s", err))
+			return nil, err
+		}
+		return systems, nil
+	}
+
+	if !sqlComplete {
+		// if we CANNOT achieve all the filtering necessary via SQL, we can hydrate the objects into
+		// SystemIntake types, and then do whatever programmatic filtering might be necessary
+		// (e.g. we need to reduce multiple SystemIntake records [proposal vs decommision] into
+		// one single record for a given LCID)
+		intakes := []*models.SystemIntake{}
+		err := s.db.Select(
+			&intakes,
+			fetchSystemIntakeSQL,
+		)
+		if err != nil {
+			appcontext.ZLogger(ctx).Error(fmt.Sprintf("Failed to fetch system intakes %s", err))
+			return nil, err
+		}
+
+		systems := []*models.System{}
+		for _, intake := range intakes {
+			needToExcludeForSomeReason := false
+			if !needToExcludeForSomeReason {
+				systems = append(systems, models.SystemFromIntake(intake))
+			}
+		}
+
+		return systems, nil
+	}
+
+	return nil, fmt.Errorf("not yet implemented")
+}


### PR DESCRIPTION
# ES-255

Changes proposed in this pull request:

- Instead of running a one-time process (or worse yet, a recurring ad-hoc request to account for an evolving data set) to populate a new table that is effectively just a subset of the data that exists in the `system_intake` table, let's just use the "live" `system_intake` table for our `System` retrieval needs. This would mean that as new systems get LCIDs issued, they would "automatically" show up in the `System` list.
