### PR TITLE
ES-255 ES-274 list systems

### DIFF
--- a/pkg/handlers/systems.go
+++ b/pkg/handlers/systems.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+// SystemsHandler is the handler for READ operations on systems
+type SystemsHandler struct {
+	HandlerBase
+	fetch func(context.Context) ([]*models.System, error)
+}
+
+// NewSystemsHandler is a constructor for SystemsHandler
+func NewSystemsHandler(base HandlerBase, fetch func(context.Context) ([]*models.System, error)) SystemsHandler {
+	return SystemsHandler{
+		HandlerBase: base,
+		fetch:       fetch,
+	}
+}
+
+// Handle handles a request for Systems
+func (h SystemsHandler) Handle() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			systems, err := h.fetch(r.Context())
+			if err != nil {
+				h.WriteErrorResponse(r.Context(), w, err)
+				return
+			}
+
+			js, err := json.Marshal(systems)
+			if err != nil {
+				h.WriteErrorResponse(r.Context(), w, err)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+
+			_, err = w.Write(js)
+			if err != nil {
+				h.WriteErrorResponse(r.Context(), w, err)
+				return
+			}
+		default:
+			h.WriteErrorResponse(r.Context(), w, &apperrors.MethodNotAllowedError{Method: r.Method})
+			return
+		}
+	}
+}

--- a/pkg/models/system.go
+++ b/pkg/models/system.go
@@ -1,0 +1,20 @@
+package models
+
+import (
+	"time"
+)
+
+// System represents something that may be tested for 508 compliance
+// TODO: if we are using the `SystemFromIntake` strategy, the "db" field tags would be unecessary;
+// but if we are trying to read the System type straight from sqlx we WOULD need the "db" field tags
+type System struct {
+	// IntakeID    uuid.UUID  `json:"intakeId" db:"id"` // TODO: is this actually necessary, if LCID is really the identifier?
+	LCID        string     `json:"lcid" db:"lcid"`
+	CreatedAt   *time.Time `json:"createdAt" db:"created_at"`
+	UpdatedAt   *time.Time `json:"updatedAt" db:"updated_at"`
+	IssuedAt    *time.Time `json:"issuedAt" db:"decided_at"`
+	ExpiresAt   *time.Time `json:"expiresAt" db:"lcid_expires_at"`
+	ProjectName string     `json:"projectName" db:"project_name"`
+	OwnerID     string     `json:"ownerId" db:"eua_user_id"`
+	OwnerName   string     `json:"ownerName" db:"requester"` // TODO: wouldn't really be necessary at DB layer if we had performant access to LDAP
+}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -539,4 +539,13 @@ func (s *Server) routes(
 
 	api.Handle("/pdf/generate", handlers.NewPDFHandler(services.NewInvokeGeneratePDF(serviceConfig, lambdaClient, princeLambdaName)).Handle())
 
+	systemsHandler := handlers.NewSystemsHandler(
+		base,
+		services.NewFetchSystems(
+			serviceConfig,
+			store.ListSystems,
+			services.NewAuthorizeHasEASiRole(),
+		),
+	)
+	api.Handle("/systems", systemsHandler.Handle())
 }

--- a/pkg/services/systems.go
+++ b/pkg/services/systems.go
@@ -1,0 +1,27 @@
+package services
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+// NewFetchSystems returns a function that will fetch all the existing systems
+func NewFetchSystems(
+	config Config,
+	fetchAll func(context.Context) ([]*models.System, error),
+	authorize func(context.Context) (bool, error),
+) func(context.Context) ([]*models.System, error) {
+	return func(ctx context.Context) ([]*models.System, error) {
+		ok, err := authorize(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, &apperrors.UnauthorizedError{Err: errors.New("failed to authorize fetch systems")}
+		}
+		return fetchAll(ctx)
+	}
+}

--- a/pkg/storage/system.go
+++ b/pkg/storage/system.go
@@ -1,0 +1,74 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+var fakeSystems []*models.System
+
+func init() {
+	t1 := time.Date(2020, time.January, 1, 8, 0, 0, 0, time.UTC)
+	t2 := t1.AddDate(2, 0, -1)
+	fakeSystems = []*models.System{
+		{
+			LCID:        "X990000",
+			CreatedAt:   &t1,
+			UpdatedAt:   &t1,
+			IssuedAt:    &t1,
+			ExpiresAt:   &t2,
+			ProjectName: "Three Amigos",
+			OwnerID:     "FAKE0",
+			OwnerName:   "Lucky Dusty Ned",
+		},
+		{
+			LCID:        "X990001",
+			CreatedAt:   &t1,
+			UpdatedAt:   &t1,
+			IssuedAt:    &t1,
+			ExpiresAt:   &t2,
+			ProjectName: "Three Musketeers",
+			OwnerID:     "FAKE1",
+			OwnerName:   "Athos Porthos Aramis",
+		},
+		{
+			LCID:        "X990002",
+			CreatedAt:   &t1,
+			UpdatedAt:   &t1,
+			IssuedAt:    &t1,
+			ExpiresAt:   &t2,
+			ProjectName: "Three Stooges",
+			OwnerID:     "FAKE2",
+			OwnerName:   "Moe Larry Curly",
+		},
+	}
+}
+
+// // FetchSystemByLCID uses the Lifecycle ID as the unique identifier for a given System
+// func (s *Store) FetchSystemByLCID(ctx context.Context, lcid string) (*models.System, error) {
+// 	useFake := true
+// 	if useFake {
+// 		for _, sys := range fakeSystems {
+// 			if lcid == sys.LCID {
+// 				return sys, nil
+// 			}
+// 		}
+// 		return nil, fmt.Errorf("system not found: %s", lcid)
+// 	}
+// 	// TODO: this code would emulate the behavior outlined in `ListSystems(...)`
+// 	return nil, fmt.Errorf("not yet implemented")
+// }
+
+// ListSystems retrieves a collection of Systems, which are a subset of all SystemIntakes that
+// have been "decided" and issued an LCID.
+func (s *Store) ListSystems(ctx context.Context) ([]*models.System, error) {
+	useFake := true
+	if useFake {
+		return fakeSystems, nil
+	}
+
+	return nil, fmt.Errorf("not yet implemented")
+}


### PR DESCRIPTION
# ES-255 ES-274

Changes proposed in this pull request:

- lightweight storage layer API for fetching systems, with a fake in-memory implementation
- quick `services` and `handlers` layers for an endpoint exposing the systems list
- this is intended to be a quickie implementation to just set up some structure, future iteration goals:
  - actually wire up to the database
  - maybe we want to expose the systems via GraphQL, rather than via RESTful endpoint?

Proved this out via the following:
```console
$ curl -H 'Authorization: Bearer {"euaId":"NELZ"}' 127.0.0.1:8080/api/v1/systems | jq .
[
  {
    "lcid": "X990000",
    "createdAt": "2020-01-01T08:00:00Z",
    "updatedAt": "2020-01-01T08:00:00Z",
    "issuedAt": "2020-01-01T08:00:00Z",
    "expiresAt": "2021-12-31T08:00:00Z",
    "projectName": "Three Amigos",
    "ownerId": "FAKE0",
    "ownerName": "Lucky Dusty Ned"
  },
  {
    "lcid": "X990001",
    "createdAt": "2020-01-01T08:00:00Z",
    "updatedAt": "2020-01-01T08:00:00Z",
    "issuedAt": "2020-01-01T08:00:00Z",
    "expiresAt": "2021-12-31T08:00:00Z",
    "projectName": "Three Musketeers",
    "ownerId": "FAKE1",
    "ownerName": "Athos Porthos Aramis"
  },
  {
    "lcid": "X990002",
    "createdAt": "2020-01-01T08:00:00Z",
    "updatedAt": "2020-01-01T08:00:00Z",
    "issuedAt": "2020-01-01T08:00:00Z",
    "expiresAt": "2021-12-31T08:00:00Z",
    "projectName": "Three Stooges",
    "ownerId": "FAKE2",
    "ownerName": "Moe Larry Curly"
  }
]
```
