### PR TITLE
alternative b: convert null values to empty strings to fix frontend

### DIFF
--- a/src/data/businessCase.ts
+++ b/src/data/businessCase.ts
@@ -237,14 +237,14 @@ export const prepareBusinessCaseForApp = (
       estimatedLifecycleCost: lifecycleCostLines.B,
       security: {
         isApproved: businessCase.alternativeBSecurityIsApproved,
-        isBeingReviewed: businessCase.alternativeBSecurityIsBeingReviewed
+        isBeingReviewed: businessCase.alternativeBSecurityIsBeingReviewed || ''
       },
       hosting: {
-        type: businessCase.alternativeBHostingType,
-        location: businessCase.alternativeBHostingLocation,
-        cloudServiceType: businessCase.alternativeBHostingCloudServiceType
+        type: businessCase.alternativeBHostingType || '',
+        location: businessCase.alternativeBHostingLocation || '',
+        cloudServiceType: businessCase.alternativeBHostingCloudServiceType || ''
       },
-      hasUserInterface: businessCase.alternativeBHasUI
+      hasUserInterface: businessCase.alternativeBHasUI || ''
     },
     initialSubmittedAt: businessCase.initialSubmittedAt,
     lastSubmittedAt: businessCase.lastSubmittedAt


### PR DESCRIPTION
This PR ensures values on alternative b aren't `null`. Alternative B is not required (until it is), so the backend returns the values a little differently.