### PR TITLE
ES-255 feature flag fake vs real data for systems

### DIFF
--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -10,8 +10,10 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
 
 	"github.com/cmsgov/easi-app/pkg/appconfig"
 	"github.com/cmsgov/easi-app/pkg/handlers"
@@ -54,6 +56,9 @@ func TestIntegrationTestSuite(t *testing.T) {
 
 	logger := zap.NewNop()
 
+	ldClient, err := ld.MakeCustomClient("fake", ld.Config{Offline: true}, 0)
+	assert.NoError(t, err)
+
 	dbConfig := storage.DBConfig{
 		Host:     config.GetString(appconfig.DBHostConfigKey),
 		Port:     config.GetString(appconfig.DBPortConfigKey),
@@ -62,7 +67,7 @@ func TestIntegrationTestSuite(t *testing.T) {
 		Password: config.GetString(appconfig.DBPasswordConfigKey),
 		SSLMode:  config.GetString(appconfig.DBSSLModeConfigKey),
 	}
-	store, err := storage.NewStore(logger, dbConfig)
+	store, err := storage.NewStore(logger, dbConfig, ldClient)
 	if err != nil {
 		fmt.Printf("Failed to get new database: %v", err)
 		t.Fail()

--- a/pkg/models/system.go
+++ b/pkg/models/system.go
@@ -5,8 +5,6 @@ import (
 )
 
 // System represents something that may be tested for 508 compliance
-// TODO: if we are using the `SystemFromIntake` strategy, the "db" field tags would be unecessary;
-// but if we are trying to read the System type straight from sqlx we WOULD need the "db" field tags
 type System struct {
 	// IntakeID    uuid.UUID  `json:"intakeId" db:"id"` // TODO: is this actually necessary, if LCID is really the identifier?
 	LCID        string     `json:"lcid" db:"lcid"`

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -134,6 +134,7 @@ func (s *Server) routes(
 	store, err := storage.NewStore(
 		s.logger,
 		s.NewDBConfig(),
+		ldClient,
 	)
 	if err != nil {
 		s.logger.Fatal("Failed to connect to database", zap.Error(err))

--- a/pkg/services/services_test.go
+++ b/pkg/services/services_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
 
 	"github.com/cmsgov/easi-app/pkg/appconfig"
 	"github.com/cmsgov/easi-app/pkg/storage"
@@ -23,6 +25,9 @@ func TestServicesTestSuite(t *testing.T) {
 	config := testhelpers.NewConfig()
 	logger := zap.NewNop()
 
+	ldClient, err := ld.MakeCustomClient("fake", ld.Config{Offline: true}, 0)
+	assert.NoError(t, err)
+
 	dbConfig := storage.DBConfig{
 		Host:     config.GetString(appconfig.DBHostConfigKey),
 		Port:     config.GetString(appconfig.DBPortConfigKey),
@@ -31,7 +36,7 @@ func TestServicesTestSuite(t *testing.T) {
 		Password: config.GetString(appconfig.DBPasswordConfigKey),
 		SSLMode:  config.GetString(appconfig.DBSSLModeConfigKey),
 	}
-	store, err := storage.NewStore(logger, dbConfig)
+	store, err := storage.NewStore(logger, dbConfig, ldClient)
 	if err != nil {
 		t.Fail()
 		fmt.Printf("Failed to connect to database: %v", err)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/facebookgo/clock"
 	"github.com/jmoiron/sqlx"
 	"go.uber.org/zap"
+	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
 )
 
 // Store performs database operations for EASi
@@ -15,6 +16,7 @@ type Store struct {
 	logger    *zap.Logger
 	clock     clock.Clock
 	easternTZ *time.Location
+	ldClient  *ld.LDClient
 }
 
 // DBConfig holds the configurations for a database connection
@@ -31,6 +33,7 @@ type DBConfig struct {
 func NewStore(
 	logger *zap.Logger,
 	config DBConfig,
+	ldClient *ld.LDClient,
 ) (*Store, error) {
 	// LifecycleIDs are generated based on Eastern Time
 	tz, err := time.LoadLocation("America/New_York")
@@ -51,5 +54,11 @@ func NewStore(
 	if err != nil {
 		return nil, err
 	}
-	return &Store{db: db, logger: logger, clock: clock.New(), easternTZ: tz}, nil
+	return &Store{
+		db:        db,
+		logger:    logger,
+		clock:     clock.New(),
+		easternTZ: tz,
+		ldClient:  ldClient,
+	}, nil
 }

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/facebookgo/clock"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq" // required for postgres driver in sqlx
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
 
 	"github.com/cmsgov/easi-app/pkg/appconfig"
 	"github.com/cmsgov/easi-app/pkg/testhelpers"
@@ -33,7 +35,11 @@ func TestStoreTestSuite(t *testing.T) {
 		Password: config.GetString(appconfig.DBPasswordConfigKey),
 		SSLMode:  config.GetString(appconfig.DBSSLModeConfigKey),
 	}
-	store, err := NewStore(logger, dbConfig)
+
+	ldClient, err := ld.MakeCustomClient("fake", ld.Config{Offline: true}, 0)
+	assert.NoError(t, err)
+
+	store, err := NewStore(logger, dbConfig, ldClient)
 	if err != nil {
 		fmt.Printf("Failed to get new database: %v", err)
 		t.Fail()

--- a/pkg/storage/system.go
+++ b/pkg/storage/system.go
@@ -2,9 +2,12 @@ package storage
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/flags"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -65,10 +68,51 @@ func init() {
 // ListSystems retrieves a collection of Systems, which are a subset of all SystemIntakes that
 // have been "decided" and issued an LCID.
 func (s *Store) ListSystems(ctx context.Context) ([]*models.System, error) {
-	useFake := true
-	if useFake {
+	if s.useFakeSystems(ctx) {
 		return fakeSystems, nil
 	}
+	return s.listSystems(ctx)
+}
 
-	return nil, fmt.Errorf("not yet implemented")
+func (s *Store) useFakeSystems(ctx context.Context) bool {
+	// generally, it's best to have feature flags named in such a way that their
+	// lifecycle goes from:
+	// _negation_ - indicating pre-existing functionality
+	// (which in this case means defaulting to fake data),
+	// to:
+	// _affirmation_ - indicating the new functionality to be rolled out
+	// (which in this case mean opting in to fetching the systems from the system_intake table)
+	real, err := s.ldClient.BoolVariation("systems-from-db", flags.Principal(ctx), false)
+	if err != nil {
+		appcontext.ZLogger(ctx).Error("problem evaluating flag", zap.Error(err))
+	}
+	return !real
+}
+
+const sqlListSystems = `
+	SELECT
+		lcid,
+		created_at,
+		updated_at,
+		decided_at,
+		lcid_expires_at,
+		project_name,
+		eua_user_id,
+		requester
+	FROM system_intake
+	WHERE
+		status='LCID_ISSUED' AND
+		request_type='NEW' AND
+		(lcid='') IS NOT TRUE;
+`
+
+func (s *Store) listSystems(ctx context.Context) ([]*models.System, error) {
+	results := []*models.System{}
+	err := s.db.Select(&results, sqlListSystems)
+	if err != nil {
+		appcontext.ZLogger(ctx).Error("Failed to fetch systems", zap.Error(err))
+		return nil, err
+	}
+
+	return results, nil
 }

--- a/pkg/storage/system_test.go
+++ b/pkg/storage/system_test.go
@@ -1,0 +1,79 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/guregu/null"
+
+	"github.com/cmsgov/easi-app/pkg/models"
+	"github.com/cmsgov/easi-app/pkg/testhelpers"
+)
+
+func (s StoreTestSuite) TestListSystems() {
+	// random-based signatures, just so multiple runs of this test don't collide
+	now := time.Now()
+	later := now.AddDate(0, 1, 0)
+	rnd := rand.New(rand.NewSource(now.Unix()))
+	base := make([]byte, 8)
+	_, err := rnd.Read(base)
+	s.NoError(err)
+	sig := fmt.Sprintf("%x", base)
+	fid := rnd.Intn(100000)
+
+	// setup construction
+	ctx := context.Background()
+	expected := map[string]bool{}
+
+	// build a number of system intakes we expect to be seen as Systems
+	for ix := 0; ix < 3; ix++ {
+		lcid := fmt.Sprintf("Z%05d%d", fid, ix) // e.g. "Z987650"
+		// t.Logf("%d: %s\n", ix, lcid)
+		expected[lcid] = true
+
+		// set the CreatedAt and UpdatedAt with a "real" date, because the
+		// testing fake clock used by `CreateSystemIntake` frequently
+		// supplies dates AFTER year 9999, which makes
+		// json.Marshal() freak out.
+		si := testhelpers.NewSystemIntake()
+		si.CreatedAt = &now
+		si.UpdatedAt = &now
+		si.ProjectName = null.StringFrom(fmt.Sprintf("%s %d", sig, ix))
+		_, err = s.store.CreateSystemIntake(ctx, &si)
+		s.NoError(err)
+
+		partial, ferr := s.store.FetchSystemIntakeByID(ctx, si.ID)
+		s.NoError(ferr)
+
+		partial.LifecycleID = null.StringFrom(lcid)
+		partial.Status = models.SystemIntakeStatusLCIDISSUED
+		partial.DecidedAt = &now
+		partial.LifecycleExpiresAt = &later
+
+		_, err = s.store.UpdateSystemIntake(ctx, partial)
+		s.NoError(err, "failed to update system intake")
+		// t.Logf("%s: %s - %s\n", lcid, si.ID.String(), partial.LifecycleScope.String)
+	}
+
+	// retrieve the list of systems
+	results, err := s.store.listSystems(ctx)
+	s.NoError(err)
+
+	// verify the list of Systems that we seeded came back to us
+	found := 0
+	for _, result := range results {
+		if !strings.HasPrefix(result.ProjectName, sig) {
+			continue
+		}
+		if _, exp := expected[result.LCID]; !exp {
+			// unexpected collision from previously existing data,
+			// possibly from previous runs of this test
+			continue
+		}
+		found++
+	}
+	s.Equal(found, len(expected), "did not retrieve the expected amound of Systems")
+}


### PR DESCRIPTION
# ES-255

Changes proposed in this pull request:

- get the LD client available at the `storage` layer
- build retrieval layer for fetching `System`s from the `system_intake` table
- flag-optionally return either fake or "real" data
