### PR TITLE
Add Tab Component

### DIFF
--- a/src/components/Tabs/TabPanel.tsx
+++ b/src/components/Tabs/TabPanel.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+type TabPanelProps = {
+  tabName: string;
+  children: React.ReactNode;
+  isActive?: boolean;
+};
+
+/**
+ * TabPanel is a compound component. TabPanel MUST BE a direct child of Tabs.
+ * The `isActive` prop isn't passed in declaratively. `isActive` is passed
+ * from the Tabs render from the React.Children cloneElement.
+ */
+const TabPanel = ({ tabName, isActive, children }: TabPanelProps) => {
+  if (isActive) {
+    return <div data-tabname={tabName}>{children}</div>;
+  }
+  return (
+    <div className="easi-only-print" data-tabname={tabName}>
+      {children}
+    </div>
+  );
+};
+
+export default TabPanel;

--- a/src/components/Tabs/TabPanel.tsx
+++ b/src/components/Tabs/TabPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 type TabPanelProps = {
+  id: string;
   tabName: string;
   children: React.ReactNode;
   isActive?: boolean;
@@ -11,16 +12,22 @@ type TabPanelProps = {
  * The `isActive` prop isn't passed in declaratively. `isActive` is passed
  * from the Tabs render from the React.Children cloneElement.
  */
-const TabPanel = ({ tabName, isActive, children }: TabPanelProps) => {
+const TabPanel = ({ id, tabName, isActive, children }: TabPanelProps) => {
   if (isActive) {
     return (
-      <div className="easi-tabs__tab-panel" data-tabname={tabName}>
+      <div
+        id={id}
+        className="easi-tabs__tab-panel"
+        role="tabpanel"
+        data-tabname={tabName}
+      >
         {children}
       </div>
     );
   }
   return (
     <div
+      id={id}
       className="easi-tabs__tab-panel easi-only-print"
       data-tabname={tabName}
     >

--- a/src/components/Tabs/TabPanel.tsx
+++ b/src/components/Tabs/TabPanel.tsx
@@ -13,10 +13,17 @@ type TabPanelProps = {
  */
 const TabPanel = ({ tabName, isActive, children }: TabPanelProps) => {
   if (isActive) {
-    return <div data-tabname={tabName}>{children}</div>;
+    return (
+      <div className="easi-tabs__tab-panel" data-tabname={tabName}>
+        {children}
+      </div>
+    );
   }
   return (
-    <div className="easi-only-print" data-tabname={tabName}>
+    <div
+      className="easi-tabs__tab-panel easi-only-print"
+      data-tabname={tabName}
+    >
       {children}
     </div>
   );

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,214 @@
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import classnames from 'classnames';
+
+import './index.scss';
+
+type TabsProps = {
+  defaultActiveTab?: string;
+  children: React.ReactElement[];
+};
+
+const Tabs = ({ defaultActiveTab, children }: TabsProps) => {
+  const tabs = children.map(child => child.props.tabName);
+  const [displayedTabs, setDisplayedTabs] = useState(tabs);
+  const [activeTab, setActiveTab] = useState(
+    defaultActiveTab || displayedTabs[0]
+  );
+  const [moreTabsList, setMoreTabsList] = useState<string[]>([]);
+  const [componentWidth, setComponentWidth] = useState(0);
+  const [tabListWidth, setTabListWidth] = useState(0);
+  const [tabInfo, setTabInfo] = useState<{ name: string; width: number }[]>([]);
+  const [isMoreMenuOpen, setIsMoreMenuOpen] = useState(false);
+  const dropdownNode = useRef<any>();
+  const moreButtonWidth = 80; // Includes extra pixels for buffer
+
+  const handleClick = (e: Event) => {
+    if (
+      dropdownNode &&
+      dropdownNode.current &&
+      dropdownNode.current.contains(e.target)
+    ) {
+      return;
+    }
+
+    setIsMoreMenuOpen(false);
+  };
+
+  // Set tabs/widths on component mount
+  useEffect(() => {
+    const tabElements: any = document.querySelectorAll('.easi-tabs__tab');
+    const arr: { name: string; width: number }[] = [];
+    tabElements.forEach((tab: HTMLElement) => {
+      arr.push({
+        name: tab.innerText,
+        width: tab.offsetWidth
+      });
+    });
+    setTabInfo(arr);
+  }, []);
+
+  // Set widths and event listners to watch for screen resizing
+  useEffect(() => {
+    const handleResize = () => {
+      const component: any = document.querySelector('.easi-tabs__navigation');
+      const tabList: any = document.querySelector('.easi-tabs__tab-list');
+
+      setComponentWidth(component.offsetWidth);
+      setTabListWidth(tabList.offsetWidth);
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  // Remove tabs when they don't fit
+  useLayoutEffect(() => {
+    if (componentWidth > 0 && tabListWidth > 0) {
+      const tabElements = document.querySelectorAll('.easi-tabs__tab');
+      const availableSpace = componentWidth - moreButtonWidth;
+      let updatedTabListWidth = tabListWidth;
+      if (availableSpace < updatedTabListWidth) {
+        let numberOfTabsToRemove = 0;
+
+        while (availableSpace < updatedTabListWidth) {
+          numberOfTabsToRemove += 1;
+          updatedTabListWidth -=
+            tabElements[tabElements.length - numberOfTabsToRemove].clientWidth;
+        }
+        if (updatedTabListWidth !== tabListWidth) {
+          setTabListWidth(updatedTabListWidth);
+        }
+        if (numberOfTabsToRemove > 0) {
+          setDisplayedTabs(prevTabs =>
+            prevTabs.slice(0, prevTabs.length - numberOfTabsToRemove)
+          );
+          setMoreTabsList(
+            tabs.slice(displayedTabs.length - numberOfTabsToRemove, tabs.length)
+          );
+        }
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tabListWidth, componentWidth]);
+
+  // Add tabs when they fit
+  useLayoutEffect(() => {
+    if (moreTabsList.length > 0) {
+      const firstMoreTab = tabInfo.find(
+        (tab: any) => tab.name === moreTabsList[0]
+      );
+      if (
+        firstMoreTab &&
+        componentWidth >= tabListWidth + firstMoreTab.width + moreButtonWidth
+      ) {
+        setDisplayedTabs(prevTabs => [...prevTabs, moreTabsList[0]]);
+        setMoreTabsList(prevTabs =>
+          prevTabs.filter(tab => tab !== moreTabsList[0])
+        );
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tabListWidth, componentWidth]);
+
+  // Close "More Tabs" menu when it is empty
+  useEffect(() => {
+    if (moreTabsList.length === 0) {
+      setIsMoreMenuOpen(false);
+    }
+  }, [moreTabsList.length]);
+
+  // Add event listner for closing the "More Tabs" menu
+  useEffect(() => {
+    document.addEventListener('mouseup', handleClick);
+
+    return () => {
+      document.removeEventListener('mouseup', handleClick);
+    };
+  }, []);
+
+  return (
+    <div className={classnames('easi-tabs')}>
+      <div className="easi-tabs__navigation">
+        <ul className="easi-tabs__tab-list">
+          {displayedTabs.map(tab => (
+            <li
+              key={tab}
+              className={classnames('easi-tabs__tab', {
+                'easi-tabs__tab--selected': activeTab === tab
+              })}
+            >
+              <button
+                type="button"
+                className="easi-tabs__tab-btn"
+                onClick={() => setActiveTab(tab)}
+              >
+                <span className="easi-tabs__tab-text">{tab}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+        <div ref={dropdownNode}>
+          {moreTabsList.length > 0 && (
+            <button
+              type="button"
+              className="easi-tabs__more-btn"
+              onClick={() => {
+                setIsMoreMenuOpen(prevOpen => !prevOpen);
+              }}
+              aria-label={
+                isMoreMenuOpen
+                  ? 'Close More Tabs Menu'
+                  : 'Expand More Tabs Menu'
+              }
+              aria-controls="Tabs-MoreMenu"
+              aria-expanded={isMoreMenuOpen}
+            >
+              <i
+                className={classnames(
+                  'fa',
+                  {
+                    'fa-angle-right': !isMoreMenuOpen,
+                    'fa-angle-down': isMoreMenuOpen
+                  },
+                  'easi-tabs__angle-right'
+                )}
+              />
+              <span>More</span>
+            </button>
+          )}
+          {isMoreMenuOpen && (
+            <ul
+              id="Tabs-MoreMenu"
+              className="easi-tabs__more-menu bg-base-lightest"
+            >
+              {moreTabsList.map(tab => (
+                <li key={`menu-tab-${tab}`}>
+                  <button
+                    type="button"
+                    className="easi-tabs__tab-btn"
+                    onClick={() => {
+                      setActiveTab(tab);
+                      setIsMoreMenuOpen(false);
+                    }}
+                  >
+                    {tab}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+      {React.Children.map(children, child => {
+        if (child.props.tabName === activeTab) {
+          return React.cloneElement(child, {
+            isActive: true
+          });
+        }
+        return child;
+      })}
+    </div>
+  );
+};
+
+export default Tabs;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import classnames from 'classnames';
 
 import './index.scss';
@@ -10,127 +10,13 @@ type TabsProps = {
 
 const Tabs = ({ defaultActiveTab, children }: TabsProps) => {
   const tabs = children.map(child => child.props.tabName);
-  const [displayedTabs, setDisplayedTabs] = useState(tabs);
-  const [activeTab, setActiveTab] = useState(
-    defaultActiveTab || displayedTabs[0]
-  );
-  const [moreTabsList, setMoreTabsList] = useState<string[]>([]);
-  const [componentWidth, setComponentWidth] = useState(0);
-  const [tabListWidth, setTabListWidth] = useState(0);
-  const [tabInfo, setTabInfo] = useState<{ name: string; width: number }[]>([]);
-  const [isMoreMenuOpen, setIsMoreMenuOpen] = useState(false);
-  const dropdownNode = useRef<any>();
-  const moreButtonWidth = 80; // Includes extra pixels for buffer
-
-  const handleClick = (e: Event) => {
-    if (
-      dropdownNode &&
-      dropdownNode.current &&
-      dropdownNode.current.contains(e.target)
-    ) {
-      return;
-    }
-
-    setIsMoreMenuOpen(false);
-  };
-
-  // Set tabs/widths on component mount
-  useEffect(() => {
-    const tabElements: any = document.querySelectorAll('.easi-tabs__tab');
-    const arr: { name: string; width: number }[] = [];
-    tabElements.forEach((tab: HTMLElement) => {
-      arr.push({
-        name: tab.innerText,
-        width: tab.offsetWidth
-      });
-    });
-    setTabInfo(arr);
-  }, []);
-
-  // Set widths and event listners to watch for screen resizing
-  useEffect(() => {
-    const handleResize = () => {
-      const component: any = document.querySelector('.easi-tabs__navigation');
-      const tabList: any = document.querySelector('.easi-tabs__tab-list');
-
-      setComponentWidth(component.offsetWidth);
-      setTabListWidth(tabList.offsetWidth);
-    };
-    handleResize();
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  // Remove tabs when they don't fit
-  useLayoutEffect(() => {
-    if (componentWidth > 0 && tabListWidth > 0) {
-      const tabElements = document.querySelectorAll('.easi-tabs__tab');
-      const availableSpace = componentWidth - moreButtonWidth;
-      let updatedTabListWidth = tabListWidth;
-      if (availableSpace < updatedTabListWidth) {
-        let numberOfTabsToRemove = 0;
-
-        while (availableSpace < updatedTabListWidth) {
-          numberOfTabsToRemove += 1;
-          updatedTabListWidth -=
-            tabElements[tabElements.length - numberOfTabsToRemove].clientWidth;
-        }
-        if (updatedTabListWidth !== tabListWidth) {
-          setTabListWidth(updatedTabListWidth);
-        }
-        if (numberOfTabsToRemove > 0) {
-          setDisplayedTabs(prevTabs =>
-            prevTabs.slice(0, prevTabs.length - numberOfTabsToRemove)
-          );
-          setMoreTabsList(
-            tabs.slice(displayedTabs.length - numberOfTabsToRemove, tabs.length)
-          );
-        }
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tabListWidth, componentWidth]);
-
-  // Add tabs when they fit
-  useLayoutEffect(() => {
-    if (moreTabsList.length > 0) {
-      const firstMoreTab = tabInfo.find(
-        (tab: any) => tab.name === moreTabsList[0]
-      );
-      if (
-        firstMoreTab &&
-        componentWidth >= tabListWidth + firstMoreTab.width + moreButtonWidth
-      ) {
-        setDisplayedTabs(prevTabs => [...prevTabs, moreTabsList[0]]);
-        setMoreTabsList(prevTabs =>
-          prevTabs.filter(tab => tab !== moreTabsList[0])
-        );
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tabListWidth, componentWidth]);
-
-  // Close "More Tabs" menu when it is empty
-  useEffect(() => {
-    if (moreTabsList.length === 0) {
-      setIsMoreMenuOpen(false);
-    }
-  }, [moreTabsList.length]);
-
-  // Add event listner for closing the "More Tabs" menu
-  useEffect(() => {
-    document.addEventListener('mouseup', handleClick);
-
-    return () => {
-      document.removeEventListener('mouseup', handleClick);
-    };
-  }, []);
+  const [activeTab, setActiveTab] = useState(defaultActiveTab || tabs[0]);
 
   return (
     <div className={classnames('easi-tabs')}>
       <div className="easi-tabs__navigation">
         <ul className="easi-tabs__tab-list">
-          {displayedTabs.map(tab => (
+          {tabs.map(tab => (
             <li
               key={tab}
               className={classnames('easi-tabs__tab', {
@@ -147,57 +33,6 @@ const Tabs = ({ defaultActiveTab, children }: TabsProps) => {
             </li>
           ))}
         </ul>
-        <div ref={dropdownNode}>
-          {moreTabsList.length > 0 && (
-            <button
-              type="button"
-              className="easi-tabs__more-btn"
-              onClick={() => {
-                setIsMoreMenuOpen(prevOpen => !prevOpen);
-              }}
-              aria-label={
-                isMoreMenuOpen
-                  ? 'Close More Tabs Menu'
-                  : 'Expand More Tabs Menu'
-              }
-              aria-controls="Tabs-MoreMenu"
-              aria-expanded={isMoreMenuOpen}
-            >
-              <i
-                className={classnames(
-                  'fa',
-                  {
-                    'fa-angle-right': !isMoreMenuOpen,
-                    'fa-angle-down': isMoreMenuOpen
-                  },
-                  'easi-tabs__angle-right'
-                )}
-              />
-              <span>More</span>
-            </button>
-          )}
-          {isMoreMenuOpen && (
-            <ul
-              id="Tabs-MoreMenu"
-              className="easi-tabs__more-menu bg-base-lightest"
-            >
-              {moreTabsList.map(tab => (
-                <li key={`menu-tab-${tab}`}>
-                  <button
-                    type="button"
-                    className="easi-tabs__tab-btn"
-                    onClick={() => {
-                      setActiveTab(tab);
-                      setIsMoreMenuOpen(false);
-                    }}
-                  >
-                    {tab}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
       </div>
       {React.Children.map(children, child => {
         if (child.props.tabName === activeTab) {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -9,26 +9,32 @@ type TabsProps = {
 };
 
 const Tabs = ({ defaultActiveTab, children }: TabsProps) => {
-  const tabs = children.map(child => child.props.tabName);
-  const [activeTab, setActiveTab] = useState(defaultActiveTab || tabs[0]);
+  const tabs = children.map(child => ({
+    id: child.props.id,
+    name: child.props.tabName
+  }));
+  const [activeTab, setActiveTab] = useState(defaultActiveTab || tabs[0].name);
 
   return (
     <div className={classnames('easi-tabs')}>
       <div className="easi-tabs__navigation">
-        <ul className="easi-tabs__tab-list">
+        <ul className="easi-tabs__tab-list" role="tablist">
           {tabs.map(tab => (
             <li
-              key={tab}
+              key={tab.id}
               className={classnames('easi-tabs__tab', {
-                'easi-tabs__tab--selected': activeTab === tab
+                'easi-tabs__tab--selected': activeTab === tab.name
               })}
+              role="tab"
             >
               <button
                 type="button"
                 className="easi-tabs__tab-btn"
-                onClick={() => setActiveTab(tab)}
+                // aria-selected={activeTab === tab.name}
+                aria-controls={tab.id}
+                onClick={() => setActiveTab(tab.name)}
               >
-                <span className="easi-tabs__tab-text">{tab}</span>
+                <span className="easi-tabs__tab-text">{tab.name}</span>
               </button>
             </li>
           ))}

--- a/src/components/Tabs/index.scss
+++ b/src/components/Tabs/index.scss
@@ -1,7 +1,5 @@
 .easi-tabs {
-  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
-  border-radius: 4px;
-  border: 1px solid #E0E0E0;
+  overflow: hidden;
 
   &__navigation {
     display: flex;
@@ -23,12 +21,33 @@
     align-items: center;
     height: 54px;
     flex-shrink: 0;
-    border-top: 4px solid transparent;
+    position: relative;
+    border: 1px solid color($theme-color-base-lighter);
     border-right: 1px solid color($theme-color-base-lighter);
 
+    &:after {
+      background-color: $easi-bright-blue;
+      content: "";
+      height: 4px;
+      left: -1px;
+      opacity: 0;
+      position: absolute;
+      right: -1px;
+      top: -1px;
+      transform: scaleX(0);
+    }
+
     &--selected {
-      border-top: 4px solid #009bc3;
       border-bottom: 1px solid #fff;
+
+      .easi-tabs__tab-btn {
+        color: $easi-bright-blue;
+      }
+
+      &:after {
+        opacity: 1;
+        transform: scaleX(1);
+      }
     }
   }
 
@@ -37,7 +56,7 @@
     padding: 0;
     background: none;
     border: 0;
-    font-size: 22px;
+    font-weight: bold;
 
     &:hover {
       cursor: pointer;
@@ -48,37 +67,9 @@
     margin: 0 1.5em;
   }
 
-  &__more-btn {
-    height: 100%;
-    padding-bottom: 0;
-    background-color: transparent;
-    border: 0;
-    font-size: 14px;
-    font-weight: bold;
-
-    &:hover {
-      cursor: pointer;
-    }
-  }
-
-  &__angle-right {
-    margin-top: -0.125em;
-    margin-right: 10px;
-    font-size: 40px !important;
-    vertical-align: middle;
-  }
-
-  &__more-menu {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    margin: 0;
-    padding: 0;
-    list-style-type: none;
-
-    li {
-      padding: 10px;
-      font-size: 22px;
-    }
+  &__tab-panel {
+    overflow: auto;
+    border: 1px solid color($theme-color-base-lighter);
+    border-top: none;
   }
 }

--- a/src/components/Tabs/index.scss
+++ b/src/components/Tabs/index.scss
@@ -1,0 +1,84 @@
+.easi-tabs {
+  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 4px;
+  border: 1px solid #E0E0E0;
+
+  &__navigation {
+    display: flex;
+    justify-content: space-between;
+    position: relative;
+    border-bottom: 1px solid color($theme-color-base-lighter);
+  }
+
+  &__tab-list {
+    display: inline-block;
+    padding: 0;
+    margin: 0 0 -1px;
+    list-style-type: none;
+    white-space: nowrap;
+  }
+
+  &__tab {
+    display: inline-flex;
+    align-items: center;
+    height: 54px;
+    flex-shrink: 0;
+    border-top: 4px solid transparent;
+    border-right: 1px solid color($theme-color-base-lighter);
+
+    &--selected {
+      border-top: 4px solid #009bc3;
+      border-bottom: 1px solid #fff;
+    }
+  }
+
+  &__tab-btn {
+    height: 100%;
+    padding: 0;
+    background: none;
+    border: 0;
+    font-size: 22px;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  &__tab-text {
+    margin: 0 1.5em;
+  }
+
+  &__more-btn {
+    height: 100%;
+    padding-bottom: 0;
+    background-color: transparent;
+    border: 0;
+    font-size: 14px;
+    font-weight: bold;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  &__angle-right {
+    margin-top: -0.125em;
+    margin-right: 10px;
+    font-size: 40px !important;
+    vertical-align: middle;
+  }
+
+  &__more-menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+
+    li {
+      padding: 10px;
+      font-size: 22px;
+    }
+  }
+}

--- a/src/components/Tabs/index.stories.tsx
+++ b/src/components/Tabs/index.stories.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { TabPanel, Tabs } from './index';
+
+export default {
+  title: 'Tabs',
+  component: Tabs
+};
+
+export const Default = () => {
+  return (
+    <Tabs>
+      <TabPanel tabName="Pepperoni">
+        <h1>Pepperoni</h1>
+      </TabPanel>
+      <TabPanel tabName="Sausage">
+        <h1>Sausage</h1>
+      </TabPanel>
+      <TabPanel tabName="Mushroom">
+        <h1>Mushroom</h1>
+      </TabPanel>
+      <TabPanel tabName="Bacon">
+        <h1>Bacon</h1>
+      </TabPanel>
+    </Tabs>
+  );
+};
+
+export const CustomDefaultTab = () => {
+  return (
+    <Tabs defaultActiveTab="Tab 3">
+      <TabPanel tabName="Tab 1">
+        <h1>Tab 1</h1>
+      </TabPanel>
+      <TabPanel tabName="Tab 2">
+        <h1>Tab 2</h1>
+      </TabPanel>
+      <TabPanel tabName="Tab 3">
+        <h1>Tab 3</h1>
+      </TabPanel>
+    </Tabs>
+  );
+};
+CustomDefaultTab.storyName = 'w/ custom default tab selected';

--- a/src/components/Tabs/index.stories.tsx
+++ b/src/components/Tabs/index.stories.tsx
@@ -10,16 +10,16 @@ export default {
 export const Default = () => {
   return (
     <Tabs>
-      <TabPanel tabName="Pepperoni">
+      <TabPanel id="Test-Pepperoni" tabName="Pepperoni">
         <h1>Pepperoni</h1>
       </TabPanel>
-      <TabPanel tabName="Sausage">
+      <TabPanel id="Test-Sausage" tabName="Sausage">
         <h1>Sausage</h1>
       </TabPanel>
-      <TabPanel tabName="Mushroom">
+      <TabPanel id="Test-Mushroom" tabName="Mushroom">
         <h1>Mushroom</h1>
       </TabPanel>
-      <TabPanel tabName="Bacon">
+      <TabPanel id="Test-Bacon" tabName="Bacon">
         <h1>Bacon</h1>
       </TabPanel>
     </Tabs>
@@ -29,13 +29,13 @@ export const Default = () => {
 export const CustomDefaultTab = () => {
   return (
     <Tabs defaultActiveTab="Tab 3">
-      <TabPanel tabName="Tab 1">
+      <TabPanel id="Test-Tab-1" tabName="Tab 1">
         <h1>Tab 1</h1>
       </TabPanel>
-      <TabPanel tabName="Tab 2">
+      <TabPanel id="Test-Tab-2" tabName="Tab 2">
         <h1>Tab 2</h1>
       </TabPanel>
-      <TabPanel tabName="Tab 3">
+      <TabPanel id="Test-Tab-3" tabName="Tab 3">
         <h1>Tab 3</h1>
       </TabPanel>
     </Tabs>

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,0 +1,7 @@
+import TabPanel from './TabPanel';
+import Tabs from './Tabs';
+
+// This component is very similar to src/components/shared/ResponsiveTabs
+// Most of the code is duplicated, but this component has some tweaks
+// TODO: https://jiraent.cms.gov/browse/ES-310
+export { Tabs, TabPanel };


### PR DESCRIPTION
# ES-280

- Adds "new" Tabs component
    - a lot of this is duplicated from `ResponsiveTab`
    - i didn't want to affect production code in one sweep, so i created a new component for this PR.
    - subsequent PRs will update instances from `ResponsiveTab` to new `Tabs` component, then remove `ResponsiveTab`
- This tab component follows a different API
```
<Tabs>
  <TabPanel tabName="Tab 1">
    <h1>Tab 1</h1>
  </TabPanel>
  <TabPanel tabName="Tab 2">
    <h1>Tab 2</h1>
  </TabPanel>
  <TabPanel tabName="Tab 3">
    <h1>Tab 3</h1>
  </TabPanel>
</Tabs>
```
- The tabs are generated based on the `TabPanel` children. This is a significant difference compared to `ResponsiveTabs` where we passed an array of strings for the tabs
- Tabs are printable (not just the one that's active)
- The tab  active state and tab change is kept internal to the component.