### PR TITLE
ES-292 Deploy storybook static assets to dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,6 +527,50 @@ jobs:
             ./scripts/circleci-announce-broken-branch
           when: on_fail
 
+  deploy_storybook_dev:
+    docker:
+      - image: *circleci_docker_primary
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+        environment:
+          AWS_DEFAULT_REGION: us-west-2
+          APP_ENV: dev
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - yarn-deps-cache-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - v1-node-modules-{{ checksum "yarn.lock" }}
+      - run:
+          name: Setup custom environment variables
+          command: |
+            temp_role=$(aws sts assume-role \
+                    --role-arn arn:aws:iam::$AWS_ACCOUNT_ID_DEV:role/circleci \
+                    --role-session-name circleci)
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
+      - run:
+          name: Deploy storybook assets
+          command: |
+            ./scripts/release_storybook_static
+      - save_cache:
+          key: yarn-deps-cache-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+      - save_cache:
+          key: v1-node-modules-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/project/node_modules
+      - run:
+          name: Announce failure
+          command: |
+            ./scripts/circleci-announce-broken-branch
+          when: on_fail
+
 workflows:
   version: 2
   compile:
@@ -539,6 +583,9 @@ workflows:
       - client_test:
           requires:
             - pre_deps
+      - deploy_storybook_dev:
+          requires:
+            - client_test
       - test:
           requires:
             - pre_deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,7 @@ jobs:
           command: yarn run build
       - run:
           name: Build Storybook
-          command: yarn run storybook-build
+          command: yarn run build-storybook
       - persist_to_workspace:
           root: /home/circleci/project
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -593,6 +593,10 @@ workflows:
           requires:
             - pre_deps
       - deploy_storybook_dev:
+          filters:
+            branches:
+              only:
+                - master
           requires:
             - client_test
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -593,10 +593,6 @@ workflows:
           requires:
             - pre_deps
       - deploy_storybook_dev:
-          filters:
-            branches:
-              only:
-                - master
           requires:
             - client_test
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,6 +285,13 @@ jobs:
       - run:
           name: Build Frontend Code
           command: yarn run build
+      - run:
+          name: Build Storybook
+          command: yarn run storybook-build
+      - persist_to_workspace:
+          root: /home/circleci/project
+          paths:
+            - storybook-static
       - save_cache:
           key: yarn-deps-cache-{{ checksum "yarn.lock" }}
           paths:
@@ -553,6 +560,8 @@ jobs:
             echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
             echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
             echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
+      - attach_workspace:
+          at: /tmp/storybook
       - run:
           name: Deploy storybook assets
           command: |
@@ -584,6 +593,10 @@ workflows:
           requires:
             - pre_deps
       - deploy_storybook_dev:
+          filters:
+            branches:
+              only:
+                - master
           requires:
             - client_test
       - test:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cypress.env.json
 
 # production
 /build
+/storybook-static
 
 # misc
 .DS_Store

--- a/scripts/release_storybook_static
+++ b/scripts/release_storybook_static
@@ -22,9 +22,7 @@ esac
 s3_err="$(aws s3 ls "$STORYBOOK_S3_BUCKET" 1>/dev/null 2>&1)"
 if [[ -z "$s3_err" ]] ; then
   ( set -x -u ;
-    yarn install
-    yarn run build-storybook || exit
-    aws s3 sync --no-progress --delete storybook-static/ s3://"$STORYBOOK_S3_BUCKET"/
+    aws s3 sync --no-progress --delete /tmp/storybook/storybook-static/ s3://"$STORYBOOK_S3_BUCKET"/
   )
 else
   echo "+ aws s3 ls $STORYBOOK_S3_BUCKET"

--- a/scripts/release_storybook_static
+++ b/scripts/release_storybook_static
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 
-set -eu -o pipefail
+set -u
 
 case "$APP_ENV" in
   "dev")

--- a/scripts/release_storybook_static
+++ b/scripts/release_storybook_static
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+
+set -eu -o pipefail
+
+case "$APP_ENV" in
+  "dev")
+    STORYBOOK_S3_BUCKET="$STORYBOOK_S3_BUCKET_DEV"
+    ;;
+  "impl")
+    STORYBOOK_S3_BUCKET="$STORYBOOK_S3_BUCKET_IMPL"
+    ;;
+  *)
+    echo "APP_ENV value not recognized: ${APP_ENV:-unset}"
+    echo "Allowed values: 'dev', 'impl'"
+    exit 1
+    ;;
+esac
+
+# Check if we have any access to the s3 bucket
+# Since `s3 ls` returns zero even if the command failed, we assume failure if this command prints anything to stderr
+s3_err="$(aws s3 ls "$STORYBOOK_S3_BUCKET" 1>/dev/null 2>&1)"
+if [[ -z "$s3_err" ]] ; then
+  ( set -x -u ;
+    yarn install
+    yarn run build-storybook || exit
+    aws s3 sync --no-progress --delete storybook-static/ s3://"$STORYBOOK_S3_BUCKET"/
+  )
+else
+  echo "+ aws s3 ls $STORYBOOK_S3_BUCKET"
+  echo "$s3_err"
+  echo "--"
+  echo "Error reading the S3 bucket. Are you authenticated?" 1>&2
+  exit 1
+fi


### PR DESCRIPTION
# ES-292

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Deploy storybook static assets to dev

The idea here is that building the storybook assets would occur on every branch to try and avoid breaking the build in master, but deploying the storybook assets would only occur on master. Since the built storybook files don't change between `client_test` and `deploy_storybook_dev`, this uses the circleci workspace to copy the files from `client_test` to `deploy_storybook_dev`.
