### PR TITLE
Fix GraphQL code generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,11 @@ jobs:
           keys:
             - v2-go-mod-sources-{{ checksum "go.sum" }}
       - run:
+          name: Generate GraphQL code
+          command: |
+            go generate ./...
+            yarn generate
+      - run:
           name: Run easi app tests
           command: |
             ./scripts/build_app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,6 @@ jobs:
           name: Generate GraphQL code
           command: |
             go generate ./...
-            yarn generate
       - run:
           name: Run easi app tests
           command: |
@@ -284,6 +283,10 @@ jobs:
       - restore_cache:
           keys:
             - v1-node-modules-{{ checksum "yarn.lock" }}
+      - run:
+          name: Generate GraphQL code
+          command: |
+            yarn generate
       - run:
           name: Run Frontend Tests
           command: yarn run test

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "lint:fix": "eslint --fix '**/*.{ts,tsx}'",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
-    "generate": "apollo client:codegen --localSchemaFile=graph/schema.graphql --target typescript  --tagName=gql --addTypename --globalTypesFile=src/types/graphql-global-types.ts types",
+    "generate": "apollo client:codegen --localSchemaFile=pkg/graph/schema.graphql --target typescript  --tagName=gql --addTypename --globalTypesFile=src/types/graphql-global-types.ts types",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public"
   },

--- a/src/queries/types/CreateAccessibilityRequest.ts
+++ b/src/queries/types/CreateAccessibilityRequest.ts
@@ -11,7 +11,7 @@ import { CreateAccessibilityRequestInput } from "./../../types/graphql-global-ty
 
 export interface CreateAccessibilityRequest_createAccessibilityRequest_accessibilityRequest {
   __typename: "AccessibilityRequest";
-  id: string;
+  id: any;
   name: string;
 }
 

--- a/src/queries/types/GetAccessibilityRequests.ts
+++ b/src/queries/types/GetAccessibilityRequests.ts
@@ -9,7 +9,7 @@
 
 export interface GetAccessibilityRequests_accessibilityRequests_edges_node {
   __typename: "AccessibilityRequest";
-  id: string;
+  id: any;
   name: string;
 }
 


### PR DESCRIPTION
We didn't add anything to CI that attempts to generate code from our GraphQL schema, which meant that we were able to check in some code that broke the client app.

This PR fixes the issue with generation and includes a very rough stab at running the code generation as a part of CI. We'll want to have a follow-up story that does a little more (e.g. checks to make sure that the generation didn't result in a difference in any of the files).