### PR TITLE
ES-274 cloudfront-friendly routes

### DIFF
--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -34,18 +34,15 @@ func (s *Server) routes(
 	traceMiddleware func(handler http.Handler) http.Handler,
 	loggerMiddleware func(handler http.Handler) http.Handler) {
 
-	// trace all requests with an ID
-	s.router.Use(traceMiddleware)
+	s.router.Use(
+		traceMiddleware, // trace all requests with an ID
+		loggerMiddleware,
+		corsMiddleware,
+		authorizationMiddleware, // is really authN, not authZ; TODO: those responsibilities should be split out
+	)
 
 	// set up handler base
 	base := handlers.NewHandlerBase(s.logger)
-
-	// health check goes directly on the main router to avoid auth
-	healthCheckHandler := handlers.NewHealthCheckHandler(
-		base,
-		s.Config,
-	)
-	s.router.HandleFunc("/api/v1/healthcheck", healthCheckHandler.Handle())
 
 	// set up Feature Flagging utilities
 	ldClient, err := flags.NewLaunchDarklyClient(s.NewFlagConfig())
@@ -130,39 +127,21 @@ func (s *Server) routes(
 		s.logger.Fatal("Failed to create store", zap.Error(storeErr))
 	}
 
-	gql := s.router.PathPrefix("/graph").Subrouter()
-
-	gql.Use(loggerMiddleware)
-	gql.Use(corsMiddleware)
-	gql.Use(authorizationMiddleware)
-
+	// set up GraphQL routes
+	gql := s.router.PathPrefix("/api/graph").Subrouter()
 	graphqlServer := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: graph.NewResolver(store)}))
 	gql.Handle("/query", graphqlServer)
-
-	gql.HandleFunc("/playground", playground.Handler("GraphQL playground", "/query"))
+	gql.HandleFunc("/playground", playground.Handler("GraphQL playground", "/api/graph/query"))
 
 	// API base path is versioned
 	api := s.router.PathPrefix("/api/v1").Subrouter()
 
-	// add a request based logger
-	api.Use(loggerMiddleware)
-
-	// wrap with CORs
-	api.Use(corsMiddleware)
-
-	// protect all API routes with authorization middleware
-	api.Use(authorizationMiddleware)
+	// health check goes directly on the main router
+	// does not need authZ, but authN is okay
+	healthCheckHandler := handlers.NewHealthCheckHandler(base, s.Config)
+	api.HandleFunc("/healthcheck", healthCheckHandler.Handle())
 
 	serviceConfig := services.NewConfig(s.logger, ldClient)
-
-	store, storeErr = storage.NewStore(
-		s.logger,
-		s.NewDBConfig(),
-		ldClient,
-	)
-	if storeErr != nil {
-		s.logger.Fatal("Failed to create store", zap.Error(storeErr))
-	}
 
 	systemIntakeHandler := handlers.NewSystemIntakeHandler(
 		base,


### PR DESCRIPTION
# ES-274

Changes proposed in this pull request:

- moved the GraphQL subrouter to be at `/api/graph` (used to be at top level `/graph`)
- don't re-init another copy of the `storage` layer
- tiny bits of tidying up around middlewares

Tested this by:
- running the server locally
- pulling up `http://localhost:8080/api/graph/playground` 
- making sure it was interacting with the query engine backend as expected
