### PR TITLE
ES-329 some intakes have NULL eauID

### DIFF
--- a/pkg/models/system.go
+++ b/pkg/models/system.go
@@ -2,17 +2,19 @@ package models
 
 import (
 	"time"
+
+	"github.com/guregu/null"
 )
 
 // System represents something that may be tested for 508 compliance
 type System struct {
 	// IntakeID    uuid.UUID  `json:"intakeId" db:"id"` // TODO: is this actually necessary, if LCID is really the identifier?
-	LCID        string     `json:"lcid" db:"lcid"`
-	CreatedAt   *time.Time `json:"createdAt" db:"created_at"`
-	UpdatedAt   *time.Time `json:"updatedAt" db:"updated_at"`
-	IssuedAt    *time.Time `json:"issuedAt" db:"decided_at"`
-	ExpiresAt   *time.Time `json:"expiresAt" db:"lcid_expires_at"`
-	ProjectName string     `json:"projectName" db:"project_name"`
-	OwnerID     string     `json:"ownerId" db:"eua_user_id"`
-	OwnerName   string     `json:"ownerName" db:"requester"` // TODO: wouldn't really be necessary at DB layer if we had performant access to LDAP
+	LCID        string      `json:"lcid" db:"lcid"`
+	CreatedAt   *time.Time  `json:"createdAt" db:"created_at"`
+	UpdatedAt   *time.Time  `json:"updatedAt" db:"updated_at"`
+	IssuedAt    *time.Time  `json:"issuedAt" db:"decided_at"`
+	ExpiresAt   *time.Time  `json:"expiresAt" db:"lcid_expires_at"`
+	ProjectName string      `json:"projectName" db:"project_name"`
+	OwnerID     null.String `json:"ownerId" db:"eua_user_id"` // backfill data in PROD has NULLs
+	OwnerName   string      `json:"ownerName" db:"requester"` // TODO: wouldn't really be necessary at DB layer if we had performant access to LDAP
 }

--- a/pkg/storage/system.go
+++ b/pkg/storage/system.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/guregu/null"
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
@@ -24,7 +25,7 @@ func init() {
 			IssuedAt:    &t1,
 			ExpiresAt:   &t2,
 			ProjectName: "Three Amigos",
-			OwnerID:     "FAKE0",
+			OwnerID:     null.StringFrom("FAKE0"),
 			OwnerName:   "Lucky Dusty Ned",
 		},
 		{
@@ -34,7 +35,7 @@ func init() {
 			IssuedAt:    &t1,
 			ExpiresAt:   &t2,
 			ProjectName: "Three Musketeers",
-			OwnerID:     "FAKE1",
+			OwnerID:     null.StringFromPtr(nil),
 			OwnerName:   "Athos Porthos Aramis",
 		},
 		{
@@ -44,7 +45,7 @@ func init() {
 			IssuedAt:    &t1,
 			ExpiresAt:   &t2,
 			ProjectName: "Three Stooges",
-			OwnerID:     "FAKE2",
+			OwnerID:     null.StringFrom("FAKE2"),
 			OwnerName:   "Moe Larry Curly",
 		},
 	}

--- a/pkg/storage/system_test.go
+++ b/pkg/storage/system_test.go
@@ -42,6 +42,11 @@ func (s StoreTestSuite) TestListSystems() {
 		si.CreatedAt = &now
 		si.UpdatedAt = &now
 		si.ProjectName = null.StringFrom(fmt.Sprintf("%s %d", sig, ix))
+		if ix%2 == 1 {
+			// this simulates some of the backfill data in PROD that
+			// was imported without an EUAUserID
+			si.EUAUserID = null.StringFromPtr(nil)
+		}
 		_, err = s.store.CreateSystemIntake(ctx, &si)
 		s.NoError(err)
 


### PR DESCRIPTION
# ES-329

Changes proposed in this pull request:

- some `SystemIntake` data was imported into PROD w/o an EUA ID assigned, make sure our SQL and types handle that
