### PR TITLE
ES-274 intake id avail on systems

### DIFF
--- a/pkg/models/system.go
+++ b/pkg/models/system.go
@@ -3,12 +3,13 @@ package models
 import (
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/guregu/null"
 )
 
 // System represents something that may be tested for 508 compliance
 type System struct {
-	// IntakeID    uuid.UUID  `json:"intakeId" db:"id"` // TODO: is this actually necessary, if LCID is really the identifier?
+	IntakeID    uuid.UUID   `json:"intakeId" db:"id"`
 	LCID        string      `json:"lcid" db:"lcid"`
 	CreatedAt   *time.Time  `json:"createdAt" db:"created_at"`
 	UpdatedAt   *time.Time  `json:"updatedAt" db:"updated_at"`

--- a/pkg/storage/system.go
+++ b/pkg/storage/system.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/guregu/null"
 	"go.uber.org/zap"
 
@@ -20,6 +21,7 @@ func init() {
 	fakeSystems = []*models.System{
 		{
 			LCID:        "X990000",
+			IntakeID:    uuid.MustParse("00000000-9999-0000-0000-000000000000"),
 			CreatedAt:   &t1,
 			UpdatedAt:   &t1,
 			IssuedAt:    &t1,
@@ -30,6 +32,7 @@ func init() {
 		},
 		{
 			LCID:        "X990001",
+			IntakeID:    uuid.MustParse("00000000-8888-0000-0000-000000000000"),
 			CreatedAt:   &t1,
 			UpdatedAt:   &t1,
 			IssuedAt:    &t1,
@@ -40,6 +43,7 @@ func init() {
 		},
 		{
 			LCID:        "X990002",
+			IntakeID:    uuid.MustParse("00000000-7777-0000-0000-000000000000"),
 			CreatedAt:   &t1,
 			UpdatedAt:   &t1,
 			IssuedAt:    &t1,
@@ -92,6 +96,7 @@ func (s *Store) useFakeSystems(ctx context.Context) bool {
 
 const sqlListSystems = `
 	SELECT
+		id,
 		lcid,
 		created_at,
 		updated_at,

--- a/pkg/storage/system_test.go
+++ b/pkg/storage/system_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/guregu/null"
 
 	"github.com/cmsgov/easi-app/pkg/models"
@@ -85,6 +86,7 @@ func (s StoreTestSuite) TestListSystems() {
 		if !strings.HasPrefix(result.ProjectName, sig) {
 			continue
 		}
+		s.NotEqual(result.IntakeID, uuid.Nil) // ensure we populate with a real IntakeID
 		if _, exp := expected[result.LCID]; !exp {
 			// unexpected collision from previously existing data,
 			// possibly from previous runs of this test


### PR DESCRIPTION
# ES-274

Changes proposed in this pull request:

- For the ID (uuid) of the `SystemIntake`/`system_intake` row where the given LCID was issued, make it available on the `System` type

Tested locally:
```shell
$ curl -H 'Authorization: Bearer {"euaId":"NELZ"}' 127.0.0.1:8080/api/v1/systems | jq .
[
  {
    "intakeId": "00000000-9999-0000-0000-000000000000",
    "lcid": "X990000",
    "createdAt": "2020-01-01T08:00:00Z",
    "updatedAt": "2020-01-01T08:00:00Z",
    "issuedAt": "2020-01-01T08:00:00Z",
    "expiresAt": "2021-12-31T08:00:00Z",
    "projectName": "Three Amigos",
    "ownerId": "FAKE0",
    "ownerName": "Lucky Dusty Ned"
  },
  {
    "intakeId": "00000000-8888-0000-0000-000000000000",
    "lcid": "X990001",
    "createdAt": "2020-01-01T08:00:00Z",
    "updatedAt": "2020-01-01T08:00:00Z",
    "issuedAt": "2020-01-01T08:00:00Z",
    "expiresAt": "2021-12-31T08:00:00Z",
    "projectName": "Three Musketeers",
    "ownerId": null,
    "ownerName": "Athos Porthos Aramis"
  },
  {
    "intakeId": "00000000-7777-0000-0000-000000000000",
    "lcid": "X990002",
    "createdAt": "2020-01-01T08:00:00Z",
    "updatedAt": "2020-01-01T08:00:00Z",
    "issuedAt": "2020-01-01T08:00:00Z",
    "expiresAt": "2021-12-31T08:00:00Z",
    "projectName": "Three Stooges",
    "ownerId": "FAKE2",
    "ownerName": "Moe Larry Curly"
  }
]
```