### PR TITLE
upgrade typescript to 3.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "redux-saga-routines": "^3.2.2",
     "reselect": "^4.0.0",
     "serialize-javascript": "^3.1.0",
-    "typescript": "3.6.4",
+    "typescript": "3.7.5",
     "uswds": "^2.8.1",
     "uuid": "^7.0.3",
     "validator": "^13.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19654,10 +19654,10 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@3.7.5:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 typescript@^3.9.3:
   version "3.9.7"


### PR DESCRIPTION
This PR upgrades Typescript to `v3.7.5`

**Why?**
TIL about [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining). It'd be great to have/use.

It got support from [Typescript](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html) in `v.3.7`. For reference, we are on `v3.6.4`

**How did you pick v3.7.5?**
I just picked the latest patch version on `v3.7`. We should think about getting to the latest version (`v.4.1`), but for now, it's safer to update to a minor version.