### PR TITLE
[DRAFT] Implement reusable command for env setup in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,23 @@ references:
   circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:822fac1c30f3bb7d5d595bed5d2dc86265c4f2f0
   postgres: &postgres postgres:11.6
   db_migrate: &db_migrate ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-db-migrate:${CIRCLE_SHA1}
+
+commands:
+  setup_env:
+    parameters:
+      AWS_ACCOUNT_ID:
+        type: string
+    steps:
+      - run:
+          name: Setup custom environment variables
+          command: |
+            temp_role=$(aws sts assume-role \
+                    --role-arn arn:aws:iam::<< parameters.AWS_ACCOUNT_ID >>:role/circleci \
+                    --role-session-name circleci)
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
+
 jobs:
   restart_impl_ecs_app_service:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,15 +399,8 @@ jobs:
       - restore_cache:
           keys:
             - v1-node-modules-{{ checksum "yarn.lock" }}
-      - run:
-          name: Setup custom environment variables
-          command: |
-            temp_role=$(aws sts assume-role \
-                    --role-arn arn:aws:iam::$AWS_ACCOUNT_ID_DEV:role/circleci \
-                    --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
+      - setup_env:
+          AWS_ACCOUNT_ID: $AWS_ACCOUNT_ID_DEV
       - run:
           name: Nuke the database
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 ---
-version: 2
+version: 2.1
 
 references:
   circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:822fac1c30f3bb7d5d595bed5d2dc86265c4f2f0
@@ -18,9 +18,9 @@ commands:
             temp_role=$(aws sts assume-role \
                     --role-arn arn:aws:iam::<< parameters.AWS_ACCOUNT_ID >>:role/circleci \
                     --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken \<< "$temp_role")" >> $BASH_ENV
 
 jobs:
   restart_impl_ecs_app_service:
@@ -40,9 +40,9 @@ jobs:
             temp_role=$(aws sts assume-role \
                     --role-arn arn:aws:iam::$AWS_ACCOUNT_ID_IMPL:role/circleci \
                     --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken \<< "$temp_role")" >> $BASH_ENV
       - run:
           name: Restart ECS app service
           command: |
@@ -65,9 +65,9 @@ jobs:
             temp_role=$(aws sts assume-role \
                     --role-arn arn:aws:iam::$AWS_ACCOUNT_ID_PROD:role/circleci \
                     --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken \<< "$temp_role")" >> $BASH_ENV
       - run:
           name: Restart ECS app service
           command: |
@@ -456,9 +456,9 @@ jobs:
             temp_role=$(aws sts assume-role \
                     --role-arn arn:aws:iam::$AWS_ACCOUNT_ID_IMPL:role/circleci \
                     --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken \<< "$temp_role")" >> $BASH_ENV
       - run:
           name: Backup the database
           command: |
@@ -514,9 +514,9 @@ jobs:
             temp_role=$(aws sts assume-role \
                     --role-arn arn:aws:iam::$AWS_ACCOUNT_ID_PROD:role/circleci \
                     --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken \<< "$temp_role")" >> $BASH_ENV
       - run:
           name: Backup the database
           command: |
@@ -572,9 +572,9 @@ jobs:
             temp_role=$(aws sts assume-role \
                     --role-arn arn:aws:iam::$AWS_ACCOUNT_ID_DEV:role/circleci \
                     --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken \<< "$temp_role")" >> $BASH_ENV
       - attach_workspace:
           at: /tmp/builds
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 ---
-version: 2.1
+version: 2
 
 references:
   circleci_docker_primary: &circleci_docker_primary trussworks/circleci-docker-primary:822fac1c30f3bb7d5d595bed5d2dc86265c4f2f0
@@ -18,9 +18,9 @@ commands:
             temp_role=$(aws sts assume-role \
                     --role-arn arn:aws:iam::<< parameters.AWS_ACCOUNT_ID >>:role/circleci \
                     --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId \<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey \<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
 
 jobs:
   restart_impl_ecs_app_service:
@@ -40,9 +40,9 @@ jobs:
             temp_role=$(aws sts assume-role \
                     --role-arn arn:aws:iam::$AWS_ACCOUNT_ID_IMPL:role/circleci \
                     --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId \<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey \<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
       - run:
           name: Restart ECS app service
           command: |
@@ -65,9 +65,9 @@ jobs:
             temp_role=$(aws sts assume-role \
                     --role-arn arn:aws:iam::$AWS_ACCOUNT_ID_PROD:role/circleci \
                     --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId \<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey \<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
       - run:
           name: Restart ECS app service
           command: |
@@ -456,9 +456,9 @@ jobs:
             temp_role=$(aws sts assume-role \
                     --role-arn arn:aws:iam::$AWS_ACCOUNT_ID_IMPL:role/circleci \
                     --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId \<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey \<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
       - run:
           name: Backup the database
           command: |
@@ -514,9 +514,9 @@ jobs:
             temp_role=$(aws sts assume-role \
                     --role-arn arn:aws:iam::$AWS_ACCOUNT_ID_PROD:role/circleci \
                     --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId \<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey \<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
       - run:
           name: Backup the database
           command: |
@@ -572,9 +572,9 @@ jobs:
             temp_role=$(aws sts assume-role \
                     --role-arn arn:aws:iam::$AWS_ACCOUNT_ID_DEV:role/circleci \
                     --role-session-name circleci)
-            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId \<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey \<< "$temp_role")" >> $BASH_ENV
-            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken \<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_ACCESS_KEY_ID=$(jq --raw-output .Credentials.AccessKeyId <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(jq --raw-output .Credentials.SecretAccessKey <<< "$temp_role")" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(jq --raw-output .Credentials.SessionToken <<< "$temp_role")" >> $BASH_ENV
       - attach_workspace:
           at: /tmp/builds
       - run:


### PR DESCRIPTION
# ES-341

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Eliminate duplication in circleCI config via a reusable command
