### PR TITLE
Revert to version 1 of ecr-scan lambda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ jobs:
       - run:
           name: Check for vulnerability scan findings
           command: |
-            ./scripts/check_ecr_findings "easi-backend" "$CIRCLE_SHA1" "3"
+            ./scripts/check_ecr_findings "easi-backend" "$CIRCLE_SHA1" "1"
       - run:
           name: Announce failure
           command: |

--- a/scripts/check_ecr_findings
+++ b/scripts/check_ecr_findings
@@ -9,7 +9,7 @@ function_qualifier="$3"
 payload="$(jq --null-input ".repository= \"$repository\" | .imageTag = \"$image_tag\"")"
 aws lambda invoke --function-name ecr-scan-findings --cli-binary-format raw-in-base64-out --payload "$payload" --qualifier "$function_qualifier" scan_response.json
 jq < scan_response.json
-totalFindings="$(jq .totalFindings scan_response.json)"
+totalFindings="$(jq "fromjson | .totalFindings" scan_response.json)"
 if [[ "$totalFindings" != 0 ]]; then
   echo "Scan found $totalFindings findings!"
   exit 1


### PR DESCRIPTION
# ES-346

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Revert to version 1 of ecr-scan lambda

The recent refactor appears to have introduced a bug whereby the code
didn't properly handle the situation where the initial call to describe
image scan findings sometimes returns empty results. The error was
intermittent and/or rerunning the job would succeed.

I'll work on a fix the newer version of the lambda, but for now this will revert to a known good state.