### PR TITLE
ES-274 expose systems via gql

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -70,6 +70,14 @@ type ComplexityRoot struct {
 	Query struct {
 		AccessibilityRequest  func(childComplexity int, id uuid.UUID) int
 		AccessibilityRequests func(childComplexity int, first int, after *string) int
+		SystemsList           func(childComplexity int) int
+	}
+
+	System struct {
+		IntakeID    func(childComplexity int) int
+		LifecycleID func(childComplexity int) int
+		OwnerName   func(childComplexity int) int
+		ProjectName func(childComplexity int) int
 	}
 
 	UserError struct {
@@ -84,6 +92,7 @@ type MutationResolver interface {
 type QueryResolver interface {
 	AccessibilityRequests(ctx context.Context, first int, after *string) (*model.AccessibilityRequestsConnection, error)
 	AccessibilityRequest(ctx context.Context, id uuid.UUID) (*model.AccessibilityRequest, error)
+	SystemsList(ctx context.Context) ([]*model.System, error)
 }
 
 type executableSchema struct {
@@ -192,6 +201,41 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.AccessibilityRequests(childComplexity, args["first"].(int), args["after"].(*string)), true
+
+	case "Query.systemsList":
+		if e.complexity.Query.SystemsList == nil {
+			break
+		}
+
+		return e.complexity.Query.SystemsList(childComplexity), true
+
+	case "System.intakeId":
+		if e.complexity.System.IntakeID == nil {
+			break
+		}
+
+		return e.complexity.System.IntakeID(childComplexity), true
+
+	case "System.lifecycleId":
+		if e.complexity.System.LifecycleID == nil {
+			break
+		}
+
+		return e.complexity.System.LifecycleID(childComplexity), true
+
+	case "System.ownerName":
+		if e.complexity.System.OwnerName == nil {
+			break
+		}
+
+		return e.complexity.System.OwnerName(childComplexity), true
+
+	case "System.projectName":
+		if e.complexity.System.ProjectName == nil {
+			break
+		}
+
+		return e.complexity.System.ProjectName(childComplexity), true
 
 	case "UserError.message":
 		if e.complexity.UserError.Message == nil {
@@ -309,12 +353,20 @@ type Mutation {
   ): CreateAccessibilityRequestPayload
 }
 
+type System {
+  intakeId: UUID
+  lifecycleId: String
+  projectName: String
+  ownerName: String
+}
+
 type Query {
   accessibilityRequests(
     first: Int!
     after: String
   ): AccessibilityRequestsConnection
   accessibilityRequest(id: UUID!): AccessibilityRequest
+  systemsList: [System]
 }
 
 scalar UUID
@@ -824,6 +876,38 @@ func (ec *executionContext) _Query_accessibilityRequest(ctx context.Context, fie
 	return ec.marshalOAccessibilityRequest2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequest(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Query_systemsList(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().SystemsList(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.System)
+	fc.Result = res
+	return ec.marshalOSystem2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐSystem(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -893,6 +977,134 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 	res := resTmp.(*introspection.Schema)
 	fc.Result = res
 	return ec.marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _System_intakeId(ctx context.Context, field graphql.CollectedField, obj *model.System) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "System",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IntakeID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*uuid.UUID)
+	fc.Result = res
+	return ec.marshalOUUID2ᚖgithubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _System_lifecycleId(ctx context.Context, field graphql.CollectedField, obj *model.System) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "System",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LifecycleID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _System_projectName(ctx context.Context, field graphql.CollectedField, obj *model.System) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "System",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ProjectName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _System_ownerName(ctx context.Context, field graphql.CollectedField, obj *model.System) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "System",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OwnerName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _UserError_message(ctx context.Context, field graphql.CollectedField, obj *model.UserError) (ret graphql.Marshaler) {
@@ -2267,10 +2479,51 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				res = ec._Query_accessibilityRequest(ctx, field)
 				return res
 			})
+		case "systemsList":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_systemsList(ctx, field)
+				return res
+			})
 		case "__type":
 			out.Values[i] = ec._Query___type(ctx, field)
 		case "__schema":
 			out.Values[i] = ec._Query___schema(ctx, field)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var systemImplementors = []string{"System"}
+
+func (ec *executionContext) _System(ctx context.Context, sel ast.SelectionSet, obj *model.System) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, systemImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("System")
+		case "intakeId":
+			out.Values[i] = ec._System_intakeId(ctx, field, obj)
+		case "lifecycleId":
+			out.Values[i] = ec._System_lifecycleId(ctx, field, obj)
+		case "projectName":
+			out.Values[i] = ec._System_projectName(ctx, field, obj)
+		case "ownerName":
+			out.Values[i] = ec._System_ownerName(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -3020,6 +3273,68 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 		return graphql.Null
 	}
 	return graphql.MarshalString(*v)
+}
+
+func (ec *executionContext) marshalOSystem2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐSystem(ctx context.Context, sel ast.SelectionSet, v []*model.System) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOSystem2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐSystem(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
+func (ec *executionContext) marshalOSystem2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐSystem(ctx context.Context, sel ast.SelectionSet, v *model.System) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._System(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOUUID2ᚖgithubᚗcomᚋgoogleᚋuuidᚐUUID(ctx context.Context, v interface{}) (*uuid.UUID, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := model.UnmarshalUUID(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOUUID2ᚖgithubᚗcomᚋgoogleᚋuuidᚐUUID(ctx context.Context, sel ast.SelectionSet, v *uuid.UUID) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return model.MarshalUUID(*v)
 }
 
 func (ec *executionContext) marshalOUserError2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUserErrorᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.UserError) graphql.Marshaler {

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -2,6 +2,10 @@
 
 package model
 
+import (
+	"github.com/google/uuid"
+)
+
 type AccessibilityRequestEdge struct {
 	Cursor string                `json:"cursor"`
 	Node   *AccessibilityRequest `json:"node"`
@@ -19,6 +23,13 @@ type CreateAccessibilityRequestInput struct {
 type CreateAccessibilityRequestPayload struct {
 	AccessibilityRequest *AccessibilityRequest `json:"accessibilityRequest"`
 	UserErrors           []*UserError          `json:"userErrors"`
+}
+
+type System struct {
+	IntakeID    *uuid.UUID `json:"intakeId"`
+	LifecycleID *string    `json:"lifecycleId"`
+	ProjectName *string    `json:"projectName"`
+	OwnerName   *string    `json:"ownerName"`
 }
 
 type UserError struct {

--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -1,6 +1,11 @@
 package graph
 
-import "github.com/cmsgov/easi-app/pkg/storage"
+import (
+	"context"
+
+	"github.com/cmsgov/easi-app/pkg/models"
+	"github.com/cmsgov/easi-app/pkg/storage"
+)
 
 //go:generate go run github.com/99designs/gqlgen
 
@@ -10,10 +15,17 @@ import "github.com/cmsgov/easi-app/pkg/storage"
 
 // Resolver is a resolver.
 type Resolver struct {
-	store *storage.Store
+	store       *storage.Store
+	systemsList func(ctx context.Context) ([]*models.System, error)
 }
 
 // NewResolver constructs a resolver
-func NewResolver(store *storage.Store) *Resolver {
-	return &Resolver{store: store}
+func NewResolver(
+	store *storage.Store,
+	systemsList func(ctx context.Context) ([]*models.System, error),
+) *Resolver {
+	return &Resolver{
+		store:       store,
+		systemsList: systemsList,
+	}
 }

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -36,12 +36,20 @@ type Mutation {
   ): CreateAccessibilityRequestPayload
 }
 
+type System {
+  intakeId: UUID
+  lifecycleId: String
+  projectName: String
+  ownerName: String
+}
+
 type Query {
   accessibilityRequests(
     first: Int!
     after: String
   ): AccessibilityRequestsConnection
   accessibilityRequest(id: UUID!): AccessibilityRequest
+  systemsList: [System]
 }
 
 scalar UUID

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -49,6 +49,23 @@ func (r *queryResolver) AccessibilityRequest(ctx context.Context, id uuid.UUID) 
 	return r.store.FetchAccessibilityRequestByID(ctx, id)
 }
 
+func (r *queryResolver) SystemsList(ctx context.Context) ([]*model.System, error) {
+	items, err := r.systemsList(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var results []*model.System
+	for _, item := range items {
+		results = append(results, &model.System{
+			IntakeID:    &item.IntakeID,
+			LifecycleID: &item.LCID,
+			ProjectName: &item.ProjectName,
+			OwnerName:   &item.OwnerName,
+		})
+	}
+	return results, nil
+}
+
 // Mutation returns generated.MutationResolver implementation.
 func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResolver{r} }
 


### PR DESCRIPTION
# ES-274

Changes proposed in this pull request:

- SUPER preliminary effort to expose the `System` list retrieval via GraphQL; the initial intent of this PR is to provoke discussion around several topics

# Tested

I ran the server locally. Using the playground (http://127.0.0.1:8080/api/playground), I crafted the following query:
```graphql
query {
  systemsList {
    lifecycleId
    intakeId
    ownerName
  }
}
```

This worked in the Playground!

Also, was able to run it as a `curl` command:
```shell
$ curl 'http://127.0.0.1:8080/api/graph/query' -H 'Authorization: Bearer {"euaId":"NELZ"}' --data-binary '{"query":"query {\n  systemsList {\n    lifecycleId\n    intakeId\n    ownerName\n  }\n}"}' --compressed | jq .

{
  "data": {
    "systemsList": [
      {
        "lifecycleId": "X990000",
        "intakeId": "00000000-9999-0000-0000-000000000000",
        "ownerName": "Lucky Dusty Ned"
      },
      {
        "lifecycleId": "X990001",
        "intakeId": "00000000-8888-0000-0000-000000000000",
        "ownerName": "Athos Porthos Aramis"
      },
      {
        "lifecycleId": "X990002",
        "intakeId": "00000000-7777-0000-0000-000000000000",
        "ownerName": "Moe Larry Curly"
      }
    ]
  }
}
```