### PR TITLE
add page heading component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -27,6 +27,7 @@ module.exports = {
           options: {
             resources: [
               path.resolve(__dirname, '../src/stylesheets/_colors.scss'),
+              path.resolve(__dirname, '../src/stylesheets/_variables.scss'),
               path.resolve(__dirname, '../src/stylesheets/_uswdsUtilities.scss')
             ]
           }

--- a/src/components/PageHeading/__snapshots__/index.test.tsx.snap
+++ b/src/components/PageHeading/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Page heading component matches the snapshot 1`] = `
+<h1
+  className="margin-top-6 margin-bottom-5"
+>
+  Test Heading
+</h1>
+`;

--- a/src/components/PageHeading/index.stories.tsx
+++ b/src/components/PageHeading/index.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import PageHeading from './index';
+
+export default {
+  title: 'Page Heading',
+  component: PageHeading
+};
+
+export const Default = () => <PageHeading>Test Page Heading</PageHeading>;

--- a/src/components/PageHeading/index.test.tsx
+++ b/src/components/PageHeading/index.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
+
+import PageHeading from './index';
+
+describe('Page heading component', () => {
+  it('renders without errors', () => {
+    shallow(<PageHeading>Test Heading</PageHeading>);
+  });
+
+  it('matches the snapshot', () => {
+    const tree = renderer
+      .create(<PageHeading>Test Heading</PageHeading>)
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/PageHeading/index.tsx
+++ b/src/components/PageHeading/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import classnames from 'classnames';
+
+type PageHeadingProps = {
+  children: React.ReactNode;
+  className?: string;
+} & JSX.IntrinsicElements['h1'];
+
+/**
+ * This is h1 that belongs on every page.
+ * Design wants to standardize the margins around h1 that appear at the top of the page.
+ * This gives the h1 element more room to breathe.
+ */
+const PageHeading = ({ children, className, ...props }: PageHeadingProps) => {
+  const classes = classnames('margin-top-6', 'margin-bottom-5', className);
+  return (
+    <h1 className={classes} {...props}>
+      {children}
+    </h1>
+  );
+};
+
+export default PageHeading;


### PR DESCRIPTION
In a design sync, design wants to keep spacing/margin consistent.

One of the main elements that appears on every page is the h1. Moving forward, the plan is to use this component for any h1 that appears at the top of the page.

I think using this component in views will be easier than adding className="margin-top-6 margin-bottom-5" to every h1.


Old PR: #737 