### PR TITLE
ES-274 authentication & authorization tidy

### DIFF
--- a/pkg/handlers/business_case.go
+++ b/pkg/handlers/business_case.go
@@ -92,6 +92,16 @@ func (h BusinessCaseHandler) Handle() http.HandlerFunc {
 
 			return
 		case "POST":
+			principal := appcontext.Principal(r.Context())
+			if !principal.AllowEASi() {
+				h.WriteErrorResponse(
+					r.Context(),
+					w,
+					&apperrors.UnauthorizedError{Err: fmt.Errorf("principal not authorized")},
+				)
+				return
+			}
+
 			if r.Body == nil {
 				h.WriteErrorResponse(
 					r.Context(),
@@ -108,17 +118,6 @@ func (h BusinessCaseHandler) Handle() http.HandlerFunc {
 				return
 			}
 
-			principal := appcontext.Principal(r.Context())
-			if !principal.AllowEASi() {
-				h.WriteErrorResponse(
-					r.Context(),
-					w,
-					&apperrors.ContextError{
-						Operation: apperrors.ContextGet,
-						Object:    "User",
-					})
-				return
-			}
 			businessCaseToCreate.EUAUserID = principal.ID()
 
 			businessCase, err := h.CreateBusinessCase(r.Context(), &businessCaseToCreate)
@@ -143,7 +142,11 @@ func (h BusinessCaseHandler) Handle() http.HandlerFunc {
 		case "PUT":
 			principal := appcontext.Principal(r.Context())
 			if !principal.AllowEASi() {
-				h.WriteErrorResponse(r.Context(), w, &apperrors.UnauthorizedError{Err: fmt.Errorf("principal not authorized")})
+				h.WriteErrorResponse(
+					r.Context(),
+					w,
+					&apperrors.UnauthorizedError{Err: fmt.Errorf("principal not authorized")},
+				)
 				return
 			}
 

--- a/pkg/handlers/business_case.go
+++ b/pkg/handlers/business_case.go
@@ -141,6 +141,12 @@ func (h BusinessCaseHandler) Handle() http.HandlerFunc {
 			}
 			return
 		case "PUT":
+			principal := appcontext.Principal(r.Context())
+			if !principal.AllowEASi() {
+				h.WriteErrorResponse(r.Context(), w, &apperrors.UnauthorizedError{Err: fmt.Errorf("principal not authorized")})
+				return
+			}
+
 			if r.Body == nil {
 				h.WriteErrorResponse(
 					r.Context(),
@@ -164,12 +170,6 @@ func (h BusinessCaseHandler) Handle() http.HandlerFunc {
 				return
 			}
 			businessCaseToUpdate.ID = businessCaseID
-
-			principal := appcontext.Principal(r.Context())
-			if !principal.AllowEASi() {
-				h.WriteErrorResponse(r.Context(), w, err)
-				return
-			}
 			businessCaseToUpdate.EUAUserID = principal.ID()
 
 			updatedBusinessCase, err := h.UpdateBusinessCase(r.Context(), &businessCaseToUpdate)

--- a/pkg/local/authorization.go
+++ b/pkg/local/authorization.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -22,54 +23,85 @@ type DevUserConfig struct {
 	JobCodes []string `json:"jobCodes"`
 }
 
-func authorizeMiddleware(logger *zap.Logger, next http.Handler, testEUAID string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.Info("Using local authorization middleware")
+func headerToPrincipal(header string, defaultEUAID string) (authn.Principal, error) {
+	if len(header) == 0 {
+		return nil, fmt.Errorf("no Authentication header present")
+	}
+	tokenParts := strings.Split(header, "Bearer ")
+	if len(tokenParts) < 2 {
+		return nil, fmt.Errorf("invalid Bearer in auth header")
+	}
+	devUserConfigJSON := tokenParts[1]
+	if devUserConfigJSON == "" {
+		return nil, fmt.Errorf("empty dev user config JSON")
+	}
 
-		if len(r.Header["Authorization"]) == 0 {
-			logger.Info("No Authentication header present")
-			next.ServeHTTP(w, r)
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		tokenParts := strings.Split(r.Header["Authorization"][0], "Bearer ")
-		if len(tokenParts) < 2 {
-			logger.Error("invalid Bearer in auth header")
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		devUserConfigJSON := tokenParts[1]
-		if devUserConfigJSON == "" {
-			logger.Error("empty dev user config JSON")
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-
-		config := DevUserConfig{}
-		if parseErr := json.Unmarshal([]byte(devUserConfigJSON), &config); parseErr != nil {
-			// Assume at this point that we've opted for Okta login on the frontend.
-			euaID := defaultTestEUAID
-			if testEUAID != "" {
-				euaID = testEUAID
-			}
-			logger.Info("Using local authorization middleware with Okta frontend login")
-			ctx := appcontext.WithPrincipal(r.Context(), &authn.EUAPrincipal{EUAID: euaID, JobCodeEASi: true, JobCodeGRT: true})
-			next.ServeHTTP(w, r.WithContext(ctx))
-			return
-		}
-
-		logger.Info("Using local authorization middleware and populating EUA ID and job codes")
-		ctx := appcontext.WithPrincipal(r.Context(), &authn.EUAPrincipal{
-			EUAID:       config.EUA,
+	config := DevUserConfig{}
+	if parseErr := json.Unmarshal([]byte(devUserConfigJSON), &config); parseErr != nil {
+		// if we can't parse the chunk of string after the "Bearer ",
+		// Assume at this point that we've opted for Okta login on the frontend.
+		// and therefore we inject a fully authorized Principal
+		return &authn.EUAPrincipal{
+			EUAID:       defaultEUAID,
 			JobCodeEASi: true,
-			JobCodeGRT:  swag.ContainsStrings(config.JobCodes, "EASI_D_GOVTEAM")})
-		next.ServeHTTP(w, r.WithContext(ctx))
+			JobCodeGRT:  true,
+		}, fmt.Errorf("default principal with Okta frontend login")
+	}
+
+	return &authn.EUAPrincipal{
+		EUAID:       config.EUA,
+		JobCodeEASi: true,
+		JobCodeGRT:  swag.ContainsStrings(config.JobCodes, "EASI_D_GOVTEAM"),
+	}, fmt.Errorf("populating EUA ID and job codes")
+}
+
+func authorizeMiddleware(next http.Handler, defaultEUAID string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		// the AUTHENTICATION layer's responsibility is to answer "Do I
+		// know who this is?", and if it can figure that out, it puts the
+		// principal onto the context. Otherwise, it just lets the request
+		// continue on.
+		// (The responsibility to answer "is this requester allowed to
+		// make this request" is the responsibility of a later
+		// AUTHORIZATION layer)
+		p, err := headerToPrincipal(r.Header.Get("Authorization"), defaultEUAID)
+		if err != nil {
+			appcontext.ZLogger(ctx).Info("LOCAL AUTH MIDDLEWARE", zap.Error(err))
+		}
+		if p != nil {
+			// principal goes on the context
+			ctx = appcontext.WithPrincipal(ctx, p)
+
+			// decorate logs with the principal info
+			logger := appcontext.ZLogger(ctx).
+				With(zap.String("user", p.ID())).
+				With(zap.Bool("grt", p.AllowGRT()))
+			ctx = appcontext.WithLogger(ctx, logger)
+
+			// new principal and loggers now available to all the
+			// downstream parts of the chain via the decorated request
+			r = r.WithContext(ctx)
+		}
+		next.ServeHTTP(w, r)
 	})
 }
 
 // NewLocalAuthorizeMiddleware stubs out context info while ignoring remote authorization
 func NewLocalAuthorizeMiddleware(logger *zap.Logger, testEUAID string) func(http.Handler) http.Handler {
+	// we log here at ERROR level, because if this code is running
+	// in any of our deployed environments, we want to be
+	// VERY LOUD (i.e. send alerts) about it
+	logger.Error("Using LOCAL AUTHENTICATION middleware!!")
+
+	// calculate whatever EUA ID will be used when we fallback
+	euaID := defaultTestEUAID
+	if testEUAID != "" {
+		euaID = testEUAID
+	}
+
 	return func(next http.Handler) http.Handler {
-		return authorizeMiddleware(logger, next, testEUAID)
+		return authorizeMiddleware(next, euaID)
 	}
 }

--- a/pkg/server/authorization.go
+++ b/pkg/server/authorization.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/handlers"
+)
+
+func newAuthorizeEASiMiddleware(base handlers.HandlerBase) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !appcontext.Principal(r.Context()).AllowEASi() {
+				base.WriteErrorResponse(
+					r.Context(),
+					w,
+					&apperrors.UnauthorizedError{
+						Err: fmt.Errorf("principal does not have EASi permissions"),
+					},
+				)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -38,7 +38,7 @@ func (s *Server) routes(
 		traceMiddleware, // trace all requests with an ID
 		loggerMiddleware,
 		corsMiddleware,
-		// authorizationMiddleware, // is supposed to be authN, not authZ; TODO: those responsibilities should be split out
+		authorizationMiddleware, // exclusively authN, not authZ
 	)
 
 	// set up handler base
@@ -133,13 +133,11 @@ func (s *Server) routes(
 
 	// set up GraphQL routes
 	gql := s.router.PathPrefix("/api/graph").Subrouter()
-	gql.Use(authorizationMiddleware) // TODO: see comment at top-level router
 	graphqlServer := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: graph.NewResolver(store)}))
 	gql.Handle("/query", graphqlServer)
 
 	// API base path is versioned
 	api := s.router.PathPrefix("/api/v1").Subrouter()
-	api.Use(authorizationMiddleware) // TODO: see comment at top-level router
 
 	serviceConfig := services.NewConfig(s.logger, ldClient)
 


### PR DESCRIPTION
# ES-274

Changes proposed in this pull request:

- AUTHENTICATION layer is only responsible for attempting to pull info off the request to populate the internal representation of a user (aka `Principal`); AUTHORIZATION ("is this user allowed to do this thing?") is delegated to other layers
- now that authn layers (local & okta) do not fail requests for being un-authenticated, we can place the authn middleware into the chain for all routes
- added an explicit AUTHORIZATION middleware that is protecting most routes
- tidied up some code and tests that were using authZ in weird orders
