### PR TITLE
Pluralize table names

### DIFF
--- a/migrations/V65__Pluralize_Tables.sql
+++ b/migrations/V65__Pluralize_Tables.sql
@@ -1,0 +1,5 @@
+ALTER TABLE accessibility_request RENAME TO accessibility_requests;
+ALTER TABLE business_case RENAME TO business_cases;
+ALTER TABLE estimated_lifecycle_cost RENAME TO estimated_lifecycle_costs;
+ALTER TABLE note RENAME TO notes;
+ALTER TABLE system_intake RENAME TO system_intakes;

--- a/pkg/storage/accessibility_request.go
+++ b/pkg/storage/accessibility_request.go
@@ -27,7 +27,7 @@ func (s *Store) CreateAccessibilityRequest(ctx context.Context, request *model.A
 		request.UpdatedAt = &createAt
 	}
 	const createRequestSQL = `
-		INSERT INTO accessibility_request (
+		INSERT INTO accessibility_requests (
 			id,
 			name,
 			intake_id,
@@ -56,7 +56,7 @@ func (s *Store) CreateAccessibilityRequest(ctx context.Context, request *model.A
 func (s *Store) FetchAccessibilityRequestByID(ctx context.Context, id uuid.UUID) (*model.AccessibilityRequest, error) {
 	request := model.AccessibilityRequest{}
 
-	err := s.db.Get(&request, `SELECT * FROM accessibility_request WHERE id=$1`, id)
+	err := s.db.Get(&request, `SELECT * FROM accessibility_requests WHERE id=$1`, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, &apperrors.ResourceNotFoundError{Err: err, Resource: models.SystemIntake{}}
@@ -77,7 +77,7 @@ func (s *Store) FetchAccessibilityRequestByID(ctx context.Context, id uuid.UUID)
 func (s *Store) FetchAccessibilityRequests(ctx context.Context) ([]model.AccessibilityRequest, error) {
 	requests := []model.AccessibilityRequest{}
 
-	err := s.db.Select(&requests, `SELECT * FROM accessibility_request`)
+	err := s.db.Select(&requests, `SELECT * FROM accessibility_requests`)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return requests, nil

--- a/pkg/storage/business_case.go
+++ b/pkg/storage/business_case.go
@@ -16,10 +16,10 @@ import (
 )
 
 // IntakeExistsMsg is the error we see when there is no valid system intake
-const IntakeExistsMsg = "Could not query model *models.BusinessCase with operation Create, received error: pq: insert or update on table \"business_case\" violates foreign key constraint \"business_case_system_intake_fkey\""
+const IntakeExistsMsg = "Could not query model *models.BusinessCase with operation Create, received error: pq: insert or update on table \"business_cases\" violates foreign key constraint \"business_case_system_intake_fkey\""
 
 // EuaIDMsg is the error we see when EUA doesn't meet EUA ID constraints
-const EuaIDMsg = "Could not query model *models.BusinessCase with operation Create, received error: pq: new row for relation \"business_case\" violates check constraint \"eua_id_check\""
+const EuaIDMsg = "Could not query model *models.BusinessCase with operation Create, received error: pq: new row for relation \"business_cases\" violates check constraint \"eua_id_check\""
 
 // ValidStatusMsg is a match for an error we see when there is no valid status
 const ValidStatusMsg = "pq: invalid input value for enum business_case_status: "
@@ -32,16 +32,16 @@ func (s *Store) FetchBusinessCaseByID(ctx context.Context, id uuid.UUID) (*model
 	businessCase := models.BusinessCase{}
 	const fetchBusinessCaseSQL = `
 		SELECT
-			business_case.*,
-			json_agg(estimated_lifecycle_cost) as lifecycle_cost_lines,
-			system_intake.status as system_intake_status
+			business_cases.*,
+			json_agg(estimated_lifecycle_costs) as lifecycle_cost_lines,
+			system_intakes.status as system_intake_status
 		FROM
-			business_case
-			LEFT JOIN estimated_lifecycle_cost ON business_case.id = estimated_lifecycle_cost.business_case
-			JOIN system_intake ON business_case.system_intake = system_intake.id
+			business_cases
+			LEFT JOIN estimated_lifecycle_costs ON business_cases.id = estimated_lifecycle_costs.business_case
+			JOIN system_intakes ON business_cases.system_intake = system_intakes.id
 		WHERE
-			business_case.id = $1
-		GROUP BY estimated_lifecycle_cost.business_case, business_case.id, system_intake.id`
+			business_cases.id = $1
+		GROUP BY estimated_lifecycle_costs.business_case, business_cases.id, system_intakes.id`
 
 	err := s.db.Get(&businessCase, fetchBusinessCaseSQL, id)
 	if err != nil {
@@ -62,14 +62,14 @@ func (s *Store) FetchOpenBusinessCaseByIntakeID(ctx context.Context, intakeID uu
 	businessCase := models.BusinessCase{}
 	const fetchBusinessCaseSQL = `
 		SELECT
-			business_case.*,
-			json_agg(estimated_lifecycle_cost) as lifecycle_cost_lines
+			business_cases.*,
+			json_agg(estimated_lifecycle_costs) as lifecycle_cost_lines
 		FROM
-			business_case
-			LEFT JOIN estimated_lifecycle_cost ON business_case.id = estimated_lifecycle_cost.business_case
+			business_case.
+			LEFT JOIN estimated_lifecycle_costs ON business_cases.id = estimated_lifecycle_costs.business_case
 		WHERE
-			business_case.system_intake = $1 AND business_case.status = 'OPEN'
-		GROUP BY estimated_lifecycle_cost.business_case, business_case.id`
+			business_cases.system_intake = $1 AND business_cases.status = 'OPEN'
+		GROUP BY estimated_lifecycle_costs.business_case, business_cases.id`
 	err := s.db.Get(&businessCase, fetchBusinessCaseSQL, intakeID)
 	if err != nil {
 		appcontext.ZLogger(ctx).Error(
@@ -89,14 +89,14 @@ func (s *Store) FetchBusinessCasesByEuaID(ctx context.Context, euaID string) (mo
 	businessCases := []models.BusinessCase{}
 	const fetchBusinessCaseSQL = `
 		SELECT
-			business_case.*,
-			json_agg(estimated_lifecycle_cost) as lifecycle_cost_lines
+			business_cases.*,
+			json_agg(estimated_lifecycle_costs) as lifecycle_cost_lines
 		FROM
-			business_case
-			LEFT JOIN estimated_lifecycle_cost ON business_case.id = estimated_lifecycle_cost.business_case
+			business_cases
+			LEFT JOIN estimated_lifecycle_costs ON business_cases.id = estimated_lifecycle_costs.business_case
 		WHERE
-			business_case.eua_user_id = $1
-		GROUP BY estimated_lifecycle_cost.business_case, business_case.id`
+			business_cases.eua_user_id = $1
+		GROUP BY estimated_lifecycle_costs.business_case, business_cases.id`
 
 	err := s.db.Select(&businessCases, fetchBusinessCaseSQL, euaID)
 	if err != nil {
@@ -111,7 +111,7 @@ func (s *Store) FetchBusinessCasesByEuaID(ctx context.Context, euaID string) (mo
 
 func createEstimatedLifecycleCosts(ctx context.Context, tx *sqlx.Tx, businessCase *models.BusinessCase) error {
 	const createEstimatedLifecycleCostSQL = `
-		INSERT INTO estimated_lifecycle_cost (
+		INSERT INTO estimated_lifecycle_costs (
 			id,
 			business_case,
 			solution,
@@ -154,7 +154,7 @@ func (s *Store) CreateBusinessCase(ctx context.Context, businessCase *models.Bus
 	id := uuid.New()
 	businessCase.ID = id
 	const createBusinessCaseSQL = `
-		INSERT INTO business_case (
+		INSERT INTO business_cases (
 			id,
 			eua_user_id,
 			system_intake,
@@ -327,7 +327,7 @@ func (s *Store) CreateBusinessCase(ctx context.Context, businessCase *models.Bus
 func (s *Store) UpdateBusinessCase(ctx context.Context, businessCase *models.BusinessCase) (*models.BusinessCase, error) {
 	// We are explicitly not updating ID, EUAUserID and SystemIntakeID
 	const updateBusinessCaseSQL = `
-		UPDATE business_case
+		UPDATE business_cases
 		SET
 			project_name = :project_name,
 			requester = :requester,
@@ -383,10 +383,10 @@ func (s *Store) UpdateBusinessCase(ctx context.Context, businessCase *models.Bus
 		  status = :status,
 			initial_submitted_at = :initial_submitted_at,
 		  last_submitted_at = :last_submitted_at
-		WHERE business_case.id = :id
+		WHERE business_cases.id = :id
 	`
 	const deleteLifecycleCostsSQL = `
-		DELETE FROM estimated_lifecycle_cost
+		DELETE FROM estimated_lifecycle_costs
 		WHERE business_case = :id
 	`
 

--- a/pkg/storage/note.go
+++ b/pkg/storage/note.go
@@ -22,7 +22,7 @@ func (s *Store) CreateNote(ctx context.Context, note *models.Note) (*models.Note
 		note.CreatedAt = &ts
 	}
 	const createNoteSQL = `	
-		INSERT INTO note (
+		INSERT INTO notes (
 			id,
 			system_intake,
 			created_at,
@@ -60,7 +60,7 @@ func (s *Store) CreateNote(ctx context.Context, note *models.Note) (*models.Note
 // FetchNoteByID retrieves a single Note by its primary key identifier
 func (s *Store) FetchNoteByID(ctx context.Context, id uuid.UUID) (*models.Note, error) {
 	note := models.Note{}
-	err := s.db.Get(&note, "SELECT * FROM public.note WHERE id=$1", id)
+	err := s.db.Get(&note, "SELECT * FROM public.notes WHERE id=$1", id)
 	if err != nil {
 		appcontext.ZLogger(ctx).Error(
 			fmt.Sprintf("Failed to fetch note %s", err),
@@ -77,7 +77,7 @@ func (s *Store) FetchNoteByID(ctx context.Context, id uuid.UUID) (*models.Note, 
 // FetchNotesBySystemIntakeID retrieves all Notes associated with a specific SystemIntake
 func (s *Store) FetchNotesBySystemIntakeID(ctx context.Context, id uuid.UUID) ([]*models.Note, error) {
 	notes := []*models.Note{}
-	err := s.db.Select(&notes, "SELECT * FROM note WHERE system_intake=$1", id)
+	err := s.db.Select(&notes, "SELECT * FROM notes WHERE system_intake=$1", id)
 	if err != nil {
 		appcontext.ZLogger(ctx).Error(
 			fmt.Sprintf("Failed to fetch notes %s", err),

--- a/pkg/storage/system.go
+++ b/pkg/storage/system.go
@@ -109,7 +109,7 @@ const sqlListSystems = `
 		project_name,
 		eua_user_id,
 		requester
-	FROM system_intake
+	FROM system_intakes
 	WHERE
 		status='LCID_ISSUED' AND
 		request_type='NEW' AND
@@ -131,7 +131,7 @@ const sqlFetchSystemByIntakeID = `
 	SELECT
 		id,
 		project_name AS name
-	FROM system_intake
+	FROM system_intakes
 	WHERE
 		status='LCID_ISSUED' AND
 		request_type='NEW' AND

--- a/pkg/storage/system_intake_test.go
+++ b/pkg/storage/system_intake_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/cmsgov/easi-app/pkg/testhelpers"
 )
 
-const insertBasicIntakeSQL = "INSERT INTO system_intake (id, eua_user_id, status, request_type, requester) VALUES (:id, :eua_user_id, :status, :request_type, :requester)"
-const insertRelatedBizCaseSQL = `INSERT INTO business_case (id, eua_user_id, status, requester, system_intake)
+const insertBasicIntakeSQL = "INSERT INTO system_intakes (id, eua_user_id, status, request_type, requester) VALUES (:id, :eua_user_id, :status, :request_type, :requester)"
+const insertRelatedBizCaseSQL = `INSERT INTO business_cases (id, eua_user_id, status, requester, system_intake)
 		VALUES(:id, :eua_user_id, :status, :requester, :system_intake)`
 
 func (s StoreTestSuite) TestCreateSystemIntake() {
@@ -58,7 +58,7 @@ func (s StoreTestSuite) TestCreateSystemIntake() {
 			_, err := s.store.CreateSystemIntake(ctx, &partialIntake)
 
 			s.Error(err)
-			s.Equal("pq: new row for relation \"system_intake\" violates check constraint \"eua_id_check\"", err.Error())
+			s.Equal("pq: new row for relation \"system_intakes\" violates check constraint \"eua_id_check\"", err.Error())
 		})
 	}
 


### PR DESCRIPTION
# Pluralize table names

Based on [a discussion in Slack](https://trussworks.slack.com/archives/C01BCRE1Q20/p1611607527123300), we'd like to have all tables use the same naming scheme. The team had a mild preference for plural names.

Changes proposed in this pull request:

- Add a migration to pluralize table names
- Update SQL to reference new table names
