### PR TITLE
helper to debug route issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ to access a GraphQL playground while
 the Go backend is running. **You will need to enter `/graph/query` as the query
 path in the UI for this to work.**
 
-#### Authorization
+### Authorization
 
 Setting this `APP_ENV` environment variable to "local"
 will turn off API authorization.
@@ -494,3 +494,23 @@ by logging into [the development app](dev.easi.cms.gov)
 and copying `okta-token-storage/accessToken` from the browser's local storage.
 Place this in the `Authorization` header
 as `Bearer ${accessToken}`.
+
+### Routes Debugging
+
+Setting the `DEBUG_ROUTES` environment variable, and upon startup, this will
+log out a representation of all routes that have been registered.
+
+```shell
+$ DEBUG_ROUTES=1 ./bin/easi serve
+...
+ROUTE: /api/v1/healthcheck
+Path regexp: ^/api/v1/healthcheck$
+Queries templates:
+Queries regexps:
+
+ROUTE: /api/graph/playground
+Path regexp: ^/api/graph/playground$
+Queries templates:
+Queries regexps:
+...
+```

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -1,13 +1,18 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/gorilla/mux"
 	_ "github.com/lib/pq" // pq is required to get the postgres driver into sqlx
 	"go.uber.org/zap"
 
@@ -552,4 +557,32 @@ func (s *Server) routes(
 		),
 	)
 	api.Handle("/systems", systemsHandler.Handle())
+
+	if ok, _ := strconv.ParseBool(os.Getenv("DEBUG_ROUTES")); ok {
+		// useful for debugging route issues
+		_ = s.router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+			pathTemplate, err := route.GetPathTemplate()
+			if err == nil {
+				fmt.Println("ROUTE:", pathTemplate)
+			}
+			pathRegexp, err := route.GetPathRegexp()
+			if err == nil {
+				fmt.Println("Path regexp:", pathRegexp)
+			}
+			queriesTemplates, err := route.GetQueriesTemplates()
+			if err == nil {
+				fmt.Println("Queries templates:", strings.Join(queriesTemplates, ","))
+			}
+			queriesRegexps, err := route.GetQueriesRegexp()
+			if err == nil {
+				fmt.Println("Queries regexps:", strings.Join(queriesRegexps, ","))
+			}
+			methods, err := route.GetMethods()
+			if err == nil {
+				fmt.Println("Methods:", strings.Join(methods, ","))
+			}
+			fmt.Println()
+			return nil
+		})
+	}
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- add a env var triggered output of the routes upon startup, intended for debugging purposes
- as per discussion on (closed) #739 

```shell
$ DEBUG_ROUTES=1 ./bin/easi serve
...
ROUTE: /api/v1/healthcheck
Path regexp: ^/api/v1/healthcheck$
Queries templates:
Queries regexps:

ROUTE: /api/graph/playground
Path regexp: ^/api/graph/playground$
Queries templates:
Queries regexps:
...
```