### PR TITLE
Document upload UI and resolver

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -58,6 +58,7 @@ type ComplexityRoot struct {
 		ID         func(childComplexity int) int
 		Mimetype   func(childComplexity int) int
 		Name       func(childComplexity int) int
+		Status     func(childComplexity int) int
 		UploadedAt func(childComplexity int) int
 	}
 
@@ -198,6 +199,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AccessibilityRequestDocument.Name(childComplexity), true
+
+	case "AccessibilityRequestDocument.status":
+		if e.complexity.AccessibilityRequestDocument.Status == nil {
+			break
+		}
+
+		return e.complexity.AccessibilityRequestDocument.Status(childComplexity), true
 
 	case "AccessibilityRequestDocument.uploadedAt":
 		if e.complexity.AccessibilityRequestDocument.UploadedAt == nil {
@@ -509,12 +517,33 @@ type System {
 }
 
 """
+Represents the availability of a document
+"""
+enum AccessibilityRequestDocumentStatus {
+  """
+  Passed security screen
+  """
+  AVAILABLE
+
+  """
+  Just uploaded
+  """
+  PENDING
+
+  """
+  Failed security screen
+  """
+  UNAVAILABLE
+}
+
+"""
 A document that belongs to an accessibility request
 """
 type AccessibilityRequestDocument {
   id: UUID!
   mimetype: String!
   name: String!
+  status: AccessibilityRequestDocumentStatus!
   uploadedAt: Time!
 }
 
@@ -1010,6 +1039,41 @@ func (ec *executionContext) _AccessibilityRequestDocument_name(ctx context.Conte
 	res := resTmp.(string)
 	fc.Result = res
 	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _AccessibilityRequestDocument_status(ctx context.Context, field graphql.CollectedField, obj *model.AccessibilityRequestDocument) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "AccessibilityRequestDocument",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.AccessibilityRequestDocumentStatus)
+	fc.Result = res
+	return ec.marshalNAccessibilityRequestDocumentStatus2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequestDocumentStatus(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _AccessibilityRequestDocument_uploadedAt(ctx context.Context, field graphql.CollectedField, obj *model.AccessibilityRequestDocument) (ret graphql.Marshaler) {
@@ -3222,6 +3286,11 @@ func (ec *executionContext) _AccessibilityRequestDocument(ctx context.Context, s
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "status":
+			out.Values[i] = ec._AccessibilityRequestDocument_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "uploadedAt":
 			out.Values[i] = ec._AccessibilityRequestDocument_uploadedAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -3917,6 +3986,16 @@ func (ec *executionContext) marshalNAccessibilityRequestDocument2ᚖgithubᚗcom
 		return graphql.Null
 	}
 	return ec._AccessibilityRequestDocument(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNAccessibilityRequestDocumentStatus2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequestDocumentStatus(ctx context.Context, v interface{}) (model.AccessibilityRequestDocumentStatus, error) {
+	var res model.AccessibilityRequestDocumentStatus
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNAccessibilityRequestDocumentStatus2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequestDocumentStatus(ctx context.Context, sel ast.SelectionSet, v model.AccessibilityRequestDocumentStatus) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) marshalNAccessibilityRequestEdge2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequestEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.AccessibilityRequestEdge) graphql.Marshaler {

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -582,7 +582,7 @@ type CreateAccessibilityRequestPayload {
 Parameters required to generate a presigned upload URL
 """
 input GeneratePresignedUploadURLInput {
-  fileType: String!
+  mimeType: String!
 }
 
 """
@@ -3178,11 +3178,11 @@ func (ec *executionContext) unmarshalInputGeneratePresignedUploadURLInput(ctx co
 
 	for k, v := range asMap {
 		switch k {
-		case "fileType":
+		case "mimeType":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("fileType"))
-			it.FileType, err = ec.unmarshalNString2string(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("mimeType"))
+			it.MimeType, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -55,6 +55,7 @@ type ComplexityRoot struct {
 
 	AccessibilityRequestDocument struct {
 		ID         func(childComplexity int) int
+		Mimetype   func(childComplexity int) int
 		Name       func(childComplexity int) int
 		UploadedAt func(childComplexity int) int
 	}
@@ -79,8 +80,14 @@ type ComplexityRoot struct {
 		UserErrors           func(childComplexity int) int
 	}
 
+	GeneratePresignedUploadURLPayload struct {
+		URL        func(childComplexity int) int
+		UserErrors func(childComplexity int) int
+	}
+
 	Mutation struct {
 		CreateAccessibilityRequest func(childComplexity int, input *model.CreateAccessibilityRequestInput) int
+		GeneratePresignedUploadURL func(childComplexity int, input *model.GeneratePresignedUploadURLInput) int
 	}
 
 	Query struct {
@@ -119,6 +126,7 @@ type AccessibilityRequestResolver interface {
 }
 type MutationResolver interface {
 	CreateAccessibilityRequest(ctx context.Context, input *model.CreateAccessibilityRequestInput) (*model.CreateAccessibilityRequestPayload, error)
+	GeneratePresignedUploadURL(ctx context.Context, input *model.GeneratePresignedUploadURLInput) (*model.GeneratePresignedUploadURLPayload, error)
 }
 type QueryResolver interface {
 	AccessibilityRequest(ctx context.Context, id uuid.UUID) (*model.AccessibilityRequest, error)
@@ -175,6 +183,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AccessibilityRequestDocument.ID(childComplexity), true
+
+	case "AccessibilityRequestDocument.mimetype":
+		if e.complexity.AccessibilityRequestDocument.Mimetype == nil {
+			break
+		}
+
+		return e.complexity.AccessibilityRequestDocument.Mimetype(childComplexity), true
 
 	case "AccessibilityRequestDocument.name":
 		if e.complexity.AccessibilityRequestDocument.Name == nil {
@@ -246,6 +261,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CreateAccessibilityRequestPayload.UserErrors(childComplexity), true
 
+	case "GeneratePresignedUploadURLPayload.url":
+		if e.complexity.GeneratePresignedUploadURLPayload.URL == nil {
+			break
+		}
+
+		return e.complexity.GeneratePresignedUploadURLPayload.URL(childComplexity), true
+
+	case "GeneratePresignedUploadURLPayload.userErrors":
+		if e.complexity.GeneratePresignedUploadURLPayload.UserErrors == nil {
+			break
+		}
+
+		return e.complexity.GeneratePresignedUploadURLPayload.UserErrors(childComplexity), true
+
 	case "Mutation.createAccessibilityRequest":
 		if e.complexity.Mutation.CreateAccessibilityRequest == nil {
 			break
@@ -257,6 +286,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.CreateAccessibilityRequest(childComplexity, args["input"].(*model.CreateAccessibilityRequestInput)), true
+
+	case "Mutation.generatePresignedUploadURL":
+		if e.complexity.Mutation.GeneratePresignedUploadURL == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_generatePresignedUploadURL_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.GeneratePresignedUploadURL(childComplexity, args["input"].(*model.GeneratePresignedUploadURLInput)), true
 
 	case "Query.accessibilityRequest":
 		if e.complexity.Query.AccessibilityRequest == nil {
@@ -467,6 +508,16 @@ type System {
 }
 
 """
+A document that belongs to an accessibility request
+"""
+type AccessibilityRequestDocument {
+  id: UUID!
+  mimetype: String!
+  name: String!
+  uploadedAt: Time!
+}
+
+"""
 A collection of Systems
 """
 type SystemConnection {
@@ -483,15 +534,6 @@ type SystemEdge {
 }
 
 """
-A document that belongs to an accessibility request
-"""
-type AccessibilityRequestDocument {
-  id: UUID!
-  name: String!
-  uploadedAt: Time!
-}
-
-"""
 Parameters required to create an AccessibilityRequest
 """
 input CreateAccessibilityRequestInput {
@@ -503,6 +545,21 @@ Result of CreateAccessibilityRequest
 """
 type CreateAccessibilityRequestPayload {
   accessibilityRequest: AccessibilityRequest
+  userErrors: [UserError!]
+}
+
+"""
+Parameters required to generate a presigned upload URL
+"""
+input GeneratePresignedUploadURLInput {
+  fileType: String!
+}
+
+"""
+Result of CreateAccessibilityRequest
+"""
+type GeneratePresignedUploadURLPayload {
+  url: String
   userErrors: [UserError!]
 }
 
@@ -529,6 +586,9 @@ type Mutation {
   createAccessibilityRequest(
     input: CreateAccessibilityRequestInput
   ): CreateAccessibilityRequestPayload
+  generatePresignedUploadURL(
+    input: GeneratePresignedUploadURLInput
+  ): GeneratePresignedUploadURLPayload
 }
 
 """
@@ -540,10 +600,7 @@ type Query {
     after: String
     first: Int!
   ): AccessibilityRequestsConnection
-  systems(
-    after: String
-    first: Int!
-  ): SystemConnection
+  systems(after: String, first: Int!): SystemConnection
 }
 
 """
@@ -570,6 +627,21 @@ func (ec *executionContext) field_Mutation_createAccessibilityRequest_args(ctx c
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalOCreateAccessibilityRequestInput2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐCreateAccessibilityRequestInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_generatePresignedUploadURL_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.GeneratePresignedUploadURLInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalOGeneratePresignedUploadURLInput2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐGeneratePresignedUploadURLInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -867,6 +939,41 @@ func (ec *executionContext) _AccessibilityRequestDocument_id(ctx context.Context
 	res := resTmp.(uuid.UUID)
 	fc.Result = res
 	return ec.marshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _AccessibilityRequestDocument_mimetype(ctx context.Context, field graphql.CollectedField, obj *model.AccessibilityRequestDocument) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "AccessibilityRequestDocument",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Mimetype, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _AccessibilityRequestDocument_name(ctx context.Context, field graphql.CollectedField, obj *model.AccessibilityRequestDocument) (ret graphql.Marshaler) {
@@ -1213,6 +1320,70 @@ func (ec *executionContext) _CreateAccessibilityRequestPayload_userErrors(ctx co
 	return ec.marshalOUserError2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUserErrorᚄ(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _GeneratePresignedUploadURLPayload_url(ctx context.Context, field graphql.CollectedField, obj *model.GeneratePresignedUploadURLPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "GeneratePresignedUploadURLPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.URL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _GeneratePresignedUploadURLPayload_userErrors(ctx context.Context, field graphql.CollectedField, obj *model.GeneratePresignedUploadURLPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "GeneratePresignedUploadURLPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UserErrors, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.UserError)
+	fc.Result = res
+	return ec.marshalOUserError2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUserErrorᚄ(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Mutation_createAccessibilityRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -1250,6 +1421,45 @@ func (ec *executionContext) _Mutation_createAccessibilityRequest(ctx context.Con
 	res := resTmp.(*model.CreateAccessibilityRequestPayload)
 	fc.Result = res
 	return ec.marshalOCreateAccessibilityRequestPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐCreateAccessibilityRequestPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_generatePresignedUploadURL(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_generatePresignedUploadURL_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().GeneratePresignedUploadURL(rctx, args["input"].(*model.GeneratePresignedUploadURLInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.GeneratePresignedUploadURLPayload)
+	fc.Result = res
+	return ec.marshalOGeneratePresignedUploadURLPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐGeneratePresignedUploadURLPayload(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_accessibilityRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -2897,6 +3107,26 @@ func (ec *executionContext) unmarshalInputCreateAccessibilityRequestInput(ctx co
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputGeneratePresignedUploadURLInput(ctx context.Context, obj interface{}) (model.GeneratePresignedUploadURLInput, error) {
+	var it model.GeneratePresignedUploadURLInput
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "fileType":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("fileType"))
+			it.FileType, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 // endregion **************************** input.gotpl *****************************
 
 // region    ************************** interface.gotpl ***************************
@@ -2978,6 +3208,11 @@ func (ec *executionContext) _AccessibilityRequestDocument(ctx context.Context, s
 			out.Values[i] = graphql.MarshalString("AccessibilityRequestDocument")
 		case "id":
 			out.Values[i] = ec._AccessibilityRequestDocument_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "mimetype":
+			out.Values[i] = ec._AccessibilityRequestDocument_mimetype(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -3124,6 +3359,32 @@ func (ec *executionContext) _CreateAccessibilityRequestPayload(ctx context.Conte
 	return out
 }
 
+var generatePresignedUploadURLPayloadImplementors = []string{"GeneratePresignedUploadURLPayload"}
+
+func (ec *executionContext) _GeneratePresignedUploadURLPayload(ctx context.Context, sel ast.SelectionSet, obj *model.GeneratePresignedUploadURLPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, generatePresignedUploadURLPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("GeneratePresignedUploadURLPayload")
+		case "url":
+			out.Values[i] = ec._GeneratePresignedUploadURLPayload_url(ctx, field, obj)
+		case "userErrors":
+			out.Values[i] = ec._GeneratePresignedUploadURLPayload_userErrors(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var mutationImplementors = []string{"Mutation"}
 
 func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet) graphql.Marshaler {
@@ -3141,6 +3402,8 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = graphql.MarshalString("Mutation")
 		case "createAccessibilityRequest":
 			out.Values[i] = ec._Mutation_createAccessibilityRequest(ctx, field)
+		case "generatePresignedUploadURL":
+			out.Values[i] = ec._Mutation_generatePresignedUploadURL(ctx, field)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -4189,6 +4452,21 @@ func (ec *executionContext) marshalOCreateAccessibilityRequestPayload2ᚖgithub�
 		return graphql.Null
 	}
 	return ec._CreateAccessibilityRequestPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOGeneratePresignedUploadURLInput2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐGeneratePresignedUploadURLInput(ctx context.Context, v interface{}) (*model.GeneratePresignedUploadURLInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputGeneratePresignedUploadURLInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOGeneratePresignedUploadURLPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐGeneratePresignedUploadURLPayload(ctx context.Context, sel ast.SelectionSet, v *model.GeneratePresignedUploadURLPayload) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._GeneratePresignedUploadURLPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOString2string(ctx context.Context, v interface{}) (string, error) {

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -11,6 +11,7 @@ import (
 // A document that belongs to an accessibility request
 type AccessibilityRequestDocument struct {
 	ID         uuid.UUID `json:"id"`
+	Mimetype   string    `json:"mimetype"`
 	Name       string    `json:"name"`
 	UploadedAt time.Time `json:"uploadedAt"`
 }
@@ -42,6 +43,17 @@ type CreateAccessibilityRequestInput struct {
 type CreateAccessibilityRequestPayload struct {
 	AccessibilityRequest *AccessibilityRequest `json:"accessibilityRequest"`
 	UserErrors           []*UserError          `json:"userErrors"`
+}
+
+// Parameters required to generate a presigned upload URL
+type GeneratePresignedUploadURLInput struct {
+	FileType string `json:"fileType"`
+}
+
+// Result of CreateAccessibilityRequest
+type GeneratePresignedUploadURLPayload struct {
+	URL        *string      `json:"url"`
+	UserErrors []*UserError `json:"userErrors"`
 }
 
 // A collection of Systems

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -46,7 +46,7 @@ type CreateAccessibilityRequestPayload struct {
 
 // Parameters required to generate a presigned upload URL
 type GeneratePresignedUploadURLInput struct {
-	FileType string `json:"fileType"`
+	MimeType string `json:"mimeType"`
 }
 
 // Result of CreateAccessibilityRequest

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -3,6 +3,9 @@
 package model
 
 import (
+	"fmt"
+	"io"
+	"strconv"
 	"time"
 
 	"github.com/cmsgov/easi-app/pkg/models"
@@ -11,10 +14,11 @@ import (
 
 // A document that belongs to an accessibility request
 type AccessibilityRequestDocument struct {
-	ID         uuid.UUID `json:"id"`
-	Mimetype   string    `json:"mimetype"`
-	Name       string    `json:"name"`
-	UploadedAt time.Time `json:"uploadedAt"`
+	ID         uuid.UUID                          `json:"id"`
+	Mimetype   string                             `json:"mimetype"`
+	Name       string                             `json:"name"`
+	Status     AccessibilityRequestDocumentStatus `json:"status"`
+	UploadedAt time.Time                          `json:"uploadedAt"`
 }
 
 // An edge of an AccessibilityRequestConnection
@@ -68,4 +72,51 @@ type SystemEdge struct {
 type UserError struct {
 	Message string   `json:"message"`
 	Path    []string `json:"path"`
+}
+
+// Represents the availability of a document
+type AccessibilityRequestDocumentStatus string
+
+const (
+	// Passed security screen
+	AccessibilityRequestDocumentStatusAvailable AccessibilityRequestDocumentStatus = "AVAILABLE"
+	// Just uploaded
+	AccessibilityRequestDocumentStatusPending AccessibilityRequestDocumentStatus = "PENDING"
+	// Failed security screen
+	AccessibilityRequestDocumentStatusUnavailable AccessibilityRequestDocumentStatus = "UNAVAILABLE"
+)
+
+var AllAccessibilityRequestDocumentStatus = []AccessibilityRequestDocumentStatus{
+	AccessibilityRequestDocumentStatusAvailable,
+	AccessibilityRequestDocumentStatusPending,
+	AccessibilityRequestDocumentStatusUnavailable,
+}
+
+func (e AccessibilityRequestDocumentStatus) IsValid() bool {
+	switch e {
+	case AccessibilityRequestDocumentStatusAvailable, AccessibilityRequestDocumentStatusPending, AccessibilityRequestDocumentStatusUnavailable:
+		return true
+	}
+	return false
+}
+
+func (e AccessibilityRequestDocumentStatus) String() string {
+	return string(e)
+}
+
+func (e *AccessibilityRequestDocumentStatus) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = AccessibilityRequestDocumentStatus(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid AccessibilityRequestDocumentStatus", str)
+	}
+	return nil
+}
+
+func (e AccessibilityRequestDocumentStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -1,6 +1,9 @@
 package graph
 
-import "github.com/cmsgov/easi-app/pkg/storage"
+import (
+	"github.com/cmsgov/easi-app/pkg/storage"
+	"github.com/cmsgov/easi-app/pkg/upload"
+)
 
 //go:generate go run github.com/99designs/gqlgen
 
@@ -10,10 +13,11 @@ import "github.com/cmsgov/easi-app/pkg/storage"
 
 // Resolver is a resolver.
 type Resolver struct {
-	store *storage.Store
+	store    *storage.Store
+	s3Client *upload.S3Client
 }
 
 // NewResolver constructs a resolver
-func NewResolver(store *storage.Store) *Resolver {
-	return &Resolver{store: store}
+func NewResolver(store *storage.Store, s3Client *upload.S3Client) *Resolver {
+	return &Resolver{store: store, s3Client: s3Client}
 }

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -102,7 +102,7 @@ type CreateAccessibilityRequestPayload {
 Parameters required to generate a presigned upload URL
 """
 input GeneratePresignedUploadURLInput {
-  fileType: String!
+  mimeType: String!
 }
 
 """

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -37,6 +37,16 @@ type System {
 }
 
 """
+A document that belongs to an accessibility request
+"""
+type AccessibilityRequestDocument {
+  id: UUID!
+  mimetype: String!
+  name: String!
+  uploadedAt: Time!
+}
+
+"""
 A collection of Systems
 """
 type SystemConnection {
@@ -53,15 +63,6 @@ type SystemEdge {
 }
 
 """
-A document that belongs to an accessibility request
-"""
-type AccessibilityRequestDocument {
-  id: UUID!
-  name: String!
-  uploadedAt: Time!
-}
-
-"""
 Parameters required to create an AccessibilityRequest
 """
 input CreateAccessibilityRequestInput {
@@ -73,6 +74,21 @@ Result of CreateAccessibilityRequest
 """
 type CreateAccessibilityRequestPayload {
   accessibilityRequest: AccessibilityRequest
+  userErrors: [UserError!]
+}
+
+"""
+Parameters required to generate a presigned upload URL
+"""
+input GeneratePresignedUploadURLInput {
+  fileType: String!
+}
+
+"""
+Result of CreateAccessibilityRequest
+"""
+type GeneratePresignedUploadURLPayload {
+  url: String
   userErrors: [UserError!]
 }
 
@@ -99,6 +115,9 @@ type Mutation {
   createAccessibilityRequest(
     input: CreateAccessibilityRequestInput
   ): CreateAccessibilityRequestPayload
+  generatePresignedUploadURL(
+    input: GeneratePresignedUploadURLInput
+  ): GeneratePresignedUploadURLPayload
 }
 
 """
@@ -110,10 +129,7 @@ type Query {
     after: String
     first: Int!
   ): AccessibilityRequestsConnection
-  systems(
-    after: String
-    first: Int!
-  ): SystemConnection
+  systems(after: String, first: Int!): SystemConnection
 }
 
 """

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -37,12 +37,33 @@ type System {
 }
 
 """
+Represents the availability of a document
+"""
+enum AccessibilityRequestDocumentStatus {
+  """
+  Passed security screen
+  """
+  AVAILABLE
+
+  """
+  Just uploaded
+  """
+  PENDING
+
+  """
+  Failed security screen
+  """
+  UNAVAILABLE
+}
+
+"""
 A document that belongs to an accessibility request
 """
 type AccessibilityRequestDocument {
   id: UUID!
   mimetype: String!
   name: String!
+  status: AccessibilityRequestDocumentStatus!
   uploadedAt: Time!
 }
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -45,6 +45,10 @@ func (r *mutationResolver) CreateAccessibilityRequest(ctx context.Context, input
 	}, nil
 }
 
+func (r *mutationResolver) GeneratePresignedUploadURL(ctx context.Context, input *model.GeneratePresignedUploadURLInput) (*model.GeneratePresignedUploadURLPayload, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
 func (r *queryResolver) AccessibilityRequest(ctx context.Context, id uuid.UUID) (*model.AccessibilityRequest, error) {
 	return r.store.FetchAccessibilityRequestByID(ctx, id)
 }

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -47,7 +47,13 @@ func (r *mutationResolver) CreateAccessibilityRequest(ctx context.Context, input
 }
 
 func (r *mutationResolver) GeneratePresignedUploadURL(ctx context.Context, input *model.GeneratePresignedUploadURLInput) (*model.GeneratePresignedUploadURLPayload, error) {
-	panic(fmt.Errorf("not implemented"))
+	url, err := r.s3Client.NewPutPresignedURL(input.MimeType)
+	if err != nil {
+		return nil, err
+	}
+	return &model.GeneratePresignedUploadURLPayload{
+		URL: &url.URL,
+	}, nil
 }
 
 func (r *queryResolver) AccessibilityRequest(ctx context.Context, id uuid.UUID) (*models.AccessibilityRequest, error) {

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -134,7 +134,7 @@ func (s *Server) routes(
 	// set up GraphQL routes
 	gql := s.router.PathPrefix("/api/graph").Subrouter()
 	gql.Use(authorizationMiddleware) // TODO: see comment at top-level router
-	graphqlServer := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: graph.NewResolver(store)}))
+	graphqlServer := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: graph.NewResolver(store, &s3Client)}))
 	gql.Handle("/query", graphqlServer)
 
 	// API base path is versioned

--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -48,10 +48,16 @@ func NewS3Client(config Config) S3Client {
 
 	s3Session := session.Must(session.NewSession(awsConfig))
 
-	// create the s3 service client
-	client := s3.New(s3Session)
+	return NewS3ClientUsingClient(s3.New(s3Session), config)
+}
 
-	return S3Client{client, config}
+// NewS3ClientUsingClient creates a new s3 wrapper using the specified s3 client
+// This is most useful for testing where the s3 client needs to be mocked out.
+func NewS3ClientUsingClient(s3Client s3iface.S3API, config Config) S3Client {
+	return S3Client{
+		s3Client,
+		config,
+	}
 }
 
 // NewPutPresignedURL returns a pre-signed URL used for PUT-ing objects

--- a/src/components/FileUpload/index.tsx
+++ b/src/components/FileUpload/index.tsx
@@ -81,7 +81,9 @@ const FileUpload = (props: FileUploadProps) => {
           </div>
         )}
         <div className={instructionsClasses} aria-hidden>
-          <span className="usa-file-input__drag-text">Drag file here or </span>
+          <span className="usa-file-input__drag-text">
+            Drag document here or{' '}
+          </span>
           <span className="usa-file-input__choose">choose from folder</span>
         </div>
         {file && (

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -75,7 +75,7 @@ const AccessibilityRequestDetailPage = () => {
                 className="usa-button"
                 variant="unstyled"
                 asCustom={Link}
-                to={`/508/requests/${accessibilityRequestId}/document-upload`}
+                to={`/508/requests/${accessibilityRequestId}/documents/new`}
               >
                 {t('requestDetails.documentUpload')}
               </UswdsLink>

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+import { Button, Form, Label } from '@trussworks/react-uswds';
+import { Formik, FormikProps } from 'formik';
+import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
+import { GetAccessibilityRequest } from 'queries/types/GetAccessibilityRequest';
+
+import FileUpload from 'components/FileUpload';
+import Footer from 'components/Footer';
+import Header from 'components/Header';
+import MainContent from 'components/MainContent';
+import PageWrapper from 'components/PageWrapper';
+import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
+import { FileUploadForm } from 'types/files';
+
+const New = () => {
+  const { t } = useTranslation('accessibility');
+
+  const { accessibilityRequestId } = useParams<{
+    accessibilityRequestId: string;
+  }>();
+  const { loading, error, data } = useQuery<GetAccessibilityRequest>(
+    GetAccessibilityRequestQuery,
+    {
+      variables: {
+        id: accessibilityRequestId
+      }
+    }
+  );
+
+  const [fileSelected, setFileSelected] = useState(false);
+
+  if (loading) {
+    return <div>Loading</div>;
+  }
+
+  if (error) {
+    return <div>{error}</div>;
+  }
+
+  if (!data) {
+    return (
+      <div>{`No request found matching id: ${accessibilityRequestId}`}</div>
+    );
+  }
+
+  const onChange = () => {
+    setFileSelected(true);
+  };
+
+  return (
+    <PageWrapper className="accessibility-request">
+      <Header />
+      <MainContent className="margin-bottom-5">
+        <SecondaryNav>
+          <NavLink to={`/508/requests/${accessibilityRequestId}`}>
+            {t('tabs.accessibilityRequests')}
+          </NavLink>
+        </SecondaryNav>
+        <div className="grid-container">
+          <Formik
+            initialValues={{
+              filename: '',
+              file: {} as File,
+              uploadURL: ''
+            }}
+            onSubmit={() => {}}
+          >
+            {(formikProps: FormikProps<FileUploadForm>) => {
+              return (
+                <Form onSubmit={formikProps.handleSubmit}>
+                  <h1>
+                    Upload a document to{' '}
+                    {data?.accessibilityRequest?.system.name}
+                  </h1>
+                  <Label htmlFor="file-upload">
+                    Choose a document to upload
+                    <FileUpload
+                      id="file-upload"
+                      name="file-upload"
+                      accept=".pdf,.txt"
+                      onChange={onChange}
+                      onBlur={() => {}}
+                      ariaDescribedBy=""
+                    />
+                  </Label>
+
+                  {fileSelected && (
+                    <div className="padding-top-2">
+                      <p>
+                        To keep CMS safe, documents are scanned for viruses
+                        after uploading. If something goes wrong, we&apos;ll let
+                        you know.
+                      </p>
+                      <Button type="submit" onClick={() => {}}>
+                        Upload document
+                      </Button>
+                    </div>
+                  )}
+                </Form>
+              );
+            }}
+          </Formik>
+
+          <p className="padding-top-2">
+            <Link to={`/508/requests/${accessibilityRequestId}`}>
+              Don&apos;t upload and return to request page
+            </Link>
+          </p>
+        </div>
+      </MainContent>
+      <Footer />
+    </PageWrapper>
+  );
+};
+
+export default New;

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -8,6 +8,7 @@ import { AppState } from 'reducers/rootReducer';
 import user from 'utils/user';
 import AccessibilityRequestDetailPage from 'views/Accessibility/AccessibilityRequestDetailPage';
 import Create from 'views/Accessibility/AccessibiltyRequest/Create';
+import AccessibilityRequestsDocumentsNew from 'views/Accessibility/AccessibiltyRequest/Documents/New';
 import List from 'views/Accessibility/AccessibiltyRequest/List';
 import AccessibilityStatement from 'views/AccessibilityStatement';
 import AuthenticationWrapper from 'views/AuthenticationWrapper';
@@ -43,6 +44,10 @@ const AppRoutes = () => {
     <Switch>
       {/* START: 508 Process Pages */}
       <SecureRoute path="/508/requests/new" exact component={Create} />
+      <SecureRoute
+        path="/508/requests/:accessibilityRequestId/documents/new"
+        component={AccessibilityRequestsDocumentsNew}
+      />
       <SecureRoute
         path="/508/requests/:accessibilityRequestId"
         render={() => <AccessibilityRequestDetailPage />}

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -42,19 +42,18 @@ const AppRoutes = () => {
   return (
     <Switch>
       {/* START: 508 Process Pages */}
-      <Route path="/accessibility/create" exact component={Create} />
+      <SecureRoute path="/508/requests/new" exact component={Create} />
       <SecureRoute
         path="/508/requests/:accessibilityRequestId"
         render={() => <AccessibilityRequestDetailPage />}
       />
+      <SecureRoute path="/508/requests" exact component={List} />
       {/* END : 508 Process Pages */}
+
       <Route path="/" exact component={Home} />
       <Redirect exact from="/login" to="/signin" />
       <Route path="/signin" exact component={Login} />
       <Route path="/governance-overview" exact component={GovernanceOverview} />
-
-      <Route path="/accessibility/create" exact component={Create} />
-      <Route path="/accessibility/list" exact component={List} />
 
       {flags.sandbox && <Route path="/sandbox" exact component={Sandbox} />}
       <SecureRoute


### PR DESCRIPTION
# ES-266

This is the first PR for ES-266. I will follow up with another that adds the second mutation (for recording the document in our system) and probably one more to tie the UI and API together.

Changes proposed in this pull request:

- Adds a new page with a form for uploading a document
- Adds a new resolver and other schema changes needed for the generatePresignedURL mutation.
- I adjusted some of the new routes so they were consistent.
