### PR TITLE
Update home page structure

### DIFF
--- a/src/views/Accessibility/AccessibiltyRequest/List/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/List/index.tsx
@@ -6,7 +6,6 @@ import GetAccessibilityRequestsQuery from 'queries/GetAccessibilityRequestsQuery
 import { GetAccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
 
 import AccessibilityRequestsTable from 'components/AccessibilityRequestsTable';
-import MainContent from 'components/MainContent';
 import PageHeading from 'components/PageHeading';
 import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 
@@ -37,7 +36,7 @@ const List = () => {
     });
 
   return (
-    <MainContent className="margin-bottom-5">
+    <>
       <SecondaryNav>
         <NavLink to="/">508 Requests</NavLink>
       </SecondaryNav>
@@ -54,7 +53,7 @@ const List = () => {
         </div>
         <AccessibilityRequestsTable requests={requests || []} />
       </div>
-    </MainContent>
+    </>
   );
 };
 

--- a/src/views/Accessibility/AccessibiltyRequest/List/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/List/index.tsx
@@ -6,7 +6,9 @@ import GetAccessibilityRequestsQuery from 'queries/GetAccessibilityRequestsQuery
 import { GetAccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
 
 import AccessibilityRequestsTable from 'components/AccessibilityRequestsTable';
+import MainContent from 'components/MainContent';
 import PageHeading from 'components/PageHeading';
+import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 
 const List = () => {
   const { t } = useTranslation('home');
@@ -35,19 +37,24 @@ const List = () => {
     });
 
   return (
-    <>
-      <div className="display-flex flex-justify flex-wrap">
-        <PageHeading>{t('accessibility.heading')}</PageHeading>
-        <Link
-          className="usa-button flex-align-self-center"
-          variant="unstyled"
-          href="/508/requests/new"
-        >
-          {t('accessibility.newRequest')}
-        </Link>
+    <MainContent className="margin-bottom-5">
+      <SecondaryNav>
+        <NavLink to="/">508 Requests</NavLink>
+      </SecondaryNav>
+      <div className="grid-container">
+        <div className="display-flex flex-justify flex-wrap">
+          <PageHeading>{t('accessibility.heading')}</PageHeading>
+          <Link
+            className="usa-button flex-align-self-center"
+            variant="unstyled"
+            href="/508/requests/new"
+          >
+            {t('accessibility.newRequest')}
+          </Link>
+        </div>
+        <AccessibilityRequestsTable requests={requests || []} />
       </div>
-      <AccessibilityRequestsTable requests={requests || []} />
-    </>
+    </MainContent>
   );
 };
 

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory, useLocation, withRouter } from 'react-router-dom';
-import { useOktaAuth } from '@okta/okta-react';
 
 import Footer from 'components/Footer';
 import Header from 'components/Header';
@@ -52,27 +51,46 @@ const Banners = () => {
 };
 
 const Home = () => {
-  const { authState } = useOktaAuth();
   const userGroups = useSelector((state: AppState) => state.auth.groups);
   const isUserSet = useSelector((state: AppState) => state.auth.isUserSet);
+
+  const renderView = () => {
+    if (isUserSet) {
+      if (user.isGrtReviewer(userGroups)) {
+        return (
+          <MainContent className="grid-container margin-bottom-5">
+            <RequestRepository />
+          </MainContent>
+        );
+      }
+
+      if (
+        user.isAccessibilityAdmin(userGroups) ||
+        user.isAccessibilityTester(userGroups)
+      ) {
+        return <List />;
+      }
+
+      if (user.isBasicUser(userGroups)) {
+        return (
+          <MainContent className="grid-container margin-bottom-5">
+            <Banners />
+            <WelcomeText />
+          </MainContent>
+        );
+      }
+    }
+    return (
+      <MainContent className="grid-container margin-bottom-5">
+        <WelcomeText />
+      </MainContent>
+    );
+  };
 
   return (
     <PageWrapper>
       <Header />
-      <MainContent className="grid-container margin-bottom-5">
-        {isUserSet && user.isGrtReviewer(userGroups) && <RequestRepository />}
-        {isUserSet && user.isBasicUser(userGroups) && (
-          <>
-            <Banners />
-            <WelcomeText />
-          </>
-        )}
-        {isUserSet &&
-          (user.isAccessibilityAdmin(userGroups) ||
-            user.isAccessibilityTester(userGroups)) && <List />}
-
-        {!authState.isAuthenticated && <WelcomeText />}
-      </MainContent>
+      {renderView()}
       <Footer />
     </PageWrapper>
   );

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -58,9 +58,9 @@ const Home = () => {
     if (isUserSet) {
       if (user.isGrtReviewer(userGroups)) {
         return (
-          <MainContent className="grid-container margin-bottom-5">
+          <div className="grid-container">
             <RequestRepository />
-          </MainContent>
+          </div>
         );
       }
 
@@ -73,24 +73,24 @@ const Home = () => {
 
       if (user.isBasicUser(userGroups)) {
         return (
-          <MainContent className="grid-container margin-bottom-5">
+          <div className="grid-container">
             <Banners />
             <WelcomeText />
-          </MainContent>
+          </div>
         );
       }
     }
     return (
-      <MainContent className="grid-container margin-bottom-5">
+      <div className="grid-container">
         <WelcomeText />
-      </MainContent>
+      </div>
     );
   };
 
   return (
     <PageWrapper>
       <Header />
-      {renderView()}
+      <MainContent className="margin-bottom-5">{renderView()}</MainContent>
       <Footer />
     </PageWrapper>
   );


### PR DESCRIPTION
For the 508 tester/admin home page view, there is a `SecondaryNav` that fits the entire width of the viewport.

Currently, the `MainContent` has `className="grid-container"` that restricts the width to `1200px`. Since the content inside of `<main>` can vary depending on the user permissions, it's best to move it up a layer.