### PR TITLE
Add accessibility requests table to home page

### DIFF
--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -12,7 +12,7 @@ const accessibility = {
     view: 'View'
   },
   requestTable: {
-    caption: 'Active 508 Requests',
+    caption: 'List of 508 requests',
     header: {
       requestName: 'Request Name',
       submissionDate: 'Submission Date',

--- a/src/i18n/en-US/home.ts
+++ b/src/i18n/en-US/home.ts
@@ -5,7 +5,11 @@ const home = {
   easiInfo:
     "Use this process only if you'd like to add a new system, service or make major changes and upgrades to an existing one. For all other requests, please use the <1>alternative request form</1>.",
   startNow: 'Start now',
-  signIn: 'Sign in to start'
+  signIn: 'Sign in to start',
+  accessibility: {
+    heading: '508 Requests',
+    newRequest: 'Add a new request'
+  }
 };
 
 export default home;

--- a/src/stylesheets/custom.scss
+++ b/src/stylesheets/custom.scss
@@ -54,3 +54,12 @@
     margin-bottom: 0;
   }
 }
+
+// Addiitional class names were introduced in v2.9.0
+// There are breaking changes in this version that crash our application.
+// On 2/7/2021, USWDS said a fix is on the way.
+// https://github.com/uswds/uswds/issues/3909
+// https://github.com/uswds/uswds/releases/tag/v2.9.0
+.flex-align-self-center {
+  align-self: center !important;
+}

--- a/src/views/Accessibility/AccessibiltyRequest/List/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/List/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useQuery } from '@apollo/client';
 import { Link } from '@trussworks/react-uswds';
 import GetAccessibilityRequestsQuery from 'queries/GetAccessibilityRequestsQuery';
@@ -8,6 +9,7 @@ import AccessibilityRequestsTable from 'components/AccessibilityRequestsTable';
 import PageHeading from 'components/PageHeading';
 
 const List = () => {
+  const { t } = useTranslation('home');
   const { loading, error, data } = useQuery<GetAccessibilityRequests>(
     GetAccessibilityRequestsQuery,
     {
@@ -35,13 +37,13 @@ const List = () => {
   return (
     <>
       <div className="display-flex flex-justify flex-wrap">
-        <PageHeading>508 Requests</PageHeading>
+        <PageHeading>{t('accessibility.heading')}</PageHeading>
         <Link
           className="usa-button flex-align-self-center"
           variant="unstyled"
           href="/508/requests/new"
         >
-          Add a new request
+          {t('accessibility.newRequest')}
         </Link>
       </div>
       <AccessibilityRequestsTable requests={requests || []} />

--- a/src/views/Accessibility/AccessibiltyRequest/List/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/List/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { useQuery } from '@apollo/client';
+import { Link } from '@trussworks/react-uswds';
 import GetAccessibilityRequestsQuery from 'queries/GetAccessibilityRequestsQuery';
 import { GetAccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
 
 import AccessibilityRequestsTable from 'components/AccessibilityRequestsTable';
-import ScyllaPage from 'components/ScyllaPage';
+import PageHeading from 'components/PageHeading';
 
 const List = () => {
   const { loading, error, data } = useQuery<GetAccessibilityRequests>(
@@ -32,9 +33,19 @@ const List = () => {
     });
 
   return (
-    <ScyllaPage>
+    <>
+      <div className="display-flex flex-justify flex-wrap">
+        <PageHeading>508 Requests</PageHeading>
+        <Link
+          className="usa-button flex-align-self-center"
+          variant="unstyled"
+          href="/508/requests/new"
+        >
+          Add a new request
+        </Link>
+      </div>
       <AccessibilityRequestsTable requests={requests || []} />
-    </ScyllaPage>
+    </>
   );
 };
 

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -10,6 +10,7 @@ import PageWrapper from 'components/PageWrapper';
 import RequestRepository from 'components/RequestRepository';
 import { AppState } from 'reducers/rootReducer';
 import user from 'utils/user';
+import List from 'views/Accessibility/AccessibiltyRequest/List';
 
 import SystemIntakeBanners from './SystemIntakeBanners';
 import WelcomeText from './WelcomeText';
@@ -66,6 +67,10 @@ const Home = () => {
             <WelcomeText />
           </>
         )}
+        {isUserSet &&
+          (user.isAccessibilityAdmin(userGroups) ||
+            user.isAccessibilityTester(userGroups)) && <List />}
+
         {!authState.isAuthenticated && <WelcomeText />}
       </MainContent>
       <Footer />


### PR DESCRIPTION
# ES-327

This PR adds the accessibility/508 requests table to the home page. It only shows up for 508 testers/admins job code.

The secondary nav is added in #770 