### PR TITLE
store systems locally by object key value pair rather than array

### DIFF
--- a/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
@@ -61,11 +61,18 @@ const Create = () => {
   };
 
   const systems = useMemo(() => {
-    return data?.systems?.edges || [];
+    const systemsObj: { [id: string]: any } = {};
+
+    data?.systems?.edges.forEach(system => {
+      systemsObj[system.node.id] = system.node;
+    });
+
+    return systemsObj;
   }, [data]);
 
   const projectComboBoxOptions = useMemo(() => {
-    return systems.map(system => {
+    const queriedSystems = data?.systems?.edges || [];
+    return queriedSystems.map(system => {
       const {
         node: { id, name }
       } = system;
@@ -74,7 +81,7 @@ const Create = () => {
         value: id
       };
     });
-  }, [systems]);
+  }, [data]);
 
   return (
     <PageWrapper>
@@ -124,19 +131,18 @@ const Create = () => {
                             id="508Request-IntakeId"
                             options={projectComboBoxOptions}
                             onChange={(intakeId: any) => {
-                              const selectedSystem = systems.find(
-                                system => system.node.id === intakeId
-                              );
-                              setFieldValue('intakeId', intakeId || '');
-                              setFieldValue(
-                                'businessOwner.name',
-                                selectedSystem?.node.businessOwner.name || ''
-                              );
-                              setFieldValue(
-                                'businessOwner.component',
-                                selectedSystem?.node.businessOwner.component ||
-                                  ''
-                              );
+                              const selectedSystem = systems[intakeId];
+                              if (selectedSystem) {
+                                setFieldValue('intakeId', intakeId || '');
+                                setFieldValue(
+                                  'businessOwner.name',
+                                  selectedSystem.businessOwner.name || ''
+                                );
+                                setFieldValue(
+                                  'businessOwner.component',
+                                  selectedSystem.businessOwner.component || ''
+                                );
+                              }
                             }}
                           />
                         </FieldGroup>

--- a/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
@@ -12,7 +12,10 @@ import {
 } from 'formik';
 import CreateAccessibilityRequestQuery from 'queries/CreateAccessibilityRequestQuery';
 import GetSystemsQuery from 'queries/GetSystems';
-import { GetSystems } from 'queries/types/GetSystems';
+import {
+  GetSystems,
+  GetSystems_systems_edges_node as SystemNode
+} from 'queries/types/GetSystems';
 
 import Footer from 'components/Footer';
 import Header from 'components/Header';
@@ -61,7 +64,7 @@ const Create = () => {
   };
 
   const systems = useMemo(() => {
-    const systemsObj: { [id: string]: any } = {};
+    const systemsObj: { [id: string]: SystemNode } = {};
 
     data?.systems?.edges.forEach(system => {
       systemsObj[system.node.id] = system.node;


### PR DESCRIPTION
This PR changes how we store systems locally queried by GraphQL.

Previously, whenever a project was selected on the accessibility request form, we would iterate over the array of systems to find the matching id.

Now we are storing the systems in an object, with the `id` as the key and the data as the value. This is more efficient so we can use dot notation to select the system rather than iteration 