### PR TITLE
First pass at data-backed documents.

### DIFF
--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -28,7 +28,7 @@ func (r *accessibilityRequestResolver) Documents(ctx context.Context, obj *model
 	for i, file := range *files {
 		document := &model.AccessibilityRequestDocument{}
 		document.ID = file.ID
-		document.Name = fmt.Sprintf("Sara's Test Doc Number %+v", i+1)
+		document.Name = fmt.Sprintf("Test Doc Number %+v", i+1)
 		document.UploadedAt = *file.CreatedAt
 
 		status := "PENDING"

--- a/pkg/storage/file_uploads.go
+++ b/pkg/storage/file_uploads.go
@@ -64,3 +64,26 @@ func (s *Store) FetchUploadedFileByID(ctx context.Context, id uuid.UUID) (*model
 
 	return &file, nil
 }
+
+// FetchFilesByAccessibilityRequestID retrieves the info for a file with a given accessibility request id
+func (s *Store) FetchFilesByAccessibilityRequestID(ctx context.Context, id uuid.UUID) (*[]models.UploadedFile, error) {
+	if id == uuid.Nil {
+		return nil, &apperrors.ResourceNotFoundError{Resource: models.UploadedFile{}}
+	}
+
+	results := []models.UploadedFile{}
+	// eventually, we should use the id here, but we don't have the db relationship set up yet
+	err := s.db.Select(&results, "SELECT * FROM files")
+
+	if err != nil {
+		appcontext.ZLogger(ctx).Error("Failed to fetch uploaded file", zap.Error(err))
+
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, &apperrors.ResourceNotFoundError{Err: err, Resource: models.UploadedFile{}}
+		}
+
+		return nil, err
+	}
+
+	return &results, nil
+}

--- a/src/queries/GetAccessibilityRequestQuery.ts
+++ b/src/queries/GetAccessibilityRequestQuery.ts
@@ -14,9 +14,10 @@ export default gql`
           component
         }
       }
-      documents @client {
+      documents {
         name
         uploadedAt
+        status
       }
     }
   }

--- a/src/queries/types/GetAccessibilityRequest.ts
+++ b/src/queries/types/GetAccessibilityRequest.ts
@@ -3,6 +3,8 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
+import { AccessibilityRequestDocumentStatus } from "./../../types/graphql-global-types";
+
 // ====================================================
 // GraphQL query operation: GetAccessibilityRequest
 // ====================================================
@@ -24,6 +26,7 @@ export interface GetAccessibilityRequest_accessibilityRequest_documents {
   __typename: "AccessibilityRequestDocument";
   name: string;
   uploadedAt: Time;
+  status: AccessibilityRequestDocumentStatus;
 }
 
 export interface GetAccessibilityRequest_accessibilityRequest {

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -8,6 +8,15 @@
 //==============================================================
 
 /**
+ * Represents the availability of a document
+ */
+export enum AccessibilityRequestDocumentStatus {
+  AVAILABLE = "AVAILABLE",
+  PENDING = "PENDING",
+  UNAVAILABLE = "UNAVAILABLE",
+}
+
+/**
  * Parameters required to create an AccessibilityRequest
  */
 export interface CreateAccessibilityRequestInput {

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/index.tsx
@@ -4,10 +4,12 @@ import { Link } from 'react-router-dom';
 import { useTable } from 'react-table';
 import { Link as UswdsLink, Table } from '@trussworks/react-uswds';
 
+import { AccessibilityRequestDocumentStatus } from 'types/graphql-global-types';
 import formatDate from 'utils/formatDate';
 
 type Document = {
   name: string;
+  status: AccessibilityRequestDocumentStatus;
   uploadedAt: string;
 };
 
@@ -38,6 +40,10 @@ const AccessibilityDocumentsList = ({
           return '';
         },
         width: '25%'
+      },
+      {
+        Header: 'Status',
+        accessor: 'status'
       },
       {
         Header: t('documentTable.header.actions'),


### PR DESCRIPTION
# ES-376

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Query docs from the db to return to the front end
- Map the props at the db layer to the props we define in the schema

Out of scope for now:
- We're not searching using the Accessibility Request id because that db connection doesn't exist yet. But the plumbing is all there for when we make the connection!
