### PR TITLE
Add missing command to run step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,11 @@ jobs:
       - checkout
       - run:
           name: Check deployed image for vulnerability findings - impl
+          command: |
             APP_ENV=impl ./scripts/check_deployed_image_findings "easi-backend" "4"
       - run:
           name: Check deployed image for vulnerability findings - prod
+          command: |
             APP_ENV=prod ./scripts/check_deployed_image_findings "easi-backend" "4"
       - run:
           name: Announce failure


### PR DESCRIPTION
# ES-125

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add missing "command" to the run steps associated with daily rescanning of deployed images.
