### PR TITLE
ES-344 relevant test date

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,10 @@ yarn generate
 
 ### Swagger Generation
 
+(Most developers will not need to do this. It is rarely done, only
+when updating our client to the CEDAR APIs. The output of these
+instructions are checked into the repository.)
+
 The EASi server uses Swagger generation
 to access APIs from CEDAR (the data source).
 Swagger specs (EASi and LDAP) can be downloaded from webMethods:
@@ -469,16 +473,21 @@ There are multiple ways to run the Cypress tests:
 
 ### APIs
 
+To start the API server: `$ ./bin/easi serve`
 The APIs reside at `localhost:8080` when running.
 To run a test request,
 you can send a GET to the health check endpoint:
 `curl localhost:8080/api/v1/healthcheck`
 
+### Front-End
+
+To start the JavaScript application serving: `$ yarn start`
+
 ### GraphQL Playground
 
 You can visit `http://localhost:8080/api/graph/playground`
 to access a GraphQL playground while
-the Go backend is running. **You will need to enter `/graph/query` as the query
+the Go backend is running. **You will need to enter `/api/graph/query` as the query
 path in the UI for this to work.**
 
 ### Authorization

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -51,11 +51,12 @@ type DirectiveRoot struct {
 
 type ComplexityRoot struct {
 	AccessibilityRequest struct {
-		CreatedAt func(childComplexity int) int
-		Documents func(childComplexity int) int
-		ID        func(childComplexity int) int
-		Name      func(childComplexity int) int
-		System    func(childComplexity int) int
+		CreatedAt        func(childComplexity int) int
+		Documents        func(childComplexity int) int
+		ID               func(childComplexity int) int
+		Name             func(childComplexity int) int
+		RelevantTestDate func(childComplexity int) int
+		System           func(childComplexity int) int
 	}
 
 	AccessibilityRequestDocument struct {
@@ -151,6 +152,8 @@ type ComplexityRoot struct {
 type AccessibilityRequestResolver interface {
 	Documents(ctx context.Context, obj *models.AccessibilityRequest) ([]*models.AccessibilityRequestDocument, error)
 
+	RelevantTestDate(ctx context.Context, obj *models.AccessibilityRequest) (*models.TestDate, error)
+
 	System(ctx context.Context, obj *models.AccessibilityRequest) (*models.System, error)
 }
 type AccessibilityRequestDocumentResolver interface {
@@ -212,6 +215,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AccessibilityRequest.Name(childComplexity), true
+
+	case "AccessibilityRequest.relevantTestDate":
+		if e.complexity.AccessibilityRequest.RelevantTestDate == nil {
+			break
+		}
+
+		return e.complexity.AccessibilityRequest.RelevantTestDate(childComplexity), true
 
 	case "AccessibilityRequest.system":
 		if e.complexity.AccessibilityRequest.System == nil {
@@ -644,6 +654,7 @@ type AccessibilityRequest {
   documents: [AccessibilityRequestDocument!]!
   id: UUID!
   name: String!
+  relevantTestDate: TestDate
   submittedAt: Time!
   system: System!
 }
@@ -1196,6 +1207,38 @@ func (ec *executionContext) _AccessibilityRequest_name(ctx context.Context, fiel
 	res := resTmp.(string)
 	fc.Result = res
 	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _AccessibilityRequest_relevantTestDate(ctx context.Context, field graphql.CollectedField, obj *models.AccessibilityRequest) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "AccessibilityRequest",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.AccessibilityRequest().RelevantTestDate(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.TestDate)
+	fc.Result = res
+	return ec.marshalOTestDate2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTestDate(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _AccessibilityRequest_submittedAt(ctx context.Context, field graphql.CollectedField, obj *models.AccessibilityRequest) (ret graphql.Marshaler) {
@@ -4202,6 +4245,17 @@ func (ec *executionContext) _AccessibilityRequest(ctx context.Context, sel ast.S
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		case "relevantTestDate":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._AccessibilityRequest_relevantTestDate(ctx, field, obj)
+				return res
+			})
 		case "submittedAt":
 			out.Values[i] = ec._AccessibilityRequest_submittedAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -15,6 +15,7 @@ type AccessibilityRequest {
   documents: [AccessibilityRequestDocument!]!
   id: UUID!
   name: String!
+  relevantTestDate: TestDate
   submittedAt: Time!
   system: System!
 }

--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -71,7 +71,8 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
       {
         Header: t('requestTable.header.testDate'),
         accessor: (row: AccessibilityRequestsTableRow) => {
-          return `${row.relevantTestDate?.date || 'Not Added'}`;
+          return `${row.relevantTestDate?.date ||
+            t('requestTable.emptyTestDate')}`;
         }
       }
       // {

--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -23,6 +23,9 @@ type AccessibilityRequestsTableRow = {
   };
   submittedAt?: DateTime;
   testDate?: DateTime;
+  relevantTestDate?: {
+    date: DateTime;
+  };
   status?: string;
   lastUpdatedAt?: DateTime;
 };
@@ -67,12 +70,8 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
       },
       {
         Header: t('requestTable.header.testDate'),
-        accessor: 'testedAt',
-        Cell: ({ value }: any) => {
-          if (value) {
-            return formatDate(value);
-          }
-          return '';
+        accessor: (row: AccessibilityRequestsTableRow) => {
+          return `${row.relevantTestDate?.date || 'Not Added'}`;
         }
       }
       // {

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -21,7 +21,8 @@ const accessibility = {
       pointOfContact: 'Point of Contact',
       status: 'Status'
     },
-    lastUpdated: 'last updated on'
+    lastUpdated: 'last updated on',
+    emptyTestDate: 'Not Added'
   },
   tabs: {
     accessibilityRequests: '508 Requests'

--- a/src/queries/GetAccessibilityRequestsQuery.ts
+++ b/src/queries/GetAccessibilityRequestsQuery.ts
@@ -6,8 +6,11 @@ export default gql`
       edges {
         node {
           id
-          submittedAt
           name
+          relevantTestDate {
+            date
+          }
+          submittedAt
           system {
             lcid
             businessOwner {

--- a/src/queries/types/GetAccessibilityRequests.ts
+++ b/src/queries/types/GetAccessibilityRequests.ts
@@ -7,6 +7,11 @@
 // GraphQL query operation: GetAccessibilityRequests
 // ====================================================
 
+export interface GetAccessibilityRequests_accessibilityRequests_edges_node_relevantTestDate {
+  __typename: "TestDate";
+  date: Time;
+}
+
 export interface GetAccessibilityRequests_accessibilityRequests_edges_node_system_businessOwner {
   __typename: "BusinessOwner";
   name: string;
@@ -22,8 +27,9 @@ export interface GetAccessibilityRequests_accessibilityRequests_edges_node_syste
 export interface GetAccessibilityRequests_accessibilityRequests_edges_node {
   __typename: "AccessibilityRequest";
   id: UUID;
-  submittedAt: Time;
   name: string;
+  relevantTestDate: GetAccessibilityRequests_accessibilityRequests_edges_node_relevantTestDate | null;
+  submittedAt: Time;
   system: GetAccessibilityRequests_accessibilityRequests_edges_node_system;
 }
 


### PR DESCRIPTION
# ES-344

Changes proposed in this pull request:

- expose `relevantTestDate`
- put the calculation of what is "relevant" into the resolver (is this the correct place for that logic?)
- stubbed out some fake data for right now, future PR will hook up to actual DB calls
