### PR TITLE
Complete basic end to end for document upload

### DIFF
--- a/cmd/devdata/main.go
+++ b/cmd/devdata/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/guregu/null"
 	_ "github.com/lib/pq" // required for postgres driver in sql
@@ -40,12 +41,17 @@ func main() {
 		panic(storeErr)
 	}
 
+	makeAccessibilityRequest("TACO", store)
+	makeAccessibilityRequest("Big Project", store)
+}
+
+func makeAccessibilityRequest(name string, store *storage.Store) {
 	ctx := context.Background()
 
 	intake := models.SystemIntake{
 		Status:                 models.SystemIntakeStatusLCIDISSUED,
 		RequestType:            models.SystemIntakeRequestTypeNEW,
-		ProjectName:            null.StringFrom("LCID Issued"),
+		ProjectName:            null.StringFrom(name),
 		BusinessOwner:          null.StringFrom("Shane Clark"),
 		BusinessOwnerComponent: null.StringFrom("OIT"),
 		LifecycleID:            null.StringFrom("123456"),
@@ -54,7 +60,7 @@ func main() {
 	must(store.UpdateSystemIntake(ctx, &intake)) // required to set lifecycle id
 
 	must(store.CreateAccessibilityRequest(ctx, &models.AccessibilityRequest{
-		Name:     "Never shown",
+		Name:     fmt.Sprintf("%s v2", name),
 		IntakeID: intake.ID,
 	}))
 }

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -59,7 +59,6 @@ type ComplexityRoot struct {
 	}
 
 	AccessibilityRequestDocument struct {
-		Bucket     func(childComplexity int) int
 		ID         func(childComplexity int) int
 		Key        func(childComplexity int) int
 		MimeType   func(childComplexity int) int
@@ -219,13 +218,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AccessibilityRequest.System(childComplexity), true
-
-	case "AccessibilityRequestDocument.bucket":
-		if e.complexity.AccessibilityRequestDocument.Bucket == nil {
-			break
-		}
-
-		return e.complexity.AccessibilityRequestDocument.Bucket(childComplexity), true
 
 	case "AccessibilityRequestDocument.id":
 		if e.complexity.AccessibilityRequestDocument.ID == nil {
@@ -690,7 +682,6 @@ enum AccessibilityRequestDocumentStatus {
 A document that belongs to an accessibility request
 """
 type AccessibilityRequestDocument {
-  bucket: String!
   id: UUID!
   key: String!
   mimeType: String!
@@ -813,7 +804,6 @@ type CreateTestDatePayload {
 Parameters for createAccessibilityRequestDocument
 """
 input CreateAccessibilityRequestDocumentInput {
-  bucket: String!
   key: String!
   mimeType: String!
   name: String!
@@ -1266,41 +1256,6 @@ func (ec *executionContext) _AccessibilityRequest_system(ctx context.Context, fi
 	res := resTmp.(*models.System)
 	fc.Result = res
 	return ec.marshalNSystem2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐSystem(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _AccessibilityRequestDocument_bucket(ctx context.Context, field graphql.CollectedField, obj *models.AccessibilityRequestDocument) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "AccessibilityRequestDocument",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Bucket, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _AccessibilityRequestDocument_id(ctx context.Context, field graphql.CollectedField, obj *models.AccessibilityRequestDocument) (ret graphql.Marshaler) {
@@ -3997,14 +3952,6 @@ func (ec *executionContext) unmarshalInputCreateAccessibilityRequestDocumentInpu
 
 	for k, v := range asMap {
 		switch k {
-		case "bucket":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("bucket"))
-			it.Bucket, err = ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
 		case "key":
 			var err error
 
@@ -4243,11 +4190,6 @@ func (ec *executionContext) _AccessibilityRequestDocument(ctx context.Context, s
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("AccessibilityRequestDocument")
-		case "bucket":
-			out.Values[i] = ec._AccessibilityRequestDocument_bucket(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "id":
 			out.Values[i] = ec._AccessibilityRequestDocument_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -804,11 +804,11 @@ type CreateTestDatePayload {
 Parameters for createAccessibilityRequestDocument
 """
 input CreateAccessibilityRequestDocumentInput {
-  key: String!
   mimeType: String!
   name: String!
   requestID: UUID!
   size: Int!
+  url: String!
 }
 
 """
@@ -3952,14 +3952,6 @@ func (ec *executionContext) unmarshalInputCreateAccessibilityRequestDocumentInpu
 
 	for k, v := range asMap {
 		switch k {
-		case "key":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("key"))
-			it.Key, err = ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
 		case "mimeType":
 			var err error
 
@@ -3989,6 +3981,14 @@ func (ec *executionContext) unmarshalInputCreateAccessibilityRequestDocumentInpu
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("size"))
 			it.Size, err = ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "url":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("url"))
+			it.URL, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -26,11 +26,11 @@ type AccessibilityRequestsConnection struct {
 
 // Parameters for createAccessibilityRequestDocument
 type CreateAccessibilityRequestDocumentInput struct {
-	Key       string    `json:"key"`
 	MimeType  string    `json:"mimeType"`
 	Name      string    `json:"name"`
 	RequestID uuid.UUID `json:"requestID"`
 	Size      int       `json:"size"`
+	URL       string    `json:"url"`
 }
 
 // Result of createAccessibilityRequestDocument

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -26,7 +26,6 @@ type AccessibilityRequestsConnection struct {
 
 // Parameters for createAccessibilityRequestDocument
 type CreateAccessibilityRequestDocumentInput struct {
-	Bucket    string    `json:"bucket"`
 	Key       string    `json:"key"`
 	MimeType  string    `json:"mimeType"`
 	Name      string    `json:"name"`

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -61,7 +61,6 @@ enum AccessibilityRequestDocumentStatus {
 A document that belongs to an accessibility request
 """
 type AccessibilityRequestDocument {
-  bucket: String!
   id: UUID!
   key: String!
   mimeType: String!
@@ -184,7 +183,6 @@ type CreateTestDatePayload {
 Parameters for createAccessibilityRequestDocument
 """
 input CreateAccessibilityRequestDocumentInput {
-  bucket: String!
   key: String!
   mimeType: String!
   name: String!

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -183,11 +183,11 @@ type CreateTestDatePayload {
 Parameters for createAccessibilityRequestDocument
 """
 input CreateAccessibilityRequestDocumentInput {
-  key: String!
   mimeType: String!
   name: String!
   requestID: UUID!
   size: Int!
+  url: String!
 }
 
 """

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -82,7 +82,6 @@ func (r *mutationResolver) CreateAccessibilityRequestDocument(ctx context.Contex
 	doc, docErr := r.store.CreateAccessibilityRequestDocument(ctx, &models.AccessibilityRequestDocument{
 		Name:      input.Name,
 		FileType:  input.MimeType,
-		Bucket:    input.Bucket,
 		Key:       input.Key,
 		Size:      input.Size,
 		RequestID: input.RequestID,

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -5,6 +5,7 @@ package graph
 
 import (
 	"context"
+	"net/url"
 	"time"
 
 	"github.com/google/uuid"
@@ -79,10 +80,20 @@ func (r *mutationResolver) CreateAccessibilityRequest(ctx context.Context, input
 }
 
 func (r *mutationResolver) CreateAccessibilityRequestDocument(ctx context.Context, input model.CreateAccessibilityRequestDocumentInput) (*model.CreateAccessibilityRequestDocumentPayload, error) {
+	url, urlErr := url.Parse(input.URL)
+	if urlErr != nil {
+		return nil, urlErr
+	}
+
+	key, keyErr := r.s3Client.KeyFromURL(url)
+	if keyErr != nil {
+		return nil, keyErr
+	}
+
 	doc, docErr := r.store.CreateAccessibilityRequestDocument(ctx, &models.AccessibilityRequestDocument{
 		Name:      input.Name,
 		FileType:  input.MimeType,
-		Key:       input.Key,
+		Key:       key,
 		Size:      input.Size,
 		RequestID: input.RequestID,
 	})

--- a/pkg/graph/schema.resolvers_test.go
+++ b/pkg/graph/schema.resolvers_test.go
@@ -83,7 +83,7 @@ func TestGraphQLTestSuite(t *testing.T) {
 		t.Fail()
 	}
 
-	s3Config := upload.Config{Bucket: "test", Region: "us-west", IsLocal: false}
+	s3Config := upload.Config{Bucket: "easi-test-bucket", Region: "us-west", IsLocal: false}
 	mockClient := mockS3Client{}
 	s3Client := upload.NewS3ClientUsingClient(mockClient, s3Config)
 
@@ -243,7 +243,7 @@ func (s GraphQLTestSuite) TestCreateAccessibilityRequestDocumentMutation() {
 				mimeType: "application/pdf",
 				size: 512512,
 				name: "test_file.pdf",
-				key: "path/to/file/fb1db6a1-3fd3-40b5-a93f-4b9d7245f80c.pdf",
+				url: "http://localhost:9000/easi-test-bucket/e9eb4a4f-9100-416f-be5b-f141bb436cfa.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&",
 				requestID: "%s"
 			}) {
 				accessibilityRequestDocument {
@@ -272,5 +272,5 @@ func (s GraphQLTestSuite) TestCreateAccessibilityRequestDocumentMutation() {
 	s.Equal("PENDING", document.Status)
 	s.NotEmpty(document.UploadedAt)
 	s.Equal(accessibilityRequest.ID.String(), document.RequestID)
-	s.Equal("path/to/file/fb1db6a1-3fd3-40b5-a93f-4b9d7245f80c.pdf", document.Key)
+	s.Equal("e9eb4a4f-9100-416f-be5b-f141bb436cfa.pdf", document.Key)
 }

--- a/pkg/graph/schema.resolvers_test.go
+++ b/pkg/graph/schema.resolvers_test.go
@@ -244,7 +244,6 @@ func (s GraphQLTestSuite) TestCreateAccessibilityRequestDocumentMutation() {
 				size: 512512,
 				name: "test_file.pdf",
 				key: "path/to/file/fb1db6a1-3fd3-40b5-a93f-4b9d7245f80c.pdf",
-				bucket: "test_bucket",
 				requestID: "%s"
 			}) {
 				accessibilityRequestDocument {

--- a/pkg/models/accessibility_request_document.go
+++ b/pkg/models/accessibility_request_document.go
@@ -75,7 +75,8 @@ type AccessibilityRequestDocument struct {
 	Key          string                             `json:"fileKey" db:"file_key"`
 	Name         string                             `json:"name" db:"file_name"`
 	Size         int                                `json:"size" db:"file_size"`
-	Status       AccessibilityRequestDocumentStatus `json:"status" db:"status"`
+	URL          string                             `json:"url"`
+	Status       AccessibilityRequestDocumentStatus `json:"status"`
 	VirusScanned null.Bool                          `json:"virusScanned" db:"virus_scanned"`
 	VirusClean   null.Bool                          `json:"virusClean" db:"virus_clean"`
 	RequestID    uuid.UUID                          `json:"requestId" db:"request_id"`

--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -2,7 +2,9 @@ package upload
 
 import (
 	"mime"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -105,4 +107,9 @@ func (c S3Client) NewGetPresignedURL(key string) (*models.PreSignedURL, error) {
 
 	return &result, nil
 
+}
+
+// KeyFromURL extracts an S3 key from a URL.
+func (c S3Client) KeyFromURL(url *url.URL) (string, error) {
+	return strings.Replace(url.Path, "/"+c.config.Bucket+"/", "", 1), nil
 }

--- a/src/components/FileUpload/index.tsx
+++ b/src/components/FileUpload/index.tsx
@@ -39,6 +39,7 @@ const FileUpload = (props: FileUploadProps) => {
   });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // eslint-disable-next-line
     if (e.target.files.length > 0) {
       if (isFileTypeValid(e.target.files[0])) {
         setError(false);

--- a/src/queries/CreateAccessibilityRequestDocumentQuery.ts
+++ b/src/queries/CreateAccessibilityRequestDocumentQuery.ts
@@ -1,0 +1,22 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  mutation CreateAccessibilityRequestDocument(
+    $input: CreateAccessibilityRequestDocumentInput!
+  ) {
+    createAccessibilityRequestDocument(input: $input) {
+      accessibilityRequestDocument {
+        id
+        mimeType
+        name
+        status
+        uploadedAt
+        requestID
+      }
+      userErrors {
+        message
+        path
+      }
+    }
+  }
+`;

--- a/src/queries/GeneratePresignedUploadURLQuery.ts
+++ b/src/queries/GeneratePresignedUploadURLQuery.ts
@@ -1,0 +1,15 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  mutation GeneratePresignedUploadURL(
+    $input: GeneratePresignedUploadURLInput!
+  ) {
+    generatePresignedUploadURL(input: $input) {
+      url
+      userErrors {
+        message
+        path
+      }
+    }
+  }
+`;

--- a/src/queries/types/CreateAccessibilityRequestDocument.ts
+++ b/src/queries/types/CreateAccessibilityRequestDocument.ts
@@ -1,0 +1,40 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { CreateAccessibilityRequestDocumentInput, AccessibilityRequestDocumentStatus } from "./../../types/graphql-global-types";
+
+// ====================================================
+// GraphQL mutation operation: CreateAccessibilityRequestDocument
+// ====================================================
+
+export interface CreateAccessibilityRequestDocument_createAccessibilityRequestDocument_accessibilityRequestDocument {
+  __typename: "AccessibilityRequestDocument";
+  id: UUID;
+  mimeType: string;
+  name: string;
+  status: AccessibilityRequestDocumentStatus;
+  uploadedAt: Time;
+  requestID: UUID;
+}
+
+export interface CreateAccessibilityRequestDocument_createAccessibilityRequestDocument_userErrors {
+  __typename: "UserError";
+  message: string;
+  path: string[];
+}
+
+export interface CreateAccessibilityRequestDocument_createAccessibilityRequestDocument {
+  __typename: "CreateAccessibilityRequestDocumentPayload";
+  accessibilityRequestDocument: CreateAccessibilityRequestDocument_createAccessibilityRequestDocument_accessibilityRequestDocument | null;
+  userErrors: CreateAccessibilityRequestDocument_createAccessibilityRequestDocument_userErrors[] | null;
+}
+
+export interface CreateAccessibilityRequestDocument {
+  createAccessibilityRequestDocument: CreateAccessibilityRequestDocument_createAccessibilityRequestDocument | null;
+}
+
+export interface CreateAccessibilityRequestDocumentVariables {
+  input: CreateAccessibilityRequestDocumentInput;
+}

--- a/src/queries/types/GeneratePresignedUploadURL.ts
+++ b/src/queries/types/GeneratePresignedUploadURL.ts
@@ -1,0 +1,30 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { GeneratePresignedUploadURLInput } from "./../../types/graphql-global-types";
+
+// ====================================================
+// GraphQL mutation operation: GeneratePresignedUploadURL
+// ====================================================
+
+export interface GeneratePresignedUploadURL_generatePresignedUploadURL_userErrors {
+  __typename: "UserError";
+  message: string;
+  path: string[];
+}
+
+export interface GeneratePresignedUploadURL_generatePresignedUploadURL {
+  __typename: "GeneratePresignedUploadURLPayload";
+  url: string | null;
+  userErrors: GeneratePresignedUploadURL_generatePresignedUploadURL_userErrors[] | null;
+}
+
+export interface GeneratePresignedUploadURL {
+  generatePresignedUploadURL: GeneratePresignedUploadURL_generatePresignedUploadURL | null;
+}
+
+export interface GeneratePresignedUploadURLVariables {
+  input: GeneratePresignedUploadURLInput;
+}

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -28,11 +28,11 @@ export enum TestDateTestType {
  * Parameters for createAccessibilityRequestDocument
  */
 export interface CreateAccessibilityRequestDocumentInput {
-  key: string;
   mimeType: string;
   name: string;
   requestID: UUID;
   size: number;
+  url: string;
 }
 
 /**

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -25,6 +25,17 @@ export enum TestDateTestType {
 }
 
 /**
+ * Parameters for createAccessibilityRequestDocument
+ */
+export interface CreateAccessibilityRequestDocumentInput {
+  key: string;
+  mimeType: string;
+  name: string;
+  requestID: UUID;
+  size: number;
+}
+
+/**
  * Parameters required to create an AccessibilityRequest
  */
 export interface CreateAccessibilityRequestInput {
@@ -40,6 +51,15 @@ export interface CreateTestDateInput {
   requestID: UUID;
   score?: number | null;
   testType: TestDateTestType;
+}
+
+/**
+ * Parameters required to generate a presigned upload URL
+ */
+export interface GeneratePresignedUploadURLInput {
+  fileName: string;
+  mimeType: string;
+  size: number;
 }
 
 //==============================================================

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -103,7 +103,7 @@ const New = () => {
             mimeType: selectedFile.type,
             size: selectedFile.size,
             name: selectedFile.name,
-            key: 'this is the key',
+            url: s3URL,
             requestID: accessibilityRequestId
           }
         }

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -1,10 +1,16 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useParams } from 'react-router-dom';
-import { useQuery } from '@apollo/client';
+import { Link, useHistory, useParams } from 'react-router-dom';
+import { useMutation, useQuery } from '@apollo/client';
 import { Button, Form, Label } from '@trussworks/react-uswds';
+import axios from 'axios';
 import { Formik, FormikProps } from 'formik';
+import { isUndefined } from 'lodash';
+import CreateAccessibilityRequestDocumentQuery from 'queries/CreateAccessibilityRequestDocumentQuery';
+import GeneratePresignedUploadURLQuery from 'queries/GeneratePresignedUploadURLQuery';
 import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
+import { CreateAccessibilityRequestDocument } from 'queries/types/CreateAccessibilityRequestDocument';
+import { GeneratePresignedUploadURL } from 'queries/types/GeneratePresignedUploadURL';
 import { GetAccessibilityRequest } from 'queries/types/GetAccessibilityRequest';
 
 import FileUpload from 'components/FileUpload';
@@ -17,6 +23,7 @@ import { FileUploadForm } from 'types/files';
 
 const New = () => {
   const { t } = useTranslation('accessibility');
+  const history = useHistory();
 
   const { accessibilityRequestId } = useParams<{
     accessibilityRequestId: string;
@@ -30,14 +37,22 @@ const New = () => {
     }
   );
 
-  const [fileSelected, setFileSelected] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File>();
+
+  const [s3URL, setS3URL] = useState('');
+  const [generateURL, generateURLStatus] = useMutation<
+    GeneratePresignedUploadURL
+  >(GeneratePresignedUploadURLQuery);
+  const [createDocument, createDocumentStatus] = useMutation<
+    CreateAccessibilityRequestDocument
+  >(CreateAccessibilityRequestDocumentQuery);
 
   if (loading) {
     return <div>Loading</div>;
   }
 
   if (error) {
-    return <div>{error}</div>;
+    return <div>{error.message}</div>;
   }
 
   if (!data) {
@@ -46,8 +61,56 @@ const New = () => {
     );
   }
 
-  const onChange = () => {
-    setFileSelected(true);
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event?.currentTarget?.files?.[0];
+    if (!file) {
+      return;
+    }
+    setSelectedFile(file);
+    generateURL({
+      variables: {
+        input: {
+          fileName: file?.name,
+          mimeType: file?.type,
+          size: file?.size
+        }
+      }
+    }).then(result => {
+      const url = result.data?.generatePresignedUploadURL?.url;
+      if (
+        generateURLStatus.error ||
+        result.data?.generatePresignedUploadURL?.userErrors ||
+        isUndefined(url)
+      ) {
+        console.error('Could not fetch presigned S3 URL');
+      } else {
+        setS3URL(url || '');
+      }
+    });
+  };
+
+  const onSubmit = () => {
+    if (!selectedFile) {
+      return;
+    }
+    const formData = new FormData();
+    formData.append('file', selectedFile);
+
+    axios.put(s3URL, formData).then(() => {
+      createDocument({
+        variables: {
+          input: {
+            mimeType: selectedFile.type,
+            size: selectedFile.size,
+            name: selectedFile.name,
+            key: 'this is the key',
+            requestID: accessibilityRequestId
+          }
+        }
+      }).then(() => {
+        history.push(`/508/requests/${accessibilityRequestId}`);
+      });
+    });
   };
 
   return (
@@ -66,7 +129,7 @@ const New = () => {
               file: {} as File,
               uploadURL: ''
             }}
-            onSubmit={() => {}}
+            onSubmit={onSubmit}
           >
             {(formikProps: FormikProps<FileUploadForm>) => {
               return (
@@ -87,14 +150,20 @@ const New = () => {
                     />
                   </Label>
 
-                  {fileSelected && (
+                  {selectedFile && (
                     <div className="padding-top-2">
                       <p>
                         To keep CMS safe, documents are scanned for viruses
                         after uploading. If something goes wrong, we&apos;ll let
                         you know.
                       </p>
-                      <Button type="submit" onClick={() => {}}>
+                      <Button
+                        type="submit"
+                        disabled={
+                          generateURLStatus.loading ||
+                          createDocumentStatus.loading
+                        }
+                      >
                         Upload document
                       </Button>
                     </div>

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -82,6 +82,7 @@ const New = () => {
         result.data?.generatePresignedUploadURL?.userErrors ||
         isUndefined(url)
       ) {
+        // eslint-disable-next-line
         console.error('Could not fetch presigned S3 URL');
       } else {
         setS3URL(url || '');


### PR DESCRIPTION
# ES-266

This is a followup to #783.

Changes proposed in this pull request:

- Added the UI to create a document
- No longer expose `bucket` to the client
- We're currently passing the entire URL back to the server and extracting the key from that. There might be different ways we want to do this (like having the client just pass the key back), so we should talk about this. I kind of like the from end just taking a URL from the backend, using it, and then passing that same value back as an opaque identifier. Definitely open to other options here.
