### PR TITLE
Update spacing/styling issues on the add test date form page

### DIFF
--- a/src/components/shared/Label/index.test.tsx
+++ b/src/components/shared/Label/index.test.tsx
@@ -28,7 +28,7 @@ describe('The Link component', () => {
 
   it('renders an aria-label', () => {
     const component = shallow(
-      <Label htmlFor="test" ariaLabel="aria test">
+      <Label htmlFor="test" aria-label="aria test">
         Test
       </Label>
     );

--- a/src/components/shared/Label/index.tsx
+++ b/src/components/shared/Label/index.tsx
@@ -5,14 +5,13 @@ type LabelProps = {
   children: React.ReactNode;
   htmlFor: string;
   className?: string;
-  ariaLabel?: string;
-};
+} & JSX.IntrinsicElements['label'];
 
-const Label = ({ children, htmlFor, className, ariaLabel }: LabelProps) => {
+const Label = ({ children, htmlFor, className, ...props }: LabelProps) => {
   const classes = classnames('usa-label', className);
 
   return (
-    <label className={classes} htmlFor={htmlFor} aria-label={ariaLabel}>
+    <label className={classes} htmlFor={htmlFor} {...props}>
       {children}
     </label>
   );

--- a/src/components/shared/TextField/index.tsx
+++ b/src/components/shared/TextField/index.tsx
@@ -14,6 +14,7 @@ type TextFieldProps = {
   value: string;
   match?: RegExp;
   inline?: boolean;
+  className?: string;
 } & JSX.IntrinsicElements['input'];
 
 const TextField = ({
@@ -27,13 +28,15 @@ const TextField = ({
   value,
   match,
   inline,
+  className,
   ...props
 }: TextFieldProps) => {
   const inputClasses = classnames(
     'usa-input',
     { 'easi-textfield--disabled': disabled },
     { 'usa-input--error': error },
-    { 'display-inline-block': inline }
+    { 'display-inline-block': inline },
+    className
   );
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/views/SystemIntake/ContactDetails/GovernanceTeamOptions.tsx
+++ b/src/views/SystemIntake/ContactDetails/GovernanceTeamOptions.tsx
@@ -67,7 +67,7 @@ const GovernanceTeamOptions = ({ formikProps }: GovernanceTeamOptionsProps) => {
                         >
                           <Label
                             htmlFor={`IntakeForm-${key}-Collaborator`}
-                            ariaLabel={`Enter ${team.acronym} Collaborator Name`}
+                            aria-label={`Enter ${team.acronym} Collaborator Name`}
                           >
                             {`${team.acronym} Collaborator Name`}
                           </Label>

--- a/src/views/TestDate/index.scss
+++ b/src/views/TestDate/index.scss
@@ -1,0 +1,5 @@
+.easi-508-test-date {
+  &__date-label.usa-label {
+    @include u-margin-top(1);
+  }
+}

--- a/src/views/TestDate/index.tsx
+++ b/src/views/TestDate/index.tsx
@@ -32,6 +32,8 @@ import { TestDateForm } from 'types/accessibilityRequest';
 import flattenErrors from 'utils/flattenErrors';
 import { TestDateValidationSchema } from 'validations/testDateSchema';
 
+import './index.scss';
+
 const TestDate = () => {
   const { t } = useTranslation('accessibility');
   const { accessibilityRequestId } = useParams<{
@@ -92,7 +94,7 @@ const TestDate = () => {
   };
 
   return (
-    <PageWrapper className="add-test-date">
+    <PageWrapper className="easi-508-test-date">
       <Header />
       <MainContent className="margin-bottom-5">
         <SecondaryNav>
@@ -203,7 +205,7 @@ const TestDate = () => {
                               <div className="usa-form-group usa-form-group--month">
                                 <Label
                                   htmlFor="TestDate-DateMonth"
-                                  style={{ marginTop: '0.5em' }}
+                                  className="easi-508-test-date__date-label"
                                 >
                                   {t('general:date.month')}
                                 </Label>
@@ -217,7 +219,7 @@ const TestDate = () => {
                               <div className="usa-form-group usa-form-group--day">
                                 <Label
                                   htmlFor="TestDate-DateDay"
-                                  style={{ marginTop: '0.5em' }}
+                                  className="easi-508-test-date__date-label"
                                 >
                                   {t('general:date.day')}
                                 </Label>
@@ -231,7 +233,7 @@ const TestDate = () => {
                               <div className="usa-form-group usa-form-group--year">
                                 <Label
                                   htmlFor="TestDate-DateYear"
-                                  style={{ marginTop: '0.5em' }}
+                                  className="easi-508-test-date__date-label"
                                 >
                                   {t('general:date.year')}
                                 </Label>

--- a/src/views/TestDate/index.tsx
+++ b/src/views/TestDate/index.tsx
@@ -13,6 +13,7 @@ import { GetAccessibilityRequest } from 'queries/types/GetAccessibilityRequest';
 import Footer from 'components/Footer';
 import Header from 'components/Header';
 import MainContent from 'components/MainContent';
+import PageHeading from 'components/PageHeading';
 import PageWrapper from 'components/PageWrapper';
 import {
   DateInputDay,
@@ -99,7 +100,7 @@ const TestDate = () => {
             {t('tabs.accessibilityRequests')}
           </NavLink>
         </SecondaryNav>
-        <div className="grid-container padding-y-6">
+        <div className="grid-container margin-y-4">
           <Formik
             initialValues={initialValues}
             onSubmit={onSubmit}
@@ -138,11 +139,11 @@ const TestDate = () => {
                       />
                     </ErrorAlert>
                   )}
-                  <h1 className="margin-bottom-1">
+                  <PageHeading>
                     {t('createTestDate.addTestDateHeader', {
                       requestName: data?.accessibilityRequest?.system?.name
                     })}
-                  </h1>
+                  </PageHeading>
                   <div className="grid-row grid-gap-lg">
                     <div className="grid-col-9">
                       <Form>
@@ -164,6 +165,9 @@ const TestDate = () => {
                             <Field
                               as={RadioField}
                               checked={values.testType === 'REMEDIATION'}
+                              // Radios have a margin-bottom
+                              // This is changing to margin-top in USWDS 2.9
+                              className="margin-bottom-0"
                               id="TestDate-TestTypeRemediation"
                               name="testType"
                               label="Remediation"
@@ -184,10 +188,7 @@ const TestDate = () => {
                             <legend className="usa-label margin-bottom-1">
                               {t('createTestDate.dateHeader')}
                             </legend>
-                            <HelpText
-                              id="TestDate-DateHelp"
-                              className="margin-bottom-2"
-                            >
+                            <HelpText id="TestDate-DateHelp">
                               {t('createTestDate.dateHelpText')}
                             </HelpText>
                             <FieldErrorMsg>
@@ -198,14 +199,11 @@ const TestDate = () => {
                             <FieldErrorMsg>
                               {flatErrors.validDate}
                             </FieldErrorMsg>
-                            <div
-                              className="usa-memorable-date"
-                              style={{ marginTop: '-2rem' }}
-                            >
+                            <div className="usa-memorable-date">
                               <div className="usa-form-group usa-form-group--month">
                                 <Label
                                   htmlFor="TestDate-DateMonth"
-                                  className="text-normal"
+                                  style={{ marginTop: '0.5em' }}
                                 >
                                   {t('general:date.month')}
                                 </Label>
@@ -219,7 +217,7 @@ const TestDate = () => {
                               <div className="usa-form-group usa-form-group--day">
                                 <Label
                                   htmlFor="TestDate-DateDay"
-                                  className="text-normal"
+                                  style={{ marginTop: '0.5em' }}
                                 >
                                   {t('general:date.day')}
                                 </Label>
@@ -233,7 +231,7 @@ const TestDate = () => {
                               <div className="usa-form-group usa-form-group--year">
                                 <Label
                                   htmlFor="TestDate-DateYear"
-                                  className="text-normal"
+                                  style={{ marginTop: '0.5em' }}
                                 >
                                   {t('general:date.year')}
                                 </Label>
@@ -281,22 +279,22 @@ const TestDate = () => {
                                 setFieldValue('score.isPresent', true);
                               }}
                               value
-                              aria-describedby="TestDate-ScoreYes"
                             />
                             {values.score.isPresent && (
-                              <div className="width-card-lg margin-top-neg-2 margin-left-4 margin-bottom-1">
+                              <div className="width-card-lg margin-left-4 margin-bottom-1">
                                 <FieldGroup
                                   scrollElement="score.value"
                                   error={!!flatErrors['score.value']}
                                 >
-                                  <Label htmlFor="TestDate-ScoreValue">
-                                    {t('createTestDate.scoreValueHeader')}
-                                  </Label>
                                   <Label
                                     htmlFor="TestDate-ScoreValue"
-                                    className="usa-sr-only"
+                                    className="margin-bottom-1"
+                                    style={{ marginTop: '0.5em' }}
+                                    aria-label={t(
+                                      'createTestDate.scoreValueSRHelpText'
+                                    )}
                                   >
-                                    {t('createTestDate.scoreValueSRHelpText')}
+                                    {t('createTestDate.scoreValueHeader')}
                                   </Label>
                                   <FieldErrorMsg>
                                     {flatErrors['score.value']}
@@ -306,12 +304,13 @@ const TestDate = () => {
                                       <Field
                                         as={TextField}
                                         error={!!flatErrors['score.value']}
+                                        className="margin-top-0"
                                         id="TestDate-ScoreValue"
                                         maxLength={4}
                                         name="score.value"
                                       />
                                     </div>
-                                    <div className="bg-black text-white width-5 margin-top-05 display-flex flex-justify-center flex-align-center">
+                                    <div className="bg-black text-white width-5 display-flex flex-justify-center flex-align-center">
                                       <span className="text-bold">%</span>
                                     </div>
                                   </div>
@@ -320,10 +319,7 @@ const TestDate = () => {
                             )}
                           </fieldset>
                         </FieldGroup>
-                        <Button
-                          className="margin-top-2 display-block"
-                          type="submit"
-                        >
+                        <Button className="margin-top-4" type="submit">
                           {t('createTestDate.submitButton')}
                         </Button>
                         <Link


### PR DESCRIPTION
![Screen Shot 2021-02-19 at 1 16 33 PM](https://user-images.githubusercontent.com/8367504/108563035-aa7e8f00-72b5-11eb-8a61-1745d3fa0017.png)

- Update `Label` to allow intrinsic attributes
- Update `TextField` to allow custom `className`
- Add `aria-label` to test score label
- Remove/update various  classnames to match styles