### PR TITLE
ES-344 wire up relevant to db

### DIFF
--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -43,18 +43,13 @@ func (r *accessibilityRequestResolver) Documents(ctx context.Context, obj *model
 }
 
 func (r *accessibilityRequestResolver) RelevantTestDate(ctx context.Context, obj *models.AccessibilityRequest) (*models.TestDate, error) {
-	allDates := []*models.TestDate{}
-
-	if time.Now().Unix()%3 == 0 {
-		allDates = append(allDates, &models.TestDate{
-			ID:       uuid.New(),
-			Date:     time.Now().AddDate(0, 0, 1),
-			TestType: models.TestDateTestTypeInitial,
-		})
+	allDates, err := r.store.FetchTestDatesByRequestID(ctx, obj.ID)
+	if err != nil {
+		return nil, err
 	}
+
 	var nearFuture *models.TestDate
 	var recentPast *models.TestDate
-
 	now := time.Now()
 
 	for _, td := range allDates {

--- a/pkg/storage/test_date.go
+++ b/pkg/storage/test_date.go
@@ -69,3 +69,19 @@ func (s *Store) FetchTestDateByID(ctx context.Context, id uuid.UUID) (*models.Te
 
 	return &testDate, nil
 }
+
+// FetchTestDatesByRequestID queries the DB for all the test dates matching the given AccessbilityRequest ID
+func (s *Store) FetchTestDatesByRequestID(ctx context.Context, requestID uuid.UUID) ([]*models.TestDate, error) {
+	results := []*models.TestDate{}
+
+	err := s.db.SelectContext(ctx, &results, `SELECT * FROM test_dates WHERE request_id=$1 AND deleted_at IS NULL`, requestID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		appcontext.ZLogger(ctx).Error("Failed to fetch test dates", zap.Error(err), zap.String("requestID", requestID.String()))
+		return nil, &apperrors.QueryError{
+			Err:       err,
+			Model:     models.TestDate{},
+			Operation: apperrors.QueryFetch,
+		}
+	}
+	return results, nil
+}


### PR DESCRIPTION
# ES-344

Changes proposed in this pull request:

- grab actual registered test dates for a given request to be evaluated as "relevant"
