### PR TITLE
View accessibility request documents

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -61,12 +61,12 @@ type ComplexityRoot struct {
 
 	AccessibilityRequestDocument struct {
 		ID         func(childComplexity int) int
-		Key        func(childComplexity int) int
 		MimeType   func(childComplexity int) int
 		Name       func(childComplexity int) int
 		RequestID  func(childComplexity int) int
 		Size       func(childComplexity int) int
 		Status     func(childComplexity int) int
+		URL        func(childComplexity int) int
 		UploadedAt func(childComplexity int) int
 	}
 
@@ -236,13 +236,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.AccessibilityRequestDocument.ID(childComplexity), true
 
-	case "AccessibilityRequestDocument.key":
-		if e.complexity.AccessibilityRequestDocument.Key == nil {
-			break
-		}
-
-		return e.complexity.AccessibilityRequestDocument.Key(childComplexity), true
-
 	case "AccessibilityRequestDocument.mimeType":
 		if e.complexity.AccessibilityRequestDocument.MimeType == nil {
 			break
@@ -277,6 +270,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AccessibilityRequestDocument.Status(childComplexity), true
+
+	case "AccessibilityRequestDocument.url":
+		if e.complexity.AccessibilityRequestDocument.URL == nil {
+			break
+		}
+
+		return e.complexity.AccessibilityRequestDocument.URL(childComplexity), true
 
 	case "AccessibilityRequestDocument.uploadedAt":
 		if e.complexity.AccessibilityRequestDocument.UploadedAt == nil {
@@ -694,13 +694,13 @@ A document that belongs to an accessibility request
 """
 type AccessibilityRequestDocument {
   id: UUID!
-  key: String!
   mimeType: String!
   name: String!
   requestID: UUID!
   size: Int!
   status: AccessibilityRequestDocumentStatus!
   uploadedAt: Time!
+  url: String!
 }
 
 """
@@ -1336,41 +1336,6 @@ func (ec *executionContext) _AccessibilityRequestDocument_id(ctx context.Context
 	return ec.marshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _AccessibilityRequestDocument_key(ctx context.Context, field graphql.CollectedField, obj *models.AccessibilityRequestDocument) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "AccessibilityRequestDocument",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Key, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _AccessibilityRequestDocument_mimeType(ctx context.Context, field graphql.CollectedField, obj *models.AccessibilityRequestDocument) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -1579,6 +1544,41 @@ func (ec *executionContext) _AccessibilityRequestDocument_uploadedAt(ctx context
 	res := resTmp.(*time.Time)
 	fc.Result = res
 	return ec.marshalNTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _AccessibilityRequestDocument_url(ctx context.Context, field graphql.CollectedField, obj *models.AccessibilityRequestDocument) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "AccessibilityRequestDocument",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.URL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _AccessibilityRequestEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.AccessibilityRequestEdge) (ret graphql.Marshaler) {
@@ -4249,11 +4249,6 @@ func (ec *executionContext) _AccessibilityRequestDocument(ctx context.Context, s
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
-		case "key":
-			out.Values[i] = ec._AccessibilityRequestDocument_key(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "mimeType":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
@@ -4302,6 +4297,11 @@ func (ec *executionContext) _AccessibilityRequestDocument(ctx context.Context, s
 				}
 				return res
 			})
+		case "url":
+			out.Values[i] = ec._AccessibilityRequestDocument_url(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -63,13 +63,13 @@ A document that belongs to an accessibility request
 """
 type AccessibilityRequestDocument {
   id: UUID!
-  key: String!
   mimeType: String!
   name: String!
   requestID: UUID!
   size: Int!
   status: AccessibilityRequestDocumentStatus!
   uploadedAt: Time!
+  url: String!
 }
 
 """

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -38,6 +38,9 @@ func (r *accessibilityRequestResolver) Documents(ctx context.Context, obj *model
 		}
 
 		document.Status = models.AccessibilityRequestDocumentStatus(status)
+		if url, urlErr := r.s3Client.NewGetPresignedURL(document.Key); urlErr == nil {
+			document.URL = url.URL
+		}
 	}
 
 	return documents, nil
@@ -138,6 +141,9 @@ func (r *mutationResolver) CreateAccessibilityRequestDocument(ctx context.Contex
 
 	if docErr != nil {
 		return nil, docErr
+	}
+	if url, urlErr := r.s3Client.NewGetPresignedURL(key); urlErr == nil {
+		doc.URL = url.URL
 	}
 
 	return &model.CreateAccessibilityRequestDocumentPayload{

--- a/src/queries/GetAccessibilityRequestQuery.ts
+++ b/src/queries/GetAccessibilityRequestQuery.ts
@@ -16,6 +16,7 @@ export default gql`
       }
       documents {
         name
+        url
         uploadedAt
         status
       }

--- a/src/queries/types/GetAccessibilityRequest.ts
+++ b/src/queries/types/GetAccessibilityRequest.ts
@@ -25,6 +25,7 @@ export interface GetAccessibilityRequest_accessibilityRequest_system {
 export interface GetAccessibilityRequest_accessibilityRequest_documents {
   __typename: "AccessibilityRequestDocument";
   name: string;
+  url: string;
   uploadedAt: Time;
   status: AccessibilityRequestDocumentStatus;
 }

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/index.tsx
@@ -10,6 +10,7 @@ import formatDate from 'utils/formatDate';
 type Document = {
   name: string;
   status: AccessibilityRequestDocumentStatus;
+  url: string;
   uploadedAt: string;
 };
 
@@ -50,12 +51,17 @@ const AccessibilityDocumentsList = ({
         Cell: ({ row }: any) => (
           <>
             <UswdsLink
+              aria-describedby={`doc-link-${row.original.id}`}
+              target="_blank"
               asCustom={Link}
-              to={`/some-508-request/${row.original.name}`}
+              to={row.original.url}
             >
               {t('documentTable.view')}
+              <span className="usa-sr-only">document type</span>
             </UswdsLink>
-            <span className="usa-sr-only">{row.original.name}</span>
+            <span className="usa-sr-only" id={`doc-link-${row.original.id}`}>
+              Open file in a new tab or window
+            </span>
             {/* <UswdsLink asCustom={Link} to="#" className="margin-left-2">
               {t('documentTable.remove')}
             </UswdsLink>


### PR DESCRIPTION
# ES-382

Changes proposed in this pull request:

- Replaced `key` in schema with `url` since we want the client to treat the path for documents as opaque.
- Generate a pre-signed URL for each document and return that as the document's URL
- Extend existing resolver tests to query for documents
- Update UI to use URL
- Open new tab/window when viewing documents
- Add accessibility hints so that users know the view link opens in a new window

Here is a recording of Voiceover reading through the page. It says "View document type. Opens in a new tab or window" when it moves over the `View` link (you'll need to turn the video's audio on!):

https://user-images.githubusercontent.com/3331/108778021-59c39c00-752a-11eb-8c38-f88ed44b3cf5.mov
