### PR TITLE
add confirmation message to document upload

### DIFF
--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -24,7 +24,6 @@ import { FileUploadForm } from 'types/files';
 const New = () => {
   const { t } = useTranslation('accessibility');
   const history = useHistory();
-
   const { accessibilityRequestId } = useParams<{
     accessibilityRequestId: string;
   }>();
@@ -109,7 +108,9 @@ const New = () => {
           }
         }
       }).then(() => {
-        history.push(`/508/requests/${accessibilityRequestId}`);
+        history.push(`/508/requests/${accessibilityRequestId}`, {
+          confirmationText: `${selectedFile.name} uploaded to ${data?.accessibilityRequest?.name}`
+        });
       });
     });
   };


### PR DESCRIPTION
# ES-368

This PR adds a confirmation message after a 508 document has been uploaded.

1. Visit `/508/requests/508_REQUEST_ID`
2. Click `Upload a document`
3. Add a document and click `Upload document`

See the confirmation message!
