### PR TITLE
Fix React keys error on 508 document table list

### DIFF
--- a/src/views/Accessibility/AccessibiltyRequest/Documents/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/index.tsx
@@ -96,6 +96,7 @@ const AccessibilityDocumentsList = ({
           <tr {...headerGroup.getHeaderGroupProps()}>
             {headerGroup.headers.map(column => (
               <th
+                {...column.getHeaderProps()}
                 style={{ whiteSpace: 'nowrap', width: column.width }}
                 scope="col"
               >


### PR DESCRIPTION
This PR fixes the 508 table list keys error:
```
Warning: Each child in a list should have a unique "key" prop.
Check the render method of `AccessibilityDocumentsList
```
