### PR TITLE
use loading from graphql query to display the combo box

### DIFF
--- a/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
@@ -38,7 +38,7 @@ import accessibilitySchema from 'validations/accessibilitySchema';
 const Create = () => {
   const history = useHistory();
   const { t } = useTranslation('accessibility');
-  const { data } = useQuery<GetSystems>(GetSystemsQuery, {
+  const { data, loading } = useQuery<GetSystems>(GetSystemsQuery, {
     variables: {
       // TODO: Is there a way to make this all? or change the query?
       first: 20
@@ -120,7 +120,7 @@ const Create = () => {
                   )}
                   <div className="margin-bottom-7">
                     <FormikForm>
-                      {projectComboBoxOptions.length > 0 && (
+                      {!loading && (
                         <FieldGroup
                           scrollElement="intakeId"
                           error={!!flatErrors.intakeId}


### PR DESCRIPTION
The `ComboBox` has issues with updating when the `options` are dynamic and get "re-initialized". The first render following the change has the old values. It's not clear whether this is a bug in `react-uswds` (my gut says no).

This became an issue because React would render the `ComboBox` while the data was still getting queried, causing the initial render to have no options. That's why the `projectComboBoxOptions.length > 0` was there.

However, it's _technically_ possible that there would be no systems returned from the API. At that point we should see the combo box and see that there aren't any options. The existing code would hide the field all together because there aren't any options. The fix will show the field with 0 options.
