### PR TITLE
update accessor in the 508 table data for test dates

### DIFF
--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -7,31 +7,14 @@ import { useSortBy, useTable } from 'react-table';
 import { Link as UswdsLink, Table } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 import { DateTime } from 'luxon';
+import { GetAccessibilityRequests_accessibilityRequests_edges_node as AccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
 
 import formatDate from 'utils/formatDate';
 
 // import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
 
-type AccessibilityRequestsTableRow = {
-  id: string;
-  system: {
-    name: string;
-    businessOwner: {
-      name?: string;
-      component?: string;
-    };
-  };
-  submittedAt?: DateTime;
-  testDate?: DateTime;
-  relevantTestDate?: {
-    date: DateTime;
-  };
-  status?: string;
-  lastUpdatedAt?: DateTime;
-};
-
 type AccessibilityRequestsTableProps = {
-  requests: AccessibilityRequestsTableRow[];
+  requests: AccessibilityRequests[];
 };
 
 const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTableProps> = ({
@@ -64,13 +47,13 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
       },
       {
         Header: t('requestTable.header.businessOwner'),
-        accessor: (row: AccessibilityRequestsTableRow) => {
+        accessor: (row: AccessibilityRequests) => {
           return `${row.system.businessOwner.name}, ${row.system.businessOwner.component}`;
         }
       },
       {
         Header: t('requestTable.header.testDate'),
-        accessor: 'relevantTestDate',
+        accessor: 'relevantTestDate.date',
         Cell: ({ value }: any) => {
           if (value) {
             return formatDate(value);


### PR DESCRIPTION
This PR fixes:
- the 508 table date accessor
- uses the type created from graphql instead of rolling our own
