### PR TITLE
Add Document Type Graphql

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -61,14 +61,20 @@ type ComplexityRoot struct {
 	}
 
 	AccessibilityRequestDocument struct {
-		ID         func(childComplexity int) int
-		MimeType   func(childComplexity int) int
-		Name       func(childComplexity int) int
-		RequestID  func(childComplexity int) int
-		Size       func(childComplexity int) int
-		Status     func(childComplexity int) int
-		URL        func(childComplexity int) int
-		UploadedAt func(childComplexity int) int
+		DocumentType func(childComplexity int) int
+		ID           func(childComplexity int) int
+		MimeType     func(childComplexity int) int
+		Name         func(childComplexity int) int
+		RequestID    func(childComplexity int) int
+		Size         func(childComplexity int) int
+		Status       func(childComplexity int) int
+		URL          func(childComplexity int) int
+		UploadedAt   func(childComplexity int) int
+	}
+
+	AccessibilityRequestDocumentType struct {
+		CommonType           func(childComplexity int) int
+		OtherTypeDescription func(childComplexity int) int
 	}
 
 	AccessibilityRequestEdge struct {
@@ -164,6 +170,8 @@ type AccessibilityRequestResolver interface {
 	TestDates(ctx context.Context, obj *models.AccessibilityRequest) ([]*models.TestDate, error)
 }
 type AccessibilityRequestDocumentResolver interface {
+	DocumentType(ctx context.Context, obj *models.AccessibilityRequestDocument) (*model.AccessibilityRequestDocumentType, error)
+
 	MimeType(ctx context.Context, obj *models.AccessibilityRequestDocument) (string, error)
 
 	UploadedAt(ctx context.Context, obj *models.AccessibilityRequestDocument) (*time.Time, error)
@@ -245,6 +253,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.AccessibilityRequest.TestDates(childComplexity), true
 
+	case "AccessibilityRequestDocument.documentType":
+		if e.complexity.AccessibilityRequestDocument.DocumentType == nil {
+			break
+		}
+
+		return e.complexity.AccessibilityRequestDocument.DocumentType(childComplexity), true
+
 	case "AccessibilityRequestDocument.id":
 		if e.complexity.AccessibilityRequestDocument.ID == nil {
 			break
@@ -300,6 +315,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AccessibilityRequestDocument.UploadedAt(childComplexity), true
+
+	case "AccessibilityRequestDocumentType.commonType":
+		if e.complexity.AccessibilityRequestDocumentType.CommonType == nil {
+			break
+		}
+
+		return e.complexity.AccessibilityRequestDocumentType.CommonType(childComplexity), true
+
+	case "AccessibilityRequestDocumentType.otherTypeDescription":
+		if e.complexity.AccessibilityRequestDocumentType.OtherTypeDescription == nil {
+			break
+		}
+
+		return e.complexity.AccessibilityRequestDocumentType.OtherTypeDescription(childComplexity), true
 
 	case "AccessibilityRequestEdge.cursor":
 		if e.complexity.AccessibilityRequestEdge.Cursor == nil {
@@ -733,9 +762,53 @@ enum AccessibilityRequestDocumentStatus {
 }
 
 """
+Common document type of an Accessibility Request document
+"""
+enum AccessibilityRequestDocumentCommonType {
+  """
+  Awarded VPAT
+  """
+  AWARDED_VPAT
+
+  """
+  Other document
+  """
+  OTHER
+
+  """
+  Remediation Plan
+  """
+  REMEDIATION_PLAN
+
+  """
+  Testing VPAT
+  """
+  TESTING_VPAT
+
+  """
+  Test Plan
+  """
+  TEST_PLAN
+
+  """
+  Test Results
+  """
+  TEST_RESULTS
+}
+
+"""
+Document type of an Accessibility Request document
+"""
+type AccessibilityRequestDocumentType {
+  commonType: AccessibilityRequestDocumentCommonType!
+  otherTypeDescription: String
+}
+
+"""
 A document that belongs to an accessibility request
 """
 type AccessibilityRequestDocument {
+  documentType: AccessibilityRequestDocumentType!
   id: UUID!
   mimeType: String!
   name: String!
@@ -876,8 +949,10 @@ type UpdateTestDatePayload {
 Parameters for createAccessibilityRequestDocument
 """
 input CreateAccessibilityRequestDocumentInput {
+  commonDocumentType: AccessibilityRequestDocumentCommonType!
   mimeType: String!
   name: String!
+  otherDocumentTypeDescription: String
   requestID: UUID!
   size: Int!
   url: String!
@@ -1414,6 +1489,41 @@ func (ec *executionContext) _AccessibilityRequest_testDates(ctx context.Context,
 	return ec.marshalNTestDate2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTestDateᚄ(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _AccessibilityRequestDocument_documentType(ctx context.Context, field graphql.CollectedField, obj *models.AccessibilityRequestDocument) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "AccessibilityRequestDocument",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.AccessibilityRequestDocument().DocumentType(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.AccessibilityRequestDocumentType)
+	fc.Result = res
+	return ec.marshalNAccessibilityRequestDocumentType2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequestDocumentType(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _AccessibilityRequestDocument_id(ctx context.Context, field graphql.CollectedField, obj *models.AccessibilityRequestDocument) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -1692,6 +1802,73 @@ func (ec *executionContext) _AccessibilityRequestDocument_url(ctx context.Contex
 	res := resTmp.(string)
 	fc.Result = res
 	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _AccessibilityRequestDocumentType_commonType(ctx context.Context, field graphql.CollectedField, obj *model.AccessibilityRequestDocumentType) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "AccessibilityRequestDocumentType",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CommonType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.AccessibilityRequestDocumentCommonType)
+	fc.Result = res
+	return ec.marshalNAccessibilityRequestDocumentCommonType2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequestDocumentCommonType(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _AccessibilityRequestDocumentType_otherTypeDescription(ctx context.Context, field graphql.CollectedField, obj *model.AccessibilityRequestDocumentType) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "AccessibilityRequestDocumentType",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OtherTypeDescription, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _AccessibilityRequestEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.AccessibilityRequestEdge) (ret graphql.Marshaler) {
@@ -4235,6 +4412,14 @@ func (ec *executionContext) unmarshalInputCreateAccessibilityRequestDocumentInpu
 
 	for k, v := range asMap {
 		switch k {
+		case "commonDocumentType":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("commonDocumentType"))
+			it.CommonDocumentType, err = ec.unmarshalNAccessibilityRequestDocumentCommonType2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequestDocumentCommonType(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "mimeType":
 			var err error
 
@@ -4248,6 +4433,14 @@ func (ec *executionContext) unmarshalInputCreateAccessibilityRequestDocumentInpu
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
 			it.Name, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "otherDocumentTypeDescription":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("otherDocumentTypeDescription"))
+			it.OtherDocumentTypeDescription, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -4542,6 +4735,20 @@ func (ec *executionContext) _AccessibilityRequestDocument(ctx context.Context, s
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("AccessibilityRequestDocument")
+		case "documentType":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._AccessibilityRequestDocument_documentType(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "id":
 			out.Values[i] = ec._AccessibilityRequestDocument_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -4600,6 +4807,35 @@ func (ec *executionContext) _AccessibilityRequestDocument(ctx context.Context, s
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var accessibilityRequestDocumentTypeImplementors = []string{"AccessibilityRequestDocumentType"}
+
+func (ec *executionContext) _AccessibilityRequestDocumentType(ctx context.Context, sel ast.SelectionSet, obj *model.AccessibilityRequestDocumentType) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, accessibilityRequestDocumentTypeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AccessibilityRequestDocumentType")
+		case "commonType":
+			out.Values[i] = ec._AccessibilityRequestDocumentType_commonType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "otherTypeDescription":
+			out.Values[i] = ec._AccessibilityRequestDocumentType_otherTypeDescription(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -5415,6 +5651,16 @@ func (ec *executionContext) marshalNAccessibilityRequestDocument2ᚖgithubᚗcom
 	return ec._AccessibilityRequestDocument(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNAccessibilityRequestDocumentCommonType2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequestDocumentCommonType(ctx context.Context, v interface{}) (model.AccessibilityRequestDocumentCommonType, error) {
+	var res model.AccessibilityRequestDocumentCommonType
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNAccessibilityRequestDocumentCommonType2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequestDocumentCommonType(ctx context.Context, sel ast.SelectionSet, v model.AccessibilityRequestDocumentCommonType) graphql.Marshaler {
+	return v
+}
+
 func (ec *executionContext) unmarshalNAccessibilityRequestDocumentStatus2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐAccessibilityRequestDocumentStatus(ctx context.Context, v interface{}) (models.AccessibilityRequestDocumentStatus, error) {
 	var res models.AccessibilityRequestDocumentStatus
 	err := res.UnmarshalGQL(v)
@@ -5423,6 +5669,20 @@ func (ec *executionContext) unmarshalNAccessibilityRequestDocumentStatus2github�
 
 func (ec *executionContext) marshalNAccessibilityRequestDocumentStatus2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐAccessibilityRequestDocumentStatus(ctx context.Context, sel ast.SelectionSet, v models.AccessibilityRequestDocumentStatus) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) marshalNAccessibilityRequestDocumentType2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequestDocumentType(ctx context.Context, sel ast.SelectionSet, v model.AccessibilityRequestDocumentType) graphql.Marshaler {
+	return ec._AccessibilityRequestDocumentType(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAccessibilityRequestDocumentType2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequestDocumentType(ctx context.Context, sel ast.SelectionSet, v *model.AccessibilityRequestDocumentType) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._AccessibilityRequestDocumentType(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNAccessibilityRequestEdge2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐAccessibilityRequestEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.AccessibilityRequestEdge) graphql.Marshaler {

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -12,6 +12,12 @@ import (
 	"github.com/google/uuid"
 )
 
+// Document type of an Accessibility Request document
+type AccessibilityRequestDocumentType struct {
+	CommonType           AccessibilityRequestDocumentCommonType `json:"commonType"`
+	OtherTypeDescription *string                                `json:"otherTypeDescription"`
+}
+
 // An edge of an AccessibilityRequestConnection
 type AccessibilityRequestEdge struct {
 	Cursor string                       `json:"cursor"`
@@ -26,11 +32,13 @@ type AccessibilityRequestsConnection struct {
 
 // Parameters for createAccessibilityRequestDocument
 type CreateAccessibilityRequestDocumentInput struct {
-	MimeType  string    `json:"mimeType"`
-	Name      string    `json:"name"`
-	RequestID uuid.UUID `json:"requestID"`
-	Size      int       `json:"size"`
-	URL       string    `json:"url"`
+	CommonDocumentType           AccessibilityRequestDocumentCommonType `json:"commonDocumentType"`
+	MimeType                     string                                 `json:"mimeType"`
+	Name                         string                                 `json:"name"`
+	OtherDocumentTypeDescription *string                                `json:"otherDocumentTypeDescription"`
+	RequestID                    uuid.UUID                              `json:"requestID"`
+	Size                         int                                    `json:"size"`
+	URL                          string                                 `json:"url"`
 }
 
 // Result of createAccessibilityRequestDocument
@@ -109,6 +117,62 @@ type UpdateTestDatePayload struct {
 type UserError struct {
 	Message string   `json:"message"`
 	Path    []string `json:"path"`
+}
+
+// Common document type of an Accessibility Request document
+type AccessibilityRequestDocumentCommonType string
+
+const (
+	// Awarded VPAT
+	AccessibilityRequestDocumentCommonTypeAwardedVpat AccessibilityRequestDocumentCommonType = "AWARDED_VPAT"
+	// Other document
+	AccessibilityRequestDocumentCommonTypeOther AccessibilityRequestDocumentCommonType = "OTHER"
+	// Remediation Plan
+	AccessibilityRequestDocumentCommonTypeRemediationPlan AccessibilityRequestDocumentCommonType = "REMEDIATION_PLAN"
+	// Testing VPAT
+	AccessibilityRequestDocumentCommonTypeTestingVpat AccessibilityRequestDocumentCommonType = "TESTING_VPAT"
+	// Test Plan
+	AccessibilityRequestDocumentCommonTypeTestPlan AccessibilityRequestDocumentCommonType = "TEST_PLAN"
+	// Test Results
+	AccessibilityRequestDocumentCommonTypeTestResults AccessibilityRequestDocumentCommonType = "TEST_RESULTS"
+)
+
+var AllAccessibilityRequestDocumentCommonType = []AccessibilityRequestDocumentCommonType{
+	AccessibilityRequestDocumentCommonTypeAwardedVpat,
+	AccessibilityRequestDocumentCommonTypeOther,
+	AccessibilityRequestDocumentCommonTypeRemediationPlan,
+	AccessibilityRequestDocumentCommonTypeTestingVpat,
+	AccessibilityRequestDocumentCommonTypeTestPlan,
+	AccessibilityRequestDocumentCommonTypeTestResults,
+}
+
+func (e AccessibilityRequestDocumentCommonType) IsValid() bool {
+	switch e {
+	case AccessibilityRequestDocumentCommonTypeAwardedVpat, AccessibilityRequestDocumentCommonTypeOther, AccessibilityRequestDocumentCommonTypeRemediationPlan, AccessibilityRequestDocumentCommonTypeTestingVpat, AccessibilityRequestDocumentCommonTypeTestPlan, AccessibilityRequestDocumentCommonTypeTestResults:
+		return true
+	}
+	return false
+}
+
+func (e AccessibilityRequestDocumentCommonType) String() string {
+	return string(e)
+}
+
+func (e *AccessibilityRequestDocumentCommonType) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = AccessibilityRequestDocumentCommonType(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid AccessibilityRequestDocumentCommonType", str)
+	}
+	return nil
+}
+
+func (e AccessibilityRequestDocumentCommonType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 // A user role associated with a job code

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -60,9 +60,53 @@ enum AccessibilityRequestDocumentStatus {
 }
 
 """
+Common document type of an Accessibility Request document
+"""
+enum AccessibilityRequestDocumentCommonType {
+  """
+  Awarded VPAT
+  """
+  AWARDED_VPAT
+
+  """
+  Other document
+  """
+  OTHER
+
+  """
+  Remediation Plan
+  """
+  REMEDIATION_PLAN
+
+  """
+  Testing VPAT
+  """
+  TESTING_VPAT
+
+  """
+  Test Plan
+  """
+  TEST_PLAN
+
+  """
+  Test Results
+  """
+  TEST_RESULTS
+}
+
+"""
+Document type of an Accessibility Request document
+"""
+type AccessibilityRequestDocumentType {
+  commonType: AccessibilityRequestDocumentCommonType!
+  otherTypeDescription: String
+}
+
+"""
 A document that belongs to an accessibility request
 """
 type AccessibilityRequestDocument {
+  documentType: AccessibilityRequestDocumentType!
   id: UUID!
   mimeType: String!
   name: String!
@@ -203,8 +247,10 @@ type UpdateTestDatePayload {
 Parameters for createAccessibilityRequestDocument
 """
 input CreateAccessibilityRequestDocumentInput {
+  commonDocumentType: AccessibilityRequestDocumentCommonType!
   mimeType: String!
   name: String!
+  otherDocumentTypeDescription: String
   requestID: UUID!
   size: Int!
   url: String!

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -97,6 +97,10 @@ func (r *accessibilityRequestResolver) TestDates(ctx context.Context, obj *model
 	return r.store.FetchTestDatesByRequestID(ctx, obj.ID)
 }
 
+func (r *accessibilityRequestDocumentResolver) DocumentType(ctx context.Context, obj *models.AccessibilityRequestDocument) (*model.AccessibilityRequestDocumentType, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
 func (r *accessibilityRequestDocumentResolver) MimeType(ctx context.Context, obj *models.AccessibilityRequestDocument) (string, error) {
 	return obj.FileType, nil
 }

--- a/pkg/graph/schema.resolvers_test.go
+++ b/pkg/graph/schema.resolvers_test.go
@@ -299,7 +299,9 @@ func (s GraphQLTestSuite) TestCreateAccessibilityRequestDocumentMutation() {
 				size: 512512,
 				name: "test_file.pdf",
 				url: "http://localhost:9000/easi-test-bucket/e9eb4a4f-9100-416f-be5b-f141bb436cfa.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&",
-				requestID: "%s"
+				requestID: "%s",
+				commonDocumentType: OTHER,
+				otherDocumentTypeDescription: "My new document"
 			}) {
 				accessibilityRequestDocument {
 					id

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -8,6 +8,18 @@
 //==============================================================
 
 /**
+ * Common document type of an Accessibility Request document
+ */
+export enum AccessibilityRequestDocumentCommonType {
+  AWARDED_VPAT = "AWARDED_VPAT",
+  OTHER = "OTHER",
+  REMEDIATION_PLAN = "REMEDIATION_PLAN",
+  TESTING_VPAT = "TESTING_VPAT",
+  TEST_PLAN = "TEST_PLAN",
+  TEST_RESULTS = "TEST_RESULTS",
+}
+
+/**
  * Represents the availability of a document
  */
 export enum AccessibilityRequestDocumentStatus {
@@ -28,8 +40,10 @@ export enum TestDateTestType {
  * Parameters for createAccessibilityRequestDocument
  */
 export interface CreateAccessibilityRequestDocumentInput {
+  commonDocumentType: AccessibilityRequestDocumentCommonType;
   mimeType: string;
   name: string;
+  otherDocumentTypeDescription?: string | null;
   requestID: UUID;
   size: number;
   url: string;


### PR DESCRIPTION
# ES-324

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- GraphQL changes for adding a type to a document
