### PR TITLE
Route to home instead of the current request

### DIFF
--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -66,7 +66,7 @@ const AccessibilityRequestDetailPage = () => {
       <Header />
       <MainContent className="margin-bottom-5">
         <SecondaryNav>
-          <NavLink to={`/508/requests/${accessibilityRequestId}`}>
+          <NavLink to="/">
             {t('tabs.accessibilityRequests')}
           </NavLink>
         </SecondaryNav>

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -66,9 +66,7 @@ const AccessibilityRequestDetailPage = () => {
       <Header />
       <MainContent className="margin-bottom-5">
         <SecondaryNav>
-          <NavLink to="/">
-            {t('tabs.accessibilityRequests')}
-          </NavLink>
+          <NavLink to="/">{t('tabs.accessibilityRequests')}</NavLink>
         </SecondaryNav>
         <div className="grid-container">
           {confirmationText && (

--- a/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
@@ -91,9 +91,7 @@ const Create = () => {
       <Header />
       <MainContent className="margin-bottom-5">
         <SecondaryNav>
-          <NavLink to="/508/requests/new">
-            {t('tabs.accessibilityRequests')}
-          </NavLink>
+          <NavLink to="/">{t('tabs.accessibilityRequests')}</NavLink>
         </SecondaryNav>
         <div className="grid-container">
           <PageHeading>{t('newRequestForm.heading')}</PageHeading>

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -120,9 +120,7 @@ const New = () => {
       <Header />
       <MainContent className="margin-bottom-5">
         <SecondaryNav>
-          <NavLink to={`/508/requests/${accessibilityRequestId}`}>
-            {t('tabs.accessibilityRequests')}
-          </NavLink>
+          <NavLink to="/">{t('tabs.accessibilityRequests')}</NavLink>
         </SecondaryNav>
         <div className="grid-container">
           <Formik

--- a/src/views/TestDate/index.tsx
+++ b/src/views/TestDate/index.tsx
@@ -98,9 +98,7 @@ const TestDate = () => {
       <Header />
       <MainContent className="margin-bottom-5">
         <SecondaryNav>
-          <NavLink to={`/508/requests/${accessibilityRequestId}`}>
-            {t('tabs.accessibilityRequests')}
-          </NavLink>
+          <NavLink to="/">{t('tabs.accessibilityRequests')}</NavLink>
         </SecondaryNav>
         <div className="grid-container margin-y-4">
           <Formik


### PR DESCRIPTION
# ES-401

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- The subnav should also route to home for now
