### PR TITLE
Use alpine-3.12 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN go get golang.org/x/tools/gopls@latest
 RUN go get github.com/cosmtrek/air
 CMD ["./bin/easi"]
 
-FROM alpine:3.11
+FROM alpine:3.12
 
 RUN apk --no-cache add ca-certificates tzdata
 WORKDIR /easi/


### PR DESCRIPTION
# ES-422

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Upgrade base image for easi-app backend to Alpine 3.12
