### PR TITLE
Fetch tags from S3

### DIFF
--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/guregu/null"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/cmsgov/easi-app/pkg/graph/generated"
@@ -19,28 +18,33 @@ import (
 )
 
 func (r *accessibilityRequestResolver) Documents(ctx context.Context, obj *models.AccessibilityRequest) ([]*models.AccessibilityRequestDocument, error) {
-	documents, documentsErr := r.store.FetchFilesByAccessibilityRequestID(ctx, obj.ID)
+	documents, documentsErr := r.store.FetchDocumentsByAccessibilityRequestID(ctx, obj.ID)
 
 	if documentsErr != nil {
 		return nil, documentsErr
 	}
 
 	for _, document := range documents {
-
-		status := "PENDING"
-		if document.VirusScanned == null.BoolFrom(true) {
-			if document.VirusClean == null.BoolFrom(false) {
-				status = "UNAVAILABLE"
-			}
-
-			if document.VirusClean == null.BoolFrom(true) {
-				status = "AVAILABLE"
-			}
-		}
-
-		document.Status = models.AccessibilityRequestDocumentStatus(status)
 		if url, urlErr := r.s3Client.NewGetPresignedURL(document.Key); urlErr == nil {
 			document.URL = url.URL
+		}
+
+		// This is not ideal- we're making a request to S3 for each document sequentially.
+		// The more documents we have on an accessibility request, the slower this resolver will get.
+		//
+		// We will either update the records in the database with the results OR implement
+		// another mechanism for doing that as a background job so that we don't need to do it here.
+		value, valueErr := r.s3Client.TagValueForKey(document.Key, "av-status")
+		if valueErr != nil {
+			return nil, valueErr
+		}
+
+		if value == "CLEAN" {
+			document.Status = models.AccessibilityRequestDocumentStatusAvailable
+		} else if value == "INFECTED" {
+			document.Status = models.AccessibilityRequestDocumentStatusUnavailable
+		} else {
+			document.Status = models.AccessibilityRequestDocumentStatusPending
 		}
 	}
 

--- a/pkg/graph/schema.resolvers_test.go
+++ b/pkg/graph/schema.resolvers_test.go
@@ -30,13 +30,19 @@ import (
 
 type GraphQLTestSuite struct {
 	suite.Suite
-	logger *zap.Logger
-	store  *storage.Store
-	client *client.Client
+	logger   *zap.Logger
+	store    *storage.Store
+	client   *client.Client
+	s3Client *mockS3Client
+}
+
+func (s *GraphQLTestSuite) BeforeTest() {
+	s.s3Client.AVStatus = ""
 }
 
 type mockS3Client struct {
 	s3iface.S3API
+	AVStatus string
 }
 
 func (m mockS3Client) PutObjectRequest(input *s3.PutObjectInput) (*request.Request, *s3.PutObjectOutput) {
@@ -58,7 +64,6 @@ func (m mockS3Client) PutObjectRequest(input *s3.PutObjectInput) (*request.Reque
 }
 
 func (m mockS3Client) GetObjectRequest(input *s3.GetObjectInput) (*request.Request, *s3.GetObjectOutput) {
-
 	newRequest := request.New(
 		aws.Config{},
 		metadata.ClientInfo{},
@@ -73,6 +78,19 @@ func (m mockS3Client) GetObjectRequest(input *s3.GetObjectInput) (*request.Reque
 		r.HTTPRequest.URL = &url.URL{Host: "signed.example.com", Path: "signed/get/123", Scheme: "https"}
 	})
 	return newRequest, &s3.GetObjectOutput{}
+}
+
+func (m mockS3Client) GetObjectTagging(input *s3.GetObjectTaggingInput) (*s3.GetObjectTaggingOutput, error) {
+	if m.AVStatus == "" {
+		return &s3.GetObjectTaggingOutput{}, nil
+	}
+
+	return &s3.GetObjectTaggingOutput{
+		TagSet: []*s3.Tag{{
+			Key:   aws.String("av-status"),
+			Value: aws.String(m.AVStatus),
+		}},
+	}, nil
 }
 
 func TestGraphQLTestSuite(t *testing.T) {
@@ -103,16 +121,17 @@ func TestGraphQLTestSuite(t *testing.T) {
 
 	s3Config := upload.Config{Bucket: "easi-test-bucket", Region: "us-west", IsLocal: false}
 	mockClient := mockS3Client{}
-	s3Client := upload.NewS3ClientUsingClient(mockClient, s3Config)
+	s3Client := upload.NewS3ClientUsingClient(&mockClient, s3Config)
 
 	schema := generated.NewExecutableSchema(generated.Config{Resolvers: NewResolver(store, ResolverService{}, &s3Client)})
 	graphQLClient := client.New(handler.NewDefaultServer(schema))
 
 	storeTestSuite := &GraphQLTestSuite{
-		Suite:  suite.Suite{},
-		logger: logger,
-		store:  store,
-		client: graphQLClient,
+		Suite:    suite.Suite{},
+		logger:   logger,
+		store:    store,
+		client:   graphQLClient,
+		s3Client: &mockClient,
 	}
 
 	suite.Run(t, storeTestSuite)
@@ -219,9 +238,85 @@ func (s GraphQLTestSuite) TestAccessibilityRequestQuery() {
 	s.Equal(document.ID.String(), responseDocument.ID)
 	s.Equal("application/pdf", responseDocument.MimeType)
 	s.Equal(1234567, responseDocument.Size)
-	s.Equal("AVAILABLE", responseDocument.Status)
+	s.Equal("PENDING", responseDocument.Status)
 	s.Equal("https://signed.example.com/signed/get/123", responseDocument.URL)
 	s.Equal("uploaded_doc.pdf", responseDocument.Name)
+}
+
+func (s GraphQLTestSuite) TestAccessibilityRequestVirusStatusQuery() {
+	ctx := context.Background()
+
+	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		ProjectName:            null.StringFrom("Big Project"),
+		Status:                 models.SystemIntakeStatusLCIDISSUED,
+		RequestType:            models.SystemIntakeRequestTypeNEW,
+		BusinessOwner:          null.StringFrom("Firstname Lastname"),
+		BusinessOwnerComponent: null.StringFrom("OIT"),
+	})
+	s.NoError(intakeErr)
+
+	// Can't set a lifecycle ID when creating system intake, so we need to do this to set that
+	// so we can then query for the system within the resolver
+	lifecycleID, lcidErr := s.store.GenerateLifecycleID(ctx)
+	s.NoError(lcidErr)
+	intake.LifecycleID = null.StringFrom(lifecycleID)
+	_, updateErr := s.store.UpdateSystemIntake(ctx, intake)
+	s.NoError(updateErr)
+
+	accessibilityRequest, requestErr := s.store.CreateAccessibilityRequest(ctx, &models.AccessibilityRequest{
+		IntakeID: intake.ID,
+	})
+	s.NoError(requestErr)
+
+	_, documentErr := s.store.CreateAccessibilityRequestDocument(ctx, &models.AccessibilityRequestDocument{
+		RequestID:    accessibilityRequest.ID,
+		Name:         "uploaded_doc.pdf",
+		FileType:     "application/pdf",
+		Size:         1234567,
+		VirusScanned: null.Bool{},
+		VirusClean:   null.Bool{},
+		Key:          "abcdefg1234567.pdf",
+	})
+	s.NoError(documentErr)
+
+	var resp struct {
+		AccessibilityRequest struct {
+			Documents []struct {
+				ID     string
+				Status string
+			}
+		}
+	}
+
+	s.s3Client.AVStatus = "CLEAN"
+
+	s.client.MustPost(fmt.Sprintf(
+		`query {
+			accessibilityRequest(id: "%s") {
+				documents {
+					id
+					status
+				}
+			}
+		}`, accessibilityRequest.ID), &resp)
+
+	responseDocument := resp.AccessibilityRequest.Documents[0]
+	s.Equal("AVAILABLE", responseDocument.Status)
+
+	s.s3Client.AVStatus = "INFECTED"
+
+	s.client.MustPost(fmt.Sprintf(
+		`query {
+			accessibilityRequest(id: "%s") {
+				documents {
+					id
+					status
+				}
+			}
+		}`, accessibilityRequest.ID), &resp)
+
+	responseDocument = resp.AccessibilityRequest.Documents[0]
+	s.Equal("UNAVAILABLE", responseDocument.Status)
 }
 
 func (s GraphQLTestSuite) TestGeneratePresignedUploadURLMutation() {

--- a/pkg/storage/accessibility_request_document.go
+++ b/pkg/storage/accessibility_request_document.go
@@ -89,8 +89,8 @@ func (s *Store) FetchAccessibilityRequestDocumentByID(ctx context.Context, id uu
 	return &document, nil
 }
 
-// FetchFilesByAccessibilityRequestID retrieves the info for a file with a given accessibility request id
-func (s *Store) FetchFilesByAccessibilityRequestID(ctx context.Context, id uuid.UUID) ([]*models.AccessibilityRequestDocument, error) {
+// FetchDocumentsByAccessibilityRequestID retrieves the info for a file with a given accessibility request id
+func (s *Store) FetchDocumentsByAccessibilityRequestID(ctx context.Context, id uuid.UUID) ([]*models.AccessibilityRequestDocument, error) {
 	if id == uuid.Nil {
 		return nil, &apperrors.ResourceNotFoundError{Resource: models.AccessibilityRequestDocument{}}
 	}

--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -113,3 +113,23 @@ func (c S3Client) NewGetPresignedURL(key string) (*models.PreSignedURL, error) {
 func (c S3Client) KeyFromURL(url *url.URL) (string, error) {
 	return strings.Replace(url.Path, "/"+c.config.Bucket+"/", "", 1), nil
 }
+
+// TagValueForKey returns the tag value and if that tag was found for the
+// specified key and tag name. If no value is found, returns an empty string.
+func (c S3Client) TagValueForKey(key string, tagName string) (string, error) {
+	input := &s3.GetObjectTaggingInput{
+		Bucket: aws.String(c.config.Bucket),
+		Key:    aws.String(key),
+	}
+	tagging, taggingErr := c.client.GetObjectTagging(input)
+	if taggingErr != nil {
+		return "", taggingErr
+	}
+
+	for _, tagSet := range tagging.TagSet {
+		if *tagSet.Key == tagName {
+			return *tagSet.Value, nil
+		}
+	}
+	return "", nil
+}

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/index.tsx
@@ -49,13 +49,15 @@ const AccessibilityDocumentsList = ({
         Header: t('documentTable.header.actions'),
         Cell: ({ row }: any) => (
           <>
-            <Link target="_blank" rel="noreferrer" href={row.original.url}>
-              {t('documentTable.view')}
-              <span className="usa-sr-only">
-                document type {/* TODO replace with real doc type */}
-              </span>
-              <span className="usa-sr-only">in a new tab or window</span>
-            </Link>
+            {row.original.status === 'AVAILABLE' && (
+              <Link target="_blank" rel="noreferrer" href={row.original.url}>
+                {t('documentTable.view')}
+                <span className="usa-sr-only">
+                  document type {/* TODO replace with real doc type */}
+                </span>
+                <span className="usa-sr-only">in a new tab or window</span>
+              </Link>
+            )}
             {/* <UswdsLink asCustom={Link} to="#" className="margin-left-2">
               {t('documentTable.remove')}
             </UswdsLink>


### PR DESCRIPTION
_Note: this is sitting on top of #807- only the last two commits are unique to this PR._

This is a stopgap while we sort out how to notify the backend that a virus scan has completed.

We're fetching the object tags from S3 for each document, which is slow, but it'll work in the short term. We could make these requests in parallel, but that's really just a slightly better hack since we shouldn't be making these network calls from within a resolver in the first place.