### PR TITLE
allow 508 test score of 0 

### DIFF
--- a/src/components/TestDateCard/index.test.tsx
+++ b/src/components/TestDateCard/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import { DateTime } from 'luxon';
 
 import TestDateCard from 'components/TestDateCard';
@@ -16,15 +16,43 @@ describe('The Test Date Card component', () => {
     );
   });
 
-  it('renders score', () => {
-    const component = mount(
-      <TestDateCard
-        date={DateTime.local().toISO()}
-        type="INITIAL"
-        testIndex={1}
-        score={1000}
-      />
-    );
-    expect(component.find('[data-testid="score"]').text()).toEqual('100.0%');
+  describe('test score', () => {
+    it('renders score', () => {
+      const component = shallow(
+        <TestDateCard
+          date={DateTime.local().toISO()}
+          type="INITIAL"
+          testIndex={1}
+          score={1000}
+        />
+      );
+      expect(component.find('[data-testid="score"]').text()).toEqual('100.0%');
+    });
+
+    it('renders a score of 0', () => {
+      const component = shallow(
+        <TestDateCard
+          date={DateTime.local().toISO()}
+          type="INITIAL"
+          testIndex={1}
+          score={0}
+        />
+      );
+      expect(component.find('[data-testid="score"]').text()).toEqual('0%');
+    });
+
+    it('renders score not added', () => {
+      const component = shallow(
+        <TestDateCard
+          date={DateTime.local().toISO()}
+          type="INITIAL"
+          testIndex={1}
+          score={null}
+        />
+      );
+      expect(component.find('[data-testid="score"]').text()).toEqual(
+        'Score not added'
+      );
+    });
   });
 });

--- a/src/components/TestDateCard/index.tsx
+++ b/src/components/TestDateCard/index.tsx
@@ -10,6 +10,13 @@ type TestDateCardProps = {
 };
 
 const TestDateCard = ({ date, type, testIndex, score }: TestDateCardProps) => {
+  const testScore = () => {
+    if (score === 0) {
+      return '0%';
+    }
+
+    return score ? `${(score / 10).toFixed(1)}%` : 'Score not added';
+  };
   return (
     <div className="bg-gray-10 padding-2 line-height-body-4 margin-bottom-2">
       <div className="text-bold margin-bottom-1">
@@ -23,7 +30,7 @@ const TestDateCard = ({ date, type, testIndex, score }: TestDateCardProps) => {
           className="display-inline-block text-base-dark"
           data-testid="score"
         >
-          {score ? `${(score / 10).toFixed(1)}%` : 'Score not added'}
+          {testScore()}
         </div>
       </div>
       {/* <div>


### PR DESCRIPTION
This PR fixes a bug where the test score cannot be 0. When a test score is 0, the UI displays "Score not added" because 0 is a  falsy value.

This PR checks for 0 and returns 0%