### PR TITLE
File upload isFileTypeValid allows any file if no accept prop

### DIFF
--- a/src/components/FileUpload/index.tsx
+++ b/src/components/FileUpload/index.tsx
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 type FileUploadProps = {
   id: string;
   name: string;
-  accept: string;
+  accept?: string;
   // multiple?: boolean;
   disabled?: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;

--- a/src/components/FileUpload/index.tsx
+++ b/src/components/FileUpload/index.tsx
@@ -53,18 +53,19 @@ const FileUpload = (props: FileUploadProps) => {
   };
 
   const isFileTypeValid = (localFile: File) => {
-    let isFileTypeAcceptable = false;
-    if (accept) {
-      const accepetedFileTypes = accept.split(',');
-      accepetedFileTypes.forEach(fileType => {
-        if (
-          localFile.name.indexOf(fileType) > 0 ||
-          localFile.type.includes(fileType.replace(/\*/g, ''))
-        ) {
-          isFileTypeAcceptable = true;
-        }
-      });
+    if (!accept) {
+      return true;
     }
+    let isFileTypeAcceptable = false;
+    const acceptedFileTypes = accept.split(',');
+    acceptedFileTypes.forEach(fileType => {
+      if (
+        localFile.name.indexOf(fileType) > 0 ||
+        localFile.type.includes(fileType.replace(/\*/g, ''))
+      ) {
+        isFileTypeAcceptable = true;
+      }
+    });
     return isFileTypeAcceptable;
   };
 


### PR DESCRIPTION
# ES-324

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Allows any file to be uploaded if no `accept` prop passed 
