### PR TITLE
Use a raw axios PUT so that we can set the content type of the file.

### DIFF
--- a/pkg/upload/upload.go
+++ b/pkg/upload/upload.go
@@ -76,8 +76,9 @@ func (c S3Client) NewPutPresignedURL(fileType string) (*models.PreSignedURL, err
 		key = key + extensions[0]
 	}
 	req, _ := c.client.PutObjectRequest(&s3.PutObjectInput{
-		Bucket: aws.String(c.config.Bucket),
-		Key:    aws.String(key),
+		Bucket:      aws.String(c.config.Bucket),
+		Key:         aws.String(key),
+		ContentType: aws.String(fileType),
 	})
 
 	url, err := req.Presign(15 * time.Minute)

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -103,10 +103,14 @@ const New = () => {
     if (!values.file.name) {
       return;
     }
-    const formData = new FormData();
-    formData.append('file', values.file);
 
-    axios.put(s3URL, formData).then(() => {
+    const options = {
+      headers: {
+        'Content-Type': values.file.type
+      }
+    };
+
+    axios.put(s3URL, values.file, options).then(() => {
       createDocument({
         variables: {
           input: {


### PR DESCRIPTION


Changes proposed in this pull request:

- Add the `Content-Type` to the params used when presigning the PUT URL
- Avoid using `FormData` to serialize the upload form so that we can set the correct `Content-Type` HTTP header.
