### PR TITLE
Show document type instead of name in table

### DIFF
--- a/src/components/AccessibilityDocumentsList/index.tsx
+++ b/src/components/AccessibilityDocumentsList/index.tsx
@@ -69,12 +69,15 @@ const AccessibilityDocumentsList = ({
               <em>Virus scan in progress...</em>
             )}
             {row.original.status === 'AVAILABLE' && (
-              <Link target="_blank" rel="noreferrer" href={row.original.url}>
+              <Link
+                target="_blank"
+                rel="noreferrer"
+                href={row.original.url}
+                aria-label={`View ${getDocType(
+                  row.original.documentType
+                )} in a new tab or window`}
+              >
                 {t('documentTable.view')}
-                <span className="usa-sr-only">
-                  document type {row.original.documentType}
-                </span>
-                <span className="usa-sr-only">in a new tab or window</span>
               </Link>
             )}
             {row.original.status === 'UNAVAILABLE' && (

--- a/src/components/AccessibilityDocumentsList/index.tsx
+++ b/src/components/AccessibilityDocumentsList/index.tsx
@@ -3,14 +3,21 @@ import { useTranslation } from 'react-i18next';
 import { useTable } from 'react-table';
 import { Link, Table } from '@trussworks/react-uswds';
 
-import { AccessibilityRequestDocumentStatus } from 'types/graphql-global-types';
+import {
+  AccessibilityRequestDocumentCommonType,
+  AccessibilityRequestDocumentStatus
+} from 'types/graphql-global-types';
+import { translateDocumentType } from 'utils/accessibilityRequest';
 import formatDate from 'utils/formatDate';
 
 type Document = {
-  name: string;
   status: AccessibilityRequestDocumentStatus;
   url: string;
   uploadedAt: string;
+  documentType: {
+    commonType: AccessibilityRequestDocumentCommonType;
+    otherTypeDescription: string | null;
+  };
 };
 
 type DocumentsListProps = {
@@ -24,11 +31,24 @@ const AccessibilityDocumentsList = ({
 }: DocumentsListProps) => {
   const { t } = useTranslation('accessibility');
 
+  const getDocType = (documentType: {
+    commonType: AccessibilityRequestDocumentCommonType;
+    otherTypeDescription: string;
+  }) => {
+    if (documentType.commonType !== 'OTHER') {
+      return translateDocumentType(
+        documentType.commonType as AccessibilityRequestDocumentCommonType
+      );
+    }
+    return documentType.otherTypeDescription;
+  };
+
   const columns: any = useMemo(() => {
     return [
       {
         Header: t('documentTable.header.documentName'),
-        accessor: 'name'
+        accessor: 'documentType',
+        Cell: ({ value }: any) => getDocType(value)
       },
       {
         Header: t('documentTable.header.uploadedAt'),
@@ -52,7 +72,7 @@ const AccessibilityDocumentsList = ({
               <Link target="_blank" rel="noreferrer" href={row.original.url}>
                 {t('documentTable.view')}
                 <span className="usa-sr-only">
-                  document type {/* TODO replace with real doc type */}
+                  document type {row.original.documentType}
                 </span>
                 <span className="usa-sr-only">in a new tab or window</span>
               </Link>

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -74,6 +74,14 @@ const accessibility = {
       'A request for 508 testing will be added to the list of 508 requests. An email will be sent to the Business Owner and the 508 team stating that a request has been added to the system.',
     submitBtn: 'Add a new request',
     confirmation: '{{requestName}} was added to the 508 requests page'
+  },
+  documentType: {
+    awardedVpat: 'Awarded VPAT',
+    testingVpat: 'Testing VPAT',
+    testPlan: 'Test plan',
+    testResults: 'Test results',
+    remediationPlan: 'Remediation plan',
+    other: 'Other'
   }
 };
 

--- a/src/queries/GetAccessibilityRequestQuery.ts
+++ b/src/queries/GetAccessibilityRequestQuery.ts
@@ -15,10 +15,13 @@ export default gql`
         }
       }
       documents {
-        name
         url
         uploadedAt
         status
+        documentType {
+          commonType
+          otherTypeDescription
+        }
       }
       testDates {
         id

--- a/src/queries/types/GetAccessibilityRequest.ts
+++ b/src/queries/types/GetAccessibilityRequest.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AccessibilityRequestDocumentStatus, TestDateTestType } from "./../../types/graphql-global-types";
+import { AccessibilityRequestDocumentStatus, AccessibilityRequestDocumentCommonType, TestDateTestType } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL query operation: GetAccessibilityRequest
@@ -22,12 +22,18 @@ export interface GetAccessibilityRequest_accessibilityRequest_system {
   businessOwner: GetAccessibilityRequest_accessibilityRequest_system_businessOwner;
 }
 
+export interface GetAccessibilityRequest_accessibilityRequest_documents_documentType {
+  __typename: "AccessibilityRequestDocumentType";
+  commonType: AccessibilityRequestDocumentCommonType;
+  otherTypeDescription: string | null;
+}
+
 export interface GetAccessibilityRequest_accessibilityRequest_documents {
   __typename: "AccessibilityRequestDocument";
-  name: string;
   url: string;
   uploadedAt: Time;
   status: AccessibilityRequestDocumentStatus;
+  documentType: GetAccessibilityRequest_accessibilityRequest_documents_documentType;
 }
 
 export interface GetAccessibilityRequest_accessibilityRequest_testDates {

--- a/src/utils/accessibilityRequest.ts
+++ b/src/utils/accessibilityRequest.ts
@@ -1,0 +1,28 @@
+import i18next from 'i18next';
+
+import { AccessibilityRequestDocumentCommonType } from 'types/graphql-global-types';
+
+/**
+ * Translate the API enum to a human readable string
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const translateDocumentType = (
+  commonDocumentType: AccessibilityRequestDocumentCommonType
+) => {
+  switch (commonDocumentType) {
+    case 'AWARDED_VPAT':
+      return i18next.t('accessibility:documentType.awardedVpat');
+    case 'REMEDIATION_PLAN':
+      return i18next.t('accessibility:documentType.remediationPlan');
+    case 'TEST_PLAN':
+      return i18next.t('accessibility:documentType.testPlan');
+    case 'TEST_RESULTS':
+      return i18next.t('accessibility:documentType.testResults');
+    case 'TESTING_VPAT':
+      return i18next.t('accessibility:documentType.testingVpat');
+    case 'OTHER':
+      return i18next.t('accessibility:documentType.other');
+    default:
+      return '';
+  }
+};

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -30,6 +30,7 @@ import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import TextField from 'components/shared/TextField';
 import { FileUploadForm } from 'types/files';
 import { AccessibilityRequestDocumentCommonType } from 'types/graphql-global-types';
+import { translateDocumentType } from 'utils/accessibilityRequest';
 import flattenErrors from 'utils/flattenErrors';
 import { DocumentUploadValidationSchema } from 'validations/documentUploadSchema';
 
@@ -128,27 +129,6 @@ const New = () => {
     });
   };
 
-  const getDocumentTypeLabel = (
-    commonType: AccessibilityRequestDocumentCommonType
-  ): string => {
-    switch (commonType) {
-      case 'AWARDED_VPAT':
-        return 'Awarded VPAT';
-      case 'TEST_PLAN':
-        return 'Test plan';
-      case 'TESTING_VPAT':
-        return 'Testing VPAT';
-      case 'TEST_RESULTS':
-        return 'Test results';
-      case 'REMEDIATION_PLAN':
-        return 'Remediation plan';
-      case 'OTHER':
-        return 'Other';
-      default:
-        return '';
-    }
-  };
-
   return (
     <PageWrapper className="accessibility-request">
       <Header />
@@ -241,7 +221,7 @@ const New = () => {
                                       }
                                       id={`FileUpload-CommonType${commonType}`}
                                       name="documentType.commonType"
-                                      label={getDocumentTypeLabel(commonType)}
+                                      label={translateDocumentType(commonType)}
                                       onChange={() => {
                                         setFieldValue(
                                           'documentType.commonType',
@@ -264,7 +244,7 @@ const New = () => {
                                 }
                                 id="FileUpload-CommonTypeOTHER"
                                 name="documentType.commonType"
-                                label={getDocumentTypeLabel(
+                                label={translateDocumentType(
                                   AccessibilityRequestDocumentCommonType.OTHER
                                 )}
                                 value="OTHER"


### PR DESCRIPTION

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Shows document type in table
