### PR TITLE
Add admin lead to GRT request repo

### DIFF
--- a/migrations/V72__Add_Admin_Lead_To_System_Intake.sql
+++ b/migrations/V72__Add_Admin_Lead_To_System_Intake.sql
@@ -1,0 +1,1 @@
+ALTER TABLE system_intakes ADD COLUMN admin_lead text;

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -129,6 +129,7 @@ type SystemIntake struct {
 	LifecycleNextSteps          null.String             `json:"lifecycleNextSteps" db:"lcid_next_steps"`
 	DecisionNextSteps           null.String             `json:"decisionNextSteps" db:"decision_next_steps"`
 	RejectionReason             null.String             `json:"rejectionReason" db:"rejection_reason"`
+	AdminLead                   null.String             `json:"adminLead" db:"admin_lead"`
 }
 
 // SystemIntakes is a list of System Intakes

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -180,7 +180,8 @@ func (s *Store) UpdateSystemIntake(ctx context.Context, intake *models.SystemInt
 			lcid_expires_at = :lcid_expires_at,
 			lcid_scope = :lcid_scope,
 			decision_next_steps = :decision_next_steps,
-			rejection_reason = :rejection_reason
+			rejection_reason = :rejection_reason,
+			admin_lead = :admin_lead
 		WHERE system_intakes.id = :id
 	`
 	_, err := s.db.NamedExec(

--- a/src/components/RequestRepository/csvHeaderMap.ts
+++ b/src/components/RequestRepository/csvHeaderMap.ts
@@ -120,6 +120,10 @@ const csvHeaderMap = (t: any) => [
   {
     key: 'archivedAt',
     label: t('intake:csvHeadings.archivedAt')
+  },
+  {
+    key: 'adminLead',
+    label: t('intake:csvHeadings.adminLead')
   }
 ];
 

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -78,7 +78,14 @@ const RequestRepository = () => {
         return value;
       }
 
-      return t('governanceReviewTeam:adminLeads.notAssigned');
+      return (
+        <>
+          {/* TODO: should probably make this a button that opens up the assign admin
+                    lead automatically. Similar to the Dates functionality */}
+          <i className="fa fa-exclamation-circle text-secondary margin-right-05" />
+          {t('governanceReviewTeam:adminLeads.notAssigned')}
+        </>
+      );
     }
   };
 

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -70,6 +70,18 @@ const RequestRepository = () => {
     accessor: 'fundingSource.fundingNumber'
   };
 
+  const adminLeadColumn = {
+    Header: t('intake:fields.adminLead'),
+    accessor: 'adminLead',
+    Cell: ({ value }: any) => {
+      if (value) {
+        return value;
+      }
+
+      return t('governanceReviewTeam:adminLeads.notAssigned');
+    }
+  };
+
   const grtDateColumn = {
     Header: t('intake:fields.grtDate'),
     accessor: 'grtDate',
@@ -124,6 +136,7 @@ const RequestRepository = () => {
         requestNameColumn,
         requesterComponentColumn,
         requestTypeColumn,
+        adminLeadColumn,
         statusColumn,
         grtDateColumn,
         grbDateColumn

--- a/src/data/systemIntake.test.ts
+++ b/src/data/systemIntake.test.ts
@@ -52,7 +52,8 @@ describe('The system intake data modifiers', () => {
         submittedAt: null,
         createdAt: null,
         decidedAt: null,
-        archivedAt: null
+        archivedAt: null,
+        adminLead: ''
       });
     });
     it('converts fully executed intake', () => {
@@ -151,7 +152,8 @@ describe('The system intake data modifiers', () => {
           month: 6,
           day: 28,
           zone: 'America/Los_Angeles'
-        })
+        }),
+        adminLead: 'Test Admin Lead'
       };
 
       expect(convertIntakeToCSV(mockIntake)).toMatchObject({
@@ -199,7 +201,8 @@ describe('The system intake data modifiers', () => {
         decidedAt: '2020-06-27T00:00:00.000-07:00',
         createdAt: '2020-06-22T00:00:00.000-07:00',
         updatedAt: '2020-06-23T00:00:00.000-07:00',
-        archivedAt: '2020-06-28T00:00:00.000-07:00'
+        archivedAt: '2020-06-28T00:00:00.000-07:00',
+        adminLead: 'Admin Lead'
       });
     });
   });

--- a/src/data/systemIntake.test.ts
+++ b/src/data/systemIntake.test.ts
@@ -202,7 +202,7 @@ describe('The system intake data modifiers', () => {
         createdAt: '2020-06-22T00:00:00.000-07:00',
         updatedAt: '2020-06-23T00:00:00.000-07:00',
         archivedAt: '2020-06-28T00:00:00.000-07:00',
-        adminLead: 'Admin Lead'
+        adminLead: 'Test Admin Lead'
       });
     });
   });

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -74,7 +74,8 @@ export const initialSystemIntakeForm: SystemIntakeForm = {
   decisionNextSteps: '',
   rejectionReason: '',
   grtDate: null,
-  grbDate: null
+  grbDate: null,
+  adminLead: ''
 };
 
 export const prepareSystemIntakeForApi = (systemIntake: SystemIntakeForm) => {
@@ -124,7 +125,8 @@ export const prepareSystemIntakeForApi = (systemIntake: SystemIntakeForm) => {
     contractEndYear: systemIntake.contract.endDate.year,
     grtDate: systemIntake.grtDate && systemIntake.grtDate.toISO(),
     grbDate: systemIntake.grbDate && systemIntake.grbDate.toISO(),
-    submittedAt: systemIntake.submittedAt && systemIntake.submittedAt.toISO()
+    submittedAt: systemIntake.submittedAt && systemIntake.submittedAt.toISO(),
+    adminLead: systemIntake.adminLead
   };
 };
 
@@ -232,7 +234,8 @@ export const prepareSystemIntakeForApp = (
       : null,
     grbDate: systemIntake.grbDate
       ? DateTime.fromISO(systemIntake.grbDate)
-      : null
+      : null,
+    adminLead: systemIntake.adminLead || ''
   };
 };
 

--- a/src/i18n/en-US/governanceReviewTeam.ts
+++ b/src/i18n/en-US/governanceReviewTeam.ts
@@ -178,6 +178,24 @@ const governanceReviewTeam = {
     label: 'Status',
     open: 'Open',
     closed: 'Closed'
+  },
+  adminLeads: {
+    assignModal: {
+      title: 'EASi',
+      header: 'Choose an Admin Lead for {{requestName}}',
+      save: 'Save',
+      noChanges: "Don't make changes and return to request page"
+    },
+    changeLead: 'Change',
+    notAssigned: 'Not Assigned',
+    members: [
+      'Matthew Schmid',
+      'Valerie Hartz',
+      'Jaime Cadwell',
+      'Alex Smith',
+      'Ann Rudolph',
+      'Surya Potu'
+    ]
   }
 };
 

--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -7,6 +7,7 @@ const intake = {
     component: 'Component',
     grtDate: 'GRT Date',
     grbDate: 'GRB Date',
+    adminLead: 'Admin Lead',
     status: 'Status',
     fundingNumber: 'Funding number',
     businessOwner: 'Business Owner'
@@ -106,7 +107,8 @@ const intake = {
     submittedAt: 'Submitted At',
     createdAt: 'Created At',
     decidedAt: 'Decided At',
-    archivedAt: 'Archived At'
+    archivedAt: 'Archived At',
+    adminLead: 'Admin Lead'
   },
   requestTypeForm: {
     heading: 'Make a System Request',

--- a/src/types/systemIntake.ts
+++ b/src/types/systemIntake.ts
@@ -87,6 +87,7 @@ export type SystemIntakeForm = {
   rejectionReason: string;
   grtDate: DateTime | null;
   grbDate: DateTime | null;
+  adminLead: string;
 } & ContractDetailsForm;
 
 export type ContractDetailsForm = {

--- a/src/views/GovernanceReviewTeam/index.scss
+++ b/src/views/GovernanceReviewTeam/index.scss
@@ -52,10 +52,18 @@
     }
   }
 
-  &__status-info {
+  &__status-group {
+    display: flex;
+    justify-content: space-between;
+
     dt, dd {
       display: inline;
     }
+  }
+
+  &__status-info {
+    display: flex;
+    justify-content: space-between;
 
     dd {
       margin: 0 1em 0 0;


### PR DESCRIPTION
# EASI-1120 and EASI-1128

Changes proposed in this pull request:

- Add admin lead (string) field to system intake
- Add button / radio button modal to GRT request table to allow for setting and changing of admin lead for each request
- Add admin lead column to GRT request table
