### PR TITLE
GRT actions sync fix

### DIFF
--- a/pkg/handlers/action.go
+++ b/pkg/handlers/action.go
@@ -73,7 +73,19 @@ func (h ActionHandler) Handle() http.HandlerFunc {
 				return
 			}
 
+			intakeStatus := action.ActionType
+			responseBody, err := json.Marshal(intakeStatus)
+			if err != nil {
+				h.WriteErrorResponse(r.Context(), w, err)
+				return
+			}
+
 			w.WriteHeader(http.StatusCreated)
+			_, err = w.Write(responseBody)
+			if err != nil {
+				h.WriteErrorResponse(r.Context(), w, err)
+				return
+			}
 			return
 		case "GET":
 			notes, err := h.FetchActions(r.Context(), intakeID)

--- a/src/reducers/systemIntakeReducer.ts
+++ b/src/reducers/systemIntakeReducer.ts
@@ -11,8 +11,10 @@ import {
   fetchIntakeNotes,
   fetchSystemIntake,
   issueLifecycleIdForSystemIntake,
+  postAction,
   postIntakeNote,
   postSystemIntake,
+  rejectSystemIntake,
   saveSystemIntake,
   storeSystemIntake
 } from 'types/routines';
@@ -126,6 +128,14 @@ function systemIntakeReducer(
       };
     case archiveSystemIntake.SUCCESS:
       return initialState;
+    case rejectSystemIntake.SUCCESS:
+      return {
+        ...state,
+        systemIntake: {
+          ...state.systemIntake,
+          ...prepareSystemIntakeForApp(action.payload)
+        }
+      };
     case issueLifecycleIdForSystemIntake.SUCCESS:
       return {
         ...state,
@@ -162,6 +172,14 @@ function systemIntakeReducer(
       return {
         ...state,
         error: action.payload
+      };
+    case postAction.SUCCESS:
+      return {
+        ...state,
+        systemIntake: {
+          ...state.systemIntake,
+          status: action.payload
+        }
       };
     default:
       return state;


### PR DESCRIPTION
# EASI-1089

Changes proposed in this pull request:

- Add more GRT actions to (all base ones and biz case not approved) to system intake reducer, this causes the redux store to automatically update when these actions are performed
- This change is a general bug fix but is most notably seen with the dates functionality
