### PR TITLE
Modify GRT request table to combine requester and component columns

### DIFF
--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -12,7 +12,10 @@ import BreadcrumbNav from 'components/BreadcrumbNav';
 import { convertIntakeToCSV } from 'data/systemIntake';
 import { AppState } from 'reducers/rootReducer';
 import { fetchSystemIntakes } from 'types/routines';
-import { translateRequestType } from 'utils/systemIntake';
+import {
+  getAcronymForComponent,
+  translateRequestType
+} from 'utils/systemIntake';
 
 import csvHeaderMap from './csvHeaderMap';
 
@@ -50,14 +53,14 @@ const RequestRepository = () => {
     }
   };
 
-  const requesterNameColumn = {
+  const requesterNameAndComponentColumn = {
     Header: t('intake:fields.requester'),
-    accessor: 'requester.name'
-  };
-
-  const requesterComponentColumn = {
-    Header: t('intake:fields.component'),
-    accessor: 'requester.component'
+    accessor: 'requester',
+    Cell: ({ value }: any) => {
+      // Display both the requester name and the acronym of their component
+      // TODO: might be better to just save the component's acronym in the intake?
+      return `${value.name}, ${getAcronymForComponent(value.component)}`;
+    }
   };
 
   const requestTypeColumn = {
@@ -122,7 +125,7 @@ const RequestRepository = () => {
       return [
         submissionDateColumn,
         requestNameColumn,
-        requesterComponentColumn,
+        requesterNameAndComponentColumn,
         requestTypeColumn,
         statusColumn,
         grtDateColumn,
@@ -133,8 +136,7 @@ const RequestRepository = () => {
       return [
         submissionDateColumn,
         requestNameColumn,
-        requesterNameColumn,
-        requesterComponentColumn,
+        requesterNameAndComponentColumn,
         fundingNumberColmun,
         statusColumn
       ];

--- a/src/utils/systemIntake.ts
+++ b/src/utils/systemIntake.ts
@@ -1,5 +1,6 @@
 import i18next from 'i18next';
 
+import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
 import {
   closedIntakeStatuses,
   openIntakeStatuses,
@@ -38,4 +39,19 @@ export const translateRequestType = (requestType: RequestType) => {
     default:
       return '';
   }
+};
+
+/**
+ * Get the acronym representation of the component name
+ * @param componentToTranslate - component name string that needs to be converted to an acronym
+ */
+export const getAcronymForComponent = (componentToTranslate: string) => {
+  const component = cmsDivisionsAndOffices.find(
+    c => c.name === componentToTranslate
+  );
+  if (component) {
+    return component.acronym;
+  }
+  // TODO: what do we return if not found? (should be impossible)
+  return 'Other';
 };


### PR DESCRIPTION
# EASI-1127

Changes proposed in this pull request:

- Modified open and closed request table to show a new column that displays [requester, requester component]
