### PR TITLE
Fix 508 request table sorting

### DIFF
--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -25,7 +25,7 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
     return [
       {
         Header: t('requestTable.header.requestName'),
-        accessor: 'name',
+        accessor: 'requestName',
         Cell: ({ row, value }: any) => {
           return (
             <UswdsLink asCustom={Link} to={`/508/requests/${row.original.id}`}>
@@ -47,13 +47,11 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
       },
       {
         Header: t('requestTable.header.businessOwner'),
-        accessor: (row: AccessibilityRequests) => {
-          return `${row.system.businessOwner.name}, ${row.system.businessOwner.component}`;
-        }
+        accessor: 'businessOwner'
       },
       {
         Header: t('requestTable.header.testDate'),
-        accessor: 'relevantTestDate.date',
+        accessor: 'relevantTestDate',
         Cell: ({ value }: any) => {
           if (value) {
             return formatDate(value);
@@ -81,6 +79,28 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const data = useMemo(() => {
+    const tableData = requests.map(request => {
+      const submittedAt = request.submittedAt
+        ? DateTime.fromISO(request.submittedAt)
+        : null;
+      const businessOwner = `${request.system.businessOwner.name}, ${request.system.businessOwner.component}`;
+      const testDate = request.relevantTestDate?.date
+        ? DateTime.fromISO(request.relevantTestDate?.date)
+        : null;
+
+      return {
+        id: request.id,
+        requestName: request.name,
+        submittedAt,
+        businessOwner,
+        relevantTestDate: testDate
+      };
+    });
+
+    return tableData;
+  }, [requests]);
+
   const {
     getTableProps,
     getTableBodyProps,
@@ -90,7 +110,7 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
   } = useTable(
     {
       columns,
-      data: requests,
+      data,
       sortTypes: {
         alphanumeric: (rowOne, rowTwo, columnName) => {
           const rowOneElem = rowOne.values[columnName];

--- a/src/utils/formatDate.test.ts
+++ b/src/utils/formatDate.test.ts
@@ -5,8 +5,10 @@ import formatDate from './formatDate';
 describe('formatDate', () => {
   describe('string', () => {
     it('converts an ISO string to the proper date', () => {
-      const date = '2021-02-27T00:00:00.000Z';
-      expect(formatDate(date)).toEqual('February 26 2021');
+      const date = DateTime.fromObject({ year: 2020, month: 6, day: 30 });
+      const isoStringDate = date.toISO();
+
+      expect(formatDate(isoStringDate)).toEqual('June 30 2020');
     });
 
     it('returns invalid datetime when a string is not ISO string', () => {

--- a/src/utils/formatDate.test.ts
+++ b/src/utils/formatDate.test.ts
@@ -5,7 +5,7 @@ import formatDate from './formatDate';
 describe('formatDate', () => {
   describe('string', () => {
     it('converts an ISO string to the proper date', () => {
-      const date = '2021-02-27T00:40:44.587Z';
+      const date = '2021-02-27T00:00:00.000Z';
       expect(formatDate(date)).toEqual('February 26 2021');
     });
 

--- a/src/utils/formatDate.test.ts
+++ b/src/utils/formatDate.test.ts
@@ -1,0 +1,31 @@
+import { DateTime } from 'luxon';
+
+import formatDate from './formatDate';
+
+describe('formatDate', () => {
+  describe('string', () => {
+    it('converts an ISO string to the proper date', () => {
+      const date = '2021-02-27T00:40:44.587Z';
+      expect(formatDate(date)).toEqual('February 26 2021');
+    });
+
+    it('returns invalid datetime when a string is not ISO string', () => {
+      const date = 'not an ISO string';
+      expect(formatDate(date)).toEqual('Invalid DateTime');
+    });
+  });
+
+  describe('DateTime', () => {
+    it('converts a luxon DateTime to the proper date', () => {
+      const date = DateTime.fromObject({ year: 2020, month: 6, day: 30 });
+
+      expect(formatDate(date)).toEqual('June 30 2020');
+    });
+
+    it('returns invalid datetime when a luxon datetime is invalid', () => {
+      const date = DateTime.fromISO('blah blah blah');
+
+      expect(formatDate(date)).toEqual('Invalid DateTime');
+    });
+  });
+});

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,6 +1,17 @@
 import { DateTime } from 'luxon';
 
-const formatDate = (date: string) =>
-  DateTime.fromISO(date).toFormat('MMMM d yyyy');
+const formatDate = (date: string | DateTime) => {
+  // ISO String
+  if (typeof date === 'string') {
+    return DateTime.fromISO(date).toFormat('MMMM d yyyy');
+  }
+
+  // luxon DateTime
+  if (date instanceof DateTime) {
+    return date.toFormat('MMMM d yyyy');
+  }
+
+  return '';
+};
 
 export default formatDate;


### PR DESCRIPTION
# ES-414

This PR fixes the sorting issue on the test date column in the AccessibilityRequestsTable component. Sorting that column with a row that does not have a test date crashes the application.

In this PR, I created a new variable called `data` that converts the `requests` to an object that’s acceptable by the table. The sorting was failing because GraphQL returns the date as an ISO string. Test dates can also be `null`.

The sort was getting through the condition
```
if (typeof rowOneElem === 'string') {
  return rowOneElem.toUpperCase() > rowTwoElem.toUpperCase() ? 1 : -1;
}
```
instead of
```
if (rowOneElem instanceof DateTime) {
  return Number(rowOneElem) > Number(rowTwoElem) ? 1 : -1;
}
```

Sorting via string should work with ISO8601 standard returned from GraphQL. However, i think it’s more defensive to convert the ISO string to a `DateTime`, so we can sort with the epoch date.

Additionally, I  also updated the `formatDate` util to accept both `string` and `DateTime` so it can be more versatile. I also added tests for that.