### PR TITLE
Add VSCode workspace config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ cypress.env.json
 .env.production.local
 .idea
 .envrc.local
-.vscode
 .eslintcache
 
 # npm/js ignores

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "apollographql.vscode-apollo",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "golang.go"
+    ]
+  }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "editor.formatOnSave": false,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
+}

--- a/apollo.config.js
+++ b/apollo.config.js
@@ -2,7 +2,7 @@ module.exports = {
   client: {
     service: {
       name: 'easi-app',
-      url: process.env.REACT_APP_GRAPHQL_ADDRESS
+      localSchemaFile: './pkg/graph/schema.graphql'
     }
   }
 };


### PR DESCRIPTION
This adds some VSCode config to the repo for folks who are using that editor.

If you use VSCode, please checkout this branch, close VSCode, and then open it again. Format-on-save and ESLint errors should be working properly.

If you're using a local `.vscode` folder in the project on your local machine already, LMK and we can figure out how to manage that along with having project-wide config that we share.