### PR TITLE
[Header] fix react set state after component unmount error

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -23,11 +23,18 @@ export const Header = ({ children }: HeaderProps) => {
   const dropdownNode = useRef<any>();
 
   useEffect(() => {
+    let isMounted = true;
     if (authState.isAuthenticated) {
       oktaAuth.getUser().then((info: any) => {
-        setUserName(info.name);
+        if (isMounted) {
+          setUserName(info.name);
+        }
       });
     }
+
+    return () => {
+      isMounted = false;
+    };
   }, [authState, oktaAuth]);
 
   const handleClick = (e: Event) => {


### PR DESCRIPTION
After updating the Okta sign in widget, we were getting some console errors because the app was trying to update local state after the component unmounted.

`oktaAuth.getUser()` executes a request to get the user's info, but the component can unmount before the request completes. So I introduced a cleanup method to make sure the application doesn't set local state