### PR TITLE
user error != alert

### DIFF
--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -233,8 +233,8 @@ func NewFetchSystemIntakeByID(
 		logger := appcontext.ZLogger(ctx)
 		intake, err := fetch(ctx, id)
 		if err != nil {
-			logger.Error("failed to fetch system intake")
-			return &models.SystemIntake{}, &apperrors.QueryError{
+			logger.Info("failed to fetch system intake", zap.Error(err))
+			return nil, &apperrors.QueryError{
 				Err:       err,
 				Model:     intake,
 				Operation: apperrors.QueryFetch,
@@ -242,11 +242,11 @@ func NewFetchSystemIntakeByID(
 		}
 		ok, err := authorize(ctx)
 		if err != nil {
-			logger.Error("failed to authorize fetch system intake")
-			return &models.SystemIntake{}, err
+			logger.Info("failed to authorize fetch system intake", zap.Error(err))
+			return nil, err
 		}
 		if !ok {
-			return &models.SystemIntake{}, &apperrors.UnauthorizedError{Err: err}
+			return nil, &apperrors.UnauthorizedError{Err: err}
 		}
 		return intake, nil
 	}

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -263,7 +263,7 @@ func (s ServicesTestSuite) TestSystemIntakeByIDFetcher() {
 		intake, err := fetchSystemIntakeByID(context.Background(), uuid.New())
 
 		s.IsType(&apperrors.QueryError{}, err)
-		s.Equal(&models.SystemIntake{}, intake)
+		s.Nil(intake)
 	})
 }
 

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -219,15 +219,21 @@ func (s *Store) FetchSystemIntakeByID(ctx context.Context, id uuid.UUID) (*model
 	const idMatchClause = `
 		WHERE system_intakes.id=$1
 `
-	err := s.db.Get(&intake, fetchSystemIntakeSQL+idMatchClause, id)
+	err := s.db.GetContext(ctx, &intake, fetchSystemIntakeSQL+idMatchClause, id)
 	if err != nil {
-		appcontext.ZLogger(ctx).Error(
-			fmt.Sprintf("Failed to fetch system intake %s", err),
-			zap.String("id", id.String()),
-		)
 		if errors.Is(err, sql.ErrNoRows) {
+			appcontext.ZLogger(ctx).Info(
+				"No system intake found",
+				zap.Error(err),
+				zap.String("id", id.String()),
+			)
 			return nil, &apperrors.ResourceNotFoundError{Err: err, Resource: models.SystemIntake{}}
 		}
+		appcontext.ZLogger(ctx).Error(
+			"Failed to fetch system intake",
+			zap.Error(err),
+			zap.String("id", id.String()),
+		)
 		return nil, &apperrors.QueryError{
 			Err:       err,
 			Model:     id,


### PR DESCRIPTION
# EASI-000

Changes proposed in this pull request:

- do not log at `Error` level when a user asks for a SystemIntake ID that does not exist (to prevent alert fatigue when splunk reports an alert based on an error-level log line: https://cmsgov.slack.com/archives/C01282R8DDK/p1615229152006300)
- a smattering of other minor hygiene and tidy fixes in the associated code path
