### PR TITLE
Lock air to a specific commit until a new version is released.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin/easi ./cmd/easi
 FROM modules AS dev
 
 RUN go get golang.org/x/tools/gopls@latest
-RUN go get github.com/cosmtrek/air
+RUN go get github.com/cosmtrek/air@895210e492af4a2dc1c5286e7c4a45cc4d8452a7
 CMD ["./bin/easi"]
 
 FROM alpine:3.12


### PR DESCRIPTION
I had issues with the version of air that was in our Dockerfile. Using the latest seems to have fixed the issue. The error I was seeing was:

```
failed to build, error: fork/exec /bin/sh: Setctty set but Ctty not valid in child
```

[Other folks have seen this crop up](https://github.com/cosmtrek/air/issues/114), and since there is some weirdness going on with the tags in that repo, I think locking to a commit is probably the way to go for now.