### PR TITLE
Run graphql-schema-linter through yarn

### DIFF
--- a/scripts/dev
+++ b/scripts/dev
@@ -140,7 +140,7 @@ end
 
 namespace :gql do
   task :lint_schema do
-    sh "graphql-schema-linter pkg/graph/schema.graphql"
+    sh "yarn run graphql-schema-linter pkg/graph/schema.graphql"
   end
 
   namespace :generate do


### PR DESCRIPTION
Changes proposed in this pull request:

- Run`graphql-schema-linter` using `yarn run` so that it doesn't need to be installed globally.