### PR TITLE
remove old breadcrumbs when task list lite was still a feature flag

### DIFF
--- a/src/views/BusinessCase/index.tsx
+++ b/src/views/BusinessCase/index.tsx
@@ -110,36 +110,19 @@ export const BusinessCase = () => {
       <Header />
       <MainContent className="margin-bottom-5">
         <div className="grid-container">
-          {!['local', 'dev', 'impl'].includes(
-            process.env.REACT_APP_APP_ENV as string
-          ) && (
-            <BreadcrumbNav className="margin-y-2">
-              <li>
-                <Link to="/">Home</Link>
-                <i className="fa fa-angle-right margin-x-05" aria-hidden />
-              </li>
-              <li>Business Case</li>
-            </BreadcrumbNav>
-          )}
-          {['local', 'dev', 'impl'].includes(
-            process.env.REACT_APP_APP_ENV as string
-          ) && (
-            <BreadcrumbNav className="margin-y-2">
-              <li>
-                <Link to="/">Home</Link>
-                <i className="fa fa-angle-right margin-x-05" aria-hidden />
-              </li>
-              <li>
-                <Link
-                  to={`/governance-task-list/${businessCase.systemIntakeId}`}
-                >
-                  Get governance approval
-                </Link>
-                <i className="fa fa-angle-right margin-x-05" aria-hidden />
-              </li>
-              <li>Business Case</li>
-            </BreadcrumbNav>
-          )}
+          <BreadcrumbNav className="margin-y-2">
+            <li>
+              <Link to="/">Home</Link>
+              <i className="fa fa-angle-right margin-x-05" aria-hidden />
+            </li>
+            <li>
+              <Link to={`/governance-task-list/${businessCase.systemIntakeId}`}>
+                Get governance approval
+              </Link>
+              <i className="fa fa-angle-right margin-x-05" aria-hidden />
+            </li>
+            <li>Business Case</li>
+          </BreadcrumbNav>
         </div>
         {businessCase.id && (
           <Switch>

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -110,34 +110,19 @@ export const SystemIntake = () => {
     <PageWrapper className="system-intake">
       <Header />
       <MainContent className="grid-container margin-bottom-5">
-        {!['local', 'dev', 'impl'].includes(
-          process.env.REACT_APP_APP_ENV as string
-        ) && (
-          <BreadcrumbNav className="margin-y-2">
-            <li>
-              <Link to="/">Home</Link>
-              <i className="fa fa-angle-right margin-x-05" aria-hidden />
-            </li>
-            <li>Intake Request</li>
-          </BreadcrumbNav>
-        )}
-        {['local', 'dev', 'impl'].includes(
-          process.env.REACT_APP_APP_ENV as string
-        ) && (
-          <BreadcrumbNav className="margin-y-2">
-            <li>
-              <Link to="/">Home</Link>
-              <i className="fa fa-angle-right margin-x-05" aria-hidden />
-            </li>
-            <li>
-              <Link to={`/governance-task-list/${systemIntake.id || 'new'}`}>
-                Get governance approval
-              </Link>
-              <i className="fa fa-angle-right margin-x-05" aria-hidden />
-            </li>
-            <li>Intake Request</li>
-          </BreadcrumbNav>
-        )}
+        <BreadcrumbNav className="margin-y-2">
+          <li>
+            <Link to="/">Home</Link>
+            <i className="fa fa-angle-right margin-x-05" aria-hidden />
+          </li>
+          <li>
+            <Link to={`/governance-task-list/${systemIntake.id || 'new'}`}>
+              Get governance approval
+            </Link>
+            <i className="fa fa-angle-right margin-x-05" aria-hidden />
+          </li>
+          <li>Intake Request</li>
+        </BreadcrumbNav>
         {isLoading === false && (
           <Switch>
             <SecureRoute


### PR DESCRIPTION
Now that the governance task list is a completed feature, we can remove the unused breadcrumb navigation on the system intake and business case forms.