### PR TITLE
Use dev-ecs-manager-docker v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,12 +397,12 @@ jobs:
       - run:
           name: Run migrations
           command: |
-            ./scripts/deploy_service "easi-app-db-migrate" "dev-ecs-manager-docker" "3" "easi-db-migrate"
-            ./scripts/db_lambda_invoke "dev-ecs-manager-docker" "3" "easi-app-db-migrate"
+            ./scripts/deploy_service "easi-app-db-migrate" "dev-ecs-manager-docker" "4" "easi-db-migrate"
+            ./scripts/db_lambda_invoke "dev-ecs-manager-docker" "4" "easi-app-db-migrate"
       - run:
           name: Deploy ECS service
           command: |
-            ./scripts/deploy_service "easi-app" "dev-ecs-manager-docker" "3" "easi-backend"
+            ./scripts/deploy_service "easi-app" "dev-ecs-manager-docker" "4" "easi-backend"
             ./scripts/healthcheck
       - run:
           name: Build static assets and release to S3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,12 +397,12 @@ jobs:
       - run:
           name: Run migrations
           command: |
-            ./scripts/deploy_service "easi-app-db-migrate" "dev-ecs-manager-docker" "2" "easi-db-migrate"
-            ./scripts/db_lambda_invoke "dev-ecs-manager-docker" "2" "easi-app-db-migrate"
+            ./scripts/deploy_service "easi-app-db-migrate" "dev-ecs-manager-docker" "3" "easi-db-migrate"
+            ./scripts/db_lambda_invoke "dev-ecs-manager-docker" "3" "easi-app-db-migrate"
       - run:
           name: Deploy ECS service
           command: |
-            ./scripts/deploy_service "easi-app" "dev-ecs-manager-docker" "2" "easi-backend"
+            ./scripts/deploy_service "easi-app" "dev-ecs-manager-docker" "3" "easi-backend"
             ./scripts/healthcheck
       - run:
           name: Build static assets and release to S3


### PR DESCRIPTION
# No JIRA

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Use a newer version of the dev-ecs-manager-docker lambda image that doesn't include dev dependencies. Including the dev dependencies wasn't causing any issues; this was minor cleanup.

