### PR TITLE
upgrade react-scripts to 4.0.3

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -91,6 +91,9 @@ export CEDAR_LDAP_DIRECTORY=$CEDAR_DIRECTORY/cedarldap
 export CEDAR_EASI_SWAGGER_FILE=$CEDAR_EASI_DIRECTORY/swagger-$CEDAR_ENV.json
 export CEDAR_LDAP_SWAGGER_FILE=$CEDAR_LDAP_DIRECTORY/swagger-$CEDAR_ENV.json
 
+# Frontend Dev
+export ESLINT_NO_DEV_ERRORS=true
+
 # Load a local overrides file. Any changes you want to make for your local
 # environment should live in that file.
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-modal": "^3.11.2",
     "react-redux": "^7.1.1",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "^4.0.0",
+    "react-scripts": "^4.0.3",
     "react-table": "^7.5.1",
     "redux": "^4.0.4",
     "redux-actions": "^2.6.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16506,7 +16506,7 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-scripts@^4.0.0:
+react-scripts@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-4.0.3.tgz#b1cafed7c3fa603e7628ba0f187787964cb5d345"
   integrity sha512-S5eO4vjUzUisvkIPB7jVsKtuH2HhWcASREYWHAQ1FP5HyCv3xgn+wpILAEWkmy+A+tTNbSZClhxjT3qz6g4L1A==


### PR DESCRIPTION
Ever seen this before?

![Screen Shot 2021-03-10 at 11 53 53 AM](https://user-images.githubusercontent.com/8367504/110689223-4d307c00-8197-11eb-8531-48a41ab50776.png)

In `react-scripts v.4.0.3`, developers can disable ESLint dev errors that prevent the application from building. This is done with [advanced configuration](https://create-react-app.dev/docs/advanced-configuration) via `ESLINT_NO_DEV_ERRORS` in `.envrc`.

This doesn't appear to affect linting on save or throwing lint errors during pre commit. Please let me know if any workflows are affected by this. Hopefully this makes our lives easier!