### PR TITLE
Add a link to the task list when actions are taken on a request.

### DIFF
--- a/pkg/email/intake_review.go
+++ b/pkg/email/intake_review.go
@@ -4,17 +4,21 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"path"
 
 	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/google/uuid"
 )
 
 type intakeReview struct {
-	EmailText string
+	EmailText    string
+	TaskListPath string
 }
 
-func (c Client) systemIntakeReviewBody(EmailText string) (string, error) {
+func (c Client) systemIntakeReviewBody(EmailText string, taskListPath string) (string, error) {
 	data := intakeReview{
-		EmailText: EmailText,
+		EmailText:    EmailText,
+		TaskListPath: c.urlFromPath(taskListPath),
 	}
 	var b bytes.Buffer
 	if c.templates.intakeReviewTemplate == nil {
@@ -28,9 +32,10 @@ func (c Client) systemIntakeReviewBody(EmailText string) (string, error) {
 }
 
 // SendSystemIntakeReviewEmail sends an email for a submitted system intake
-func (c Client) SendSystemIntakeReviewEmail(ctx context.Context, emailText string, recipientAddress string) error {
+func (c Client) SendSystemIntakeReviewEmail(ctx context.Context, emailText string, recipientAddress string, intakeID uuid.UUID) error {
 	subject := "Feedback on your intake request"
-	body, err := c.systemIntakeReviewBody(emailText)
+	taskListPath := path.Join("governance-task-list", intakeID.String())
+	body, err := c.systemIntakeReviewBody(emailText, taskListPath)
 	if err != nil {
 		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}
 	}

--- a/pkg/email/intake_review.go
+++ b/pkg/email/intake_review.go
@@ -6,8 +6,9 @@ import (
 	"errors"
 	"path"
 
-	"github.com/cmsgov/easi-app/pkg/apperrors"
 	"github.com/google/uuid"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
 )
 
 type intakeReview struct {

--- a/pkg/email/intake_review_test.go
+++ b/pkg/email/intake_review_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cmsgov/easi-app/pkg/apperrors"
 	"github.com/google/uuid"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
 )
 
 func (s *EmailTestSuite) TestSendIntakeReviewEmail() {

--- a/pkg/email/templates/system_intake_review.gohtml
+++ b/pkg/email/templates/system_intake_review.gohtml
@@ -1,1 +1,2 @@
 <p><pre style="white-space: pre-wrap; word-break: keep-all;">{{.EmailText}}</pre></p>
+<p><a href="{{.TaskListPath}}">See the most recent status of your request</a></p>

--- a/pkg/services/action.go
+++ b/pkg/services/action.go
@@ -238,7 +238,7 @@ func NewTakeActionUpdateStatus(
 	authorize func(context.Context) (bool, error),
 	saveAction func(context.Context, *models.Action) error,
 	fetchUserInfo func(context.Context, string) (*models.UserInfo, error),
-	sendReviewEmail func(ctx context.Context, emailText string, recipientAddress string) error,
+	sendReviewEmail func(ctx context.Context, emailText string, recipientAddress string, intakeID uuid.UUID) error,
 	shouldCloseBusinessCase bool,
 	closeBusinessCase func(context.Context, uuid.UUID) error,
 ) ActionExecuter {
@@ -289,7 +289,7 @@ func NewTakeActionUpdateStatus(
 			}
 		}
 
-		err = sendReviewEmail(ctx, action.Feedback.String, requesterInfo.Email)
+		err = sendReviewEmail(ctx, action.Feedback.String, requesterInfo.Email, intake.ID)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/action_test.go
+++ b/pkg/services/action_test.go
@@ -394,7 +394,7 @@ func (s ServicesTestSuite) TestNewTakeActionUpdateStatus() {
 	}
 	reviewEmailCount := 0
 	feedbackForEmailText := ""
-	sendReviewEmail := func(ctx context.Context, emailText string, recipientAddress string) error {
+	sendReviewEmail := func(ctx context.Context, emailText string, recipientAddress string, intakeID uuid.UUID) error {
 		feedbackForEmailText = emailText
 		reviewEmailCount++
 		return nil
@@ -585,7 +585,7 @@ func (s ServicesTestSuite) TestNewTakeActionUpdateStatus() {
 
 	s.Run("returns notification error when review email fails", func() {
 		ctx := context.Background()
-		failSendReviewEmail := func(ctx context.Context, emailText string, recipientAddress string) error {
+		failSendReviewEmail := func(ctx context.Context, emailText string, recipientAddress string, intakeID uuid.UUID) error {
 			return &apperrors.NotificationError{
 				Err:             errors.New("failed to send Email"),
 				DestinationType: apperrors.DestinationTypeEmail,


### PR DESCRIPTION
# ES-1109

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Add a link to the action emails so the requester can remember where their task list is
