### PR TITLE
ES-1093 add fields to csv

### DIFF
--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -130,6 +130,8 @@ type SystemIntake struct {
 	DecisionNextSteps           null.String             `json:"decisionNextSteps" db:"decision_next_steps"`
 	RejectionReason             null.String             `json:"rejectionReason" db:"rejection_reason"`
 	AdminLead                   null.String             `json:"adminLead" db:"admin_lead"`
+	LastAdminNoteContent        null.String             `json:"lastAdminNoteContent" db:"last_admin_note_content"`
+	LastAdminNoteCreatedAt      *time.Time              `json:"lastAdminNoteCreatedAt" db:"last_admin_note_created_at"`
 }
 
 // SystemIntakes is a list of System Intakes

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -275,20 +275,34 @@ func (s *Store) FetchSystemIntakes(ctx context.Context) (models.SystemIntakes, e
 
 // FetchSystemIntakesByStatuses queries the DB for all system intakes matching a status filter
 func (s *Store) FetchSystemIntakesByStatuses(ctx context.Context, allowedStatuses []models.SystemIntakeStatus) (models.SystemIntakes, error) {
-	intakes := []models.SystemIntake{}
-	const byStatusClause = `
-		WHERE system_intakes.status IN (?)
+	var intakes models.SystemIntakes
+	query := `
+		SELECT
+			system_intakes.*,
+			business_cases.id as business_case_id,
+			intakes_and_notes.content AS last_admin_note_content,
+			intakes_and_notes.created_at AS last_admin_note_created_at
+		FROM
+			(	SELECT
+					distinct ON (system_intakes.id) system_intakes.id, notes.content, notes.created_at
+				FROM system_intakes
+					LEFT JOIN notes on notes.system_intake = system_intakes.id
+				WHERE system_intakes.status IN (?)
+				ORDER BY system_intakes.id, notes.created_at DESC
+			) AS intakes_and_notes
+		LEFT JOIN system_intakes ON system_intakes.id = intakes_and_notes.id
+		LEFT JOIN business_cases ON business_cases.system_intake = system_intakes.id
 	`
-	query, args, err := sqlx.In(fetchSystemIntakeSQL+byStatusClause, allowedStatuses)
+	query, args, err := sqlx.In(query, allowedStatuses)
 	if err != nil {
 		appcontext.ZLogger(ctx).Error(fmt.Sprintf("Failed to fetch system intakes %s", err))
-		return models.SystemIntakes{}, err
+		return nil, err
 	}
 	query = s.db.Rebind(query)
 	err = s.db.Select(&intakes, query, args...)
 	if err != nil {
 		appcontext.ZLogger(ctx).Error(fmt.Sprintf("Failed to fetch system intakes %s", err))
-		return models.SystemIntakes{}, err
+		return nil, err
 	}
 	return intakes, nil
 }

--- a/src/components/RequestRepository/csvHeaderMap.ts
+++ b/src/components/RequestRepository/csvHeaderMap.ts
@@ -102,6 +102,14 @@ const csvHeaderMap = (t: any) => [
     label: t('intake:csvHeadings.status')
   },
   {
+    key: 'lcidScope',
+    label: t('intake:csvHeadings.lcidScope')
+  },
+  {
+    key: 'lastAdminNote',
+    label: t('intake:csvHeadings.lastAdminNote')
+  },
+  {
     key: 'updatedAt',
     label: t('intake:csvHeadings.updatedAt')
   },

--- a/src/data/systemIntake.test.ts
+++ b/src/data/systemIntake.test.ts
@@ -54,7 +54,7 @@ describe('The system intake data modifiers', () => {
         decidedAt: null,
         archivedAt: null,
         adminLead: '',
-        lastAdminNote: undefined,
+        lastAdminNote: null,
         lcidScope: ''
       });
     });
@@ -157,7 +157,15 @@ describe('The system intake data modifiers', () => {
           zone: 'America/Los_Angeles'
         }),
         adminLead: 'Test Admin Lead',
-        lastAdminNote: 'last admin note',
+        lastAdminNote: {
+          content: 'last admin note',
+          createdAt: DateTime.fromObject({
+            year: 2020,
+            month: 6,
+            day: 22,
+            zone: 'America/Los_Angeles'
+          })
+        },
         lcidScope: ''
       };
 
@@ -208,7 +216,7 @@ describe('The system intake data modifiers', () => {
         updatedAt: '2020-06-23T00:00:00.000-07:00',
         archivedAt: '2020-06-28T00:00:00.000-07:00',
         adminLead: 'Test Admin Lead',
-        lastAdminNote: 'last admin note',
+        lastAdminNote: 'last admin note (June 22 2020)',
         lcidScope: ''
       });
     });

--- a/src/data/systemIntake.test.ts
+++ b/src/data/systemIntake.test.ts
@@ -53,9 +53,12 @@ describe('The system intake data modifiers', () => {
         createdAt: null,
         decidedAt: null,
         archivedAt: null,
-        adminLead: ''
+        adminLead: '',
+        lastAdminNote: undefined,
+        lcidScope: ''
       });
     });
+
     it('converts fully executed intake', () => {
       const mockIntake = {
         ...initialSystemIntakeForm,
@@ -153,7 +156,9 @@ describe('The system intake data modifiers', () => {
           day: 28,
           zone: 'America/Los_Angeles'
         }),
-        adminLead: 'Test Admin Lead'
+        adminLead: 'Test Admin Lead',
+        lastAdminNote: 'last admin note',
+        lcidScope: ''
       };
 
       expect(convertIntakeToCSV(mockIntake)).toMatchObject({
@@ -202,7 +207,9 @@ describe('The system intake data modifiers', () => {
         createdAt: '2020-06-22T00:00:00.000-07:00',
         updatedAt: '2020-06-23T00:00:00.000-07:00',
         archivedAt: '2020-06-28T00:00:00.000-07:00',
-        adminLead: 'Test Admin Lead'
+        adminLead: 'Test Admin Lead',
+        lastAdminNote: 'last admin note',
+        lcidScope: ''
       });
     });
   });

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -5,6 +5,7 @@ import {
   GovernanceCollaborationTeam,
   SystemIntakeForm
 } from 'types/systemIntake';
+import formatDate from 'utils/formatDate';
 
 // On the frontend, the field is now "requestName", but the backend API
 // has it as "projectName". This was an update from design.
@@ -75,7 +76,8 @@ export const initialSystemIntakeForm: SystemIntakeForm = {
   rejectionReason: '',
   grtDate: null,
   grbDate: null,
-  adminLead: ''
+  adminLead: '',
+  lastAdminNote: null
 };
 
 export const prepareSystemIntakeForApi = (systemIntake: SystemIntakeForm) => {
@@ -235,7 +237,13 @@ export const prepareSystemIntakeForApp = (
     grbDate: systemIntake.grbDate
       ? DateTime.fromISO(systemIntake.grbDate)
       : null,
-    adminLead: systemIntake.adminLead || ''
+    adminLead: systemIntake.adminLead || '',
+    lastAdminNote: systemIntake.lastAdminNoteContent
+      ? {
+          content: systemIntake.lastAdminNoteContent,
+          createdAt: systemIntake.lastAdminNoteCreatedAt
+        }
+      : null
   };
 };
 
@@ -258,10 +266,15 @@ export const convertIntakeToCSV = (intake: SystemIntakeForm) => {
       }
     });
   }
+
   return {
     ...intake,
     ...collaboratorTeams,
-    lastAdminNote: intake.lastAdminNote,
+    lastAdminNote: intake.lastAdminNote
+      ? `${intake.lastAdminNote.content} (${formatDate(
+          intake.lastAdminNote.createdAt
+        )})`
+      : null,
     lcidScope: intake.lcidScope,
     contractStartDate: ['HAVE_CONTRACT', 'IN_PROGRESS'].includes(
       intake.contract.hasContract

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -261,6 +261,8 @@ export const convertIntakeToCSV = (intake: SystemIntakeForm) => {
   return {
     ...intake,
     ...collaboratorTeams,
+    lastAdminNote: intake.lastAdminNote,
+    lcidScope: intake.lcidScope,
     contractStartDate: ['HAVE_CONTRACT', 'IN_PROGRESS'].includes(
       intake.contract.hasContract
     )

--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -103,6 +103,8 @@ const intake = {
     contractStart: 'Period of Performance Start',
     contractEnd: 'Period of Performance End',
     status: 'Status',
+    lcidScope: 'LCID Scope',
+    lastAdminNote: 'Last Admin Team Note',
     updatedAt: 'Updated At',
     submittedAt: 'Submitted At',
     createdAt: 'Created At',

--- a/src/types/systemIntake.ts
+++ b/src/types/systemIntake.ts
@@ -88,7 +88,10 @@ export type SystemIntakeForm = {
   grtDate: DateTime | null;
   grbDate: DateTime | null;
   adminLead: string;
-  lastAdminNote: string | null;
+  lastAdminNote: {
+    content: string;
+    createdAt: DateTime;
+  } | null;
 } & ContractDetailsForm;
 
 export type ContractDetailsForm = {

--- a/src/types/systemIntake.ts
+++ b/src/types/systemIntake.ts
@@ -88,6 +88,7 @@ export type SystemIntakeForm = {
   grtDate: DateTime | null;
   grbDate: DateTime | null;
   adminLead: string;
+  lastAdminNote: string | null;
 } & ContractDetailsForm;
 
 export type ContractDetailsForm = {


### PR DESCRIPTION
# ES-1093

Changes proposed in this pull request:

- Add `lastAdminNoteContent` and `lastAdminNoteCreatedAt` to the payload returned when loading system intakes
- Add new fields to CSV export
