### PR TITLE
Break the summary into its own component.

### DIFF
--- a/src/views/GovernanceReviewTeam/RequestOverview.test.tsx
+++ b/src/views/GovernanceReviewTeam/RequestOverview.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
-import { mount, ReactWrapper } from 'enzyme';
+import { shallow, ShallowWrapper } from 'enzyme';
 import configureMockStore from 'redux-mock-store';
 
 import { initialSystemIntakeForm } from 'data/systemIntake';
@@ -27,7 +27,7 @@ jest.mock('@okta/okta-react', () => ({
 }));
 
 describe('The GRT Review page', () => {
-  it('shows open status', async () => {
+  it('renders the Summary component', async () => {
     const mockStore = configureMockStore();
     const store = mockStore({
       auth: {
@@ -45,9 +45,9 @@ describe('The GRT Review page', () => {
       }
     });
 
-    let component: ReactWrapper;
+    let component: ShallowWrapper;
     await act(async () => {
-      component = mount(
+      component = shallow(
         <MemoryRouter>
           <Provider store={store}>
             <RequestOverview />
@@ -55,72 +55,6 @@ describe('The GRT Review page', () => {
         </MemoryRouter>
       );
     });
-    expect(component!.find('[data-testid="grt-status"]').text()).toEqual(
-      'Open'
-    );
-  });
-
-  it('shows closed status', async () => {
-    const mockStore = configureMockStore();
-    const store = mockStore({
-      auth: {
-        groups: ['EASI_D_GOVTEAM'],
-        isUserSet: true
-      },
-      systemIntake: {
-        systemIntake: {
-          ...initialSystemIntakeForm,
-          status: 'LCID_ISSUED'
-        }
-      },
-      businessCase: {
-        form: {}
-      }
-    });
-
-    let component: ReactWrapper;
-    await act(async () => {
-      component = mount(
-        <MemoryRouter>
-          <Provider store={store}>
-            <RequestOverview />
-          </Provider>
-        </MemoryRouter>
-      );
-    });
-    expect(component!.find('[data-testid="grt-status"]').text()).toEqual(
-      'Closed'
-    );
-  });
-
-  it('shows lifecycle id if it exists', async () => {
-    const mockStore = configureMockStore();
-    const store = mockStore({
-      auth: {
-        groups: ['EASI_D_GOVTEAM'],
-        isUserSet: true
-      },
-      systemIntake: {
-        systemIntake: {
-          ...initialSystemIntakeForm,
-          lcid: '12345'
-        }
-      },
-      businessCase: {
-        form: {}
-      }
-    });
-
-    let component: ReactWrapper;
-    await act(async () => {
-      component = mount(
-        <MemoryRouter>
-          <Provider store={store}>
-            <RequestOverview />
-          </Provider>
-        </MemoryRouter>
-      );
-    });
-    expect(component!.find('[data-testid="grt-lcid"]').text()).toEqual('12345');
+    expect(component!.find('Summary').exists()).toBeFalsy();
   });
 });

--- a/src/views/GovernanceReviewTeam/RequestOverview.tsx
+++ b/src/views/GovernanceReviewTeam/RequestOverview.tsx
@@ -1,30 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link, Route, useParams } from 'react-router-dom';
-import { Button } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 import { DateTime } from 'luxon';
 
-import BreadcrumbNav from 'components/BreadcrumbNav';
 import Footer from 'components/Footer';
 import Header from 'components/Header';
 import MainContent from 'components/MainContent';
-import Modal from 'components/Modal';
 import PageWrapper from 'components/PageWrapper';
-import { RadioField, RadioGroup } from 'components/shared/RadioField';
-import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
 import { AppState } from 'reducers/rootReducer';
-import {
-  fetchBusinessCase,
-  fetchSystemIntake,
-  saveSystemIntake
-} from 'types/routines';
-import {
-  isIntakeClosed,
-  isIntakeOpen,
-  translateRequestType
-} from 'utils/systemIntake';
+import { fetchBusinessCase, fetchSystemIntake } from 'types/routines';
 
 import ChooseAction from './Actions/ChooseAction';
 import IssueLifecycleId from './Actions/IssueLifecycleId';
@@ -35,6 +21,7 @@ import Dates from './Dates';
 import Decision from './Decision';
 import IntakeReview from './IntakeReview';
 import Notes from './Notes';
+import Summary from './Summary';
 
 import './index.scss';
 
@@ -43,7 +30,6 @@ const RequestOverview = () => {
   const { t: actionsT } = useTranslation('action');
   const dispatch = useDispatch();
   const { systemId, activePage } = useParams();
-  const [isModalOpen, setModalOpen] = useState(false);
 
   const systemIntake = useSelector(
     (state: AppState) => state.systemIntake.systemIntake
@@ -63,76 +49,6 @@ const RequestOverview = () => {
     }
   }, [dispatch, systemIntake.businessCaseId]);
 
-  const component = cmsDivisionsAndOffices.find(
-    c => c.name === systemIntake.requester.component
-  );
-
-  const requesterNameAndComponent = component
-    ? `${systemIntake.requester.name}, ${component.acronym}`
-    : systemIntake.requester.name;
-
-  // Get admin lead assigned to intake
-  const getAdminLead = () => {
-    if (systemIntake.adminLead) {
-      return systemIntake.adminLead;
-    }
-    return (
-      <>
-        <i className="fa fa-exclamation-circle text-secondary margin-right-05" />
-        {t('governanceReviewTeam:adminLeads.notAssigned')}
-      </>
-    );
-  };
-
-  const [newAdminLead, setAdminLead] = useState('');
-
-  // Resets newAdminLead to what is in intake currently. This is used to
-  // reset state of modal upon exit without saving
-  const resetNewAdminLead = () => {
-    setAdminLead(systemIntake.adminLead);
-  };
-
-  // Send newly selected admin lead to database
-  const saveAdminLead = () => {
-    const data = {
-      ...systemIntake,
-      adminLead: newAdminLead
-    };
-    dispatch(saveSystemIntake({ ...data }));
-  };
-
-  // List of current GRT admin team members
-  const grtMembers: string[] = t('governanceReviewTeam:adminLeads.members', {
-    returnObjects: true
-  });
-
-  // Admin lead modal radio button
-  type AdminLeadRadioOptionProps = {
-    checked: boolean;
-    label: string;
-    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  };
-
-  const AdminLeadRadioOption = ({
-    checked,
-    label,
-    onChange
-  }: AdminLeadRadioOptionProps) => {
-    const radioFieldClassName = 'margin-y-3';
-
-    return (
-      <RadioField
-        checked={checked}
-        id={label}
-        label={label}
-        name={label}
-        value={label}
-        onChange={onChange}
-        className={radioFieldClassName}
-      />
-    );
-  };
-
   const getNavLinkClasses = (page: string) =>
     classnames('easi-grt__nav-link', {
       'easi-grt__nav-link--active': page === activePage
@@ -142,142 +58,7 @@ const RequestOverview = () => {
     <PageWrapper className="easi-grt">
       <Header />
       <MainContent>
-        <section className="easi-grt__request-summary">
-          <div className="grid-container padding-y-2">
-            <BreadcrumbNav>
-              <li>
-                <Link className="text-white" to="/">
-                  Home
-                </Link>
-                <i className="fa fa-angle-right margin-x-05" aria-hidden />
-              </li>
-              <li>{systemIntake.requestName}</li>
-            </BreadcrumbNav>
-            <dl className="easi-grt__request-info">
-              <div>
-                <dt>{t('intake:fields.projectName')}</dt>
-                <dd>{systemIntake.requestName}</dd>
-              </div>
-              <div className="easi-grt__request-info-col">
-                <div className="easi-grt__description-group">
-                  <dt>{t('intake:fields.requester')}</dt>
-                  <dd>{requesterNameAndComponent}</dd>
-                </div>
-                <div className="easi-grt__description-group">
-                  <dt>{t('intake:fields.submissionDate')}</dt>
-                  <dd>
-                    {systemIntake.submittedAt
-                      ? systemIntake.submittedAt.toLocaleString(
-                          DateTime.DATE_FULL
-                        )
-                      : 'N/A'}
-                  </dd>
-                </div>
-                <div className="easi-grt__description-group">
-                  <dt>{t('intake:fields.requestFor')}</dt>
-                  <dd>{translateRequestType(systemIntake.requestType)}</dd>
-                </div>
-              </div>
-            </dl>
-          </div>
-
-          <div
-            className={classnames({
-              'bg-base-lightest': isIntakeClosed(systemIntake.status),
-              'easi-grt__status--open': isIntakeOpen(systemIntake.status)
-            })}
-          >
-            <div className="grid-container overflow-auto">
-              <dl className="easi-grt__status-group">
-                <div className="easi-grt__status-info text-gray-90">
-                  <dt className="text-bold">{t('status.label')}</dt>
-                  &nbsp;
-                  <dd
-                    className="text-uppercase text-white bg-base-dark padding-05 font-body-3xs"
-                    data-testid="grt-status"
-                  >
-                    {isIntakeClosed(systemIntake.status)
-                      ? t('status.closed')
-                      : t('status.open')}
-                  </dd>
-                  {systemIntake.lcid && (
-                    <>
-                      <dt>{t('intake:lifecycleId')}:&nbsp;</dt>
-                      <dd data-testid="grt-lcid">{systemIntake.lcid}</dd>
-                    </>
-                  )}
-                </div>
-                <div className="text-gray-90">
-                  <dt className="text-bold">{t('intake:fields.adminLead')}</dt>
-                  <dt className="padding-1">{getAdminLead()}</dt>
-                  <dt>
-                    <Button
-                      type="button"
-                      unstyled
-                      onClick={() => {
-                        // Reset newAdminLead to value in intake
-                        resetNewAdminLead();
-                        setModalOpen(true);
-                      }}
-                    >
-                      {t('governanceReviewTeam:adminLeads.changeLead')}
-                    </Button>
-                    <Modal
-                      title={t(
-                        'governanceReviewTeam:adminLeads:assignModal.title'
-                      )}
-                      isOpen={isModalOpen}
-                      closeModal={() => {
-                        setModalOpen(false);
-                      }}
-                    >
-                      <h1 className="margin-top-0 font-heading-2xl line-height-heading-2">
-                        {t(
-                          'governanceReviewTeam:adminLeads:assignModal.header',
-                          { requestName: systemIntake.requestName }
-                        )}
-                      </h1>
-                      <RadioGroup>
-                        {grtMembers.map(k => (
-                          <AdminLeadRadioOption
-                            key={k}
-                            checked={k === newAdminLead}
-                            label={k}
-                            onChange={() => {
-                              setAdminLead(k);
-                            }}
-                          />
-                        ))}
-                      </RadioGroup>
-                      <Button
-                        type="button"
-                        className="margin-right-4"
-                        onClick={() => {
-                          // Set admin lead as newAdminLead in the intake
-                          saveAdminLead();
-                          setModalOpen(false);
-                        }}
-                      >
-                        {t('governanceReviewTeam:adminLeads:assignModal.save')}
-                      </Button>
-                      <Button
-                        type="button"
-                        unstyled
-                        onClick={() => {
-                          setModalOpen(false);
-                        }}
-                      >
-                        {t(
-                          'governanceReviewTeam:adminLeads:assignModal.noChanges'
-                        )}
-                      </Button>
-                    </Modal>
-                  </dt>
-                </div>
-              </dl>
-            </div>
-          </div>
-        </section>
+        <Summary intake={systemIntake} />
         <section className="grid-container grid-row margin-y-5 ">
           <nav className="tablet:grid-col-2 margin-right-2">
             <ul className="easi-grt__nav-list">

--- a/src/views/GovernanceReviewTeam/Summary/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/Summary/index.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { mount, ReactWrapper } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+
+import { initialSystemIntakeForm } from 'data/systemIntake';
+
+import Summary from '.';
+
+jest.mock('@okta/okta-react', () => ({
+  useOktaAuth: () => {
+    return {
+      authState: {
+        isAuthenticated: true
+      },
+      oktaAuth: {
+        getAccessToken: () => Promise.resolve('test-access-token'),
+        getUser: () =>
+          Promise.resolve({
+            name: 'John Doe'
+          })
+      }
+    };
+  }
+}));
+
+const renderComponent = (intake: any) => {
+  const mockStore = configureMockStore();
+  return mount(
+    <MemoryRouter>
+      <Provider store={mockStore()}>
+        <Summary intake={intake} />
+      </Provider>
+    </MemoryRouter>
+  );
+};
+
+describe('The GRT Review page', () => {
+  it('shows open status', async () => {
+    const intake = {
+      ...initialSystemIntakeForm,
+      status: 'INTAKE_SUBMITTED'
+    };
+    const component: ReactWrapper = renderComponent(intake);
+    expect(component!.find('[data-testid="grt-status"]').text()).toEqual(
+      'Open'
+    );
+  });
+
+  it('shows closed status', async () => {
+    const intake = {
+      ...initialSystemIntakeForm,
+      status: 'LCID_ISSUED'
+    };
+    const component: ReactWrapper = renderComponent(intake);
+    expect(component!.find('[data-testid="grt-status"]').text()).toEqual(
+      'Closed'
+    );
+  });
+
+  it('shows lifecycle id if it exists', async () => {
+    const intake = {
+      ...initialSystemIntakeForm,
+      lcid: '12345'
+    };
+    const component: ReactWrapper = renderComponent(intake);
+    expect(component.find('[data-testid="grt-lcid"]').text()).toEqual('12345');
+  });
+});

--- a/src/views/GovernanceReviewTeam/Summary/index.tsx
+++ b/src/views/GovernanceReviewTeam/Summary/index.tsx
@@ -1,0 +1,228 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { Button } from '@trussworks/react-uswds';
+import classnames from 'classnames';
+import { DateTime } from 'luxon';
+
+import BreadcrumbNav from 'components/BreadcrumbNav';
+import Modal from 'components/Modal';
+import { RadioField, RadioGroup } from 'components/shared/RadioField';
+import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
+import { saveSystemIntake } from 'types/routines';
+import { SystemIntakeForm } from 'types/systemIntake';
+import {
+  isIntakeClosed,
+  isIntakeOpen,
+  translateRequestType
+} from 'utils/systemIntake';
+
+const RequestSummary = ({ intake }: { intake: SystemIntakeForm }) => {
+  const { t } = useTranslation('governanceReviewTeam');
+  const dispatch = useDispatch();
+  const [isModalOpen, setModalOpen] = useState(false);
+  const [newAdminLead, setAdminLead] = useState('');
+
+  const component = cmsDivisionsAndOffices.find(
+    c => c.name === intake.requester.component
+  );
+
+  const requesterNameAndComponent = component
+    ? `${intake.requester.name}, ${component.acronym}`
+    : intake.requester.name;
+
+  // Get admin lead assigned to intake
+  const getAdminLead = () => {
+    if (intake.adminLead) {
+      return intake.adminLead;
+    }
+    return (
+      <>
+        <i className="fa fa-exclamation-circle text-secondary margin-right-05" />
+        {t('governanceReviewTeam:adminLeads.notAssigned')}
+      </>
+    );
+  };
+
+  // Resets newAdminLead to what is in intake currently. This is used to
+  // reset state of modal upon exit without saving
+  const resetNewAdminLead = () => {
+    setAdminLead(intake.adminLead);
+  };
+
+  // Send newly selected admin lead to database
+  const saveAdminLead = () => {
+    const data = {
+      ...intake,
+      adminLead: newAdminLead
+    };
+    dispatch(saveSystemIntake({ ...data }));
+  };
+
+  // List of current GRT admin team members
+  const grtMembers: string[] = t('governanceReviewTeam:adminLeads.members', {
+    returnObjects: true
+  });
+
+  // Admin lead modal radio button
+  type AdminLeadRadioOptionProps = {
+    checked: boolean;
+    label: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  };
+
+  const AdminLeadRadioOption = ({
+    checked,
+    label,
+    onChange
+  }: AdminLeadRadioOptionProps) => {
+    const radioFieldClassName = 'margin-y-3';
+
+    return (
+      <RadioField
+        checked={checked}
+        id={label}
+        label={label}
+        name={label}
+        value={label}
+        onChange={onChange}
+        className={radioFieldClassName}
+      />
+    );
+  };
+
+  return (
+    <section className="easi-grt__request-summary">
+      <div className="grid-container padding-y-2">
+        <BreadcrumbNav>
+          <li>
+            <Link className="text-white" to="/">
+              Home
+            </Link>
+            <i className="fa fa-angle-right margin-x-05" aria-hidden />
+          </li>
+          <li>{intake.requestName}</li>
+        </BreadcrumbNav>
+        <dl className="easi-grt__request-info">
+          <div>
+            <dt>{t('intake:fields.projectName')}</dt>
+            <dd>{intake.requestName}</dd>
+          </div>
+          <div className="easi-grt__request-info-col">
+            <div className="easi-grt__description-group">
+              <dt>{t('intake:fields.requester')}</dt>
+              <dd>{requesterNameAndComponent}</dd>
+            </div>
+            <div className="easi-grt__description-group">
+              <dt>{t('intake:fields.submissionDate')}</dt>
+              <dd>
+                {intake.submittedAt
+                  ? intake.submittedAt.toLocaleString(DateTime.DATE_FULL)
+                  : 'N/A'}
+              </dd>
+            </div>
+            <div className="easi-grt__description-group">
+              <dt>{t('intake:fields.requestFor')}</dt>
+              <dd>{translateRequestType(intake.requestType)}</dd>
+            </div>
+          </div>
+        </dl>
+      </div>
+
+      <div
+        className={classnames({
+          'bg-base-lightest': isIntakeClosed(intake.status),
+          'easi-grt__status--open': isIntakeOpen(intake.status)
+        })}
+      >
+        <div className="grid-container overflow-auto">
+          <dl className="easi-grt__status-group">
+            <div className="easi-grt__status-info text-gray-90">
+              <dt className="text-bold">{t('status.label')}</dt>
+              &nbsp;
+              <dd
+                className="text-uppercase text-white bg-base-dark padding-05 font-body-3xs"
+                data-testid="grt-status"
+              >
+                {isIntakeClosed(intake.status)
+                  ? t('status.closed')
+                  : t('status.open')}
+              </dd>
+              {intake.lcid && (
+                <>
+                  <dt>{t('intake:lifecycleId')}:&nbsp;</dt>
+                  <dd data-testid="grt-lcid">{intake.lcid}</dd>
+                </>
+              )}
+            </div>
+            <div className="text-gray-90">
+              <dt className="text-bold">{t('intake:fields.adminLead')}</dt>
+              <dt className="padding-1">{getAdminLead()}</dt>
+              <dt>
+                <Button
+                  type="button"
+                  unstyled
+                  onClick={() => {
+                    // Reset newAdminLead to value in intake
+                    resetNewAdminLead();
+                    setModalOpen(true);
+                  }}
+                >
+                  {t('governanceReviewTeam:adminLeads.changeLead')}
+                </Button>
+                <Modal
+                  title={t('governanceReviewTeam:adminLeads:assignModal.title')}
+                  isOpen={isModalOpen}
+                  closeModal={() => {
+                    setModalOpen(false);
+                  }}
+                >
+                  <h1 className="margin-top-0 font-heading-2xl line-height-heading-2">
+                    {t('governanceReviewTeam:adminLeads:assignModal.header', {
+                      requestName: intake.requestName
+                    })}
+                  </h1>
+                  <RadioGroup>
+                    {grtMembers.map(k => (
+                      <AdminLeadRadioOption
+                        key={k}
+                        checked={k === newAdminLead}
+                        label={k}
+                        onChange={() => {
+                          setAdminLead(k);
+                        }}
+                      />
+                    ))}
+                  </RadioGroup>
+                  <Button
+                    type="button"
+                    className="margin-right-4"
+                    onClick={() => {
+                      // Set admin lead as newAdminLead in the intake
+                      saveAdminLead();
+                      setModalOpen(false);
+                    }}
+                  >
+                    {t('governanceReviewTeam:adminLeads:assignModal.save')}
+                  </Button>
+                  <Button
+                    type="button"
+                    unstyled
+                    onClick={() => {
+                      setModalOpen(false);
+                    }}
+                  >
+                    {t('governanceReviewTeam:adminLeads:assignModal.noChanges')}
+                  </Button>
+                </Modal>
+              </dt>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default RequestSummary;


### PR DESCRIPTION
Changes proposed in this pull request:

- Our tests for the request overview were getting tangled with other bits, but we really only care about the intake
- Separate the summary into its own component so it's easier to test and the overview page is easier to parse by humans
