### PR TITLE
Update lifecycle costs to be checkboxes

### DIFF
--- a/cypress/integration/businessCase.spec.js
+++ b/cypress/integration/businessCase.spec.js
@@ -145,11 +145,76 @@ describe('The Business Case Form', () => {
           pros: 'As is Solution Pros',
           cons: 'As is Solution Cons',
           estimatedLifecycleCost: {
-            year1: [{ phase: 'Development', cost: '0' }],
-            year2: [{ phase: 'Development', cost: '0' }],
-            year3: [{ phase: 'Other', cost: '0' }],
-            year4: [{ phase: 'Operations and Maintenance', cost: '0' }],
-            year5: [{ phase: 'Operations and Maintenance', cost: '0' }]
+            year1: {
+              development: {
+                isPresent: true,
+                cost: '1'
+              },
+              operationsMaintenance: {
+                isPresent: true,
+                cost: '5'
+              },
+              other: {
+                isPresent: false,
+                cost: ''
+              }
+            },
+            year2: {
+              development: {
+                isPresent: false,
+                cost: ''
+              },
+              operationsMaintenance: {
+                isPresent: true,
+                cost: '5'
+              },
+              other: {
+                isPresent: false,
+                cost: ''
+              }
+            },
+            year3: {
+              development: {
+                isPresent: false,
+                cost: ''
+              },
+              operationsMaintenance: {
+                isPresent: false,
+                cost: ''
+              },
+              other: {
+                isPresent: true,
+                cost: '10'
+              }
+            },
+            year4: {
+              development: {
+                isPresent: true,
+                cost: '15'
+              },
+              operationsMaintenance: {
+                isPresent: false,
+                cost: ''
+              },
+              other: {
+                isPresent: false,
+                cost: ''
+              }
+            },
+            year5: {
+              development: {
+                isPresent: false,
+                cost: ''
+              },
+              operationsMaintenance: {
+                isPresent: false,
+                cost: ''
+              },
+              other: {
+                isPresent: true,
+                cost: '15'
+              }
+            }
           },
           costSavings: 'As is Solution Cost Savings'
         },
@@ -170,11 +235,76 @@ describe('The Business Case Form', () => {
           pros: 'Preferred Solution Pros',
           cons: 'Preferred Solution Cons',
           estimatedLifecycleCost: {
-            year1: [{ phase: 'Development', cost: '0' }],
-            year2: [{ phase: 'Development', cost: '0' }],
-            year3: [{ phase: 'Other', cost: '0' }],
-            year4: [{ phase: 'Operations and Maintenance', cost: '0' }],
-            year5: [{ phase: 'Operations and Maintenance', cost: '0' }]
+            year1: {
+              development: {
+                isPresent: false,
+                cost: ''
+              },
+              operationsMaintenance: {
+                isPresent: true,
+                cost: '5'
+              },
+              other: {
+                isPresent: false,
+                cost: ''
+              }
+            },
+            year2: {
+              development: {
+                isPresent: true,
+                cost: '10'
+              },
+              operationsMaintenance: {
+                isPresent: false,
+                cost: ''
+              },
+              other: {
+                isPresent: false,
+                cost: ''
+              }
+            },
+            year3: {
+              development: {
+                isPresent: false,
+                cost: ''
+              },
+              operationsMaintenance: {
+                isPresent: false,
+                cost: ''
+              },
+              other: {
+                isPresent: true,
+                cost: '15'
+              }
+            },
+            year4: {
+              development: {
+                isPresent: false,
+                cost: ''
+              },
+              operationsMaintenance: {
+                isPresent: true,
+                cost: '20'
+              },
+              other: {
+                isPresent: false,
+                cost: ''
+              }
+            },
+            year5: {
+              development: {
+                isPresent: true,
+                cost: '25'
+              },
+              operationsMaintenance: {
+                isPresent: false,
+                cost: ''
+              },
+              other: {
+                isPresent: false,
+                cost: ''
+              }
+            }
           },
           costSavings: '0'
         },
@@ -195,11 +325,76 @@ describe('The Business Case Form', () => {
           pros: 'Alternative A Pros',
           cons: 'Alternative A Cons',
           estimatedLifecycleCost: {
-            year1: [{ phase: 'Development', cost: '0' }],
-            year2: [{ phase: 'Development', cost: '0' }],
-            year3: [{ phase: 'Other', cost: '0' }],
-            year4: [{ phase: 'Operations and Maintenance', cost: '0' }],
-            year5: [{ phase: 'Operations and Maintenance', cost: '0' }]
+            year1: {
+              development: {
+                isPresent: true,
+                cost: '2'
+              },
+              operationsMaintenance: {
+                isPresent: false,
+                cost: ''
+              },
+              other: {
+                isPresent: true,
+                cost: '4'
+              }
+            },
+            year2: {
+              development: {
+                isPresent: false,
+                cost: ''
+              },
+              operationsMaintenance: {
+                isPresent: true,
+                cost: '6'
+              },
+              other: {
+                isPresent: false,
+                cost: ''
+              }
+            },
+            year3: {
+              development: {
+                isPresent: false,
+                cost: ''
+              },
+              operationsMaintenance: {
+                isPresent: false,
+                cost: ''
+              },
+              other: {
+                isPresent: true,
+                cost: '8'
+              }
+            },
+            year4: {
+              development: {
+                isPresent: false,
+                cost: ''
+              },
+              operationsMaintenance: {
+                isPresent: true,
+                cost: '10'
+              },
+              other: {
+                isPresent: false,
+                cost: ''
+              }
+            },
+            year5: {
+              development: {
+                isPresent: true,
+                cost: '12'
+              },
+              operationsMaintenance: {
+                isPresent: false,
+                cost: ''
+              },
+              other: {
+                isPresent: false,
+                cost: ''
+              }
+            }
           },
           costSavings: 'Alternative A Cost Savings'
         }

--- a/cypress/support/businessCase.js
+++ b/cypress/support/businessCase.js
@@ -55,50 +55,82 @@ cy.businessCase = {
         .type('As is Solution Cons')
         .should('have.value', 'As is Solution Cons');
 
-      // Estimated Lifecycle Costs Years 1-2
-      [1, 2].forEach(year => {
-        cy.get(
-          `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.Development`
-        )
-          .check({ force: true })
-          .should('be.checked');
+      // Estimated Lifecycle Costs Years 1
+      cy.get(
+        `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year1\\.development\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
 
-        cy.get(
-          `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.cost`
-        )
-          .type('0')
-          .should('have.value', '0');
-      });
+      cy.get(
+        `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year1\\.development\\.cost`
+      )
+        .type('1')
+        .should('have.value', '1');
+
+      cy.get(
+        `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year1\\.operationsMaintenance\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
+
+      cy.get(
+        `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year1\\.operationsMaintenance\\.cost`
+      )
+        .type('5')
+        .should('have.value', '5');
+
+      // Estimated Lifecycle Costs Years 2
+      cy.get(
+        `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year2\\.operationsMaintenance\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
+
+      cy.get(
+        `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year2\\.operationsMaintenance\\.cost`
+      )
+        .type('5')
+        .should('have.value', '5');
 
       // Estimated Lifecycle Costs Years 3
-      [3].forEach(year => {
-        cy.get(
-          `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.Other`
-        )
-          .check({ force: true })
-          .should('be.checked');
+      cy.get(
+        `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year3\\.other\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
 
-        cy.get(
-          `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.cost`
-        )
-          .type('0')
-          .should('have.value', '0');
-      });
+      cy.get(
+        `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year3\\.other\\.cost`
+      )
+        .type('10')
+        .should('have.value', '10');
 
-      // Estimated Lifecycle Costs Years 4-5
-      [4, 5].forEach(year => {
-        cy.get(
-          `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.opsMaintenance`
-        )
-          .check({ force: true })
-          .should('be.checked');
+      // Estimated Lifecycle Costs Years 4
+      cy.get(
+        `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year4\\.development\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
 
-        cy.get(
-          `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.cost`
-        )
-          .type('0')
-          .should('have.value', '0');
-      });
+      cy.get(
+        `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year4\\.development\\.cost`
+      )
+        .type('15')
+        .should('have.value', '15');
+
+      // Estimated Lifecycle Costs Years 5
+      cy.get(
+        `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year5\\.other\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
+
+      cy.get(
+        `#BusinessCase-asIsSolution\\.estimatedLifecycleCost\\.Year5\\.other\\.cost`
+      )
+        .type('15')
+        .should('have.value', '15');
 
       cy.get('#BusinessCase-AsIsSolutionCostSavings')
         .type('As is Solution Cost Savings')
@@ -151,50 +183,70 @@ cy.businessCase = {
         .type('Preferred Solution Cons')
         .should('have.value', 'Preferred Solution Cons');
 
-      // Estimated Lifecycle Costs Years 1-2
-      [1, 2].forEach(year => {
-        cy.get(
-          `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.Development`
-        )
-          .check({ force: true })
-          .should('be.checked');
+      // Estimated Lifecycle Costs Year 1
+      cy.get(
+        `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year1\\.operationsMaintenance\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
 
-        cy.get(
-          `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.cost`
-        )
-          .type('0')
-          .should('have.value', '0');
-      });
+      cy.get(
+        `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year1\\.operationsMaintenance\\.cost`
+      )
+        .type('5')
+        .should('have.value', '5');
 
-      // Estimated Lifecycle Costs Years 3
-      [3].forEach(year => {
-        cy.get(
-          `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.Other`
-        )
-          .check({ force: true })
-          .should('be.checked');
+      // Estimated Lifecycle Costs Year 2
+      cy.get(
+        `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year2\\.development\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
 
-        cy.get(
-          `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.cost`
-        )
-          .type('0')
-          .should('have.value', '0');
-      });
+      cy.get(
+        `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year2\\.development\\.cost`
+      )
+        .type('10')
+        .should('have.value', '10');
 
-      // Estimated Lifecycle Costs Years 4-5
-      [4, 5].forEach(year => {
-        cy.get(
-          `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.opsMaintenance`
-        )
-          .check({ force: true })
-          .should('be.checked');
+      // Estimated Lifecycle Costs Year 3
+      cy.get(
+        `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year3\\.other\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
 
-        cy.get(
-          `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.cost`
-        )
-          .type('0')
-          .should('have.value', '0');
-      });
+      cy.get(
+        `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year3\\.other\\.cost`
+      )
+        .type('15')
+        .should('have.value', '15');
+
+      // Estimated Lifecycle Costs Year 4
+      cy.get(
+        `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year4\\.operationsMaintenance\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
+
+      cy.get(
+        `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year4\\.operationsMaintenance\\.cost`
+      )
+        .type('20')
+        .should('have.value', '20');
+
+      // Estimated Lifecycle Costs Year 5
+      cy.get(
+        `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year5\\.development\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
+
+      cy.get(
+        `#BusinessCase-preferredSolution\\.estimatedLifecycleCost\\.Year5\\.development\\.cost`
+      )
+        .type('25')
+        .should('have.value', '25');
 
       cy.get('#BusinessCase-PreferredSolutionCostSavings')
         .type('0')
@@ -247,50 +299,82 @@ cy.businessCase = {
         .type('Alternative A Cons')
         .should('have.value', 'Alternative A Cons');
 
-      // Estimated Lifecycle Costs Years 1-2
-      [1, 2].forEach(year => {
-        cy.get(
-          `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.Development`
-        )
-          .check({ force: true })
-          .should('be.checked');
+      // Estimated Lifecycle Costs Years 1
+      cy.get(
+        `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year1\\.development\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
 
-        cy.get(
-          `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.cost`
-        )
-          .type('0')
-          .should('have.value', '0');
-      });
+      cy.get(
+        `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year1\\.development\\.cost`
+      )
+        .type('2')
+        .should('have.value', '2');
+
+      cy.get(
+        `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year1\\.other\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
+
+      cy.get(
+        `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year1\\.other\\.cost`
+      )
+        .type('4')
+        .should('have.value', '4');
+
+      // Estimated Lifecycle Costs Years 2
+      cy.get(
+        `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year2\\.operationsMaintenance\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
+
+      cy.get(
+        `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year2\\.operationsMaintenance\\.cost`
+      )
+        .type('6')
+        .should('have.value', '6');
 
       // Estimated Lifecycle Costs Years 3
-      [3].forEach(year => {
-        cy.get(
-          `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.Other`
-        )
-          .check({ force: true })
-          .should('be.checked');
+      cy.get(
+        `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year3\\.other\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
 
-        cy.get(
-          `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.cost`
-        )
-          .type('0')
-          .should('have.value', '0');
-      });
+      cy.get(
+        `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year3\\.other\\.cost`
+      )
+        .type('8')
+        .should('have.value', '8');
 
-      // Estimated Lifecycle Costs Years 4-5
-      [4, 5].forEach(year => {
-        cy.get(
-          `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.opsMaintenance`
-        )
-          .check({ force: true })
-          .should('be.checked');
+      // Estimated Lifecycle Costs Years 4
+      cy.get(
+        `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year4\\.operationsMaintenance\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
 
-        cy.get(
-          `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year${year}\\.Phase0\\.cost`
-        )
-          .type('0')
-          .should('have.value', '0');
-      });
+      cy.get(
+        `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year4\\.operationsMaintenance\\.cost`
+      )
+        .type('10')
+        .should('have.value', '10');
+
+      // Estimated Lifecycle Costs Years 5
+      cy.get(
+        `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year5\\.development\\.isPresent`
+      )
+        .check({ force: true })
+        .should('be.checked');
+
+      cy.get(
+        `#BusinessCase-alternativeA\\.estimatedLifecycleCost\\.Year5\\.development\\.cost`
+      )
+        .type('12')
+        .should('have.value', '12');
 
       cy.get('#BusinessCase-alternativeACostSavings')
         .type('Alternative A Cost Savings')

--- a/src/components/BusinessCaseReview/index.test.tsx
+++ b/src/components/BusinessCaseReview/index.test.tsx
@@ -13,6 +13,7 @@ describe('The Business Case Review Component', () => {
   const businessCase = {
     status: 'OPEN',
     systemIntakeId: '048c26ea-07be-4f40-b29e-761fc17bf414',
+    systemIntakeStatus: 'BIZ_CASE_DRAFT',
     requestName: 'EASi Test',
     requester: {
       name: 'Jane Smith',
@@ -31,11 +32,76 @@ describe('The Business Case Review Component', () => {
       pros: 'Test pros',
       cons: 'Test cons',
       estimatedLifecycleCost: {
-        year1: [{ phase: 'Development', cost: '0' }],
-        year2: [{ phase: 'Development', cost: '0' }],
-        year3: [{ phase: 'Development', cost: '0' }],
-        year4: [{ phase: 'Development', cost: '0' }],
-        year5: [{ phase: 'Development', cost: '0' }]
+        year1: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year2: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year3: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year4: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year5: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        }
       },
       costSavings: 'Test cost savings'
     },
@@ -46,13 +112,82 @@ describe('The Business Case Review Component', () => {
       pros: 'Test pros',
       cons: 'Test cons',
       estimatedLifecycleCost: {
-        year1: [{ phase: 'Development', cost: '0' }],
-        year2: [{ phase: 'Development', cost: '0' }],
-        year3: [{ phase: 'Development', cost: '0' }],
-        year4: [{ phase: 'Development', cost: '0' }],
-        year5: [{ phase: 'Development', cost: '0' }]
+        year1: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year2: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year3: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year4: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year5: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        }
       },
       costSavings: 'Test cost savings',
+      security: {
+        isApproved: false,
+        isBeingReviewed: 'YES'
+      },
       hosting: {
         type: 'cloud',
         location: 'Test location',
@@ -67,13 +202,82 @@ describe('The Business Case Review Component', () => {
       pros: 'Test pros',
       cons: 'Test cons',
       estimatedLifecycleCost: {
-        year1: [{ phase: 'Development', cost: '0' }],
-        year2: [{ phase: 'Development', cost: '0' }],
-        year3: [{ phase: 'Development', cost: '0' }],
-        year4: [{ phase: 'Development', cost: '0' }],
-        year5: [{ phase: 'Development', cost: '0' }]
+        year1: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year2: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year3: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year4: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year5: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        }
       },
       costSavings: 'Test cost savings',
+      security: {
+        isApproved: false,
+        isBeingReviewed: 'YES'
+      },
       hosting: {
         type: 'cloud',
         location: 'Test location',
@@ -88,13 +292,82 @@ describe('The Business Case Review Component', () => {
       pros: 'Test pros',
       cons: 'Test cons',
       estimatedLifecycleCost: {
-        year1: [{ phase: 'Development', cost: '0' }],
-        year2: [{ phase: 'Development', cost: '0' }],
-        year3: [{ phase: 'Development', cost: '0' }],
-        year4: [{ phase: 'Development', cost: '0' }],
-        year5: [{ phase: 'Development', cost: '0' }]
+        year1: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year2: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year3: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year4: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year5: {
+          development: {
+            isPresent: false,
+            cost: '0'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        }
       },
       costSavings: 'Test cost savings',
+      security: {
+        isApproved: false,
+        isBeingReviewed: 'YES'
+      },
       hosting: {
         type: 'cloud',
         location: 'Test location',

--- a/src/components/EstimatedLifecycleCost/Review/index.test.tsx
+++ b/src/components/EstimatedLifecycleCost/Review/index.test.tsx
@@ -9,28 +9,77 @@ import EstimatedLifecycleCostReview from './index';
 declare const global: any;
 
 describe('The Estimated Lifecycle Cost review component', () => {
-  const developmentSampleData = {
-    year1: [{ phase: 'Development', cost: '5000' }],
-    year2: [{ phase: 'Development', cost: '5000' }],
-    year3: [{ phase: 'Development', cost: '5000' }],
-    year4: [{ phase: 'Development', cost: '5000' }],
-    year5: [{ phase: 'Development', cost: '5000' }]
-  };
-
-  const omSampleData = {
-    year1: [{ phase: 'Operations and Maintenance', cost: '5000' }],
-    year2: [{ phase: 'Operations and Maintenance', cost: '5000' }],
-    year3: [{ phase: 'Operations and Maintenance', cost: '5000' }],
-    year4: [{ phase: 'Operations and Maintenance', cost: '5000' }],
-    year5: [{ phase: 'Operations and Maintenance', cost: '5000' }]
-  };
-
-  const otherPhaseSampleData = {
-    year1: [{ phase: 'Other', cost: '5000' }],
-    year2: [{ phase: 'Other', cost: '5000' }],
-    year3: [{ phase: 'Other', cost: '5000' }],
-    year4: [{ phase: 'Other', cost: '5000' }],
-    year5: [{ phase: 'Other', cost: '5000' }]
+  const sampleData = {
+    year1: {
+      development: {
+        isPresent: true,
+        cost: '5000'
+      },
+      operationsMaintenance: {
+        isPresent: true,
+        cost: '5000'
+      },
+      other: {
+        isPresent: true,
+        cost: '5000'
+      }
+    },
+    year2: {
+      development: {
+        isPresent: true,
+        cost: '5000'
+      },
+      operationsMaintenance: {
+        isPresent: true,
+        cost: '5000'
+      },
+      other: {
+        isPresent: true,
+        cost: '5000'
+      }
+    },
+    year3: {
+      development: {
+        isPresent: true,
+        cost: '5000'
+      },
+      operationsMaintenance: {
+        isPresent: true,
+        cost: '5000'
+      },
+      other: {
+        isPresent: true,
+        cost: '5000'
+      }
+    },
+    year4: {
+      development: {
+        isPresent: true,
+        cost: '5000'
+      },
+      operationsMaintenance: {
+        isPresent: true,
+        cost: '5000'
+      },
+      other: {
+        isPresent: true,
+        cost: '5000'
+      }
+    },
+    year5: {
+      development: {
+        isPresent: true,
+        cost: '5000'
+      },
+      operationsMaintenance: {
+        isPresent: true,
+        cost: '5000'
+      },
+      other: {
+        isPresent: true,
+        cost: '5000'
+      }
+    }
   };
 
   it('renders without crashing', () => {
@@ -61,7 +110,7 @@ describe('The Estimated Lifecycle Cost review component', () => {
 
     it('adds up development total correctly', () => {
       const component = mount(
-        <EstimatedLifecycleCostReview data={developmentSampleData} />
+        <EstimatedLifecycleCostReview data={sampleData} />
       );
 
       expect(
@@ -92,15 +141,15 @@ describe('The Estimated Lifecycle Cost review component', () => {
     });
 
     it('renders mobile view with development data', () => {
-      mount(<EstimatedLifecycleCostReview data={developmentSampleData} />);
+      mount(<EstimatedLifecycleCostReview data={sampleData} />);
     });
 
     it('renders mobile view with O&M data', () => {
-      mount(<EstimatedLifecycleCostReview data={omSampleData} />);
+      mount(<EstimatedLifecycleCostReview data={sampleData} />);
     });
 
     it('renders mobile view with Other data', () => {
-      mount(<EstimatedLifecycleCostReview data={otherPhaseSampleData} />);
+      mount(<EstimatedLifecycleCostReview data={sampleData} />);
     });
   });
 });

--- a/src/components/EstimatedLifecycleCost/Review/index.tsx
+++ b/src/components/EstimatedLifecycleCost/Review/index.tsx
@@ -7,16 +7,16 @@ import {
   DescriptionList,
   DescriptionTerm
 } from 'components/shared/DescriptionGroup';
-import { LifecyclePhase } from 'types/estimatedLifecycle';
+import { LifecycleCosts } from 'types/estimatedLifecycle';
 import formatDollars from 'utils/formatDollars';
 
 type EstimatedLifecycleCostReviewProps = {
   data: {
-    year1: LifecyclePhase[];
-    year2: LifecyclePhase[];
-    year3: LifecyclePhase[];
-    year4: LifecyclePhase[];
-    year5: LifecyclePhase[];
+    year1: LifecycleCosts;
+    year2: LifecycleCosts;
+    year3: LifecycleCosts;
+    year4: LifecycleCosts;
+    year5: LifecycleCosts;
   };
 };
 
@@ -30,64 +30,80 @@ const EstimatedLifecycleCostReview = ({
     year4: 'Year 4',
     year5: 'Year 5'
   };
-  const costForPhase = (items: LifecyclePhase[], phaseID: string) => {
-    const phaseMap: { [key: string]: string } = {
-      development: 'Development',
-      om: 'Operations and Maintenance',
-      other: 'Other'
-    };
-
-    const phase = items.find(obj => obj.phase === phaseMap[phaseID]);
-    if (phase) {
-      return parseFloat(phase.cost);
-    }
-    return undefined;
-  };
 
   const formatDollarsOrDash = (value: number | undefined): string => {
-    if (typeof value === 'undefined') {
+    if (Number.isNaN(value)) {
       return '-';
     }
     return formatDollars(value);
   };
 
-  const sum = (values: (number | undefined)[]): number => {
+  const sum = (values: number[]): number => {
     return values.reduce(
-      (total: number, value: number | undefined) => total + (value || 0),
+      (total: number, value: number) => total + (value || 0),
       0
     );
   };
 
-  const developmentCosts: { [key: string]: number | undefined } = {
-    year1: costForPhase(data.year1, 'development'),
-    year2: costForPhase(data.year2, 'development'),
-    year3: costForPhase(data.year3, 'development'),
-    year4: costForPhase(data.year4, 'development'),
-    year5: costForPhase(data.year5, 'development')
+  // Can be float or NaN
+  const developmentCosts: { [key: string]: number } = {
+    year1: parseFloat(data.year1.development.cost),
+    year2: parseFloat(data.year2.development.cost),
+    year3: parseFloat(data.year3.development.cost),
+    year4: parseFloat(data.year4.development.cost),
+    year5: parseFloat(data.year5.development.cost)
   };
 
-  const omCosts: { [key: string]: number | undefined } = {
-    year1: costForPhase(data.year1, 'om'),
-    year2: costForPhase(data.year2, 'om'),
-    year3: costForPhase(data.year3, 'om'),
-    year4: costForPhase(data.year4, 'om'),
-    year5: costForPhase(data.year5, 'om')
+  // Can be float or NaN
+  const omCosts: { [key: string]: number } = {
+    year1: parseFloat(data.year1.operationsMaintenance.cost),
+    year2: parseFloat(data.year2.operationsMaintenance.cost),
+    year3: parseFloat(data.year3.operationsMaintenance.cost),
+    year4: parseFloat(data.year4.operationsMaintenance.cost),
+    year5: parseFloat(data.year5.operationsMaintenance.cost)
   };
 
-  const otherCosts: { [key: string]: any } = {
-    year1: costForPhase(data.year1, 'other'),
-    year2: costForPhase(data.year2, 'other'),
-    year3: costForPhase(data.year3, 'other'),
-    year4: costForPhase(data.year4, 'other'),
-    year5: costForPhase(data.year5, 'other')
+  // Can be float or NaN
+  const otherCosts: { [key: string]: number } = {
+    year1: parseFloat(data.year1.other.cost),
+    year2: parseFloat(data.year2.other.cost),
+    year3: parseFloat(data.year3.other.cost),
+    year4: parseFloat(data.year4.other.cost),
+    year5: parseFloat(data.year5.other.cost)
   };
 
-  const totalCosts: { [key: string]: number } = {
-    year1: sum([developmentCosts.year1, omCosts.year1, otherCosts.year1]),
-    year2: sum([developmentCosts.year2, omCosts.year2, otherCosts.year2]),
-    year3: sum([developmentCosts.year3, omCosts.year3, otherCosts.year3]),
-    year4: sum([developmentCosts.year4, omCosts.year4, otherCosts.year4]),
-    year5: sum([developmentCosts.year5, omCosts.year5, otherCosts.year5])
+  const totalCosts: {
+    [key: string]: {
+      development: number;
+      operationsMaintenance: number;
+      other: number;
+    };
+  } = {
+    year1: {
+      development: developmentCosts.year1 || 0,
+      operationsMaintenance: omCosts.year1 || 0,
+      other: otherCosts.year1 || 0
+    },
+    year2: {
+      development: developmentCosts.year2 || 0,
+      operationsMaintenance: omCosts.year2 || 0,
+      other: otherCosts.year2 || 0
+    },
+    year3: {
+      development: developmentCosts.year3 || 0,
+      operationsMaintenance: omCosts.year3 || 0,
+      other: otherCosts.year3 || 0
+    },
+    year4: {
+      development: developmentCosts.year4 || 0,
+      operationsMaintenance: omCosts.year4 || 0,
+      other: otherCosts.year4 || 0
+    },
+    year5: {
+      development: developmentCosts.year5 || 0,
+      operationsMaintenance: omCosts.year5 || 0,
+      other: otherCosts.year5 || 0
+    }
   };
 
   const totalDevelopmentCosts = sum(Object.values(developmentCosts));
@@ -135,7 +151,9 @@ const EstimatedLifecycleCostReview = ({
                             {yearMapping[year]}
                           </th>
                           <td className="padding-y-2 text-right text-bold">
-                            {formatDollarsOrDash(totalCosts[year])}
+                            {formatDollarsOrDash(
+                              sum(Object.values(totalCosts[year]))
+                            )}
                           </td>
                         </tr>
                         {developmentCosts[year] > 0 && (
@@ -144,7 +162,7 @@ const EstimatedLifecycleCostReview = ({
                               Development
                             </th>
                             <td className="padding-y-2 text-right text-normal">
-                              {formatDollarsOrDash([developmentCosts[year]])}
+                              {formatDollarsOrDash(developmentCosts[year])}
                             </td>
                           </tr>
                         )}
@@ -250,7 +268,9 @@ const EstimatedLifecycleCostReview = ({
                           key={`${year}-costs`}
                           className="padding-y-3 text-right"
                         >
-                          {formatDollarsOrDash(totalCosts[year])}
+                          {formatDollarsOrDash(
+                            sum(Object.values(totalCosts[year]))
+                          )}
                         </td>
                       ))}
                       <td />

--- a/src/components/EstimatedLifecycleCost/index.scss
+++ b/src/components/EstimatedLifecycleCost/index.scss
@@ -24,17 +24,6 @@
     }
   }
 
-  &__phase-btn-wrapper {
-    display: flex;
-    align-items: flex-end;
-  }
-
-  &__remove-phase-btn {
-    &.usa-button--unstyled {
-      padding: 0.75rem 0;
-    }
-  }
-
   .usa-label {
     margin-top: 0;
   }

--- a/src/components/EstimatedLifecycleCost/index.scss
+++ b/src/components/EstimatedLifecycleCost/index.scss
@@ -44,16 +44,6 @@
     padding-left: 0;
   }
 
-  &__phase-cost-row {
-    display: grid;
-    grid-gap: 16px;
-    margin-right: 1rem;
-
-    @media screen and (min-width: $desktop) {
-      grid-template-columns: minmax(100px, 250px) 150px;
-    }
-  }
-
   .help-title {
     font-size: 1.375em;
   }

--- a/src/components/EstimatedLifecycleCost/index.tsx
+++ b/src/components/EstimatedLifecycleCost/index.tsx
@@ -40,7 +40,6 @@ const Phase = ({
       `${formikKey}.year${year}.${phase}.isPresent`,
       e.target.checked
     );
-    setFieldValue(`${formikKey}.year${year}.${phase}.cost`, '');
   };
 
   return (

--- a/src/components/EstimatedLifecycleCost/index.tsx
+++ b/src/components/EstimatedLifecycleCost/index.tsx
@@ -87,6 +87,7 @@ const Phase = ({
                       <Field
                         as={TextField}
                         // error={!!phaseError.cost}
+                        className="width-card-lg"
                         id={`BusinessCase-${formikKey}.Year${year}.development.cost`}
                         name={`${formikKey}.year${year}.development.cost`}
                         maxLength={10}
@@ -121,6 +122,7 @@ const Phase = ({
                       <Field
                         as={TextField}
                         // error={!!phaseError.cost}
+                        className="width-card-lg"
                         id={`BusinessCase-${formikKey}.Year${year}.operationsMaintenance.cost`}
                         name={`${formikKey}.year${year}.operationsMaintenance.cost`}
                         maxLength={10}
@@ -155,6 +157,7 @@ const Phase = ({
                       <Field
                         as={TextField}
                         // error={!!phaseError.cost}
+                        className="width-card-lg"
                         id={`BusinessCase-${formikKey}.Year${year}.other.cost`}
                         name={`${formikKey}.year${year}.other.cost`}
                         maxLength={10}

--- a/src/components/EstimatedLifecycleCost/index.tsx
+++ b/src/components/EstimatedLifecycleCost/index.tsx
@@ -1,19 +1,18 @@
 import React from 'react';
-import { Button } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 import { Field, FieldArray } from 'formik';
 
+import CheckboxField from 'components/shared/CheckboxField/';
 import {
   DescriptionDefinition,
   DescriptionList,
   DescriptionTerm
 } from 'components/shared/DescriptionGroup';
-import FieldErrorMsg from 'components/shared/FieldErrorMsg';
+// import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import Label from 'components/shared/Label';
-import { RadioField, RadioGroup } from 'components/shared/RadioField';
 import TextField from 'components/shared/TextField';
-import { LifecyclePhase } from 'types/estimatedLifecycle';
+import { LifecycleCosts } from 'types/estimatedLifecycle';
 import formatDollars from 'utils/formatDollars';
 
 import './index.scss';
@@ -21,116 +20,150 @@ import './index.scss';
 type PhaseProps = {
   formikKey: string;
   year: number;
-  index: number;
-  values: LifecyclePhase;
+  values: LifecycleCosts;
+  setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void;
   errors: any[];
 };
-const Phase = ({ formikKey, year, index, values, errors = [] }: PhaseProps) => {
-  const phaseError = errors[index] || {};
+
+const Phase = ({
+  formikKey,
+  year,
+  values,
+  setFieldValue,
+  errors = []
+}: PhaseProps) => {
+  const handleCheckboxChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    phase: string
+  ) => {
+    setFieldValue(
+      `${formikKey}.year${year}.${phase}.isPresent`,
+      e.target.checked
+    );
+    setFieldValue(`${formikKey}.year${year}.${phase}.cost`, '');
+  };
+
   return (
     <FieldArray name={`${formikKey}.year${year}`}>
-      {arrayHelpers => (
+      {() => (
         <div className="est-lifecycle-cost__phase-cost-wrapper">
-          <FieldGroup error={phaseError.phase || phaseError.cost}>
-            {phaseError.phase && (
-              <FieldErrorMsg>{phaseError.phase}</FieldErrorMsg>
-            )}
-            {phaseError.cost && (
-              <FieldErrorMsg>{phaseError.cost}</FieldErrorMsg>
-            )}
+          <FieldGroup error={errors.length > 0}>
             <div className="margin-right-2">
               <fieldset
                 className="usa-fieldset"
                 aria-describedby="BusinessCase-EstimatedLifecycleCostHelp"
-                data-scroll={`${formikKey}.year${year}.${index}.phase`}
               >
                 <div>
                   <legend
                     className={classnames('usa-label', 'margin-bottom-1')}
-                    aria-label={`Year ${year} Phase ${index + 1} Phase Type`}
+                    aria-label={`Year ${year}`}
                   >
                     Phase
                   </legend>
-                  <RadioGroup>
-                    <Field
-                      as={RadioField}
-                      checked={values.phase === 'Development'}
-                      id={`BusinessCase-${formikKey}.Year${year}.Phase${index}.Development`}
-                      name={`${formikKey}.year${year}.${index}.phase`}
-                      label="Development"
-                      value="Development"
-                    />
 
-                    <Field
-                      as={RadioField}
-                      checked={values.phase === 'Operations and Maintenance'}
-                      id={`BusinessCase-${formikKey}.Year${year}.Phase${index}.opsMaintenance`}
-                      name={`${formikKey}.year${year}.${index}.phase`}
-                      label="Operations and Maintenance"
-                      value="Operations and Maintenance"
-                    />
+                  <Field
+                    as={CheckboxField}
+                    checked={values.development.isPresent}
+                    id={`BusinessCase-${formikKey}.Year${year}.Development`}
+                    name={`${formikKey}.year${year}.development.isPresent`}
+                    label="Development"
+                    value="Development"
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      handleCheckboxChange(e, 'development');
+                    }}
+                  />
+                  {values.development.isPresent && (
+                    <FieldGroup
+                      className="margin-left-4 margin-bottom-2"
+                      scrollElement={`${formikKey}.year${year}.development.cost`}
+                    >
+                      <Label
+                        htmlFor={`BusinessCase-${formikKey}.Year${year}.development.cost`}
+                        aria-label={`Enter year ${year} development cost`}
+                      >
+                        Cost
+                      </Label>
+                      {/* ERROR */}
+                      <Field
+                        as={TextField}
+                        // error={!!phaseError.cost}
+                        id={`BusinessCase-${formikKey}.Year${year}.development.cost`}
+                        name={`${formikKey}.year${year}.development.cost`}
+                        maxLength={10}
+                        match={/^[0-9\b]+$/}
+                      />
+                    </FieldGroup>
+                  )}
 
-                    <Field
-                      as={RadioField}
-                      checked={values.phase === 'Other'}
-                      id={`BusinessCase-${formikKey}.Year${year}.Phase${index}.Other`}
-                      name={`${formikKey}.year${year}.${index}.phase`}
-                      label="Other"
-                      value="Other"
-                    />
-                  </RadioGroup>
+                  <Field
+                    as={CheckboxField}
+                    checked={values.operationsMaintenance.isPresent}
+                    id={`BusinessCase-${formikKey}.Year${year}.opsMaintenance`}
+                    name={`${formikKey}.year${year}.operationsMaintenance.isPresent`}
+                    label="Operations and Maintenance"
+                    value="Operations and Maintenance"
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      handleCheckboxChange(e, 'operationsMaintenance');
+                    }}
+                  />
+                  {values.operationsMaintenance.isPresent && (
+                    <FieldGroup
+                      className="margin-left-4 margin-bottom-2"
+                      scrollElement={`${formikKey}.year${year}.operationsMaintenance.cost`}
+                    >
+                      <Label
+                        htmlFor={`BusinessCase-${formikKey}.Year${year}.operationsMaintenance.cost`}
+                        aria-label={`Enter year ${year} operations and maintenance cost`}
+                      >
+                        Cost
+                      </Label>
+                      {/* ERROR */}
+                      <Field
+                        as={TextField}
+                        // error={!!phaseError.cost}
+                        id={`BusinessCase-${formikKey}.Year${year}.operationsMaintenance.cost`}
+                        name={`${formikKey}.year${year}.operationsMaintenance.cost`}
+                        maxLength={10}
+                        match={/^[0-9\b]+$/}
+                      />
+                    </FieldGroup>
+                  )}
+
+                  <Field
+                    as={CheckboxField}
+                    checked={values.other.isPresent}
+                    id={`BusinessCase-${formikKey}.Year${year}.other`}
+                    name={`${formikKey}.year${year}.other.isPresent`}
+                    label="Other"
+                    value="Other"
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      handleCheckboxChange(e, 'other');
+                    }}
+                  />
+                  {values.other.isPresent && (
+                    <FieldGroup
+                      className="margin-left-4 margin-bottom-2"
+                      scrollElement={`${formikKey}.year${year}.other.cost`}
+                    >
+                      <Label
+                        htmlFor={`BusinessCase-${formikKey}.Year${year}.other.cost`}
+                        aria-label={`Enter year ${year} other cost`}
+                      >
+                        Cost
+                      </Label>
+                      {/* ERROR */}
+                      <Field
+                        as={TextField}
+                        // error={!!phaseError.cost}
+                        id={`BusinessCase-${formikKey}.Year${year}.other.cost`}
+                        name={`${formikKey}.year${year}.other.cost`}
+                        maxLength={10}
+                        match={/^[0-9\b]+$/}
+                      />
+                    </FieldGroup>
+                  )}
                 </div>
               </fieldset>
-            </div>
-            <div
-              className="est-lifecycle-cost__phase-cost-row"
-              data-scroll={`${formikKey}.year${year}.${index}.cost`}
-            >
-              <div>
-                <Label
-                  htmlFor={`BusinessCase-${formikKey}.Year${year}.Phase${index}.cost`}
-                  aria-label={`Year ${year} Phase ${index + 1} Cost`}
-                >
-                  Cost
-                </Label>
-                <Field
-                  as={TextField}
-                  error={!!phaseError.cost}
-                  id={`BusinessCase-${formikKey}.Year${year}.Phase${index}.cost`}
-                  name={`${formikKey}.year${year}.${index}.cost`}
-                  maxLength={10}
-                  match={/^[0-9\b]+$/}
-                />
-              </div>
-
-              <div className="est-lifecycle-cost__phase-btn-wrapper">
-                {index === 0 ? (
-                  <Button
-                    type="button"
-                    outline
-                    onClick={() => {
-                      arrayHelpers.push({
-                        phase: '',
-                        cost: ''
-                      });
-                    }}
-                  >
-                    + Add Phase
-                  </Button>
-                ) : (
-                  <Button
-                    className="est-lifecycle-cost__remove-phase-btn"
-                    type="button"
-                    outline
-                    onClick={() => {
-                      arrayHelpers.remove(index);
-                    }}
-                    unstyled
-                  >
-                    Remove phase
-                  </Button>
-                )}
-              </div>
             </div>
           </FieldGroup>
         </div>
@@ -142,26 +175,27 @@ const Phase = ({ formikKey, year, index, values, errors = [] }: PhaseProps) => {
 type EstimatedLifecycleCostProps = {
   formikKey: string;
   years: {
-    year1: LifecyclePhase[];
-    year2: LifecyclePhase[];
-    year3: LifecyclePhase[];
-    year4: LifecyclePhase[];
-    year5: LifecyclePhase[];
+    year1: LifecycleCosts;
+    year2: LifecycleCosts;
+    year3: LifecycleCosts;
+    year4: LifecycleCosts;
+    year5: LifecycleCosts;
   };
+  setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void;
   errors: any;
 };
 const EstimatedLifecycleCost = ({
   formikKey,
   years,
+  setFieldValue,
   errors = {}
 }: EstimatedLifecycleCostProps) => {
-  const sumCostinYear = (phases: LifecyclePhase[]) => {
-    return phases.reduce((prev, current) => {
-      if (current.cost) {
-        return prev + parseFloat(current.cost);
-      }
-      return prev;
-    }, 0);
+  const sumCostinYear = (phases: LifecycleCosts) => {
+    return (
+      parseFloat(phases.development.cost || '0') +
+      parseFloat(phases.operationsMaintenance.cost || '0') +
+      parseFloat(phases.other.cost || '0')
+    );
   };
   const year1Cost = sumCostinYear(years.year1);
   const year2Cost = sumCostinYear(years.year2);
@@ -201,78 +235,53 @@ const EstimatedLifecycleCost = ({
       <div className="tablet:grid-col-7">
         <div className="est-lifecycle-cost__year-costs margin-top-0">
           <span className="text-bold">Year 1</span>
-          {years.year1.map((year: LifecyclePhase, index: number) => {
-            return (
-              <Phase
-                key={`Year1Phase-${index + 1}`}
-                formikKey={formikKey}
-                year={1}
-                index={index}
-                values={year}
-                errors={errors.year1}
-              />
-            );
-          })}
+          <Phase
+            formikKey={formikKey}
+            year={1}
+            values={years.year1}
+            setFieldValue={setFieldValue}
+            errors={errors.year1}
+          />
         </div>
         <div className="est-lifecycle-cost__year-costs">
           <span className="text-bold">Year 2</span>
-          {years.year2.map((year: LifecyclePhase, index: number) => {
-            return (
-              <Phase
-                key={`Year2Phase-${index + 1}`}
-                formikKey={formikKey}
-                year={2}
-                index={index}
-                values={year}
-                errors={errors.year2}
-              />
-            );
-          })}
+          <Phase
+            formikKey={formikKey}
+            year={2}
+            values={years.year2}
+            setFieldValue={setFieldValue}
+            errors={errors.year2}
+          />
         </div>
         <div className="est-lifecycle-cost__year-costs">
           <span className="text-bold">Year 3</span>
-          {years.year3.map((year: LifecyclePhase, index: number) => {
-            return (
-              <Phase
-                key={`Year3Phase-${index + 1}`}
-                formikKey={formikKey}
-                year={3}
-                index={index}
-                values={year}
-                errors={errors.year3}
-              />
-            );
-          })}
+          <Phase
+            formikKey={formikKey}
+            year={3}
+            values={years.year3}
+            setFieldValue={setFieldValue}
+            errors={errors.year3}
+          />
         </div>
         <div className="est-lifecycle-cost__year-costs">
           <span className="text-bold">Year 4</span>
-          {years.year4.map((year: LifecyclePhase, index: number) => {
-            return (
-              <Phase
-                key={`Year4Phase-${index + 1}`}
-                formikKey={formikKey}
-                year={4}
-                index={index}
-                values={year}
-                errors={errors.year4}
-              />
-            );
-          })}
+          <Phase
+            formikKey={formikKey}
+            year={4}
+            values={years.year4}
+            setFieldValue={setFieldValue}
+            errors={errors.year4}
+          />
         </div>
         <div className="est-lifecycle-cost__year-costs">
           <span className="text-bold">Year 5</span>
-          {years.year5.map((year: LifecyclePhase, index: number) => {
-            return (
-              <Phase
-                key={`Year5Phase-${index + 1}`}
-                formikKey={formikKey}
-                year={5}
-                index={index}
-                values={year}
-                errors={errors.year5}
-              />
-            );
-          })}
+          <Phase
+            formikKey={formikKey}
+            year={5}
+            values={years.year5}
+            setFieldValue={setFieldValue}
+            errors={errors.year5}
+          />
         </div>
         <div className="est-lifecycle-cost__total bg-base-lightest overflow-auto margin-top-3 padding-x-2">
           <DescriptionList title="System total cost">

--- a/src/components/EstimatedLifecycleCost/index.tsx
+++ b/src/components/EstimatedLifecycleCost/index.tsx
@@ -8,7 +8,7 @@ import {
   DescriptionList,
   DescriptionTerm
 } from 'components/shared/DescriptionGroup';
-// import FieldErrorMsg from 'components/shared/FieldErrorMsg';
+import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import Label from 'components/shared/Label';
 import TextField from 'components/shared/TextField';
@@ -22,7 +22,7 @@ type PhaseProps = {
   year: number;
   values: LifecycleCosts;
   setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void;
-  errors: any[];
+  errors: any;
 };
 
 const Phase = ({
@@ -30,7 +30,7 @@ const Phase = ({
   year,
   values,
   setFieldValue,
-  errors = []
+  errors = {}
 }: PhaseProps) => {
   const handleCheckboxChange = (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -47,13 +47,19 @@ const Phase = ({
     <FieldArray name={`${formikKey}.year${year}`}>
       {() => (
         <div className="est-lifecycle-cost__phase-cost-wrapper">
-          <FieldGroup error={errors.length > 0}>
+          <FieldGroup
+            error={Object.keys(errors).length > 0}
+            scrollElement={`${formikKey}.year${year}`}
+          >
             <div className="margin-right-2">
               <fieldset
                 className="usa-fieldset"
                 aria-describedby="BusinessCase-EstimatedLifecycleCostHelp"
               >
                 <div>
+                  <FieldErrorMsg>
+                    {typeof errors === 'string' ? errors : ''}
+                  </FieldErrorMsg>
                   <legend
                     className={classnames('usa-label', 'margin-bottom-1')}
                     aria-label={`Year ${year}`}
@@ -83,10 +89,10 @@ const Phase = ({
                       >
                         Cost
                       </Label>
-                      {/* ERROR */}
+                      <FieldErrorMsg>{errors?.development?.cost}</FieldErrorMsg>
                       <Field
                         as={TextField}
-                        // error={!!phaseError.cost}
+                        error={!!errors?.development?.cost}
                         className="width-card-lg"
                         id={`BusinessCase-${formikKey}.Year${year}.development.cost`}
                         name={`${formikKey}.year${year}.development.cost`}
@@ -118,10 +124,12 @@ const Phase = ({
                       >
                         Cost
                       </Label>
-                      {/* ERROR */}
+                      <FieldErrorMsg>
+                        {errors?.operationsMaintenance?.cost}
+                      </FieldErrorMsg>
                       <Field
                         as={TextField}
-                        // error={!!phaseError.cost}
+                        error={!!errors?.operationsMaintenance?.cost}
                         className="width-card-lg"
                         id={`BusinessCase-${formikKey}.Year${year}.operationsMaintenance.cost`}
                         name={`${formikKey}.year${year}.operationsMaintenance.cost`}
@@ -153,10 +161,10 @@ const Phase = ({
                       >
                         Cost
                       </Label>
-                      {/* ERROR */}
+                      <FieldErrorMsg>{errors?.other?.cost}</FieldErrorMsg>
                       <Field
                         as={TextField}
-                        // error={!!phaseError.cost}
+                        error={!!errors?.other?.cost}
                         className="width-card-lg"
                         id={`BusinessCase-${formikKey}.Year${year}.other.cost`}
                         name={`${formikKey}.year${year}.other.cost`}

--- a/src/components/EstimatedLifecycleCost/index.tsx
+++ b/src/components/EstimatedLifecycleCost/index.tsx
@@ -64,7 +64,7 @@ const Phase = ({
                   <Field
                     as={CheckboxField}
                     checked={values.development.isPresent}
-                    id={`BusinessCase-${formikKey}.Year${year}.Development`}
+                    id={`BusinessCase-${formikKey}.Year${year}.development.isPresent`}
                     name={`${formikKey}.year${year}.development.isPresent`}
                     label="Development"
                     value="Development"
@@ -99,7 +99,7 @@ const Phase = ({
                   <Field
                     as={CheckboxField}
                     checked={values.operationsMaintenance.isPresent}
-                    id={`BusinessCase-${formikKey}.Year${year}.opsMaintenance`}
+                    id={`BusinessCase-${formikKey}.Year${year}.operationsMaintenance.isPresent`}
                     name={`${formikKey}.year${year}.operationsMaintenance.isPresent`}
                     label="Operations and Maintenance"
                     value="Operations and Maintenance"
@@ -134,7 +134,7 @@ const Phase = ({
                   <Field
                     as={CheckboxField}
                     checked={values.other.isPresent}
-                    id={`BusinessCase-${formikKey}.Year${year}.other`}
+                    id={`BusinessCase-${formikKey}.Year${year}.other.isPresent`}
                     name={`${formikKey}.year${year}.other.isPresent`}
                     label="Other"
                     value="Other"

--- a/src/data/businessCase.test.ts
+++ b/src/data/businessCase.test.ts
@@ -1,4 +1,8 @@
-import { prepareBusinessCaseForApp } from './businessCase';
+import {
+  businessCaseInitialData,
+  prepareBusinessCaseForApi,
+  prepareBusinessCaseForApp
+} from './businessCase';
 
 describe('The business case data', () => {
   describe('prepareBusinessCaseForApp', () => {
@@ -510,6 +514,142 @@ describe('The business case data', () => {
       expect(prepareBusinessCaseForApp(testDataFromApi).asIsSolution).toEqual(
         asisSolution
       );
+    });
+  });
+
+  describe('prepareBusinessCaseForApi', () => {
+    it('does not save estimated lifecycle cost if checkbox is not checked', () => {
+      // ONLY checking As is solution lifecycle lines in this test
+      // other solutions should behave the same
+      const testBusinessCase = {
+        ...businessCaseInitialData,
+        asIsSolution: {
+          title: '',
+          summary: '',
+          pros: '',
+          cons: '',
+          estimatedLifecycleCost: {
+            year1: {
+              development: {
+                isPresent: false,
+                cost: '500'
+              },
+              operationsMaintenance: {
+                isPresent: true,
+                cost: '1000'
+              },
+              other: {
+                isPresent: false,
+                cost: '1500'
+              }
+            },
+            year2: {
+              development: {
+                isPresent: true,
+                cost: '500'
+              },
+              operationsMaintenance: {
+                isPresent: false,
+                cost: '1000'
+              },
+              other: {
+                isPresent: false,
+                cost: '1500'
+              }
+            },
+            year3: {
+              development: {
+                isPresent: false,
+                cost: '500'
+              },
+              operationsMaintenance: {
+                isPresent: true,
+                cost: '1000'
+              },
+              other: {
+                isPresent: true,
+                cost: '1500'
+              }
+            },
+            year4: {
+              development: {
+                isPresent: false,
+                cost: '500'
+              },
+              operationsMaintenance: {
+                isPresent: false,
+                cost: '1000'
+              },
+              other: {
+                isPresent: false,
+                cost: '1500'
+              }
+            },
+            year5: {
+              development: {
+                isPresent: true,
+                cost: '500'
+              },
+              operationsMaintenance: {
+                isPresent: true,
+                cost: '1000'
+              },
+              other: {
+                isPresent: true,
+                cost: '1500'
+              }
+            }
+          },
+          costSavings: ''
+        }
+      };
+
+      const asIsLifecycleLines = [
+        { solution: 'As Is', phase: 'Development', cost: '', year: '1' },
+        {
+          solution: 'As Is',
+          phase: 'Operations and Maintenance',
+          cost: 1000,
+          year: '1'
+        },
+        { solution: 'As Is', phase: 'Other', cost: '', year: '1' },
+        { solution: 'As Is', phase: 'Development', cost: 500, year: '2' },
+        {
+          solution: 'As Is',
+          phase: 'Operations and Maintenance',
+          cost: '',
+          year: '2'
+        },
+        { solution: 'As Is', phase: 'Other', cost: '', year: '2' },
+        { solution: 'As Is', phase: 'Development', cost: '', year: '3' },
+        {
+          solution: 'As Is',
+          phase: 'Operations and Maintenance',
+          cost: 1000,
+          year: '3'
+        },
+        { solution: 'As Is', phase: 'Other', cost: 1500, year: '3' },
+        { solution: 'As Is', phase: 'Development', cost: '', year: '4' },
+        {
+          solution: 'As Is',
+          phase: 'Operations and Maintenance',
+          cost: '',
+          year: '4'
+        },
+        { solution: 'As Is', phase: 'Other', cost: '', year: '4' },
+        { solution: 'As Is', phase: 'Development', cost: 500, year: '5' },
+        {
+          solution: 'As Is',
+          phase: 'Operations and Maintenance',
+          cost: 1000,
+          year: '5'
+        },
+        { solution: 'As Is', phase: 'Other', cost: 1500, year: '5' }
+      ];
+
+      expect(
+        prepareBusinessCaseForApi(testBusinessCase).lifecycleCostLines
+      ).toEqual(expect.arrayContaining(asIsLifecycleLines));
     });
   });
 });

--- a/src/data/businessCase.test.ts
+++ b/src/data/businessCase.test.ts
@@ -605,23 +605,23 @@ describe('The business case data', () => {
       };
 
       const asIsLifecycleLines = [
-        { solution: 'As Is', phase: 'Development', cost: '', year: '1' },
+        { solution: 'As Is', phase: 'Development', cost: null, year: '1' },
         {
           solution: 'As Is',
           phase: 'Operations and Maintenance',
           cost: 1000,
           year: '1'
         },
-        { solution: 'As Is', phase: 'Other', cost: '', year: '1' },
+        { solution: 'As Is', phase: 'Other', cost: null, year: '1' },
         { solution: 'As Is', phase: 'Development', cost: 500, year: '2' },
         {
           solution: 'As Is',
           phase: 'Operations and Maintenance',
-          cost: '',
+          cost: null,
           year: '2'
         },
-        { solution: 'As Is', phase: 'Other', cost: '', year: '2' },
-        { solution: 'As Is', phase: 'Development', cost: '', year: '3' },
+        { solution: 'As Is', phase: 'Other', cost: null, year: '2' },
+        { solution: 'As Is', phase: 'Development', cost: null, year: '3' },
         {
           solution: 'As Is',
           phase: 'Operations and Maintenance',
@@ -629,14 +629,14 @@ describe('The business case data', () => {
           year: '3'
         },
         { solution: 'As Is', phase: 'Other', cost: 1500, year: '3' },
-        { solution: 'As Is', phase: 'Development', cost: '', year: '4' },
+        { solution: 'As Is', phase: 'Development', cost: null, year: '4' },
         {
           solution: 'As Is',
           phase: 'Operations and Maintenance',
-          cost: '',
+          cost: null,
           year: '4'
         },
-        { solution: 'As Is', phase: 'Other', cost: '', year: '4' },
+        { solution: 'As Is', phase: 'Other', cost: null, year: '4' },
         { solution: 'As Is', phase: 'Development', cost: 500, year: '5' },
         {
           solution: 'As Is',

--- a/src/data/businessCase.test.ts
+++ b/src/data/businessCase.test.ts
@@ -1,0 +1,515 @@
+import { prepareBusinessCaseForApp } from './businessCase';
+
+describe('The business case data', () => {
+  describe('prepareBusinessCaseForApp', () => {
+    const testDataFromApi = {
+      id: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+      euaUserId: 'ABCD',
+      systemIntakeId: 'b6dce250-c13e-4704-b09c-cbcee8541479',
+      systemIntakeStatus: 'BIZ_CASE_DRAFT',
+      status: 'OPEN',
+      projectName: 'Test System',
+      requester: 'User ABCD',
+      requesterPhoneNumber: '1234567890',
+      businessOwner: 'User HXEP',
+      businessNeed: 'My business need',
+      cmsBenefit: 'asdf',
+      priorityAlignment: 'asdf',
+      successIndicators: 'asdf',
+      asIsTitle: 'As is title',
+      asIsSummary: 'As is summary',
+      asIsPros: 'As is pros',
+      asIsCons: 'As is cons',
+      asIsCostSavings: 'As is cost savings',
+      preferredTitle: '',
+      preferredSummary: '',
+      preferredAcquisitionApproach: '',
+      preferredSecurityIsApproved: null,
+      preferredSecurityIsBeingReviewed: '',
+      preferredHostingType: '',
+      preferredHostingLocation: '',
+      preferredHostingCloudServiceType: '',
+      preferredHasUI: '',
+      preferredPros: '',
+      preferredCons: '',
+      preferredCostSavings: '',
+      alternativeATitle: '',
+      alternativeASummary: '',
+      alternativeAAcquisitionApproach: '',
+      alternativeASecurityIsApproved: null,
+      alternativeASecurityIsBeingReviewed: '',
+      alternativeAHostingType: '',
+      alternativeAHostingLocation: '',
+      alternativeAHostingCloudServiceType: '',
+      alternativeAHasUI: '',
+      alternativeAPros: '',
+      alternativeACons: '',
+      alternativeACostSavings: '',
+      alternativeBTitle: null,
+      alternativeBSummary: null,
+      alternativeBAcquisitionApproach: null,
+      alternativeBSecurityIsApproved: null,
+      alternativeBSecurityIsBeingReviewed: null,
+      alternativeBHostingType: null,
+      alternativeBHostingLocation: null,
+      alternativeBHostingCloudServiceType: null,
+      alternativeBHasUI: null,
+      alternativeBPros: null,
+      alternativeBCons: null,
+      alternativeBCostSavings: null,
+      lifecycleCostLines: [
+        {
+          id: '5e232a8d-8f76-4d6c-b902-158f19fc85cd',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Development',
+          year: '1',
+          cost: 1
+        },
+        {
+          id: '18dab0c5-c48a-43a1-8ade-5348d684c51c',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Operations and Maintenance',
+          year: '1',
+          cost: 2
+        },
+        {
+          id: '64800155-b01f-45f4-bf56-0c407aed4bd5',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Other',
+          year: '1',
+          cost: 3
+        },
+        {
+          id: '65f6f0f8-ce09-41e0-94ed-331aa6e0449a',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Development',
+          year: '2',
+          cost: 4
+        },
+        {
+          id: 'a2c93ac5-1897-4d40-a259-98c3b953e9d5',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Operations and Maintenance',
+          year: '2',
+          cost: null
+        },
+        {
+          id: '7e74157c-4e15-4b63-aa03-7d3d3614f7fa',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Other',
+          year: '2',
+          cost: 5
+        },
+        {
+          id: '99d1dffc-c09f-4d78-a47a-bf9df6c470af',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Development',
+          year: '3',
+          cost: null
+        },
+        {
+          id: '97aa59a3-804c-454a-85e9-266a7ee1a204',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Operations and Maintenance',
+          year: '3',
+          cost: 6
+        },
+        {
+          id: 'd9bfd983-60f0-4cf5-894a-8df6de644e18',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Other',
+          year: '3',
+          cost: 7
+        },
+        {
+          id: 'eba6c59f-4274-4024-a41e-7692cc2bf617',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Development',
+          year: '4',
+          cost: 8
+        },
+        {
+          id: '715fd337-d4bb-4460-bf0f-7d55fd5958c1',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Operations and Maintenance',
+          year: '4',
+          cost: 9
+        },
+        {
+          id: '533528be-f2b5-4b31-acdd-75fe01ef934b',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Other',
+          year: '4',
+          cost: null
+        },
+        {
+          id: '8f4045ee-bb74-446c-9574-43f42c7adebe',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Development',
+          year: '5',
+          cost: 10
+        },
+        {
+          id: 'fb023b7b-bc38-473e-9804-d8741981253b',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Operations and Maintenance',
+          year: '5',
+          cost: 11
+        },
+        {
+          id: '69ab8880-59db-45dc-a959-6551f6714dce',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'As Is',
+          phase: 'Other',
+          year: '5',
+          cost: 12
+        },
+        {
+          id: '11ac8fc1-18c6-4085-acd3-ca3f96caba8e',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Development',
+          year: '1',
+          cost: null
+        },
+        {
+          id: '390ba808-5ee3-4547-b371-6fcff7d4bb42',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Operations and Maintenance',
+          year: '1',
+          cost: null
+        },
+        {
+          id: '23d4de1f-13a4-4ddf-905e-2cdf601d4bb4',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Other',
+          year: '1',
+          cost: null
+        },
+        {
+          id: 'baf4314e-f9c3-4c9d-a838-abf53bbba63a',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Development',
+          year: '2',
+          cost: null
+        },
+        {
+          id: '136b50c2-221d-4f65-a8f0-b64bcda03610',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Operations and Maintenance',
+          year: '2',
+          cost: null
+        },
+        {
+          id: '0c7bda06-a714-4fa2-98d2-dd48c80c5148',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Other',
+          year: '2',
+          cost: null
+        },
+        {
+          id: '876bf41d-148b-4ae9-8991-2c13ff07cd41',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Development',
+          year: '3',
+          cost: null
+        },
+        {
+          id: '7500f2f5-844a-4286-ba16-0107df203280',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Operations and Maintenance',
+          year: '3',
+          cost: null
+        },
+        {
+          id: '6b0fe308-a83b-4819-aa1a-3ea53ab798d1',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Other',
+          year: '3',
+          cost: null
+        },
+        {
+          id: '2ba3664c-0f2c-47fd-84fe-06b4f901c1a7',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Development',
+          year: '4',
+          cost: null
+        },
+        {
+          id: '721086b9-5fe0-4601-8e62-763404460eb7',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Operations and Maintenance',
+          year: '4',
+          cost: null
+        },
+        {
+          id: 'f0514373-7f38-4a64-ba03-e659b21d52fd',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Other',
+          year: '4',
+          cost: null
+        },
+        {
+          id: 'cfde10c9-6b46-443f-aae7-39f82c809f1d',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Development',
+          year: '5',
+          cost: null
+        },
+        {
+          id: '4f7baf84-3826-4853-8f1f-1bf990bc656c',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Operations and Maintenance',
+          year: '5',
+          cost: null
+        },
+        {
+          id: '12905fc0-2085-49d9-9e64-0f9dafa21a93',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'Preferred',
+          phase: 'Other',
+          year: '5',
+          cost: null
+        },
+        {
+          id: '67d9f6ce-c22c-4887-b667-bbbe3951e615',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Development',
+          year: '1',
+          cost: null
+        },
+        {
+          id: 'ea9fef9e-80f5-48f6-9de7-663979da455e',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Operations and Maintenance',
+          year: '1',
+          cost: null
+        },
+        {
+          id: '9280b1d1-c10b-4eb3-99c4-4bb5574c545f',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Other',
+          year: '1',
+          cost: null
+        },
+        {
+          id: 'e602f75c-d4dc-4a07-a5fd-3bbfad1476e2',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Development',
+          year: '2',
+          cost: null
+        },
+        {
+          id: '77c2f7a7-33cf-4910-b055-2e6a3ab71590',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Operations and Maintenance',
+          year: '2',
+          cost: null
+        },
+        {
+          id: '6fcc8ce6-64bc-4ca3-a12d-cc714912fcaf',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Other',
+          year: '2',
+          cost: null
+        },
+        {
+          id: '42ccb9f4-ea29-4eb3-aa97-bf831bc3b113',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Development',
+          year: '3',
+          cost: null
+        },
+        {
+          id: '7a68e6f9-a188-4986-9ebc-648046d2b73a',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Operations and Maintenance',
+          year: '3',
+          cost: null
+        },
+        {
+          id: '2bdd8054-b5cd-465a-9853-86e6c7f1a527',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Other',
+          year: '3',
+          cost: null
+        },
+        {
+          id: 'c4e4b40c-51da-4bcd-9a1c-05fe8058c43c',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Development',
+          year: '4',
+          cost: null
+        },
+        {
+          id: 'ebdd1c72-0a81-4b8b-b7d6-efee9c10786d',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Operations and Maintenance',
+          year: '4',
+          cost: null
+        },
+        {
+          id: 'bfb66616-9d7f-42b7-83ac-52c215c9a77b',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Other',
+          year: '4',
+          cost: null
+        },
+        {
+          id: '7ff6ac81-758e-454c-a9d7-c5998613116d',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Development',
+          year: '5',
+          cost: null
+        },
+        {
+          id: '15f4dd91-ed5c-4555-84c7-feef9a5aa90f',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Operations and Maintenance',
+          year: '5',
+          cost: null
+        },
+        {
+          id: 'a22a7e7b-0a3b-4a0d-87f7-0d21bf785e80',
+          business_case: '879dec4a-6bab-4cfa-bd55-e6e4b91ea8f0',
+          solution: 'A',
+          phase: 'Other',
+          year: '5',
+          cost: null
+        }
+      ],
+      createdAt: '2021-03-16T20:05:10.95265Z',
+      updatedAt: '2021-03-16T20:11:36.867585Z',
+      submittedAt: null,
+      ArchivedAt: null,
+      initialSubmittedAt: null,
+      lastSubmittedAt: null
+    };
+
+    it('transforms as is solution for app', () => {
+      const asisSolution = {
+        title: 'As is title',
+        summary: 'As is summary',
+        pros: 'As is pros',
+        cons: 'As is cons',
+        costSavings: 'As is cost savings',
+        estimatedLifecycleCost: {
+          year1: {
+            development: {
+              isPresent: true,
+              cost: '1'
+            },
+            operationsMaintenance: {
+              isPresent: true,
+              cost: '2'
+            },
+            other: {
+              isPresent: true,
+              cost: '3'
+            }
+          },
+          year2: {
+            development: {
+              isPresent: true,
+              cost: '4'
+            },
+            operationsMaintenance: {
+              isPresent: false,
+              cost: ''
+            },
+            other: {
+              isPresent: true,
+              cost: '5'
+            }
+          },
+          year3: {
+            development: {
+              isPresent: false,
+              cost: ''
+            },
+            operationsMaintenance: {
+              isPresent: true,
+              cost: '6'
+            },
+            other: {
+              isPresent: true,
+              cost: '7'
+            }
+          },
+          year4: {
+            development: {
+              isPresent: true,
+              cost: '8'
+            },
+            operationsMaintenance: {
+              isPresent: true,
+              cost: '9'
+            },
+            other: {
+              isPresent: false,
+              cost: ''
+            }
+          },
+          year5: {
+            development: {
+              isPresent: true,
+              cost: '10'
+            },
+            operationsMaintenance: {
+              isPresent: true,
+              cost: '11'
+            },
+            other: {
+              isPresent: true,
+              cost: '12'
+            }
+          }
+        }
+      };
+      expect(prepareBusinessCaseForApp(testDataFromApi).asIsSolution).toEqual(
+        asisSolution
+      );
+    });
+  });
+});

--- a/src/data/businessCase.ts
+++ b/src/data/businessCase.ts
@@ -309,22 +309,25 @@ export const prepareBusinessCaseForApi = (
     .map(({ solutionLifecycleCostLines, solutionApiName }) => {
       return yearMap(solutionLifecycleCostLines)
         .map(({ phases, year }) => {
+          const { development, operationsMaintenance, other } = phases;
           const developmentCost = {
             solution: solutionApiName,
             phase: 'Development',
-            cost: parseFloat(phases.development.cost),
+            cost: development.isPresent ? parseFloat(development.cost) : '',
             year
           };
           const omCost = {
             solution: solutionApiName,
             phase: 'Operations and Maintenance',
-            cost: parseFloat(phases.operationsMaintenance.cost),
+            cost: operationsMaintenance.isPresent
+              ? parseFloat(phases.operationsMaintenance.cost)
+              : '',
             year
           };
           const otherCost = {
             solution: solutionApiName,
             phase: 'Other',
-            cost: parseFloat(phases.other.cost),
+            cost: other.isPresent ? parseFloat(phases.other.cost) : '',
             year
           };
           return [developmentCost, omCost, otherCost];

--- a/src/data/businessCase.ts
+++ b/src/data/businessCase.ts
@@ -313,7 +313,7 @@ export const prepareBusinessCaseForApi = (
           const developmentCost = {
             solution: solutionApiName,
             phase: 'Development',
-            cost: development.isPresent ? parseFloat(development.cost) : '',
+            cost: development.isPresent ? parseFloat(development.cost) : null,
             year
           };
           const omCost = {
@@ -321,13 +321,13 @@ export const prepareBusinessCaseForApi = (
             phase: 'Operations and Maintenance',
             cost: operationsMaintenance.isPresent
               ? parseFloat(phases.operationsMaintenance.cost)
-              : '',
+              : null,
             year
           };
           const otherCost = {
             solution: solutionApiName,
             phase: 'Other',
-            cost: other.isPresent ? parseFloat(phases.other.cost) : '',
+            cost: other.isPresent ? parseFloat(phases.other.cost) : null,
             year
           };
           return [developmentCost, omCost, otherCost];

--- a/src/data/businessCase.ts
+++ b/src/data/businessCase.ts
@@ -1,3 +1,5 @@
+import cloneDeep from 'lodash/cloneDeep';
+
 import {
   BusinessCaseModel,
   EstimatedLifecycleCostLines,
@@ -21,11 +23,11 @@ const emptyPhaseValues = {
 };
 
 export const defaultEstimatedLifecycle = {
-  year1: { ...emptyPhaseValues },
-  year2: { ...emptyPhaseValues },
-  year3: { ...emptyPhaseValues },
-  year4: { ...emptyPhaseValues },
-  year5: { ...emptyPhaseValues }
+  year1: cloneDeep(emptyPhaseValues),
+  year2: cloneDeep(emptyPhaseValues),
+  year3: cloneDeep(emptyPhaseValues),
+  year4: cloneDeep(emptyPhaseValues),
+  year5: cloneDeep(emptyPhaseValues)
 };
 
 export const defaultProposedSolution = {
@@ -34,7 +36,7 @@ export const defaultProposedSolution = {
   acquisitionApproach: '',
   pros: '',
   cons: '',
-  estimatedLifecycleCost: defaultEstimatedLifecycle,
+  estimatedLifecycleCost: cloneDeep(defaultEstimatedLifecycle),
   costSavings: '',
   security: {
     isApproved: null,
@@ -69,12 +71,12 @@ export const businessCaseInitialData: BusinessCaseModel = {
     summary: '',
     pros: '',
     cons: '',
-    estimatedLifecycleCost: defaultEstimatedLifecycle,
+    estimatedLifecycleCost: cloneDeep(defaultEstimatedLifecycle),
     costSavings: ''
   },
-  preferredSolution: defaultProposedSolution,
-  alternativeA: defaultProposedSolution,
-  alternativeB: defaultProposedSolution
+  preferredSolution: cloneDeep(defaultProposedSolution),
+  alternativeA: cloneDeep(defaultProposedSolution),
+  alternativeB: cloneDeep(defaultProposedSolution)
 };
 
 type lifecycleCostLinesType = {
@@ -141,10 +143,10 @@ export const prepareBusinessCaseForApp = (
   };
 
   const lifecycleCostLines: lifecycleCostLinesType = {
-    'As Is': { ...defaultEstimatedLifecycle },
-    Preferred: { ...defaultEstimatedLifecycle },
-    A: { ...defaultEstimatedLifecycle },
-    B: { ...defaultEstimatedLifecycle }
+    'As Is': cloneDeep(defaultEstimatedLifecycle),
+    Preferred: cloneDeep(defaultEstimatedLifecycle),
+    A: cloneDeep(defaultEstimatedLifecycle),
+    B: cloneDeep(defaultEstimatedLifecycle)
   };
 
   let doesAltBHaveLifecycleCostLines = false;
@@ -161,12 +163,12 @@ export const prepareBusinessCaseForApp = (
       `year${line.year}` as keyof EstimatedLifecycleCostLines
     ][phaseType] = {
       isPresent: !!line.cost,
-      cost: (line.cost && line.cost.toString()) || ''
+      cost: line.cost ? line.cost.toString() : ''
     };
   });
 
   if (!doesAltBHaveLifecycleCostLines) {
-    lifecycleCostLines.B = defaultEstimatedLifecycle;
+    lifecycleCostLines.B = cloneDeep(defaultEstimatedLifecycle);
   }
 
   return {

--- a/src/types/businessCase.ts
+++ b/src/types/businessCase.ts
@@ -1,14 +1,14 @@
 import { DateTime } from 'luxon';
 
-import { LifecyclePhase } from 'types/estimatedLifecycle';
+import { LifecycleCosts } from 'types/estimatedLifecycle';
 import { SystemIntakeStatus } from 'types/systemIntake';
 
 export type EstimatedLifecycleCostLines = {
-  year1: LifecyclePhase[];
-  year2: LifecyclePhase[];
-  year3: LifecyclePhase[];
-  year4: LifecyclePhase[];
-  year5: LifecyclePhase[];
+  year1: LifecycleCosts;
+  year2: LifecycleCosts;
+  year3: LifecycleCosts;
+  year4: LifecycleCosts;
+  year5: LifecycleCosts;
 };
 
 // Base Solution
@@ -54,7 +54,6 @@ export type RequestDescriptionForm = {
   cmsBenefit: string;
   priorityAlignment: string;
   successIndicators: string;
-  systemIntakeStatus: SystemIntakeStatus;
 };
 
 export type AsIsSolutionForm = {

--- a/src/types/estimatedLifecycle.ts
+++ b/src/types/estimatedLifecycle.ts
@@ -1,4 +1,14 @@
-export type LifecyclePhase = {
-  phase: string;
-  cost: string;
+export type LifecycleCosts = {
+  development: {
+    isPresent: boolean;
+    cost: string;
+  };
+  operationsMaintenance: {
+    isPresent: boolean;
+    cost: string;
+  };
+  other: {
+    isPresent: boolean;
+    cost: string;
+  };
 };

--- a/src/validations/businessCaseSchema.ts
+++ b/src/validations/businessCaseSchema.ts
@@ -2,6 +2,167 @@ import * as Yup from 'yup';
 
 //
 const phoneNumberRegex = /( *-*[0-9] *?){10,}/;
+
+const estimatedLifecycleCostSchema = Yup.object().shape({
+  year1: Yup.object()
+    .test(
+      'requiredPhase',
+      'Select at least one of: Phase, Operations and Maintenance, or Other',
+      (value: any) => {
+        if (
+          value.development.isPresent ||
+          value.operationsMaintenance.isPresent ||
+          value.other.isPresent
+        ) {
+          return true;
+        }
+        return false;
+      }
+    )
+    .shape({
+      development: Yup.object().shape({
+        cost: Yup.string().when('isPresent', {
+          is: true,
+          then: Yup.string().required('Enter the development cost for Year 1')
+        })
+      }),
+      operationsMaintenance: Yup.object().shape({
+        cost: Yup.string().when('isPresent', {
+          is: true,
+          then: Yup.string().required(
+            'Enter the operations and maintenance cost for Year 1'
+          )
+        })
+      }),
+      other: Yup.object().shape({
+        cost: Yup.string().when('isPresent', {
+          is: true,
+          then: Yup.string().required('Enter the other cost for Year 1')
+        })
+      })
+    }),
+  year2: Yup.object()
+    .test(
+      'requiredPhase',
+      'Select at least one of: Phase, Operations and Maintenance, or Other',
+      (value: any) => {
+        if (
+          value.development.isPresent ||
+          value.operationsMaintenance.isPresent ||
+          value.other.isPresent
+        ) {
+          return true;
+        }
+        return false;
+      }
+    )
+    .shape({
+      development: Yup.object().shape({
+        cost: Yup.string().when('isPresent', {
+          is: true,
+          then: Yup.string().required('Enter the development cost for Year 2')
+        })
+      }),
+      operationsMaintenance: Yup.object().shape({
+        cost: Yup.string().when('isPresent', {
+          is: true,
+          then: Yup.string().required(
+            'Enter the operations and maintenance cost for Year 2'
+          )
+        })
+      }),
+      other: Yup.object().shape({
+        cost: Yup.string().when('isPresent', {
+          is: true,
+          then: Yup.string().required('Enter the other cost for Year 2')
+        })
+      })
+    }),
+  year3: Yup.object()
+    .test(
+      'requiredPhase',
+      'Select at least one of: Phase, Operations and Maintenance, or Other',
+      (value: any) => {
+        if (
+          value.development.isPresent ||
+          value.operationsMaintenance.isPresent ||
+          value.other.isPresent
+        ) {
+          return true;
+        }
+        return false;
+      }
+    )
+    .shape({
+      development: Yup.object().shape({
+        cost: Yup.string().when('isPresent', {
+          is: true,
+          then: Yup.string().required('Enter the development cost for Year 3')
+        })
+      }),
+      operationsMaintenance: Yup.object().shape({
+        cost: Yup.string().when('isPresent', {
+          is: true,
+          then: Yup.string().required(
+            'Enter the operations and maintenance cost for Year 3'
+          )
+        })
+      }),
+      other: Yup.object().shape({
+        cost: Yup.string().when('isPresent', {
+          is: true,
+          then: Yup.string().required('Enter the other cost for Year 3')
+        })
+      })
+    }),
+  // Year 4 is not required
+  year4: Yup.object().shape({
+    development: Yup.object().shape({
+      cost: Yup.string().when('isPresent', {
+        is: true,
+        then: Yup.string().required('Enter the development cost for Year 4')
+      })
+    }),
+    operationsMaintenance: Yup.object().shape({
+      cost: Yup.string().when('isPresent', {
+        is: true,
+        then: Yup.string().required(
+          'Enter the operations and maintenance cost for Year 4'
+        )
+      })
+    }),
+    other: Yup.object().shape({
+      cost: Yup.string().when('isPresent', {
+        is: true,
+        then: Yup.string().required('Enter the other cost for Year 4')
+      })
+    })
+  }),
+  // Year 5 is not required
+  year5: Yup.object().shape({
+    development: Yup.object().shape({
+      cost: Yup.string().when('isPresent', {
+        is: true,
+        then: Yup.string().required('Enter the development cost for Year 5')
+      })
+    }),
+    operationsMaintenance: Yup.object().shape({
+      cost: Yup.string().when('isPresent', {
+        is: true,
+        then: Yup.string().required(
+          'Enter the operations and maintenance cost for Year 5'
+        )
+      })
+    }),
+    other: Yup.object().shape({
+      cost: Yup.string().when('isPresent', {
+        is: true,
+        then: Yup.string().required('Enter the other cost for Year 5')
+      })
+    })
+  })
+});
+
 export const BusinessCaseFinalValidationSchema = {
   generalRequestInfo: Yup.object().shape({
     requestName: Yup.string().trim().required('Enter the Project Name'),
@@ -53,38 +214,7 @@ export const BusinessCaseFinalValidationSchema = {
       cons: Yup.string()
         .trim()
         .required('Tell us about the cons of "As is" solution'),
-      estimatedLifecycleCost: Yup.object().shape({
-        year1: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 1'),
-            cost: Yup.string().trim().required('Enter the cost for Year 1')
-          })
-        ),
-        year2: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 2'),
-            cost: Yup.string().trim().required('Enter the cost for Year 2')
-          })
-        ),
-        year3: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 3'),
-            cost: Yup.string().trim().required('Enter the cost for Year 3')
-          })
-        ),
-        year4: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 4'),
-            cost: Yup.string().trim().required('Enter the cost for Year 4')
-          })
-        ),
-        year5: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 5'),
-            cost: Yup.string().trim().required('Enter the cost for Year 5')
-          })
-        )
-      }),
+      estimatedLifecycleCost: estimatedLifecycleCostSchema,
       costSavings: Yup.string()
         .trim()
         .required(
@@ -153,38 +283,7 @@ export const BusinessCaseFinalValidationSchema = {
       cons: Yup.string()
         .trim()
         .required('Tell us about the cons of Preferred solution'),
-      estimatedLifecycleCost: Yup.object().shape({
-        year1: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 1'),
-            cost: Yup.string().trim().required('Enter the cost for Year 1')
-          })
-        ),
-        year2: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 2'),
-            cost: Yup.string().trim().required('Enter the cost for Year 2')
-          })
-        ),
-        year3: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 3'),
-            cost: Yup.string().trim().required('Enter the cost for Year 3')
-          })
-        ),
-        year4: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 4'),
-            cost: Yup.string().trim().required('Enter the cost for Year 4')
-          })
-        ),
-        year5: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 5'),
-            cost: Yup.string().trim().required('Enter the cost for Year 5')
-          })
-        )
-      }),
+      estimatedLifecycleCost: estimatedLifecycleCostSchema,
       costSavings: Yup.string()
         .trim()
         .required(
@@ -253,38 +352,7 @@ export const BusinessCaseFinalValidationSchema = {
       cons: Yup.string()
         .trim()
         .required('Tell us about the cons of Alternative A solution'),
-      estimatedLifecycleCost: Yup.object().shape({
-        year1: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 1'),
-            cost: Yup.string().trim().required('Enter the cost for Year 1')
-          })
-        ),
-        year2: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 2'),
-            cost: Yup.string().trim().required('Enter the cost for Year 2')
-          })
-        ),
-        year3: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 3'),
-            cost: Yup.string().trim().required('Enter the cost for Year 3')
-          })
-        ),
-        year4: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 4'),
-            cost: Yup.string().trim().required('Enter the cost for Year 4')
-          })
-        ),
-        year5: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 5'),
-            cost: Yup.string().trim().required('Enter the cost for Year 5')
-          })
-        )
-      }),
+      estimatedLifecycleCost: estimatedLifecycleCostSchema,
       costSavings: Yup.string()
         .trim()
         .required(
@@ -353,38 +421,7 @@ export const BusinessCaseFinalValidationSchema = {
       cons: Yup.string()
         .trim()
         .required('Tell us about the cons of Alternative B solution'),
-      estimatedLifecycleCost: Yup.object().shape({
-        year1: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 1'),
-            cost: Yup.string().trim().required('Enter the cost for Year 1')
-          })
-        ),
-        year2: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 2'),
-            cost: Yup.string().trim().required('Enter the cost for Year 2')
-          })
-        ),
-        year3: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 3'),
-            cost: Yup.string().trim().required('Enter the cost for Year 3')
-          })
-        ),
-        year4: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 4'),
-            cost: Yup.string().trim().required('Enter the cost for Year 4')
-          })
-        ),
-        year5: Yup.array().of(
-          Yup.object().shape({
-            phase: Yup.string().required('Select the type of phase for Year 5'),
-            cost: Yup.string().trim().required('Enter the cost for Year 5')
-          })
-        )
-      }),
+      estimatedLifecycleCost: estimatedLifecycleCostSchema,
       costSavings: Yup.string()
         .trim()
         .required(

--- a/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionFields.tsx
+++ b/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionFields.tsx
@@ -448,6 +448,7 @@ const AlternativeSolutionFields = ({
             // @ts-ignore
             errors[`${altId}`].estimatedLifecycleCost
           }
+          setFieldValue={setFieldValue}
         />
       </div>
       <div className="margin-top-2 margin-bottom-7">

--- a/src/views/BusinessCase/AsIsSolution/index.tsx
+++ b/src/views/BusinessCase/AsIsSolution/index.tsx
@@ -55,7 +55,13 @@ const AsIsSolution = ({
       innerRef={formikRef}
     >
       {(formikProps: FormikProps<AsIsSolutionForm>) => {
-        const { values, errors, setErrors, validateForm } = formikProps;
+        const {
+          values,
+          errors,
+          setErrors,
+          setFieldValue,
+          validateForm
+        } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <div className="grid-container">
@@ -246,6 +252,7 @@ const AsIsSolution = ({
                 </HelpText>
                 <EstimatedLifecycleCost
                   formikKey="asIsSolution.estimatedLifecycleCost"
+                  setFieldValue={setFieldValue}
                   years={values.asIsSolution.estimatedLifecycleCost}
                   errors={
                     errors.asIsSolution &&

--- a/src/views/BusinessCase/PreferredSolution/index.tsx
+++ b/src/views/BusinessCase/PreferredSolution/index.tsx
@@ -616,6 +616,7 @@ const PreferredSolution = ({
                     errors.preferredSolution &&
                     errors.preferredSolution.estimatedLifecycleCost
                   }
+                  setFieldValue={setFieldValue}
                 />
               </div>
               <div className="tablet:grid-col-9 margin-bottom-7">

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/index.test.tsx
@@ -34,11 +34,76 @@ describe('The GRT business case review', () => {
       pros: 'Mock As is solution  pros',
       cons: 'Mock As is solution cons',
       estimatedLifecycleCost: {
-        year1: [{ phase: 'Development', cost: '1' }],
-        year2: [{ phase: 'Development', cost: '2' }],
-        year3: [{ phase: 'Development', cost: '3' }],
-        year4: [{ phase: 'Development', cost: '4' }],
-        year5: [{ phase: 'Development', cost: '5' }]
+        year1: {
+          development: {
+            isPresent: true,
+            cost: '1'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year2: {
+          development: {
+            isPresent: true,
+            cost: '2'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year3: {
+          development: {
+            isPresent: true,
+            cost: '3'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year4: {
+          development: {
+            isPresent: true,
+            cost: '4'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        },
+        year5: {
+          development: {
+            isPresent: true,
+            cost: '5'
+          },
+          operationsMaintenance: {
+            isPresent: false,
+            cost: '0'
+          },
+          other: {
+            isPresent: false,
+            cost: '0'
+          }
+        }
       },
       costSavings: ''
     }


### PR DESCRIPTION
# EASI-1125

This PR updates the Business Case Estimated Lifecycle Costs to leverage checkboxes instead of radio buttons. It also eliminates the need to "Add Phase" or "Remove Phase". There are now a fixed number of lifecycle costs a user could add to a solution.

They can add 5 years of costs. Each year can have development, operations and maintenance, and other costs. So that's a total of 15 lines.

This is a **frontend only** change.

Since there are a fixed number of known options, I updated the frontend estimated lifecycle cost model to look like:
```
estimatedLifecycleCost: {
  year1: {
    development: {
      isPresent: false,
      cost: ''
    },
    operationsMaintenance: {
      isPresent: false,
      cost: ''
    },
    other: {
      isPresent: false,
      cost: ''
    }
  },
  year2: {
    development: {
      isPresent: false,
      cost: ''
    },
    operationsMaintenance: {
      isPresent:false,
      cost: ''
    },
    other: {
      isPresent: false,
      cost: ''
    }
  },
  year3: {
    development: {
      isPresent: false,
      cost: ''
    },
    operationsMaintenance: {
      isPresent: false,
      cost: ''
    },
    other: {
      isPresent: false,
      cost: ''
    }
  },
  year4: {
    development: {
      isPresent: false,
      cost: ''
    },
    operationsMaintenance: {
      isPresent: false,
      cost: ''
    },
    other: {
      isPresent: false,
      cost: ''
    }
  },
  year5: {
    development: {
      isPresent: false,
      cost: ''
    },
    operationsMaintenance: {
      isPresent: false,
      cost: ''
    },
    other: {
      isPresent: false,
      cost: ''
    }
  }
}
```

Notes for review
- A lot of the diff is dummy/setup data. We can probably store some in a variable and re-use
- Focus on the model of the data, data conversion, and the EstimatedLifecycleCosts component
- It's _probably_ safe to skip the tests. I just re-purposed them with the updated data model to pass

Make sure you can:
- [ ] see the proper fields and fill them out
- [ ] save the data
- [ ] reloaded and see data persists (in form fields and on the review page)