### PR TITLE
Redirect GRT admins to admin notes after issuing LCID

### DIFF
--- a/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
@@ -55,7 +55,7 @@ const IssueLifecycleId = () => {
     const payload = { id: systemId, lcidPayload };
     dispatch(issueLifecycleIdForSystemIntake(payload));
 
-    history.push(`/governance-review-team/${systemId}/intake-request`);
+    history.push(`/governance-review-team/${systemId}/notes`);
   };
 
   return (


### PR DESCRIPTION
# EASI-1111

Changes proposed in this pull request:

- Changed redirect after issuing LCID from intake overview to admin notes
