### PR TITLE
Update CircleCI image to Node 12.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
             - yarn-deps-cache-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-node-modules-{{ checksum "yarn.lock" }}
+            - v2-node-modules-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
             - v2-go-mod-sources-{{ checksum "go.sum" }}
@@ -214,7 +214,7 @@ jobs:
           paths:
             - ~/.cache/yarn
       - save_cache:
-          key: v1-node-modules-{{ checksum "yarn.lock" }}
+          key: v2-node-modules-{{ checksum "yarn.lock" }}
           paths:
             - ~/project/node_modules
       - save_cache:
@@ -240,7 +240,7 @@ jobs:
             - yarn-deps-cache-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-node-modules-{{ checksum "yarn.lock" }}
+            - v2-node-modules-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
             - v2-go-mod-sources-{{ checksum "go.sum" }}
@@ -256,7 +256,7 @@ jobs:
           paths:
             - ~/.cache/yarn
       - save_cache:
-          key: v1-node-modules-{{ checksum "yarn.lock" }}
+          key: v2-node-modules-{{ checksum "yarn.lock" }}
           paths:
             - ~/project/node_modules
       - save_cache:
@@ -290,7 +290,7 @@ jobs:
             - yarn-deps-cache-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-node-modules-{{ checksum "yarn.lock" }}
+            - v2-node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: Run Frontend Tests
           command: yarn run test
@@ -310,7 +310,7 @@ jobs:
           paths:
             - ~/.cache/yarn
       - save_cache:
-          key: v1-node-modules-{{ checksum "yarn.lock" }}
+          key: v2-node-modules-{{ checksum "yarn.lock" }}
           paths:
             - ~/project/node_modules
       - run:
@@ -380,7 +380,7 @@ jobs:
             - yarn-deps-cache-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-node-modules-{{ checksum "yarn.lock" }}
+            - v2-node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: Setup custom environment variables
           command: |
@@ -413,7 +413,7 @@ jobs:
           paths:
             - ~/.cache/yarn
       - save_cache:
-          key: v1-node-modules-{{ checksum "yarn.lock" }}
+          key: v2-node-modules-{{ checksum "yarn.lock" }}
           paths:
             - ~/project/node_modules
       - run:
@@ -435,7 +435,7 @@ jobs:
             - yarn-deps-cache-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-node-modules-{{ checksum "yarn.lock" }}
+            - v2-node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: Setup custom environment variables
           command: |
@@ -468,7 +468,7 @@ jobs:
           paths:
             - ~/.cache/yarn
       - save_cache:
-          key: v1-node-modules-{{ checksum "yarn.lock" }}
+          key: v2-node-modules-{{ checksum "yarn.lock" }}
           paths:
             - ~/project/node_modules
       - run:
@@ -490,7 +490,7 @@ jobs:
             - yarn-deps-cache-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-node-modules-{{ checksum "yarn.lock" }}
+            - v2-node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: Setup custom environment variables
           command: |
@@ -523,7 +523,7 @@ jobs:
           paths:
             - ~/.cache/yarn
       - save_cache:
-          key: v1-node-modules-{{ checksum "yarn.lock" }}
+          key: v2-node-modules-{{ checksum "yarn.lock" }}
           paths:
             - ~/project/node_modules
       - run:
@@ -545,7 +545,7 @@ jobs:
             - yarn-deps-cache-{{ checksum "yarn.lock" }}
       - restore_cache:
           keys:
-            - v1-node-modules-{{ checksum "yarn.lock" }}
+            - v2-node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: Setup custom environment variables
           command: |
@@ -566,7 +566,7 @@ jobs:
           paths:
             - ~/.cache/yarn
       - save_cache:
-          key: v1-node-modules-{{ checksum "yarn.lock" }}
+          key: v2-node-modules-{{ checksum "yarn.lock" }}
           paths:
             - ~/project/node_modules
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2
 
 references:
-  circleci_docker_primary: &circleci_docker_primary ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-circleci:easi-app-5a67b21fb6f82e0a27f2d905f9242f4d3f8d23c8
+  circleci_docker_primary: &circleci_docker_primary ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-circleci:easi-app-41d6969ae6511fc7076af6646be6f44b4a9c599b
   postgres: &postgres postgres:11.6
   db_migrate: &db_migrate ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/easi-db-migrate:${CIRCLE_SHA1}
 jobs:

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,4 +1,4 @@
-FROM node:10.23.3 AS base
+FROM node:12.21.0 AS base
 
 WORKDIR /app
 
@@ -31,7 +31,7 @@ ARG REACT_APP_OKTA_SERVER_ID
 
 RUN yarn run build
 
-FROM node:10.23.3 as srv
+FROM node:12.21.0 as srv
 
 RUN yarn global add serve
 WORKDIR /app

--- a/Dockerfile.client_circleci
+++ b/Dockerfile.client_circleci
@@ -1,4 +1,4 @@
-FROM node:10.23.3
+FROM node:12.21.0
 
 WORKDIR /app
 RUN yarn global add serve

--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM cypress/base:10
+FROM cypress/base:12.19.0
 
 COPY package.json /
 RUN npm install --dev --silent


### PR DESCRIPTION
# ES-471

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Update the easi-app CircleCI image to use Node 12.x
- Update the client Dockerfiles to use the same version of Node as the CircleCI image
