### PR TITLE
Rename hasAlternativeB to hasAlternativeSolution

### DIFF
--- a/src/components/BusinessCaseReview/AlternativeAnalysisReview/index.tsx
+++ b/src/components/BusinessCaseReview/AlternativeAnalysisReview/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import PrintableTabContent from 'components/PrintableTabContent';
 import ResponsiveTabs from 'components/shared/ResponsiveTabs';
-import { hasAlternativeSolution } from 'data/businessCase';
+import { alternativeSolutionHasFilledFields } from 'data/businessCase';
 import {
   BusinessCaseSolution,
   ProposedBusinessCaseSolution
@@ -35,7 +35,7 @@ const AlternativeAnalysisReview = (values: AlternativeAnalysisReviewProps) => {
       'Preferred solution',
       'Alternative A'
     ];
-    if (alternativeB && hasAlternativeSolution(alternativeB)) {
+    if (alternativeB && alternativeSolutionHasFilledFields(alternativeB)) {
       solutions.push('Alternative B');
     }
     return solutions;
@@ -73,7 +73,7 @@ const AlternativeAnalysisReview = (values: AlternativeAnalysisReviewProps) => {
         </PrintableTabContent>
 
         <PrintableTabContent visible={activeSolutionTab === 'Alternative B'}>
-          {alternativeB && hasAlternativeSolution(alternativeB) && (
+          {alternativeB && alternativeSolutionHasFilledFields(alternativeB) && (
             <ProposedBusinessCaseSolutionReview
               name="Alternative B"
               solution={alternativeB}

--- a/src/components/BusinessCaseReview/AlternativeAnalysisReview/index.tsx
+++ b/src/components/BusinessCaseReview/AlternativeAnalysisReview/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import PrintableTabContent from 'components/PrintableTabContent';
 import ResponsiveTabs from 'components/shared/ResponsiveTabs';
-import { hasAlternativeB } from 'data/businessCase';
+import { alternativeSolution } from 'data/businessCase';
 import {
   BusinessCaseSolution,
   ProposedBusinessCaseSolution
@@ -35,7 +35,7 @@ const AlternativeAnalysisReview = (values: AlternativeAnalysisReviewProps) => {
       'Preferred solution',
       'Alternative A'
     ];
-    if (alternativeB && hasAlternativeB(alternativeB)) {
+    if (alternativeB && alternativeSolution(alternativeB)) {
       solutions.push('Alternative B');
     }
     return solutions;
@@ -73,7 +73,7 @@ const AlternativeAnalysisReview = (values: AlternativeAnalysisReviewProps) => {
         </PrintableTabContent>
 
         <PrintableTabContent visible={activeSolutionTab === 'Alternative B'}>
-          {alternativeB && hasAlternativeB(alternativeB) && (
+          {alternativeB && alternativeSolution(alternativeB) && (
             <ProposedBusinessCaseSolutionReview
               name="Alternative B"
               solution={alternativeB}

--- a/src/components/BusinessCaseReview/AlternativeAnalysisReview/index.tsx
+++ b/src/components/BusinessCaseReview/AlternativeAnalysisReview/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import PrintableTabContent from 'components/PrintableTabContent';
 import ResponsiveTabs from 'components/shared/ResponsiveTabs';
-import { alternativeSolution } from 'data/businessCase';
+import { hasAlternativeSolution } from 'data/businessCase';
 import {
   BusinessCaseSolution,
   ProposedBusinessCaseSolution
@@ -35,7 +35,7 @@ const AlternativeAnalysisReview = (values: AlternativeAnalysisReviewProps) => {
       'Preferred solution',
       'Alternative A'
     ];
-    if (alternativeB && alternativeSolution(alternativeB)) {
+    if (alternativeB && hasAlternativeSolution(alternativeB)) {
       solutions.push('Alternative B');
     }
     return solutions;
@@ -73,7 +73,7 @@ const AlternativeAnalysisReview = (values: AlternativeAnalysisReviewProps) => {
         </PrintableTabContent>
 
         <PrintableTabContent visible={activeSolutionTab === 'Alternative B'}>
-          {alternativeB && alternativeSolution(alternativeB) && (
+          {alternativeB && hasAlternativeSolution(alternativeB) && (
             <ProposedBusinessCaseSolutionReview
               name="Alternative B"
               solution={alternativeB}

--- a/src/data/businessCase.ts
+++ b/src/data/businessCase.ts
@@ -90,7 +90,7 @@ type lifecycleCostLinesType = {
  * This function tells us whether the parameter alternativeSolution has been started
  * @param alternativeSolution - an alternative solution case (e.g. A, B)
  */
-export const hasAlternativeSolution = (
+export const alternativeSolutionHasFilledFields = (
   alternativeSolution: ProposedBusinessCaseSolution
 ) => {
   if (!alternativeSolution) {
@@ -267,7 +267,9 @@ export const prepareBusinessCaseForApp = (
 export const prepareBusinessCaseForApi = (
   businessCase: BusinessCaseModel
 ): any => {
-  const alternativeBExists = hasAlternativeSolution(businessCase.alternativeB);
+  const alternativeBExists = alternativeSolutionHasFilledFields(
+    businessCase.alternativeB
+  );
   const solutionNameMap: {
     solutionLifecycleCostLines: EstimatedLifecycleCostLines;
     solutionApiName: string;

--- a/src/data/businessCase.ts
+++ b/src/data/businessCase.ts
@@ -78,9 +78,14 @@ type lifecycleCostLinesType = {
   B: EstimatedLifecycleCostLines;
 };
 
-// Function that lets us know if a user has filled out an alternative B
-export const hasAlternativeB = (alternativeB: ProposedBusinessCaseSolution) => {
-  if (!alternativeB) {
+/**
+ * This function tells us whether the parameter alternativeSolution has been started
+ * @param alternativeSolution - an alternative solution case (e.g. A, B)
+ */
+export const hasAlternativeSolution = (
+  alternativeSolution: ProposedBusinessCaseSolution
+) => {
+  if (!alternativeSolution) {
     return false;
   }
 
@@ -95,7 +100,7 @@ export const hasAlternativeB = (alternativeB: ProposedBusinessCaseSolution) => {
     cons,
     costSavings,
     estimatedLifecycleCost
-  } = alternativeB;
+  } = alternativeSolution;
 
   let hasLineItem;
   Object.values(estimatedLifecycleCost).forEach(phaseCost => {
@@ -254,7 +259,7 @@ export const prepareBusinessCaseForApp = (
 export const prepareBusinessCaseForApi = (
   businessCase: BusinessCaseModel
 ): any => {
-  const alternativeBExists = hasAlternativeB(businessCase.alternativeB);
+  const alternativeBExists = hasAlternativeSolution(businessCase.alternativeB);
   const solutionNameMap: {
     solutionLifecycleCostLines: EstimatedLifecycleCostLines;
     solutionApiName: string;

--- a/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionA.tsx
+++ b/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionA.tsx
@@ -9,7 +9,7 @@ import PageNumber from 'components/PageNumber';
 import AutoSave from 'components/shared/AutoSave';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import HelpText from 'components/shared/HelpText';
-import { hasAlternativeB } from 'data/businessCase';
+import { hasAlternativeSolution } from 'data/businessCase';
 import { BusinessCaseModel } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
 import { isBusinessCaseFinal } from 'utils/systemIntake';
@@ -107,7 +107,7 @@ const AlternativeSolutionA = ({
                   formikProps={formikProps}
                 />
 
-                {!hasAlternativeB(businessCase.alternativeB) && (
+                {!hasAlternativeSolution(businessCase.alternativeB) && (
                   <div className="margin-bottom-7">
                     <h2 className="margin-bottom-1">Additional alternatives</h2>
                     <HelpText>
@@ -153,7 +153,9 @@ const AlternativeSolutionA = ({
                 validateForm().then(err => {
                   if (Object.keys(err).length === 0) {
                     dispatchSave();
-                    const newUrl = hasAlternativeB(businessCase.alternativeB)
+                    const newUrl = hasAlternativeSolution(
+                      businessCase.alternativeB
+                    )
                       ? 'alternative-solution-b'
                       : 'review';
                     history.push(newUrl);
@@ -182,7 +184,9 @@ const AlternativeSolutionA = ({
             </div>
             <PageNumber
               currentPage={5}
-              totalPages={hasAlternativeB(businessCase.alternativeB) ? 6 : 5}
+              totalPages={
+                hasAlternativeSolution(businessCase.alternativeB) ? 6 : 5
+              }
             />
             <AutoSave
               values={values}

--- a/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionA.tsx
+++ b/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionA.tsx
@@ -9,7 +9,7 @@ import PageNumber from 'components/PageNumber';
 import AutoSave from 'components/shared/AutoSave';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import HelpText from 'components/shared/HelpText';
-import { hasAlternativeSolution } from 'data/businessCase';
+import { alternativeSolutionHasFilledFields } from 'data/businessCase';
 import { BusinessCaseModel } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
 import { isBusinessCaseFinal } from 'utils/systemIntake';
@@ -107,7 +107,9 @@ const AlternativeSolutionA = ({
                   formikProps={formikProps}
                 />
 
-                {!hasAlternativeSolution(businessCase.alternativeB) && (
+                {!alternativeSolutionHasFilledFields(
+                  businessCase.alternativeB
+                ) && (
                   <div className="margin-bottom-7">
                     <h2 className="margin-bottom-1">Additional alternatives</h2>
                     <HelpText>
@@ -153,7 +155,7 @@ const AlternativeSolutionA = ({
                 validateForm().then(err => {
                   if (Object.keys(err).length === 0) {
                     dispatchSave();
-                    const newUrl = hasAlternativeSolution(
+                    const newUrl = alternativeSolutionHasFilledFields(
                       businessCase.alternativeB
                     )
                       ? 'alternative-solution-b'
@@ -185,7 +187,9 @@ const AlternativeSolutionA = ({
             <PageNumber
               currentPage={5}
               totalPages={
-                hasAlternativeSolution(businessCase.alternativeB) ? 6 : 5
+                alternativeSolutionHasFilledFields(businessCase.alternativeB)
+                  ? 6
+                  : 5
               }
             />
             <AutoSave

--- a/src/views/BusinessCase/AsIsSolution/index.tsx
+++ b/src/views/BusinessCase/AsIsSolution/index.tsx
@@ -16,7 +16,7 @@ import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import TextAreaField from 'components/shared/TextAreaField';
 import TextField from 'components/shared/TextField';
-import { hasAlternativeSolution } from 'data/businessCase';
+import { alternativeSolutionHasFilledFields } from 'data/businessCase';
 import { AsIsSolutionForm, BusinessCaseModel } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
 import { isBusinessCaseFinal } from 'utils/systemIntake';
@@ -345,7 +345,9 @@ const AsIsSolution = ({
             <PageNumber
               currentPage={3}
               totalPages={
-                hasAlternativeSolution(businessCase.alternativeB) ? 6 : 5
+                alternativeSolutionHasFilledFields(businessCase.alternativeB)
+                  ? 6
+                  : 5
               }
             />
             <AutoSave

--- a/src/views/BusinessCase/AsIsSolution/index.tsx
+++ b/src/views/BusinessCase/AsIsSolution/index.tsx
@@ -16,7 +16,7 @@ import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import TextAreaField from 'components/shared/TextAreaField';
 import TextField from 'components/shared/TextField';
-import { hasAlternativeB } from 'data/businessCase';
+import { hasAlternativeSolution } from 'data/businessCase';
 import { AsIsSolutionForm, BusinessCaseModel } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
 import { isBusinessCaseFinal } from 'utils/systemIntake';
@@ -337,7 +337,9 @@ const AsIsSolution = ({
             </div>
             <PageNumber
               currentPage={3}
-              totalPages={hasAlternativeB(businessCase.alternativeB) ? 6 : 5}
+              totalPages={
+                hasAlternativeSolution(businessCase.alternativeB) ? 6 : 5
+              }
             />
             <AutoSave
               values={values}

--- a/src/views/BusinessCase/GeneralRequestInfo/index.tsx
+++ b/src/views/BusinessCase/GeneralRequestInfo/index.tsx
@@ -12,7 +12,7 @@ import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import Label from 'components/shared/Label';
 import TextField from 'components/shared/TextField';
-import { hasAlternativeB } from 'data/businessCase';
+import { hasAlternativeSolution } from 'data/businessCase';
 import { BusinessCaseModel, GeneralRequestInfoForm } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
 import { isBusinessCaseFinal } from 'utils/systemIntake';
@@ -196,7 +196,9 @@ const GeneralRequestInfo = ({
             </div>
             <PageNumber
               currentPage={1}
-              totalPages={hasAlternativeB(businessCase.alternativeB) ? 6 : 5}
+              totalPages={
+                hasAlternativeSolution(businessCase.alternativeB) ? 6 : 5
+              }
             />
             <AutoSave
               values={values}

--- a/src/views/BusinessCase/GeneralRequestInfo/index.tsx
+++ b/src/views/BusinessCase/GeneralRequestInfo/index.tsx
@@ -12,7 +12,7 @@ import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import Label from 'components/shared/Label';
 import TextField from 'components/shared/TextField';
-import { hasAlternativeSolution } from 'data/businessCase';
+import { alternativeSolutionHasFilledFields } from 'data/businessCase';
 import { BusinessCaseModel, GeneralRequestInfoForm } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
 import { isBusinessCaseFinal } from 'utils/systemIntake';
@@ -197,7 +197,9 @@ const GeneralRequestInfo = ({
             <PageNumber
               currentPage={1}
               totalPages={
-                hasAlternativeSolution(businessCase.alternativeB) ? 6 : 5
+                alternativeSolutionHasFilledFields(businessCase.alternativeB)
+                  ? 6
+                  : 5
               }
             />
             <AutoSave

--- a/src/views/BusinessCase/PreferredSolution/index.tsx
+++ b/src/views/BusinessCase/PreferredSolution/index.tsx
@@ -17,7 +17,7 @@ import Label from 'components/shared/Label';
 import { RadioField } from 'components/shared/RadioField';
 import TextAreaField from 'components/shared/TextAreaField';
 import TextField from 'components/shared/TextField';
-import { hasAlternativeSolution } from 'data/businessCase';
+import { alternativeSolutionHasFilledFields } from 'data/businessCase';
 import { yesNoMap } from 'data/common';
 import { BusinessCaseModel, PreferredSolutionForm } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
@@ -705,7 +705,9 @@ const PreferredSolution = ({
             <PageNumber
               currentPage={4}
               totalPages={
-                hasAlternativeSolution(businessCase.alternativeB) ? 6 : 5
+                alternativeSolutionHasFilledFields(businessCase.alternativeB)
+                  ? 6
+                  : 5
               }
             />
             <AutoSave

--- a/src/views/BusinessCase/PreferredSolution/index.tsx
+++ b/src/views/BusinessCase/PreferredSolution/index.tsx
@@ -17,7 +17,7 @@ import Label from 'components/shared/Label';
 import { RadioField } from 'components/shared/RadioField';
 import TextAreaField from 'components/shared/TextAreaField';
 import TextField from 'components/shared/TextField';
-import { hasAlternativeB } from 'data/businessCase';
+import { hasAlternativeSolution } from 'data/businessCase';
 import { yesNoMap } from 'data/common';
 import { BusinessCaseModel, PreferredSolutionForm } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
@@ -703,7 +703,9 @@ const PreferredSolution = ({
             </div>
             <PageNumber
               currentPage={4}
-              totalPages={hasAlternativeB(businessCase.alternativeB) ? 6 : 5}
+              totalPages={
+                hasAlternativeSolution(businessCase.alternativeB) ? 6 : 5
+              }
             />
             <AutoSave
               values={values}

--- a/src/views/BusinessCase/RequestDescription/index.tsx
+++ b/src/views/BusinessCase/RequestDescription/index.tsx
@@ -14,7 +14,7 @@ import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import TextAreaField from 'components/shared/TextAreaField';
-import { hasAlternativeSolution } from 'data/businessCase';
+import { alternativeSolutionHasFilledFields } from 'data/businessCase';
 import { BusinessCaseModel, RequestDescriptionForm } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
 import { isBusinessCaseFinal } from 'utils/systemIntake';
@@ -276,7 +276,9 @@ const RequestDescription = ({
             <PageNumber
               currentPage={2}
               totalPages={
-                hasAlternativeSolution(businessCase.alternativeB) ? 6 : 5
+                alternativeSolutionHasFilledFields(businessCase.alternativeB)
+                  ? 6
+                  : 5
               }
             />
             <AutoSave

--- a/src/views/BusinessCase/RequestDescription/index.tsx
+++ b/src/views/BusinessCase/RequestDescription/index.tsx
@@ -14,7 +14,7 @@ import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import TextAreaField from 'components/shared/TextAreaField';
-import { hasAlternativeB } from 'data/businessCase';
+import { hasAlternativeSolution } from 'data/businessCase';
 import { BusinessCaseModel, RequestDescriptionForm } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
 import { isBusinessCaseFinal } from 'utils/systemIntake';
@@ -275,7 +275,9 @@ const RequestDescription = ({
             </div>
             <PageNumber
               currentPage={2}
-              totalPages={hasAlternativeB(businessCase.alternativeB) ? 6 : 5}
+              totalPages={
+                hasAlternativeSolution(businessCase.alternativeB) ? 6 : 5
+              }
             />
             <AutoSave
               values={values}

--- a/src/views/BusinessCase/Review/index.tsx
+++ b/src/views/BusinessCase/Review/index.tsx
@@ -5,7 +5,7 @@ import { Button } from '@trussworks/react-uswds';
 
 import BusinessCaseReview from 'components/BusinessCaseReview';
 import PageHeading from 'components/PageHeading';
-import { hasAlternativeB } from 'data/businessCase';
+import { hasAlternativeSolution } from 'data/businessCase';
 import { AppState } from 'reducers/rootReducer';
 import { BusinessCaseModel } from 'types/businessCase';
 import { postAction } from 'types/routines';
@@ -37,7 +37,7 @@ const Review = ({ businessCase }: ReviewProps) => {
           type="button"
           outline
           onClick={() => {
-            const newUrl = hasAlternativeB(businessCase.alternativeB)
+            const newUrl = hasAlternativeSolution(businessCase.alternativeB)
               ? 'alternative-solution-b'
               : 'alternative-solution-a';
             history.push(newUrl);

--- a/src/views/BusinessCase/Review/index.tsx
+++ b/src/views/BusinessCase/Review/index.tsx
@@ -5,7 +5,7 @@ import { Button } from '@trussworks/react-uswds';
 
 import BusinessCaseReview from 'components/BusinessCaseReview';
 import PageHeading from 'components/PageHeading';
-import { hasAlternativeSolution } from 'data/businessCase';
+import { alternativeSolutionHasFilledFields } from 'data/businessCase';
 import { AppState } from 'reducers/rootReducer';
 import { BusinessCaseModel } from 'types/businessCase';
 import { postAction } from 'types/routines';
@@ -37,7 +37,9 @@ const Review = ({ businessCase }: ReviewProps) => {
           type="button"
           outline
           onClick={() => {
-            const newUrl = hasAlternativeSolution(businessCase.alternativeB)
+            const newUrl = alternativeSolutionHasFilledFields(
+              businessCase.alternativeB
+            )
               ? 'alternative-solution-b'
               : 'alternative-solution-a';
             history.push(newUrl);


### PR DESCRIPTION
# EASI-1119

This PR renames the common `hasAlternativeB` solution to `hasAlternativeSolution`. `hasAlternativeSolution` takes a parameter of alternative solution and checks if it is filled out (or touched).

There is nothing functionally different; just renaming a function
