### PR TITLE
add function to return the fiscal year a DateTime belongs to

### DIFF
--- a/src/utils/formatDate.test.ts
+++ b/src/utils/formatDate.test.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon';
 
-import formatDate, { formatContractDate } from './formatDate';
+import formatDate, { formatContractDate, getFiscalYear } from './formatDate';
 
 describe('formatDate', () => {
   describe('string', () => {
@@ -51,5 +51,25 @@ describe('formatDate', () => {
 
       expect(formatDate(date)).toEqual('Invalid DateTime');
     });
+  });
+});
+
+describe('getFiscalYear', () => {
+  it('returns fiscal year for a random date in the middle of the year', () => {
+    const date = DateTime.fromObject({ year: 2021, month: 3, day: 1 });
+
+    expect(getFiscalYear(date)).toEqual('2021');
+  });
+
+  it('returns fiscal year for a date at the beginning of the fiscal year', () => {
+    const date = DateTime.fromObject({ year: 2024, month: 10, day: 1 });
+
+    expect(getFiscalYear(date)).toEqual('2025');
+  });
+
+  it('returns fiscal year for a date at the end of the fiscal year', () => {
+    const date = DateTime.fromObject({ year: 2029, month: 9, day: 30 });
+
+    expect(getFiscalYear(date)).toEqual('2029');
   });
 });

--- a/src/utils/formatDate.test.ts
+++ b/src/utils/formatDate.test.ts
@@ -58,18 +58,18 @@ describe('getFiscalYear', () => {
   it('returns fiscal year for a random date in the middle of the year', () => {
     const date = DateTime.fromObject({ year: 2021, month: 3, day: 1 });
 
-    expect(getFiscalYear(date)).toEqual('2021');
+    expect(getFiscalYear(date)).toEqual(2021);
   });
 
   it('returns fiscal year for a date at the beginning of the fiscal year', () => {
     const date = DateTime.fromObject({ year: 2024, month: 10, day: 1 });
 
-    expect(getFiscalYear(date)).toEqual('2025');
+    expect(getFiscalYear(date)).toEqual(2025);
   });
 
   it('returns fiscal year for a date at the end of the fiscal year', () => {
     const date = DateTime.fromObject({ year: 2029, month: 9, day: 30 });
 
-    expect(getFiscalYear(date)).toEqual('2029');
+    expect(getFiscalYear(date)).toEqual(2029);
   });
 });

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -31,12 +31,12 @@ export const formatContractDate = (date: ContractDate): string => {
  * FY 2022 : October 1 2021 - September 30 2022
  * @param date DateTime date object
  */
-export const getFiscalYear = (date: DateTime): string => {
+export const getFiscalYear = (date: DateTime): number => {
   const { month, year } = date;
   if (month >= 10) {
-    return String(year + 1);
+    return year + 1;
   }
-  return String(year);
+  return year;
 };
 
 export default formatDate;

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -25,4 +25,18 @@ export const formatContractDate = (date: ContractDate): string => {
   return parts.filter((value: string) => value.length > 0).join('/');
 };
 
+/**
+ * Returns the input parameter's fiscal year
+ * FY 2021 : October 1 2020 - September 30 2021
+ * FY 2022 : October 1 2021 - September 30 2022
+ * @param date DateTime date object
+ */
+export const getFiscalYear = (date: DateTime): string => {
+  const { month, year } = date;
+  if (month >= 10) {
+    return String(year + 1);
+  }
+  return String(year);
+};
+
 export default formatDate;


### PR DESCRIPTION
In the upcoming business case lifecycle cost revisions, we will need to display the **fiscal year** instead of year 1, 2, 3, etc.

In this PR, I created a function that returns the fiscal year for a `DateTime` 