### PR TITLE
fix race condition when trying to save a system intake

### DIFF
--- a/src/reducers/systemIntakeReducer.ts
+++ b/src/reducers/systemIntakeReducer.ts
@@ -84,16 +84,14 @@ function systemIntakeReducer(
     case saveSystemIntake.REQUEST:
       return {
         ...state,
+        systemIntake: {
+          ...state.systemIntake,
+          ...action.payload
+        },
         isSaving: true
       };
     case saveSystemIntake.SUCCESS:
-      return {
-        ...state,
-        systemIntake: {
-          ...state.systemIntake,
-          ...prepareSystemIntakeForApp(action.payload)
-        }
-      };
+      return state;
     case saveSystemIntake.FAILURE:
       return {
         ...state,

--- a/src/sagas/systemIntakeSaga.ts
+++ b/src/sagas/systemIntakeSaga.ts
@@ -47,7 +47,7 @@ function* createSystemIntake(action: Action<any>) {
 
 function* putSystemIntake(action: Action<any>) {
   try {
-    yield put(saveSystemIntake.request());
+    yield put(saveSystemIntake.request(action.payload));
     const response = yield call(putSystemIntakeRequest, action.payload);
     yield put(saveSystemIntake.success(response.data));
   } catch (error) {


### PR DESCRIPTION
# ES-1159

This PR fixes the race condition that was observed on the intake form. This was originally thought to have only affected the business case, but it turns out data is getting lost on the intake as well. It's a bit curious why it took so long for this issue to appear, considering the intake integration tests ensure all the data is present.