### PR TITLE
add scroll to top hook for all routes

### DIFF
--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -1,5 +1,11 @@
-import React from 'react';
-import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
+import React, { useLayoutEffect } from 'react';
+import {
+  BrowserRouter,
+  Redirect,
+  Route,
+  Switch,
+  useLocation
+} from 'react-router-dom';
 import { LoginCallback, SecureRoute } from '@okta/okta-react';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 
@@ -31,7 +37,13 @@ import UserInfoWrapper from 'views/UserInfoWrapper';
 import './index.scss';
 
 const AppRoutes = () => {
+  const location = useLocation();
   const flags = useFlags();
+
+  // Scroll to top
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
 
   return (
     <Switch>

--- a/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionA.tsx
+++ b/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionA.tsx
@@ -126,7 +126,6 @@ const AlternativeSolutionA = ({
                         onClick={() => {
                           dispatchSave();
                           history.push('alternative-solution-b');
-                          window.scrollTo(0, 0);
                         }}
                       >
                         + Alternative B
@@ -144,7 +143,6 @@ const AlternativeSolutionA = ({
                 setErrors({});
                 const newUrl = 'preferred-solution';
                 history.push(newUrl);
-                window.scrollTo(0, 0);
               }}
             >
               Back
@@ -161,9 +159,10 @@ const AlternativeSolutionA = ({
                       ? 'alternative-solution-b'
                       : 'review';
                     history.push(newUrl);
+                  } else {
+                    window.scrollTo(0, 0);
                   }
                 });
-                window.scrollTo(0, 0);
               }}
             >
               Next

--- a/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionB.tsx
+++ b/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionB.tsx
@@ -125,7 +125,6 @@ const AlternativeSolutionB = ({
                         history.replace(
                           `/business/${businessCase.id}/alternative-solution-a`
                         );
-                        window.scrollTo(0, 0);
                       }
                     }}
                   >
@@ -147,7 +146,6 @@ const AlternativeSolutionB = ({
                 setErrors({});
                 const newUrl = 'alternative-solution-a';
                 history.push(newUrl);
-                window.scrollTo(0, 0);
               }}
             >
               Back
@@ -160,9 +158,10 @@ const AlternativeSolutionB = ({
                     dispatchSave();
                     const newUrl = 'review';
                     history.push(newUrl);
+                  } else {
+                    window.scrollTo(0, 0);
                   }
                 });
-                window.scrollTo(0, 0);
               }}
             >
               Next

--- a/src/views/BusinessCase/AsIsSolution/index.tsx
+++ b/src/views/BusinessCase/AsIsSolution/index.tsx
@@ -306,7 +306,6 @@ const AsIsSolution = ({
                 setErrors({});
                 const newUrl = 'request-description';
                 history.push(newUrl);
-                window.scrollTo(0, 0);
               }}
             >
               Back
@@ -319,9 +318,10 @@ const AsIsSolution = ({
                     dispatchSave();
                     const newUrl = 'preferred-solution';
                     history.push(newUrl);
+                  } else {
+                    window.scrollTo(0, 0);
                   }
                 });
-                window.scrollTo(0, 0);
               }}
             >
               Next

--- a/src/views/BusinessCase/GeneralRequestInfo/index.tsx
+++ b/src/views/BusinessCase/GeneralRequestInfo/index.tsx
@@ -171,9 +171,10 @@ const GeneralRequestInfo = ({
                     dispatchSave();
                     const newUrl = 'request-description';
                     history.push(newUrl);
+                  } else {
+                    window.scrollTo(0, 0);
                   }
                 });
-                window.scrollTo(0, 0);
               }}
             >
               Next

--- a/src/views/BusinessCase/PreferredSolution/index.tsx
+++ b/src/views/BusinessCase/PreferredSolution/index.tsx
@@ -666,7 +666,6 @@ const PreferredSolution = ({
                 setErrors({});
                 const newUrl = 'as-is-solution';
                 history.push(newUrl);
-                window.scrollTo(0, 0);
               }}
             >
               Back
@@ -679,9 +678,10 @@ const PreferredSolution = ({
                     dispatchSave();
                     const newUrl = 'alternative-solution-a';
                     history.push(newUrl);
+                  } else {
+                    window.scrollTo(0, 0);
                   }
                 });
-                window.scrollTo(0, 0);
               }}
             >
               Next

--- a/src/views/BusinessCase/RequestDescription/index.tsx
+++ b/src/views/BusinessCase/RequestDescription/index.tsx
@@ -237,7 +237,6 @@ const RequestDescription = ({
                 setErrors({});
                 const newUrl = 'general-request-info';
                 history.push(newUrl);
-                window.scrollTo(0, 0);
               }}
             >
               Back
@@ -250,9 +249,10 @@ const RequestDescription = ({
                     dispatchSave();
                     const newUrl = 'as-is-solution';
                     history.push(newUrl);
+                  } else {
+                    window.scrollTo(0, 0);
                   }
                 });
-                window.scrollTo(0, 0);
               }}
             >
               Next

--- a/src/views/BusinessCase/Review/index.tsx
+++ b/src/views/BusinessCase/Review/index.tsx
@@ -43,7 +43,6 @@ const Review = ({ businessCase }: ReviewProps) => {
               ? 'alternative-solution-b'
               : 'alternative-solution-a';
             history.push(newUrl);
-            window.scrollTo(0, 0);
           }}
         >
           Back

--- a/src/views/SystemIntake/ContactDetails/index.tsx
+++ b/src/views/SystemIntake/ContactDetails/index.tsx
@@ -471,7 +471,6 @@ const ContactDetails = ({
                         const newUrl = 'request-details';
                         history.push(newUrl);
                       }
-                      window.scrollTo(0, 0);
                     });
                   }}
                 >

--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -806,7 +806,6 @@ const ContractDetails = ({
                     formikProps.setErrors({});
                     const newUrl = 'request-details';
                     history.push(newUrl);
-                    window.scrollTo(0, 0);
                   }}
                 >
                   Back
@@ -819,8 +818,9 @@ const ContractDetails = ({
                         dispatchSave();
                         const newUrl = 'review';
                         history.push(newUrl);
+                      } else {
+                        window.scrollTo(0, 0);
                       }
-                      window.scrollTo(0, 0);
                     });
                   }}
                 >

--- a/src/views/SystemIntake/RequestDetails/index.tsx
+++ b/src/views/SystemIntake/RequestDetails/index.tsx
@@ -286,7 +286,6 @@ const RequestDetails = ({
                     formikProps.setErrors({});
                     const newUrl = 'contact-details';
                     history.push(newUrl);
-                    window.scrollTo(0, 0);
                   }}
                 >
                   Back
@@ -299,8 +298,9 @@ const RequestDetails = ({
                         dispatchSave();
                         const newUrl = 'contract-details';
                         history.push(newUrl);
+                      } else {
+                        window.scrollTo(0, 0);
                       }
-                      window.scrollTo(0, 0);
                     });
                   }}
                 >

--- a/src/views/SystemIntake/Review/index.tsx
+++ b/src/views/SystemIntake/Review/index.tsx
@@ -53,7 +53,6 @@ const Review = ({ systemIntake, now }: ReviewProps) => {
         onClick={() => {
           const newUrl = 'contract-details';
           history.push(newUrl);
-          window.scrollTo(0, 0);
         }}
       >
         Back


### PR DESCRIPTION
# ES-1161

🎵 _nothing can stop me, i'm all the way up_ 🎵 

This PR adds a hook that will scroll to top on any page change in the application. I removed all unnecessary manual scroll to top (`window.scrollTo(0, 0)`), but left in those that are necessary. The necessary ones are the ones that scroll to top on the same page when there are validation errors.

Still thinking on whether there's a more re-usable way to do it. I don't see one so far.