### PR TITLE
EASI-1134 new CEDAR API internal interface

### DIFF
--- a/pkg/cedar/intake/client.go
+++ b/pkg/cedar/intake/client.go
@@ -1,0 +1,77 @@
+// Package intake serves as an Anti-Corruption Layer (in Domain Driven Design
+// parlance), keeping the implementation details of working with the
+// downstream CEDAR Intake API well separated, so the rest of the internal
+// workings of the EASi code are not using anything defined by the
+// external API
+package intake
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/flags"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+const (
+	emitFlagKey = "emit-to-cedar"
+	emitDefault = false
+)
+
+// NewClient builds the type that holds a connection to the CEDAR Intake API
+func NewClient(cedarHost string, cedarAPIKey string, ldClient *ld.LDClient) *Client {
+	_ = cedarHost
+	_ = cedarAPIKey
+
+	fnEmit := func(ctx context.Context) bool {
+		// this is the conditional way of stopping us from submitting to CEDAR; see EASI-1025
+		lduser := flags.Principal(ctx)
+		result, err := ldClient.BoolVariation(emitFlagKey, lduser, emitDefault)
+		if err != nil {
+			appcontext.ZLogger(ctx).Info(
+				"problem evaluating feature flag",
+				zap.Error(err),
+				zap.String("flagName", emitFlagKey),
+				zap.Bool("flagDefault", emitDefault),
+				zap.Bool("flagResult", result),
+			)
+		}
+		return result
+	}
+
+	return &Client{emitToCedar: fnEmit}
+}
+
+// Client represents a connection to the CEDAR Intake API
+type Client struct {
+	emitToCedar func(context.Context) bool
+}
+
+// CheckConnection hits the CEDAR Intake API `/healthcheck` endpoint to verify
+// that our connection is functional
+func (c *Client) CheckConnection(ctx context.Context) error {
+	if !c.emitToCedar(ctx) {
+		return nil
+	}
+	return fmt.Errorf("not yet implemented")
+}
+
+// PublishSnapshot sends the given current state of a SystemIntake and all its
+// associated entities to CEDAR for eventual storage in Alfabet
+func (c *Client) PublishSnapshot(
+	ctx context.Context,
+	si *models.SystemIntake,
+	bc *models.BusinessCase,
+	acts []*models.Action,
+	notes []*models.Note,
+	fbs []*models.GRTFeedback,
+) error {
+	if !c.emitToCedar(ctx) {
+		return nil
+	}
+	return fmt.Errorf("not yet implemented")
+}

--- a/pkg/cedar/intake/client.go
+++ b/pkg/cedar/intake/client.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
 
@@ -71,6 +72,11 @@ func (c *Client) PublishSnapshot(
 	fbs []*models.GRTFeedback,
 ) error {
 	if !c.emitToCedar(ctx) {
+		id := uuid.Nil
+		if si != nil {
+			id = si.ID
+		}
+		appcontext.ZLogger(ctx).Info("snapshot publishing disabled", zap.String("intakeID", id.String()))
 		return nil
 	}
 	return fmt.Errorf("not yet implemented")

--- a/pkg/cedar/intake/client_test.go
+++ b/pkg/cedar/intake/client_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
 )
 
 type ClientTestSuite struct {
@@ -16,12 +18,14 @@ type ClientTestSuite struct {
 func TestClientTestSuite(t *testing.T) {
 	tests := &ClientTestSuite{
 		Suite:  suite.Suite{},
-		logger: zap.NewNop(),
+		logger: zap.NewExample(),
 	}
 	suite.Run(t, tests)
 }
 
 func (s ClientTestSuite) TestClient() {
+	ctx := appcontext.WithLogger(context.Background(), s.logger)
+
 	s.Run("Instantiation successful", func() {
 		c := NewClient("fake", "fake", nil)
 		s.NotNil(c)
@@ -29,17 +33,17 @@ func (s ClientTestSuite) TestClient() {
 
 	s.Run("LD protects invocation", func() {
 		c := &Client{emitToCedar: func(context.Context) bool { return false }}
-		err := c.CheckConnection(context.Background())
+		err := c.CheckConnection(ctx)
 		s.NoError(err)
-		err = c.PublishSnapshot(context.Background(), nil, nil, nil, nil, nil)
+		err = c.PublishSnapshot(ctx, nil, nil, nil, nil, nil)
 		s.NoError(err)
 	})
 
 	s.Run("Not yet implemented", func() {
 		c := &Client{emitToCedar: func(context.Context) bool { return true }}
-		err := c.CheckConnection(context.Background())
+		err := c.CheckConnection(ctx)
 		s.Error(err)
-		err = c.PublishSnapshot(context.Background(), nil, nil, nil, nil, nil)
+		err = c.PublishSnapshot(ctx, nil, nil, nil, nil, nil)
 		s.Error(err)
 	})
 

--- a/pkg/cedar/intake/client_test.go
+++ b/pkg/cedar/intake/client_test.go
@@ -1,0 +1,46 @@
+package intake
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+)
+
+type ClientTestSuite struct {
+	suite.Suite
+	logger *zap.Logger
+}
+
+func TestClientTestSuite(t *testing.T) {
+	tests := &ClientTestSuite{
+		Suite:  suite.Suite{},
+		logger: zap.NewNop(),
+	}
+	suite.Run(t, tests)
+}
+
+func (s ClientTestSuite) TestClient() {
+	s.Run("Instantiation successful", func() {
+		c := NewClient("fake", "fake", nil)
+		s.NotNil(c)
+	})
+
+	s.Run("LD protects invocation", func() {
+		c := &Client{emitToCedar: func(context.Context) bool { return false }}
+		err := c.CheckConnection(context.Background())
+		s.NoError(err)
+		err = c.PublishSnapshot(context.Background(), nil, nil, nil, nil, nil)
+		s.NoError(err)
+	})
+
+	s.Run("Not yet implemented", func() {
+		c := &Client{emitToCedar: func(context.Context) bool { return true }}
+		err := c.CheckConnection(context.Background())
+		s.Error(err)
+		err = c.PublishSnapshot(context.Background(), nil, nil, nil, nil, nil)
+		s.Error(err)
+	})
+
+}


### PR DESCRIPTION
# EASI-1134

Changes proposed in this pull request:

- while I've been doing some of the "bottom-up" work on #891 (where that will also continue), now that I'm pretty confident what the internal client interface is going to look like, I decided to make this smaller PR for defining the interface and wiring it up into the active path code
- you'll notice that other than the LD checks, the client package is pretty empty... this is in pursuit of showing what a feature-flag driven development approach can look like
- I'm pretty chuffed with the functional adapter for adhering to the signature for `ValidateAndSubmitSystemIntake`, so the underlying code in the `services` package didn't need to have any modifications
- I plan to remove the old/deprecated `cedareasi` package and associated cruft in a later PR
