### PR TITLE
Log graphql queries

### DIFF
--- a/pkg/server/gqllogging.go
+++ b/pkg/server/gqllogging.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"go.uber.org/zap"
+)
+
+// NewGQLResponseMiddleware returns a handler with a request based logger
+func NewGQLResponseMiddleware(logger *zap.Logger) graphql.ResponseMiddleware {
+	return func(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
+
+		result := next(ctx)
+
+		requestContext := graphql.GetRequestContext(ctx)
+		errorList := graphql.GetErrors(ctx)
+
+		duration := time.Now().Sub(requestContext.Stats.OperationStart)
+		complexityStats := extension.GetComplexityStats(ctx)
+
+		errored := len(errorList) > 0
+		fields := []zap.Field{
+			zap.String("operation", requestContext.OperationName),
+			zap.Duration("duration", duration),
+			zap.Bool("error", errored),
+		}
+
+		if complexityStats != nil {
+			fields = append(fields, zap.Int("complexity", complexityStats.Complexity))
+		}
+
+		if errored {
+			fields = append(fields, zap.Any("errorList", errorList), zap.String("query", requestContext.RawQuery))
+		}
+		logger.Info("graphql query", fields...)
+
+		return result
+	}
+}

--- a/pkg/server/gqllogging.go
+++ b/pkg/server/gqllogging.go
@@ -7,12 +7,14 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
 )
 
 // NewGQLResponseMiddleware returns a handler with a request based logger
-func NewGQLResponseMiddleware(logger *zap.Logger) graphql.ResponseMiddleware {
+func NewGQLResponseMiddleware() graphql.ResponseMiddleware {
 	return func(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
-
+		logger := appcontext.ZLogger(ctx)
 		result := next(ctx)
 
 		requestContext := graphql.GetRequestContext(ctx)

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -215,6 +216,9 @@ func (s *Server) routes(
 	}}
 	gqlConfig := generated.Config{Resolvers: resolver, Directives: gqlDirectives}
 	graphqlServer := handler.NewDefaultServer(generated.NewExecutableSchema(gqlConfig))
+	graphqlServer.Use(extension.FixedComplexityLimit(1000))
+	graphqlServer.AroundResponses(NewGQLResponseMiddleware(s.logger))
+
 	gql.Handle("/query", graphqlServer)
 
 	// API base path is versioned

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -217,7 +217,7 @@ func (s *Server) routes(
 	gqlConfig := generated.Config{Resolvers: resolver, Directives: gqlDirectives}
 	graphqlServer := handler.NewDefaultServer(generated.NewExecutableSchema(gqlConfig))
 	graphqlServer.Use(extension.FixedComplexityLimit(1000))
-	graphqlServer.AroundResponses(NewGQLResponseMiddleware(s.logger))
+	graphqlServer.AroundResponses(NewGQLResponseMiddleware())
 
 	gql.Handle("/query", graphqlServer)
 


### PR DESCRIPTION
# ES-1137

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

Changes proposed in this pull request:

- Log all GraphQL queries, including operation name and duration
- When there are errors, also log the query and the errors.

Here is an example of a successful query:

```
easi_1         | 2021-03-30T20:18:43.350Z	INFO	server/gqllogging.go:36	graphql query	{"operation": "GetSystemIntake", "duration": "20.6908ms", "error": false, "complexity": 75}
```

Here is an example of a query that left out a query argument:

```
easi_1         | 2021-03-30T20:48:43.987Z	INFO	server/gqllogging.go:38	graphql query	{"operation": "", "duration": "424.5µs", "error": true, "errorList": "input:2: Field \"systemIntake\" argument \"id\" of type \"UUID!\" is required but not provided.\n", "query": "{\n  systemIntake {\n    lcid\n    __typename\n  }\n}\n"}
```

And here is a panic within a resolver:

```
easi_1         | 2021-03-30T20:03:52.873Z	ERROR	server/gqllogging.go:33	error in graphql query	{"operation": "GetSystemIntake", "duration": "16.7703ms", "error": true, "complexity": 75, "errorList": "input: systemIntake panic: a problem\n"}
easi_1         | github.com/cmsgov/easi-app/pkg/server.NewGQLResponseMiddleware.func1
easi_1         | 	/easi/pkg/server/gqllogging.go:33
easi_1         | github.com/99designs/gqlgen/graphql/executor.aroundRespFunc.InterceptResponse
easi_1         | 	/go/pkg/mod/github.com/99designs/gqlgen@v0.13.0/graphql/executor/extensions.go:141
easi_1         | github.com/99designs/gqlgen/graphql/executor.processExtensions.func5
easi_1         | 	/go/pkg/mod/github.com/99designs/gqlgen@v0.13.0/graphql/executor/extensions.go:81
easi_1         | github.com/99designs/gqlgen/graphql/executor.(*Executor).DispatchOperation.func1.1
easi_1         | 	/go/pkg/mod/github.com/99designs/gqlgen@v0.13.0/graphql/executor/executor.go:104
easi_1         | github.com/99designs/gqlgen/graphql/handler/transport.POST.Do
easi_1         | 	/go/pkg/mod/github.com/99designs/gqlgen@v0.13.0/graphql/handler/transport/http_post.go:53
easi_1         | github.com/99designs/gqlgen/graphql/handler.(*Server).ServeHTTP
easi_1         | 	/go/pkg/mod/github.com/99designs/gqlgen@v0.13.0/graphql/handler/server.go:115
easi_1         | github.com/cmsgov/easi-app/pkg/local.authorizeMiddleware.func1
easi_1         | 	/easi/pkg/local/authorization.go:75
easi_1         | net/http.HandlerFunc.ServeHTTP
easi_1         | 	/usr/local/go/src/net/http/server.go:2042
easi_1         | github.com/cmsgov/easi-app/pkg/server.newCORSMiddleware.func1.1
easi_1         | 	/easi/pkg/server/cors.go:17
easi_1         | net/http.HandlerFunc.ServeHTTP
easi_1         | 	/usr/local/go/src/net/http/server.go:2042
easi_1         | github.com/cmsgov/easi-app/pkg/server.loggerMiddleware.func1
easi_1         | 	/easi/pkg/server/logger.go:37
easi_1         | net/http.HandlerFunc.ServeHTTP
easi_1         | 	/usr/local/go/src/net/http/server.go:2042
easi_1         | github.com/cmsgov/easi-app/pkg/server.traceMiddleware.func1
easi_1         | 	/easi/pkg/server/trace.go:17
easi_1         | net/http.HandlerFunc.ServeHTTP
easi_1         | 	/usr/local/go/src/net/http/server.go:2042
easi_1         | github.com/gorilla/mux.(*Router).ServeHTTP
easi_1         | 	/go/pkg/mod/github.com/gorilla/mux@v1.7.4/mux.go:210
easi_1         | github.com/cmsgov/easi-app/pkg/server.(*Server).ServeHTTP
easi_1         | 	/easi/pkg/server/server.go:29
easi_1         | net/http.serverHandler.ServeHTTP
easi_1         | 	/usr/local/go/src/net/http/server.go:2843
easi_1         | net/http.(*conn).serve
easi_1         | 	/usr/local/go/src/net/http/server.go:1925
```