### PR TITLE
hide withdraw intake button when intake is already closed

### DIFF
--- a/src/i18n/en-US/taskList.ts
+++ b/src/i18n/en-US/taskList.ts
@@ -12,6 +12,7 @@ const taskList = {
     bizCaseApproved: 'Your business case has been approved.',
     bizCaseRejected: 'Your business case has been rejected.',
     lcid: 'Project Lifecycle ID',
+    lcidScope: 'Lifecycle ID Scope',
     lcidExpiration: 'This ID expires on {{date}}',
     reasons: 'Reasons',
     nextSteps: 'Next steps',

--- a/src/views/GovernanceTaskList/RequestDecision/Approved.tsx
+++ b/src/views/GovernanceTaskList/RequestDecision/Approved.tsx
@@ -22,6 +22,7 @@ const Approved = ({ intake }: ApprovedProps) => {
             {intake.lcid}
           </dd>
         </dl>
+        <h3>{t('decision.lcidScope')}</h3>
         <p className="text-pre-wrap">{intake.lcidScope}</p>
         {intake.lcidExpiration && (
           <p className="text-bold">

--- a/src/views/GovernanceTaskList/SideNavActions/index.test.tsx
+++ b/src/views/GovernanceTaskList/SideNavActions/index.test.tsx
@@ -7,7 +7,9 @@ import Modal from 'components/Modal';
 import SideNavActions from './index';
 
 const renderComponent = () => {
-  return shallow(<SideNavActions archiveIntake={() => {}} />);
+  return shallow(
+    <SideNavActions intakeStatus="INTAKE_DRAFT" archiveIntake={() => {}} />
+  );
 };
 
 describe('The TaskListSideNavActions', () => {

--- a/src/views/GovernanceTaskList/SideNavActions/index.tsx
+++ b/src/views/GovernanceTaskList/SideNavActions/index.tsx
@@ -5,14 +5,20 @@ import { Button, Link as UswdsLink } from '@trussworks/react-uswds';
 
 import Modal from 'components/Modal';
 import PageHeading from 'components/PageHeading';
+import { SystemIntakeStatus } from 'types/systemIntake';
+import { isIntakeOpen } from 'utils/systemIntake';
 
 import './index.scss';
 
 type SideNavActionsProps = {
+  intakeStatus: SystemIntakeStatus;
   archiveIntake: () => void;
 };
 
-const SideNavActions = ({ archiveIntake }: SideNavActionsProps) => {
+const SideNavActions = ({
+  intakeStatus,
+  archiveIntake
+}: SideNavActionsProps) => {
   const { t } = useTranslation();
   const [isModalOpen, setModalOpen] = useState(false);
 
@@ -21,36 +27,38 @@ const SideNavActions = ({ archiveIntake }: SideNavActionsProps) => {
       <div className="grid-col margin-top-105">
         <Link to="/">Save & Exit</Link>
       </div>
-      <div className="grid-col margin-top-2">
-        <Button
-          className="line-height-body-5 test-withdraw-request"
-          type="button"
-          unstyled
-          onClick={() => setModalOpen(true)}
-        >
-          Remove your request to add a new system
-        </Button>
-        <Modal
-          title={t('taskList:withdraw_modal:title')}
-          isOpen={isModalOpen}
-          closeModal={() => setModalOpen(false)}
-        >
-          <PageHeading headingLevel="h2" className="margin-top-0">
-            {t('taskList:withdraw_modal:header')}
-          </PageHeading>
-          <p>{t('taskList:withdraw_modal:warning')}</p>
+      {isIntakeOpen(intakeStatus) && (
+        <div className="grid-col margin-top-2">
           <Button
+            className="line-height-body-5 test-withdraw-request"
             type="button"
-            className="margin-right-4"
-            onClick={archiveIntake}
+            unstyled
+            onClick={() => setModalOpen(true)}
           >
-            {t('taskList:withdraw_modal:confirm')}
+            Remove your request to add a new system
           </Button>
-          <Button type="button" unstyled onClick={() => setModalOpen(false)}>
-            {t('taskList:withdraw_modal:cancel')}
-          </Button>
-        </Modal>
-      </div>
+          <Modal
+            title={t('taskList:withdraw_modal:title')}
+            isOpen={isModalOpen}
+            closeModal={() => setModalOpen(false)}
+          >
+            <PageHeading headingLevel="h2" className="margin-top-0">
+              {t('taskList:withdraw_modal:header')}
+            </PageHeading>
+            <p>{t('taskList:withdraw_modal:warning')}</p>
+            <Button
+              type="button"
+              className="margin-right-4"
+              onClick={archiveIntake}
+            >
+              {t('taskList:withdraw_modal:confirm')}
+            </Button>
+            <Button type="button" unstyled onClick={() => setModalOpen(false)}>
+              {t('taskList:withdraw_modal:cancel')}
+            </Button>
+          </Modal>
+        </div>
+      )}
       <div className="grid-col margin-top-5">
         <h4>Related Content</h4>
         <UswdsLink

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -264,7 +264,10 @@ const GovernanceTaskList = () => {
           </div>
           <div className="tablet:grid-col-1" />
           <div className="tablet:grid-col-2">
-            <SideNavActions archiveIntake={archiveIntake} />
+            <SideNavActions
+              intakeStatus={systemIntake.status}
+              archiveIntake={archiveIntake}
+            />
           </div>
         </div>
         <ImproveEasiSurvey />


### PR DESCRIPTION
# ES-1157

- hide remove intake button when intake is already closed
button is hidden for intakes with statuses:
```
1.  'LCID_ISSUED'
2.  'WITHDRAWN'
3.  'NOT_IT_REQUEST'
4.  'NOT_APPROVED'
5.  'NO_GOVERNANCE'
6.  'SHUTDOWN_COMPLETE'
```