### PR TITLE
clear out day when contract effort changes

### DIFF
--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -771,8 +771,10 @@ const ContractDetails = ({
                         setFieldValue('contract.contractor', '');
                         setFieldValue('contract.vehicle', '');
                         setFieldValue('contract.startDate.month', '');
+                        setFieldValue('contract.startDate.day', '');
                         setFieldValue('contract.startDate.year', '');
                         setFieldValue('contract.endDate.month', '');
+                        setFieldValue('contract.endDate.day', '');
                         setFieldValue('contract.endDate.year', '');
                       }}
                     />
@@ -788,8 +790,10 @@ const ContractDetails = ({
                         setFieldValue('contract.contractor', '');
                         setFieldValue('contract.vehicle', '');
                         setFieldValue('contract.startDate.month', '');
+                        setFieldValue('contract.startDate.day', '');
                         setFieldValue('contract.startDate.year', '');
                         setFieldValue('contract.endDate.month', '');
+                        setFieldValue('contract.endDate.day', '');
                         setFieldValue('contract.endDate.year', '');
                       }}
                     />


### PR DESCRIPTION
small catch. we need to clear out the period of performance day when the option changes and the contract is no longer applicable. i think this was missed when adding the day field.