### PR TITLE
Add EmailAddress type

### DIFF
--- a/pkg/appses/ses.go
+++ b/pkg/appses/ses.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 // Config is email configs used only for SES
@@ -38,14 +39,14 @@ func NewSender(config Config) Sender {
 // Send sends an email
 func (s Sender) Send(
 	ctx context.Context,
-	toAddress string,
+	toAddress models.EmailAddress,
 	subject string,
 	body string,
 ) error {
 	input := &ses.SendEmailInput{
 		Destination: &ses.Destination{
 			ToAddresses: []*string{
-				aws.String(toAddress),
+				aws.String(toAddress.String()),
 			},
 		},
 		Message: &ses.Message{
@@ -66,7 +67,7 @@ func (s Sender) Send(
 	_, err := s.client.SendEmail(input)
 	if err == nil {
 		appcontext.ZLogger(ctx).Info("Sending email with SES",
-			zap.String("To", toAddress),
+			zap.String("To", toAddress.String()),
 			zap.String("Subject", subject),
 		)
 	}

--- a/pkg/appses/ses_test.go
+++ b/pkg/appses/ses_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/appconfig"
+	"github.com/cmsgov/easi-app/pkg/models"
 	"github.com/cmsgov/easi-app/pkg/testhelpers"
 )
 
@@ -65,7 +66,7 @@ func (s SESTestSuite) TestSend() {
 	s.Run("Sends successfully", func() {
 		err := s.sender.Send(
 			context.Background(),
-			"success@simulator.amazonses.com",
+			models.NewEmailAddress("success@simulator.amazonses.com"),
 			"Test Subject",
 			"Test Body",
 		)

--- a/pkg/cedar/cedarldap/translated_client.go
+++ b/pkg/cedar/cedarldap/translated_client.go
@@ -70,7 +70,7 @@ func (c TranslatedClient) FetchUserInfo(ctx context.Context, euaID string) (*mod
 
 	return &models2.UserInfo{
 		CommonName: resp.Payload.CommonName,
-		Email:      resp.Payload.Email,
+		Email:      models2.NewEmailAddress(resp.Payload.Email),
 		EuaUserID:  resp.Payload.UserName,
 	}, nil
 }

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -7,11 +7,13 @@ import (
 	"io"
 	"net/url"
 	"path"
+
+	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 // Config holds EASi application specific configs for SES
 type Config struct {
-	GRTEmail          string
+	GRTEmail          models.EmailAddress
 	URLHost           string
 	URLScheme         string
 	TemplateDirectory string
@@ -36,7 +38,7 @@ type templates struct {
 
 // sender is an interface for swapping out email provider implementations
 type sender interface {
-	Send(ctx context.Context, toAddress string, subject string, body string) error
+	Send(ctx context.Context, toAddress models.EmailAddress, subject string, body string) error
 }
 
 // Client is an EASi SES client wrapper
@@ -128,6 +130,6 @@ func (c Client) urlFromPath(path string) string {
 
 // SendTestEmail sends an email to a no-reply address
 func (c Client) SendTestEmail(ctx context.Context) error {
-	const testToAddress = "success@simulator.amazonses.com"
+	testToAddress := models.NewEmailAddress("success@simulator.amazonses.com")
 	return c.sender.Send(ctx, testToAddress, "test", "test")
 }

--- a/pkg/email/email_test.go
+++ b/pkg/email/email_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/appconfig"
+	"github.com/cmsgov/easi-app/pkg/models"
 	"github.com/cmsgov/easi-app/pkg/testhelpers"
 )
 
@@ -20,12 +21,12 @@ type EmailTestSuite struct {
 }
 
 type mockSender struct {
-	toAddress string
+	toAddress models.EmailAddress
 	subject   string
 	body      string
 }
 
-func (s *mockSender) Send(ctx context.Context, toAddress string, subject string, body string) error {
+func (s *mockSender) Send(ctx context.Context, toAddress models.EmailAddress, subject string, body string) error {
 	s.toAddress = toAddress
 	s.subject = subject
 	s.body = body
@@ -34,7 +35,7 @@ func (s *mockSender) Send(ctx context.Context, toAddress string, subject string,
 
 type mockFailedSender struct{}
 
-func (s *mockFailedSender) Send(ctx context.Context, toAddress string, subject string, body string) error {
+func (s *mockFailedSender) Send(ctx context.Context, toAddress models.EmailAddress, subject string, body string) error {
 	return errors.New("sender had an error")
 }
 
@@ -49,7 +50,7 @@ func TestEmailTestSuite(t *testing.T) {
 	config := testhelpers.NewConfig()
 
 	emailConfig := Config{
-		GRTEmail:          config.GetString(appconfig.GRTEmailKey),
+		GRTEmail:          models.NewEmailAddress(config.GetString(appconfig.GRTEmailKey)),
 		URLHost:           config.GetString(appconfig.ClientHostKey),
 		URLScheme:         config.GetString(appconfig.ClientProtocolKey),
 		TemplateDirectory: config.GetString(appconfig.EmailTemplateDirectoryKey),

--- a/pkg/email/intake_review.go
+++ b/pkg/email/intake_review.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 type intakeReview struct {
@@ -33,7 +34,7 @@ func (c Client) systemIntakeReviewBody(EmailText string, taskListPath string) (s
 }
 
 // SendSystemIntakeReviewEmail sends an email for a submitted system intake
-func (c Client) SendSystemIntakeReviewEmail(ctx context.Context, emailText string, recipientAddress string, intakeID uuid.UUID) error {
+func (c Client) SendSystemIntakeReviewEmail(ctx context.Context, emailText string, recipientAddress models.EmailAddress, intakeID uuid.UUID) error {
 	subject := "Feedback on your intake request"
 	taskListPath := path.Join("governance-task-list", intakeID.String())
 	body, err := c.systemIntakeReviewBody(emailText, taskListPath)

--- a/pkg/email/intake_review_test.go
+++ b/pkg/email/intake_review_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 func (s *EmailTestSuite) TestSendIntakeReviewEmail() {
 	sender := mockSender{}
 	ctx := context.Background()
-	recipientAddress := "sample@test.com"
+	recipientAddress := models.NewEmailAddress("sample@test.com")
 	emailBody := "Test Text\n\nTest"
 	intakeID := uuid.New()
 

--- a/pkg/email/issue_lcid.go
+++ b/pkg/email/issue_lcid.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 type issueLCID struct {
@@ -37,7 +38,7 @@ func (c Client) issueLCIDBody(lcid string, expiresAt *time.Time, scope string, n
 }
 
 // SendIssueLCIDEmail sends an email for issuing an LCID
-func (c Client) SendIssueLCIDEmail(ctx context.Context, recipient string, lcid string, expirationDate *time.Time, scope string, nextSteps string, feedback string) error {
+func (c Client) SendIssueLCIDEmail(ctx context.Context, recipient models.EmailAddress, lcid string, expirationDate *time.Time, scope string, nextSteps string, feedback string) error {
 	subject := "Your request has been approved"
 	body, err := c.issueLCIDBody(lcid, expirationDate, scope, nextSteps, feedback)
 	if err != nil {

--- a/pkg/email/issue_lcid_test.go
+++ b/pkg/email/issue_lcid_test.go
@@ -5,12 +5,13 @@ import (
 	"time"
 
 	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 func (s *EmailTestSuite) TestSendIssueLCIDEmail() {
 	sender := mockSender{}
 	ctx := context.Background()
-	recipient := "fake@fake.com"
+	recipient := models.NewEmailAddress("fake@fake.com")
 	lcid := "123456"
 	expiresAt, _ := time.Parse("2020-12-25", "2021-12-25")
 	scope := "scope"

--- a/pkg/email/reject_request.go
+++ b/pkg/email/reject_request.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 type rejectRequest struct {
@@ -32,7 +33,7 @@ func (c Client) rejectRequestBody(reason string, nextSteps string, feedback stri
 }
 
 // SendRejectRequestEmail sends an email for rejecting a request
-func (c Client) SendRejectRequestEmail(ctx context.Context, recipient string, reason string, nextSteps string, feedback string) error {
+func (c Client) SendRejectRequestEmail(ctx context.Context, recipient models.EmailAddress, reason string, nextSteps string, feedback string) error {
 	subject := "Your request has not been approved"
 	body, err := c.rejectRequestBody(reason, nextSteps, feedback)
 	if err != nil {

--- a/pkg/email/reject_request_test.go
+++ b/pkg/email/reject_request_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 func (s *EmailTestSuite) TestSendRejectRequestEmail() {
 	sender := mockSender{}
 	ctx := context.Background()
-	recipient := "fake@fake.com"
+	recipient := models.NewEmailAddress("fake@fake.com")
 	reason := "reason"
 	nextSteps := "nextSteps"
 	feedback := "feedback"

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -679,7 +679,7 @@ func (r *systemIntakeResolver) Actions(ctx context.Context, obj *models.SystemIn
 			Type: model.SystemIntakeActionType(action.ActionType),
 			Actor: &model.SystemIntakeActionActor{
 				Name:  action.ActorName,
-				Email: action.ActorEmail,
+				Email: action.ActorEmail.String(),
 			},
 			Feedback:  action.Feedback.Ptr(),
 			CreatedAt: *action.CreatedAt,

--- a/pkg/local/cedar_ldap.go
+++ b/pkg/local/cedar_ldap.go
@@ -34,7 +34,7 @@ func (c CedarLdapClient) FetchUserInfo(_ context.Context, euaID string) (*models
 	c.logger.Info("Mock FetchUserInfo from LDAP", zap.String("euaID", euaID))
 	return &models.UserInfo{
 		CommonName: strings.ToLower(euaID),
-		Email:      fmt.Sprintf("%s@local.fake", euaID),
+		Email:      models.NewEmailAddress(fmt.Sprintf("%s@local.fake", euaID)),
 		EuaUserID:  euaID,
 	}, nil
 }

--- a/pkg/local/email.go
+++ b/pkg/local/email.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 // NewSender returns a fake email sender
@@ -18,9 +19,9 @@ type Sender struct {
 }
 
 // Send logs an email
-func (s Sender) Send(ctx context.Context, toAddress string, subject string, body string) error {
+func (s Sender) Send(ctx context.Context, toAddress models.EmailAddress, subject string, body string) error {
 	appcontext.ZLogger(ctx).Info("Mock sending email",
-		zap.String("To", toAddress),
+		zap.String("To", toAddress.String()),
 		zap.String("Subject", subject),
 		zap.String("Body", body),
 	)

--- a/pkg/models/action.go
+++ b/pkg/models/action.go
@@ -51,13 +51,13 @@ const (
 
 // Action is the model for an action on a system intake
 type Action struct {
-	ID             uuid.UUID   `json:"id"`
-	IntakeID       *uuid.UUID  `db:"intake_id"`
-	BusinessCaseID *uuid.UUID  `db:"business_case_id"`
-	ActionType     ActionType  `json:"actionType" db:"action_type"`
-	ActorName      string      `json:"actorName" db:"actor_name"`
-	ActorEmail     string      `json:"actorEmail" db:"actor_email"`
-	ActorEUAUserID string      `json:"actorEuaUserId" db:"actor_eua_user_id"`
-	Feedback       null.String `json:"feedback"`
-	CreatedAt      *time.Time  `json:"createdAt" db:"created_at"`
+	ID             uuid.UUID    `json:"id"`
+	IntakeID       *uuid.UUID   `db:"intake_id"`
+	BusinessCaseID *uuid.UUID   `db:"business_case_id"`
+	ActionType     ActionType   `json:"actionType" db:"action_type"`
+	ActorName      string       `json:"actorName" db:"actor_name"`
+	ActorEmail     EmailAddress `json:"actorEmail" db:"actor_email"`
+	ActorEUAUserID string       `json:"actorEuaUserId" db:"actor_eua_user_id"`
+	Feedback       null.String  `json:"feedback"`
+	CreatedAt      *time.Time   `json:"createdAt" db:"created_at"`
 }

--- a/pkg/models/email_address.go
+++ b/pkg/models/email_address.go
@@ -1,0 +1,14 @@
+package models
+
+// EmailAddress represents an email address
+type EmailAddress string
+
+// String returns the email address as a string
+func (e EmailAddress) String() string {
+	return string(e)
+}
+
+// NewEmailAddress creates a new email address
+func NewEmailAddress(address string) EmailAddress {
+	return EmailAddress(address)
+}

--- a/pkg/models/user_info.go
+++ b/pkg/models/user_info.go
@@ -3,6 +3,6 @@ package models
 // UserInfo is the model for personal details of a user
 type UserInfo struct {
 	CommonName string
-	Email      string
+	Email      EmailAddress
 	EuaUserID  string
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cmsgov/easi-app/pkg/appses"
 	"github.com/cmsgov/easi-app/pkg/email"
 	"github.com/cmsgov/easi-app/pkg/flags"
+	"github.com/cmsgov/easi-app/pkg/models"
 	"github.com/cmsgov/easi-app/pkg/storage"
 	"github.com/cmsgov/easi-app/pkg/upload"
 )
@@ -48,7 +49,7 @@ func (s Server) NewEmailConfig() email.Config {
 	s.checkRequiredConfig(appconfig.EmailTemplateDirectoryKey)
 
 	return email.Config{
-		GRTEmail:          s.Config.GetString(appconfig.GRTEmailKey),
+		GRTEmail:          models.NewEmailAddress(s.Config.GetString(appconfig.GRTEmailKey)),
 		URLHost:           s.Config.GetString(appconfig.ClientHostKey),
 		URLScheme:         s.Config.GetString(appconfig.ClientProtocolKey),
 		TemplateDirectory: s.Config.GetString(appconfig.EmailTemplateDirectoryKey),

--- a/pkg/services/action.go
+++ b/pkg/services/action.go
@@ -238,7 +238,7 @@ func NewTakeActionUpdateStatus(
 	authorize func(context.Context) (bool, error),
 	saveAction func(context.Context, *models.Action) error,
 	fetchUserInfo func(context.Context, string) (*models.UserInfo, error),
-	sendReviewEmail func(ctx context.Context, emailText string, recipientAddress string, intakeID uuid.UUID) error,
+	sendReviewEmail func(ctx context.Context, emailText string, recipientAddress models.EmailAddress, intakeID uuid.UUID) error,
 	shouldCloseBusinessCase bool,
 	closeBusinessCase func(context.Context, uuid.UUID) error,
 ) ActionExecuter {
@@ -305,7 +305,7 @@ func NewCreateActionUpdateStatus(
 	updateStatus func(c context.Context, id uuid.UUID, newStatus models.SystemIntakeStatus) (*models.SystemIntake, error),
 	saveAction func(context.Context, *models.Action) error,
 	fetchUserInfo func(context.Context, string) (*models.UserInfo, error),
-	sendReviewEmail func(ctx context.Context, emailText string, recipientAddress string, intakeID uuid.UUID) error,
+	sendReviewEmail func(ctx context.Context, emailText string, recipientAddress models.EmailAddress, intakeID uuid.UUID) error,
 	closeBusinessCase func(context.Context, uuid.UUID) error,
 ) func(context.Context, *models.Action, uuid.UUID, models.SystemIntakeStatus, bool) (*models.SystemIntake, error) {
 	return func(

--- a/pkg/services/action_test.go
+++ b/pkg/services/action_test.go
@@ -394,7 +394,7 @@ func (s ServicesTestSuite) TestNewTakeActionUpdateStatus() {
 	}
 	reviewEmailCount := 0
 	feedbackForEmailText := ""
-	sendReviewEmail := func(ctx context.Context, emailText string, recipientAddress string, intakeID uuid.UUID) error {
+	sendReviewEmail := func(ctx context.Context, emailText string, recipientAddress models.EmailAddress, intakeID uuid.UUID) error {
 		feedbackForEmailText = emailText
 		reviewEmailCount++
 		return nil
@@ -585,7 +585,7 @@ func (s ServicesTestSuite) TestNewTakeActionUpdateStatus() {
 
 	s.Run("returns notification error when review email fails", func() {
 		ctx := context.Background()
-		failSendReviewEmail := func(ctx context.Context, emailText string, recipientAddress string, intakeID uuid.UUID) error {
+		failSendReviewEmail := func(ctx context.Context, emailText string, recipientAddress models.EmailAddress, intakeID uuid.UUID) error {
 			return &apperrors.NotificationError{
 				Err:             errors.New("failed to send Email"),
 				DestinationType: apperrors.DestinationTypeEmail,

--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -261,7 +261,7 @@ func NewUpdateLifecycleFields(
 	update func(context.Context, *models.SystemIntake) (*models.SystemIntake, error),
 	saveAction func(context.Context, *models.Action) error,
 	fetchUserInfo func(context.Context, string) (*models.UserInfo, error),
-	sendIssueLCIDEmail func(context.Context, string, string, *time.Time, string, string, string) error,
+	sendIssueLCIDEmail func(context.Context, models.EmailAddress, string, *time.Time, string, string, string) error,
 	generateLCID func(context.Context) (string, error),
 ) func(context.Context, *models.SystemIntake, *models.Action) (*models.SystemIntake, error) {
 	return func(ctx context.Context, intake *models.SystemIntake, action *models.Action) (*models.SystemIntake, error) {
@@ -365,7 +365,7 @@ func NewUpdateRejectionFields(
 	update func(context.Context, *models.SystemIntake) (*models.SystemIntake, error),
 	saveAction func(context.Context, *models.Action) error,
 	fetchUserInfo func(context.Context, string) (*models.UserInfo, error),
-	sendRejectRequestEmail func(ctx context.Context, recipient string, reason string, nextSteps string, feedback string) error,
+	sendRejectRequestEmail func(ctx context.Context, recipient models.EmailAddress, reason string, nextSteps string, feedback string) error,
 ) func(context.Context, *models.SystemIntake, *models.Action) (*models.SystemIntake, error) {
 	return func(ctx context.Context, intake *models.SystemIntake, action *models.Action) (*models.SystemIntake, error) {
 		existing, err := fetch(ctx, intake.ID)
@@ -436,7 +436,7 @@ func NewProvideGRTFeedback(
 	saveAction func(context.Context, *models.Action) error,
 	saveGRTFeedback func(context.Context, *models.GRTFeedback) (*models.GRTFeedback, error),
 	fetchUserInfo func(context.Context, string) (*models.UserInfo, error),
-	sendReviewEmail func(ctx context.Context, emailText string, recipientAddress string, intakeID uuid.UUID) error,
+	sendReviewEmail func(ctx context.Context, emailText string, recipientAddress models.EmailAddress, intakeID uuid.UUID) error,
 ) func(context.Context, *models.GRTFeedback, *models.Action, models.SystemIntakeStatus) (*models.GRTFeedback, error) {
 	return func(ctx context.Context, grtFeedback *models.GRTFeedback, action *models.Action, newStatus models.SystemIntakeStatus) (*models.GRTFeedback, error) {
 		intake, err := fetch(ctx, grtFeedback.IntakeID)

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -400,7 +400,7 @@ func (s ServicesTestSuite) TestUpdateLifecycleFields() {
 	}
 	reviewEmailCount := 0
 	feedbackForEmailText := ""
-	fnSendLCIDEmail := func(_ context.Context, _ string, _ string, _ *time.Time, _ string, _string, emailText string) error {
+	fnSendLCIDEmail := func(_ context.Context, _ models.EmailAddress, _ string, _ *time.Time, _ string, _string, emailText string) error {
 		feedbackForEmailText = emailText
 		reviewEmailCount++
 		return nil
@@ -447,7 +447,7 @@ func (s ServicesTestSuite) TestUpdateLifecycleFields() {
 	fnFetchUserInfoErr := func(_ context.Context, euaID string) (*models.UserInfo, error) {
 		return nil, errors.New("fetch user info error")
 	}
-	fnSendLCIDEmailErr := func(_ context.Context, string, _ string, _ *time.Time, _ string, _ string, _ string) error {
+	fnSendLCIDEmailErr := func(_ context.Context, _ models.EmailAddress, _ string, _ *time.Time, _ string, _ string, _ string) error {
 		return errors.New("send email error")
 	}
 	fnGenerateErr := func(context.Context) (string, error) { return "", errors.New("gen error") }
@@ -530,7 +530,7 @@ func (s ServicesTestSuite) TestUpdateRejectionFields() {
 	}
 	reviewEmailCount := 0
 	feedbackForEmailText := ""
-	fnSendRejectRequestEmail := func(ctx context.Context, recipientAddress string, reason string, nextSteps string, feedback string) error {
+	fnSendRejectRequestEmail := func(ctx context.Context, recipientAddress models.EmailAddress, reason string, nextSteps string, feedback string) error {
 		feedbackForEmailText = feedback
 		reviewEmailCount++
 		return nil
@@ -562,7 +562,7 @@ func (s ServicesTestSuite) TestUpdateRejectionFields() {
 	fnFetchUserInfoErr := func(_ context.Context, euaID string) (*models.UserInfo, error) {
 		return nil, errors.New("fetch user info error")
 	}
-	fnSendRejectRequestEmailErr := func(ctx context.Context, recipientAddress string, reason string, nextSteps string, feedback string) error {
+	fnSendRejectRequestEmailErr := func(ctx context.Context, recipientAddress models.EmailAddress, reason string, nextSteps string, feedback string) error {
 		return errors.New("send email error")
 	}
 


### PR DESCRIPTION
This is part of our followup to #931. By using a new `models.EmailAddress` type in the application, we can have the type system help prevent issues like that from happening again.

Changes proposed in this pull request:

- Add a new `models.EmailAddress` type
- Update code across the app to use the new type
