### PR TITLE
bandaid for broken formatContractDate function

### DIFF
--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -21,8 +21,9 @@ type ContractDate = {
 };
 
 export const formatContractDate = (date: ContractDate): string => {
-  const parts = [date.month, date.day, date.year];
-  return parts.filter((value: string) => value.length > 0).join('/');
+  const { month, day, year } = date;
+  const parts = [month, day, year];
+  return parts.filter((value: string) => value && value.length > 0).join('/');
 };
 
 /**


### PR DESCRIPTION
bandaid - long term fix coming
```
Cannot read property 'length' of null
    at formatDate.ts:25
```

So just check if it's truthy before getting length.