### PR TITLE
add slightly better validation for the period of performance dates

### DIFF
--- a/src/validations/systemIntakeSchema.ts
+++ b/src/validations/systemIntakeSchema.ts
@@ -139,7 +139,26 @@ const SystemIntakeValidationSchema: any = {
             .trim()
             .required('Tell us the contract start month'),
           day: Yup.string().trim().required('Tell us the contract start day'),
-          year: Yup.string().trim().required('Tell us the contract start year')
+          year: Yup.string().trim().required('Tell us the contract start year'),
+          validDate: Yup.string().when(['month', 'day', 'year'], {
+            is: (month: string, day: string, year: string) => {
+              if (
+                DateTime.fromObject({
+                  month: Number(month) || 0,
+                  day: Number(day) || 0,
+                  year: Number(year) || 0
+                }).isValid
+              ) {
+                return true;
+              }
+              return false;
+            },
+            otherwise: Yup.string().test(
+              'validStartDate',
+              'Period of performance date: Please enter a valid start date',
+              () => false
+            )
+          })
         })
       }),
       endDate: Yup.mixed().when('hasContract', {
@@ -147,7 +166,26 @@ const SystemIntakeValidationSchema: any = {
         then: Yup.object().shape({
           month: Yup.string().trim().required('Tell us the contract end month'),
           day: Yup.string().trim().required('Tell us the contract end day'),
-          year: Yup.string().trim().required('Tell us the contract end year')
+          year: Yup.string().trim().required('Tell us the contract end year'),
+          validDate: Yup.string().when(['month', 'day', 'year'], {
+            is: (month: string, day: string, year: string) => {
+              if (
+                DateTime.fromObject({
+                  month: Number(month) || 0,
+                  day: Number(day) || 0,
+                  year: Number(year) || 0
+                }).isValid
+              ) {
+                return true;
+              }
+              return false;
+            },
+            otherwise: Yup.string().test(
+              'validStartDate',
+              'Period of performance date: Please enter a valid end date',
+              () => false
+            )
+          })
         })
       })
     })

--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -643,7 +643,10 @@ const ContractDetails = ({
                             {flatErrors['contract.endDate.year']}
                           </FieldErrorMsg>
                           <div className="display-flex flex-align-center">
-                            <div className="usa-memorable-date">
+                            <div
+                              className="usa-memorable-date"
+                              data-scroll="contract.startDate.validDate"
+                            >
                               <FieldGroup
                                 className="usa-form-group--month"
                                 scrollElement="contract.startDate.month"
@@ -657,7 +660,8 @@ const ContractDetails = ({
                                 <Field
                                   as={DateInputMonth}
                                   error={
-                                    !!flatErrors['contract.startDate.month']
+                                    !!flatErrors['contract.startDate.month'] ||
+                                    !!flatErrors['contract.startDate.validDate']
                                   }
                                   id="IntakeForm-ContractStartMonth"
                                   name="contract.startDate.month"
@@ -675,7 +679,10 @@ const ContractDetails = ({
                                 </Label>
                                 <Field
                                   as={DateInputDay}
-                                  error={!!flatErrors['contract.startDate.day']}
+                                  error={
+                                    !!flatErrors['contract.startDate.day'] ||
+                                    !!flatErrors['contract.startDate.validDate']
+                                  }
                                   id="IntakeForm-ContractStartDay"
                                   name="contract.startDate.day"
                                 />
@@ -693,7 +700,8 @@ const ContractDetails = ({
                                 <Field
                                   as={DateInputYear}
                                   error={
-                                    !!flatErrors['contract.startDate.year']
+                                    !!flatErrors['contract.startDate.year'] ||
+                                    !!flatErrors['contract.startDate.validDate']
                                   }
                                   id="IntakeForm-ContractStartYear"
                                   name="contract.startDate.year"
@@ -702,7 +710,10 @@ const ContractDetails = ({
                             </div>
 
                             <span className="margin-right-2">to</span>
-                            <div className="usa-memorable-date">
+                            <div
+                              className="usa-memorable-date"
+                              data-scroll="contract.endDate.validDate"
+                            >
                               <FieldGroup
                                 className="usa-form-group--month"
                                 scrollElement="contract.endDate.month"
@@ -715,7 +726,10 @@ const ContractDetails = ({
                                 </Label>
                                 <Field
                                   as={DateInputMonth}
-                                  error={!!flatErrors['contract.endDate.month']}
+                                  error={
+                                    !!flatErrors['contract.endDate.month'] ||
+                                    !!flatErrors['contract.endDate.validDate']
+                                  }
                                   id="IntakeForm-ContractEndMonth"
                                   name="contract.endDate.month"
                                 />
@@ -732,7 +746,10 @@ const ContractDetails = ({
                                 </Label>
                                 <Field
                                   as={DateInputDay}
-                                  error={!!flatErrors['contract.endDate.day']}
+                                  error={
+                                    !!flatErrors['contract.endDate.day'] ||
+                                    !!flatErrors['contract.endDate.validDate']
+                                  }
                                   id="IntakeForm-ContractEndDay"
                                   name="contract.endDate.day"
                                 />
@@ -749,7 +766,10 @@ const ContractDetails = ({
                                 </Label>
                                 <Field
                                   as={DateInputYear}
-                                  error={!!flatErrors['contract.endDate.year']}
+                                  error={
+                                    !!flatErrors['contract.endDate.year'] ||
+                                    !!flatErrors['contract.endDate.validDate']
+                                  }
                                   id="IntakeForm-ContractEndYear"
                                   name="contract.endDate.year"
                                 />


### PR DESCRIPTION
Actually validate the month, date, year field(s) to ensure that they are valid dates. This is more than just checking month is between 1-12, day between 1-31, and year.

For example, 2/30/2021 is not a valid date.

We do the same thing on GRT dates. I'm still a little uncertain about this, but fixes the current issue and leverages code we are already using.