### PR TITLE
fix mobile sidenav opening/closing

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -20,6 +20,7 @@ export const Header = ({ children }: HeaderProps) => {
   const { t } = useTranslation();
   const [userName, setUserName] = useState('');
   const [displayDropdown, setDisplayDropdown] = useState(false);
+  const [isMobileSideNavExpanded, setIsMobileSideNavExpanded] = useState(false);
   const dropdownNode = useRef<any>();
 
   useEffect(() => {
@@ -57,6 +58,18 @@ export const Header = ({ children }: HeaderProps) => {
     };
   }, []);
 
+  useEffect(() => {
+    const handleResize = () => {
+      if (isMobileSideNavExpanded && window.innerWidth > 1023) {
+        setIsMobileSideNavExpanded(false);
+      }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const arrowClassname = classnames(
     'fa',
     'fa-angle-down',
@@ -65,6 +78,11 @@ export const Header = ({ children }: HeaderProps) => {
       'easi-header__caret--rotate': displayDropdown
     }
   );
+
+  const mobileSideNavClasses = classnames('usa-nav', 'sidenav-mobile', {
+    'is-visible': isMobileSideNavExpanded
+  });
+
   return (
     <header className="usa-header easi-header" role="banner">
       <UsGovBanner />
@@ -76,7 +94,11 @@ export const Header = ({ children }: HeaderProps) => {
             </em>
           </Link>
         </div>
-        <button type="button" className="usa-menu-btn">
+        <button
+          type="button"
+          className="usa-menu-btn"
+          onClick={() => setIsMobileSideNavExpanded(true)}
+        >
           <span className="fa fa-bars" />
         </button>
         <div className="navbar--container">
@@ -122,10 +144,19 @@ export const Header = ({ children }: HeaderProps) => {
       </div>
 
       <div className="grid-container easi-header--desktop ">{children}</div>
-
+      <div
+        className={classnames('usa-overlay', {
+          'is-visible': isMobileSideNavExpanded
+        })}
+      />
       {/* Mobile Display */}
-      <div className="usa-nav sidenav-mobile">
-        <button type="button" className="usa-nav__close" aria-label="Close">
+      <div className={mobileSideNavClasses}>
+        <button
+          type="button"
+          className="usa-nav__close"
+          aria-label="Close"
+          onClick={() => setIsMobileSideNavExpanded(false)}
+        >
           <span className="fa fa-close" />
         </button>
         <div className="usa-nav__inner">

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -22,6 +22,7 @@ export const Header = ({ children }: HeaderProps) => {
   const [displayDropdown, setDisplayDropdown] = useState(false);
   const [isMobileSideNavExpanded, setIsMobileSideNavExpanded] = useState(false);
   const dropdownNode = useRef<any>();
+  const mobileSideNav = useRef<any>();
 
   useEffect(() => {
     let isMounted = true;
@@ -47,7 +48,16 @@ export const Header = ({ children }: HeaderProps) => {
       return;
     }
 
+    if (
+      mobileSideNav &&
+      mobileSideNav.current &&
+      mobileSideNav.current.contains(e.target)
+    ) {
+      return;
+    }
+
     setDisplayDropdown(false);
+    setIsMobileSideNavExpanded(false);
   };
 
   useEffect(() => {
@@ -150,7 +160,7 @@ export const Header = ({ children }: HeaderProps) => {
         })}
       />
       {/* Mobile Display */}
-      <div className={mobileSideNavClasses}>
+      <div ref={mobileSideNav} className={mobileSideNavClasses}>
         <button
           type="button"
           className="usa-nav__close"

--- a/src/views/GovernanceOverview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceOverview/__snapshots__/index.test.tsx.snap
@@ -175,6 +175,7 @@ exports[`The governance overview page matches the snapshot 1`] = `
       </div>
       <button
         className="usa-menu-btn"
+        onClick={[Function]}
         type="button"
       >
         <span
@@ -207,11 +208,15 @@ exports[`The governance overview page matches the snapshot 1`] = `
       className="grid-container easi-header--desktop "
     />
     <div
+      className="usa-overlay"
+    />
+    <div
       className="usa-nav sidenav-mobile"
     >
       <button
         aria-label="Close"
         className="usa-nav__close"
+        onClick={[Function]}
         type="button"
       >
         <span

--- a/src/views/NotFound/__snapshots__/index.test.tsx.snap
+++ b/src/views/NotFound/__snapshots__/index.test.tsx.snap
@@ -175,6 +175,7 @@ exports[`The Not Found Page matches the snapshot 1`] = `
       </div>
       <button
         className="usa-menu-btn"
+        onClick={[Function]}
         type="button"
       >
         <span
@@ -207,11 +208,15 @@ exports[`The Not Found Page matches the snapshot 1`] = `
       className="grid-container easi-header--desktop "
     />
     <div
+      className="usa-overlay"
+    />
+    <div
       className="usa-nav sidenav-mobile"
     >
       <button
         aria-label="Close"
         className="usa-nav__close"
+        onClick={[Function]}
         type="button"
       >
         <span

--- a/src/views/TermsAndConditions/__snapshots__/index.test.tsx.snap
+++ b/src/views/TermsAndConditions/__snapshots__/index.test.tsx.snap
@@ -175,6 +175,7 @@ exports[`The Terms & Conditions page matches the snapshot 1`] = `
       </div>
       <button
         className="usa-menu-btn"
+        onClick={[Function]}
         type="button"
       >
         <span
@@ -207,11 +208,15 @@ exports[`The Terms & Conditions page matches the snapshot 1`] = `
       className="grid-container easi-header--desktop "
     />
     <div
+      className="usa-overlay"
+    />
+    <div
       className="usa-nav sidenav-mobile"
     >
       <button
         aria-label="Close"
         className="usa-nav__close"
+        onClick={[Function]}
         type="button"
       >
         <span


### PR DESCRIPTION
This PR allows the mobile header to open/close the mobile sidenav.

This broke because we removed the USWDS Javascript and forget to update this component.
