### PR TITLE
EASI-1134 ES-525 translation helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/guregu/null v4.0.0+incompatible
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/launchdarkly/eventsource v1.6.1 // indirect
 	github.com/lestrrat-go/jwx v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -232,11 +232,14 @@ github.com/guregu/null v4.0.0+incompatible h1:4zw0ckM7ECd6FNNddc3Fu4aty9nTlpkkzH
 github.com/guregu/null v4.0.0+incompatible/go.mod h1:ePGpQaN9cw0tj45IR5E5ehMvsFlLlQZAkkOXZurJ3NM=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=

--- a/pkg/cedar/intake/action.go
+++ b/pkg/cedar/intake/action.go
@@ -1,0 +1,53 @@
+package intake
+
+import (
+	"context"
+	"encoding/json"
+
+	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+// func translateActions(c context.Context, actions []*models.Action) ([]*wire.IntakeInput, error) {
+// 	var results []*wire.IntakeInput
+// 	for _, action := range actions {
+// 		ii, err := translateAction(c, action)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		results = append(results, ii)
+// 	}
+// 	return results, nil
+// }
+
+func translateAction(_ context.Context, action *models.Action) (*wire.IntakeInput, error) {
+	obj := wire.EASIAction{
+		IntakeID:   pStr(action.IntakeID.String()),
+		ActionType: pStr(string(action.ActionType)),
+		ActorEUA:   pStr(action.ActorEUAUserID),
+		Feedback:   pStr(action.Feedback.ValueOrZero()),
+	}
+
+	blob, err := json.Marshal(&obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := wire.IntakeInput{
+		ID:   pStr(action.ID.String()),
+		Body: pStr(string(blob)),
+
+		// invariants for this type
+		Status:     pStr(wire.IntakeInputStatusFinal),
+		BodyFormat: pStr(wire.IntakeInputBodyFormatJSON),
+		Type:       pStr(wire.IntakeInputTypeEASIAction),
+		Schema:     pStr(wire.IntakeInputSchemaEASIActionV01),
+	}
+
+	if action.CreatedAt != nil {
+		result.CreatedDate = pDateTime(action.CreatedAt)
+		result.LastUpdate = pDateTime(action.CreatedAt)
+	}
+
+	return &result, nil
+}

--- a/pkg/cedar/intake/action.go
+++ b/pkg/cedar/intake/action.go
@@ -3,24 +3,17 @@ package intake
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
-// func translateActions(c context.Context, actions []*models.Action) ([]*wire.IntakeInput, error) {
-// 	var results []*wire.IntakeInput
-// 	for _, action := range actions {
-// 		ii, err := translateAction(c, action)
-// 		if err != nil {
-// 			return nil, err
-// 		}
-// 		results = append(results, ii)
-// 	}
-// 	return results, nil
-// }
-
 func translateAction(_ context.Context, action *models.Action) (*wire.IntakeInput, error) {
+	if action == nil {
+		return nil, fmt.Errorf("nil action received")
+	}
+
 	obj := wire.EASIAction{
 		IntakeID:   pStr(action.IntakeID.String()),
 		ActionType: pStr(string(action.ActionType)),

--- a/pkg/cedar/intake/biz.go
+++ b/pkg/cedar/intake/biz.go
@@ -1,0 +1,121 @@
+package intake
+
+import (
+	"context"
+	"encoding/json"
+
+	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+func translateBizCase(ctx context.Context, bc *models.BusinessCase) ([]*wire.IntakeInput, error) {
+	bcID := bc.ID.String()
+
+	obj := wire.EASIBizCase{
+		UserEUA:              pStr(bc.EUAUserID),
+		ProjectName:          pStr(bc.ProjectName.ValueOrZero()),
+		Requester:            pStr(bc.Requester.ValueOrZero()),
+		RequesterPhoneNumber: pStr(bc.RequesterPhoneNumber.ValueOrZero()),
+		BusinessOwner:        pStr(bc.BusinessOwner.ValueOrZero()),
+		BusinessNeed:         pStr(bc.BusinessNeed.ValueOrZero()),
+		CmsBenefit:           pStr(bc.CMSBenefit.ValueOrZero()),
+		PriorityAlignment:    pStr(bc.PriorityAlignment.ValueOrZero()),
+		SuccessIndicators:    pStr(bc.SuccessIndicators.ValueOrZero()),
+
+		AsIsTitle:       pStr(bc.AsIsTitle.ValueOrZero()),
+		AsIsSummary:     pStr(bc.AsIsSummary.ValueOrZero()),
+		AsIsPros:        pStr(bc.AsIsPros.ValueOrZero()),
+		AsIsCons:        pStr(bc.AsIsCons.ValueOrZero()),
+		AsIsCostSavings: pStr(bc.AsIsCostSavings.ValueOrZero()),
+
+		PreferredTitle:                   pStr(bc.PreferredTitle.ValueOrZero()),
+		PreferredSummary:                 pStr(bc.PreferredSummary.ValueOrZero()),
+		PreferredAcquisitionApproach:     pStr(bc.PreferredAcquisitionApproach.ValueOrZero()),
+		PreferredSecurityIsApproved:      pBool(bc.PreferredSecurityIsApproved),
+		PreferredSecurityIsBeingReviewed: pStr(bc.PreferredSecurityIsBeingReviewed.ValueOrZero()),
+		PreferredHostingType:             pStr(bc.PreferredHostingType.ValueOrZero()),
+		PreferredHostingLocation:         pStr(bc.PreferredHostingLocation.ValueOrZero()),
+		PreferredHostingCloudServiceType: pStr(bc.PreferredHostingCloudServiceType.ValueOrZero()),
+		PreferredHasUI:                   pStr(bc.PreferredHasUI.ValueOrZero()),
+		PreferredPros:                    pStr(bc.PreferredPros.ValueOrZero()),
+		PreferredCons:                    pStr(bc.PreferredCons.ValueOrZero()),
+		PreferredCostSavings:             pStr(bc.PreferredCostSavings.ValueOrZero()),
+
+		AlternativeATitle:                   pStr(bc.AlternativeATitle.ValueOrZero()),
+		AlternativeASummary:                 pStr(bc.AlternativeASummary.ValueOrZero()),
+		AlternativeAAcquisitionApproach:     pStr(bc.AlternativeAAcquisitionApproach.ValueOrZero()),
+		AlternativeASecurityIsApproved:      pBool(bc.AlternativeASecurityIsApproved),
+		AlternativeASecurityIsBeingReviewed: pStr(bc.AlternativeASecurityIsBeingReviewed.ValueOrZero()),
+		AlternativeAHostingType:             pStr(bc.AlternativeAHostingType.ValueOrZero()),
+		AlternativeAHostingLocation:         pStr(bc.AlternativeAHostingLocation.ValueOrZero()),
+		AlternativeAHostingCloudServiceType: pStr(bc.AlternativeAHostingCloudServiceType.ValueOrZero()),
+		AlternativeAHasUI:                   pStr(bc.AlternativeAHasUI.ValueOrZero()),
+		AlternativeAPros:                    pStr(bc.AlternativeAPros.ValueOrZero()),
+		AlternativeACons:                    pStr(bc.AlternativeACons.ValueOrZero()),
+		AlternativeACostSavings:             pStr(bc.AlternativeACostSavings.ValueOrZero()),
+
+		AlternativeBTitle:                   pStr(bc.AlternativeBTitle.ValueOrZero()),
+		AlternativeBSummary:                 pStr(bc.AlternativeBSummary.ValueOrZero()),
+		AlternativeBAcquisitionApproach:     pStr(bc.AlternativeBAcquisitionApproach.ValueOrZero()),
+		AlternativeBSecurityIsApproved:      pBool(bc.AlternativeBSecurityIsApproved),
+		AlternativeBSecurityIsBeingReviewed: pStr(bc.AlternativeBSecurityIsBeingReviewed.ValueOrZero()),
+		AlternativeBHostingType:             pStr(bc.AlternativeBHostingType.ValueOrZero()),
+		AlternativeBHostingLocation:         pStr(bc.AlternativeBHostingLocation.ValueOrZero()),
+		AlternativeBHostingCloudServiceType: pStr(bc.AlternativeBHostingCloudServiceType.ValueOrZero()),
+		AlternativeBHasUI:                   pStr(bc.AlternativeBHasUI.ValueOrZero()),
+		AlternativeBPros:                    pStr(bc.AlternativeBPros.ValueOrZero()),
+		AlternativeBCons:                    pStr(bc.AlternativeBCons.ValueOrZero()),
+		AlternativeBCostSavings:             pStr(bc.PreferredCostSavings.ValueOrZero()),
+
+		SubmittedAt:        pDateTime(bc.SubmittedAt),
+		ArchivedAt:         pDateTime(bc.ArchivedAt),
+		InitialSubmittedAt: pDateTime(bc.InitialSubmittedAt),
+		LastSubmittedAt:    pDateTime(bc.LastSubmittedAt),
+	}
+
+	blob, err := json.Marshal(&obj)
+	if err != nil {
+		return nil, err
+	}
+
+	status := wire.IntakeInputStatusInitiated
+	// if true {
+	// 	// TODO: what defines a bizcase as being Final|Initiated?
+	// 	return nil, fmt.Errorf("not yet implemented")
+	// }
+
+	result := wire.IntakeInput{
+		ID:     pStr(bcID),
+		Body:   pStr(string(blob)),
+		Status: pStr(status),
+
+		// invariants for this type
+		BodyFormat: pStr(wire.IntakeInputBodyFormatJSON),
+		Type:       pStr(wire.IntakeInputTypeEASIBizCase),
+		Schema:     pStr(wire.IntakeInputSchemaEASIBizCaseV01),
+	}
+
+	if bc.CreatedAt != nil {
+		result.CreatedDate = pDateTime(bc.CreatedAt)
+	}
+	if bc.UpdatedAt != nil {
+		result.LastUpdate = pDateTime(bc.UpdatedAt)
+	}
+
+	results := []*wire.IntakeInput{&result}
+	for _, lc := range bc.LifecycleCostLines {
+		ii, err := translateLifecycleCost(ctx, bcID, lc)
+		if err != nil {
+			return nil, err
+		}
+
+		// Lifecycle cost inherits these values from the parent BusinessCase
+		ii.Status = pStr(status)
+		ii.CreatedDate = result.CreatedDate
+		ii.LastUpdate = result.LastUpdate
+
+		results = append(results, ii)
+	}
+	// return nil, fmt.Errorf("not yet implemented")
+	return results, nil
+}

--- a/pkg/cedar/intake/biz.go
+++ b/pkg/cedar/intake/biz.go
@@ -3,16 +3,22 @@ package intake
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 func translateBizCase(ctx context.Context, bc *models.BusinessCase) ([]*wire.IntakeInput, error) {
+	if bc == nil {
+		return nil, fmt.Errorf("nil bizcase received")
+	}
+
 	bcID := bc.ID.String()
 
 	obj := wire.EASIBizCase{
 		UserEUA:              pStr(bc.EUAUserID),
+		IntakeID:             pStr(bc.SystemIntakeID.String()),
 		ProjectName:          pStr(bc.ProjectName.ValueOrZero()),
 		Requester:            pStr(bc.Requester.ValueOrZero()),
 		RequesterPhoneNumber: pStr(bc.RequesterPhoneNumber.ValueOrZero()),

--- a/pkg/cedar/intake/cedar_intake.yml
+++ b/pkg/cedar/intake/cedar_intake.yml
@@ -162,7 +162,7 @@ definitions:
       - alternativeBPros
       - alternativeBCons
       - alternativeBCostSavings
-      - lifecycleCostLines
+      # - lifecycleCostLines
       - submittedAt
       - archivedAt
       - initialSubmittedAt
@@ -293,10 +293,10 @@ definitions:
         type: string
       alternativeBCostSavings:
         type: string
-      lifecycleCostLines:
-        type: array
-        items:
-          $ref: '#/definitions/EASILifecycleCost'
+      # lifecycleCostLines:
+      #   type: array
+      #   items:
+      #     $ref: '#/definitions/EASILifecycleCost'
       submittedAt:
         type: string
         # format: date-time

--- a/pkg/cedar/intake/client_test.go
+++ b/pkg/cedar/intake/client_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
+	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
+	"github.com/cmsgov/easi-app/pkg/testhelpers"
 )
 
 type ClientTestSuite struct {
@@ -43,7 +46,111 @@ func (s ClientTestSuite) TestClient() {
 		c := &Client{emitToCedar: func(context.Context) bool { return true }}
 		err := c.CheckConnection(ctx)
 		s.Error(err)
-		err = c.PublishSnapshot(ctx, nil, nil, nil, nil, nil)
+
+		si := testhelpers.NewSystemIntake()
+		si.CreatedAt = si.ContractStartDate
+		si.UpdatedAt = si.ContractStartDate
+
+		err = c.PublishSnapshot(ctx, &si, nil, nil, nil, nil)
+		s.Error(err)
+	})
+}
+
+func (s ClientTestSuite) TestTranslation() {
+	ctx := appcontext.WithLogger(context.Background(), s.logger)
+
+	s.Run("action", func() {
+		action := testhelpers.NewAction()
+		id := uuid.New()
+		action.IntakeID = &id
+
+		ii, err := translateAction(ctx, &action)
+		s.NoError(err)
+
+		err = validateInputs(ctx, []*wire.IntakeInput{ii})
+		s.NoError(err)
+	})
+
+	s.Run("system intake", func() {
+		si := testhelpers.NewSystemIntake()
+		si.CreatedAt = si.ContractStartDate
+		si.UpdatedAt = si.ContractStartDate
+
+		ii, err := translateSystemIntake(ctx, &si)
+		s.NoError(err)
+
+		err = validateInputs(ctx, []*wire.IntakeInput{ii})
+		s.NoError(err)
+	})
+
+	s.Run("note", func() {
+		note := testhelpers.NewNote()
+
+		ii, err := translateNote(ctx, &note)
+		s.NoError(err)
+
+		err = validateInputs(ctx, []*wire.IntakeInput{ii})
+		s.NoError(err)
+	})
+
+	s.Run("biz case", func() {
+		bc := testhelpers.NewBusinessCase()
+
+		iis, err := translateBizCase(ctx, &bc)
+		s.NoError(err)
+
+		err = validateInputs(ctx, iis)
+		s.NoError(err)
+	})
+
+	s.Run("feedback", func() {
+		fb := testhelpers.NewGRTFeedback()
+
+		ii, err := translateFeedback(ctx, &fb)
+		s.NoError(err)
+
+		err = validateInputs(ctx, []*wire.IntakeInput{ii})
+		s.NoError(err)
+	})
+
+	s.Run("nil entry throws exception", func() {
+		err := validateInputs(context.Background(), []*wire.IntakeInput{nil})
+		s.Error(err)
+	})
+
+	s.Run("unrecognized type", func() {
+		note := testhelpers.NewNote()
+
+		ii, err := translateNote(ctx, &note)
+		s.NoError(err)
+		inType := "FakeType"
+		ii.Type = &inType
+
+		err = validateInputs(ctx, []*wire.IntakeInput{ii})
+		s.Error(err)
+	})
+
+	s.Run("unrecognized schema", func() {
+		note := testhelpers.NewNote()
+
+		ii, err := translateNote(ctx, &note)
+		s.NoError(err)
+		inSchema := "FakeType01"
+		ii.Schema = &inSchema
+
+		err = validateInputs(ctx, []*wire.IntakeInput{ii})
+		s.Error(err)
+	})
+
+	s.Run("mismatch type and schema", func() {
+		note := testhelpers.NewNote()
+
+		ii, err := translateNote(ctx, &note)
+		s.NoError(err)
+		inSchema := wire.IntakeInputSchemaEASIActionV01
+		ii.Schema = &inSchema
+
+		err = validateInputs(ctx, []*wire.IntakeInput{ii})
 		s.Error(err)
 	})
 

--- a/pkg/cedar/intake/feedback.go
+++ b/pkg/cedar/intake/feedback.go
@@ -1,0 +1,47 @@
+package intake
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+func translateFeedback(_ context.Context, fb *models.GRTFeedback) (*wire.IntakeInput, error) {
+	if fb == nil {
+		return nil, fmt.Errorf("nil feedback received")
+	}
+
+	obj := wire.EASIGrtFeedback{
+		IntakeID:     pStr(fb.IntakeID.String()),
+		Feedback:     pStr(fb.Feedback),
+		FeedbackType: pStr(string(fb.FeedbackType)),
+	}
+
+	blob, err := json.Marshal(&obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := wire.IntakeInput{
+		ID:   pStr(fb.ID.String()),
+		Body: pStr(string(blob)),
+
+		// invariants for this type
+		Status:     pStr(wire.IntakeInputStatusFinal),
+		BodyFormat: pStr(wire.IntakeInputBodyFormatJSON),
+		Type:       pStr(wire.IntakeInputTypeEASIGrtFeedback),
+		Schema:     pStr(wire.IntakeInputSchemaEASIGrtFeedbackV01),
+	}
+
+	if fb.CreatedAt != nil {
+		result.CreatedDate = pDateTime(fb.CreatedAt)
+	}
+	if fb.UpdatedAt != nil {
+		result.LastUpdate = pDateTime(fb.CreatedAt)
+	}
+
+	return &result, nil
+}

--- a/pkg/cedar/intake/gen/models/e_a_s_i_biz_case.go
+++ b/pkg/cedar/intake/gen/models/e_a_s_i_biz_case.go
@@ -7,7 +7,6 @@ package models
 
 import (
 	"encoding/json"
-	"strconv"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -165,10 +164,6 @@ type EASIBizCase struct {
 	// last submitted at
 	// Required: true
 	LastSubmittedAt *string `json:"lastSubmittedAt"`
-
-	// lifecycle cost lines
-	// Required: true
-	LifecycleCostLines []*EASILifecycleCost `json:"lifecycleCostLines"`
 
 	// preferred acquisition approach
 	// Required: true
@@ -393,10 +388,6 @@ func (m *EASIBizCase) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateLastSubmittedAt(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateLifecycleCostLines(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -875,31 +866,6 @@ func (m *EASIBizCase) validateLastSubmittedAt(formats strfmt.Registry) error {
 
 	if err := validate.Required("lastSubmittedAt", "body", m.LastSubmittedAt); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func (m *EASIBizCase) validateLifecycleCostLines(formats strfmt.Registry) error {
-
-	if err := validate.Required("lifecycleCostLines", "body", m.LifecycleCostLines); err != nil {
-		return err
-	}
-
-	for i := 0; i < len(m.LifecycleCostLines); i++ {
-		if swag.IsZero(m.LifecycleCostLines[i]) { // not required
-			continue
-		}
-
-		if m.LifecycleCostLines[i] != nil {
-			if err := m.LifecycleCostLines[i].Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("lifecycleCostLines" + "." + strconv.Itoa(i))
-				}
-				return err
-			}
-		}
-
 	}
 
 	return nil

--- a/pkg/cedar/intake/helpers.go
+++ b/pkg/cedar/intake/helpers.go
@@ -1,19 +1,32 @@
 package intake
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/guregu/null"
+	"github.com/hashicorp/go-multierror"
+
+	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
 )
 
 const iso8601 = "2006-01-02 15:04:05Z07:00"
 
+// pStr is a quick helper for turning a string into a string-pointer
+// inline, without having to clutter your mainline code with the
+// indirection, e.g. when building a type and assigning properties
 func pStr(s string) *string {
 	return &s
 }
 
+// pDate turns a Time pointer into either an empty string in the
+// negative case, or to a whole day string in CEDAR's preferred
+// ISO8601 format, e.g. "2006-01-02"
 func pDate(t *time.Time) *string {
 	val := ""
 	if t != nil {
@@ -22,19 +35,93 @@ func pDate(t *time.Time) *string {
 	return pStr(val)
 }
 
+// pDate turns a Time pointer into either an empty string in the
+// negative case, or to a string rin CEDAR's preferred
+// ISO8601 format, e.g. "2006-01-02 15:04:05Z"
 func pDateTime(t *time.Time) *string {
 	val := ""
 	if t != nil {
 		// val = strfmt.DateTime(*t).String()
-		val = t.Format(iso8601)
+		val = t.UTC().Format(iso8601)
 	}
 	return pStr(val)
 }
 
+// pBool turns a nullable boolean into a string, using the empty
+// string to represent the un-set case, or "true" or "false"
+// otherwise
 func pBool(b null.Bool) *string {
 	val := ""
 	if b.Ptr() != nil {
 		val = strconv.FormatBool(b.Bool)
 	}
 	return pStr(val)
+}
+
+type validater interface {
+	Validate(strfmt.Registry) error
+}
+
+// validateInputs ensures each of the payload bodies that we build are fully
+// adhering to the schema requirements
+func validateInputs(c context.Context, iis []*wire.IntakeInput) error {
+	var errs *multierror.Error
+	for _, ii := range iis {
+		if err := validateInput(c, ii); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+	return errs.ErrorOrNil()
+}
+
+func validateInput(_ context.Context, ii *wire.IntakeInput) error {
+	if ii == nil {
+		return fmt.Errorf("nil IntakeInput disallowed")
+	}
+
+	inID := "n/a"
+	if ii.ID != nil {
+		inID = *ii.ID
+	}
+	inType := "n/a"
+	if ii.Type != nil {
+		inType = *ii.Type
+	}
+	ePrefix := fmt.Sprintf("id:%s type:%s", inID, inType)
+	if err := ii.Validate(strfmt.Default); err != nil {
+		return fmt.Errorf("%s: %w", ePrefix, err)
+	}
+
+	inSchema := *ii.Schema
+	if !strings.HasPrefix(inSchema, inType) {
+		return fmt.Errorf("%s: schema disagreement: %s", ePrefix, inSchema)
+	}
+
+	var v validater
+	switch inSchema {
+	case wire.IntakeInputSchemaEASIActionV01:
+		v = &wire.EASIAction{}
+	case wire.IntakeInputSchemaEASIBizCaseV01:
+		v = &wire.EASIBizCase{}
+	case wire.IntakeInputSchemaEASIGrtFeedbackV01:
+		v = &wire.EASIGrtFeedback{}
+	case wire.IntakeInputSchemaEASIIntakeV01:
+		v = &wire.EASIIntake{}
+	case wire.IntakeInputSchemaEASILifecycleCostV01:
+		v = &wire.EASILifecycleCost{}
+	case wire.IntakeInputSchemaEASINoteV01:
+		v = &wire.EASINote{}
+	default:
+		return fmt.Errorf("unrecognized schema: %s", inSchema)
+	}
+
+	body := *ii.Body
+	if err := json.Unmarshal([]byte(body), v); err != nil {
+		return fmt.Errorf("%s: %w", ePrefix, err)
+	}
+	if err := v.Validate(strfmt.Default); err != nil {
+		return fmt.Errorf("%s: %w", ePrefix, err)
+	}
+
+	return nil
 }

--- a/pkg/cedar/intake/helpers.go
+++ b/pkg/cedar/intake/helpers.go
@@ -1,0 +1,40 @@
+package intake
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/guregu/null"
+)
+
+const iso8601 = "2006-01-02 15:04:05Z07:00"
+
+func pStr(s string) *string {
+	return &s
+}
+
+func pDate(t *time.Time) *string {
+	val := ""
+	if t != nil {
+		val = strfmt.Date(*t).String()
+	}
+	return pStr(val)
+}
+
+func pDateTime(t *time.Time) *string {
+	val := ""
+	if t != nil {
+		// val = strfmt.DateTime(*t).String()
+		val = t.Format(iso8601)
+	}
+	return pStr(val)
+}
+
+func pBool(b null.Bool) *string {
+	val := ""
+	if b.Ptr() != nil {
+		val = strconv.FormatBool(b.Bool)
+	}
+	return pStr(val)
+}

--- a/pkg/cedar/intake/lifecycle_cost.go
+++ b/pkg/cedar/intake/lifecycle_cost.go
@@ -1,0 +1,53 @@
+package intake
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+func translateLifecycleCost(_ context.Context, bcID string, lc models.EstimatedLifecycleCost) (*wire.IntakeInput, error) {
+	obj := wire.EASILifecycleCost{
+		BusinessCaseID: pStr(bcID),
+		Solution:       pStr(string(lc.Solution)),
+		Year:           pStr(string(lc.Year)),
+	}
+	phase := ""
+	if lc.Phase != nil {
+		phase = string(*lc.Phase)
+	}
+	obj.Phase = pStr(phase)
+
+	cost := ""
+	if lc.Cost != nil {
+		cost = strconv.Itoa(*lc.Cost)
+	}
+	obj.Cost = pStr(cost)
+
+	blob, err := json.Marshal(&obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &wire.IntakeInput{
+		ID:   pStr(lc.ID.String()),
+		Body: pStr(string(blob)),
+
+		// invariants for this type
+		BodyFormat: pStr(wire.IntakeInputBodyFormatJSON),
+		Type:       pStr(wire.IntakeInputTypeEASILifecycleCost),
+		Schema:     pStr(wire.IntakeInputSchemaEASILifecycleCostV01),
+
+		// these fields will be inherited/applied from the wrapping business case
+		// Status:     pStr(wire.IntakeInputStatusFinal),
+		// CreatedDate: pDateTime(lc.CreatedAt)
+		// LastUpdate: pDateTime(lc.CreatedAt)
+	}
+
+	// _ = result
+	// return nil, fmt.Errorf("not yet implemented")
+	return result, nil
+}

--- a/pkg/cedar/intake/note.go
+++ b/pkg/cedar/intake/note.go
@@ -10,6 +10,10 @@ import (
 )
 
 func translateNote(_ context.Context, note *models.Note) (*wire.IntakeInput, error) {
+	if note == nil {
+		return nil, fmt.Errorf("nil note received")
+	}
+
 	obj := wire.EASINote{
 		IntakeID:  pStr(note.SystemIntakeID.String()),
 		AuthorEUA: pStr(note.AuthorEUAID),
@@ -37,5 +41,5 @@ func translateNote(_ context.Context, note *models.Note) (*wire.IntakeInput, err
 		result.LastUpdate = pDateTime(note.CreatedAt)
 	}
 
-	return nil, fmt.Errorf("not yet implemented")
+	return &result, nil
 }

--- a/pkg/cedar/intake/note.go
+++ b/pkg/cedar/intake/note.go
@@ -1,0 +1,41 @@
+package intake
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+func translateNote(_ context.Context, note *models.Note) (*wire.IntakeInput, error) {
+	obj := wire.EASINote{
+		IntakeID:  pStr(note.SystemIntakeID.String()),
+		AuthorEUA: pStr(note.AuthorEUAID),
+		Content:   pStr(note.Content.ValueOrZero()),
+	}
+
+	blob, err := json.Marshal(&obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := wire.IntakeInput{
+		ID:   pStr(note.ID.String()),
+		Body: pStr(string(blob)),
+
+		// invariants for this type
+		Status:     pStr(wire.IntakeInputStatusFinal),
+		BodyFormat: pStr(wire.IntakeInputBodyFormatJSON),
+		Type:       pStr(wire.IntakeInputTypeEASINote),
+		Schema:     pStr(wire.IntakeInputSchemaEASINoteV01),
+	}
+
+	if note.CreatedAt != nil {
+		result.CreatedDate = pDateTime(note.CreatedAt)
+		result.LastUpdate = pDateTime(note.CreatedAt)
+	}
+
+	return nil, fmt.Errorf("not yet implemented")
+}

--- a/pkg/cedar/intake/system_intake.go
+++ b/pkg/cedar/intake/system_intake.go
@@ -1,0 +1,92 @@
+package intake
+
+import (
+	"context"
+	"encoding/json"
+
+	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+func translateSystemIntake(_ context.Context, si *models.SystemIntake) (*wire.IntakeInput, error) {
+	obj := &wire.EASIIntake{
+		UserEUA:                     pStr(si.EUAUserID.ValueOrZero()),
+		Status:                      pStr(string(si.Status)),
+		RequestType:                 pStr(string(si.RequestType)),
+		Requester:                   pStr(si.Requester),
+		Component:                   pStr(si.Component.ValueOrZero()),
+		BusinessOwner:               pStr(si.BusinessOwner.ValueOrZero()),
+		BusinessOwnerComponent:      pStr(si.BusinessOwnerComponent.ValueOrZero()),
+		ProductManager:              pStr(si.ProductManager.ValueOrZero()),
+		ProductManagerComponent:     pStr(si.ProductManagerComponent.ValueOrZero()),
+		Isso:                        pStr(si.ISSO.ValueOrZero()),
+		IssoName:                    pStr(si.ISSOName.ValueOrZero()),
+		TrbCollaborator:             pStr(si.TRBCollaborator.ValueOrZero()),
+		TrbCollaboratorName:         pStr(si.TRBCollaboratorName.ValueOrZero()),
+		OitSecurityCollaborator:     pStr(si.OITSecurityCollaborator.ValueOrZero()),
+		OitSecurityCollaboratorName: pStr(si.OITSecurityCollaboratorName.ValueOrZero()),
+		EaCollaborator:              pStr(si.EACollaborator.ValueOrZero()),
+		EaCollaboratorName:          pStr(si.EACollaboratorName.ValueOrZero()),
+		ProjectName:                 pStr(si.ProjectName.ValueOrZero()),
+		ProjectAcronym:              pStr(si.ProjectAcronym.ValueOrZero()),
+		FundingSource:               pStr(si.FundingSource.ValueOrZero()),
+		FundingNumber:               pStr(si.FundingNumber.ValueOrZero()),
+		BusinessNeed:                pStr(si.BusinessNeed.ValueOrZero()),
+		Solution:                    pStr(si.Solution.ValueOrZero()),
+		ProcessStatus:               pStr(si.ProcessStatus.ValueOrZero()),
+		ExistingContract:            pStr(si.ExistingContract.ValueOrZero()),
+		CostIncrease:                pStr(si.CostIncrease.ValueOrZero()),
+		CostIncreaseAmount:          pStr(si.CostIncreaseAmount.ValueOrZero()),
+		Contractor:                  pStr(si.Contractor.ValueOrZero()),
+		ContractVehicle:             pStr(si.ContractVehicle.ValueOrZero()),
+		GrtReviewEmailBody:          pStr(si.GrtReviewEmailBody.ValueOrZero()),
+		RequesterEmailAddress:       pStr(si.RequesterEmailAddress.ValueOrZero()),
+		LifecycleID:                 pStr(si.LifecycleID.ValueOrZero()),
+		LifecycleScope:              pStr(si.LifecycleScope.ValueOrZero()),
+		DecisionNextSteps:           pStr(si.DecisionNextSteps.ValueOrZero()),
+		RejectionReason:             pStr(si.RejectionReason.ValueOrZero()),
+		AdminLead:                   pStr(si.AdminLead.ValueOrZero()),
+
+		ExistingFunding:    pBool(si.ExistingFunding),
+		EaSupportRequest:   pBool(si.EASupportRequest),
+		ContractStartDate:  pDate(si.ContractStartDate),
+		ContractEndDate:    pDate(si.ContractEndDate),
+		SubmittedAt:        pDateTime(si.SubmittedAt),
+		DecidedAt:          pDateTime(si.DecidedAt),
+		ArchivedAt:         pDateTime(si.ArchivedAt),
+		GrbDate:            pDate(si.GRBDate),
+		GrtDate:            pDate(si.GRTDate),
+		LifecycleExpiresAt: pDate(si.LifecycleExpiresAt),
+	}
+
+	blob, err := json.Marshal(&obj)
+	if err != nil {
+		return nil, err
+	}
+
+	status := wire.IntakeInputStatusInitiated
+	// if true {
+	// 	// TODO: need to figure out when to say the SystemIntake is "Final"
+	// 	return nil, fmt.Errorf("not yet implemented")
+	// }
+
+	result := wire.IntakeInput{
+		ID:     pStr(si.ID.String()),
+		Body:   pStr(string(blob)),
+		Status: pStr(status),
+
+		// invariants for this type
+		Type:       pStr(wire.IntakeInputTypeEASIIntake),
+		Schema:     pStr(wire.IntakeInputSchemaEASIIntakeV01),
+		BodyFormat: pStr(wire.IntakeInputBodyFormatJSON),
+	}
+
+	if si.CreatedAt != nil {
+		result.CreatedDate = pDateTime(si.CreatedAt)
+	}
+	if si.UpdatedAt != nil {
+		result.LastUpdate = pDateTime(si.UpdatedAt)
+	}
+
+	return &result, nil
+}

--- a/pkg/cedar/intake/system_intake.go
+++ b/pkg/cedar/intake/system_intake.go
@@ -3,12 +3,17 @@ package intake
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
 func translateSystemIntake(_ context.Context, si *models.SystemIntake) (*wire.IntakeInput, error) {
+	if si == nil {
+		return nil, fmt.Errorf("nil system intake received")
+	}
+
 	obj := &wire.EASIIntake{
 		UserEUA:                     pStr(si.EUAUserID.ValueOrZero()),
 		Status:                      pStr(string(si.Status)),

--- a/pkg/testhelpers/action.go
+++ b/pkg/testhelpers/action.go
@@ -1,6 +1,9 @@
 package testhelpers
 
 import (
+	"time"
+
+	"github.com/google/uuid"
 	"github.com/guregu/null"
 
 	"github.com/cmsgov/easi-app/pkg/models"
@@ -8,12 +11,15 @@ import (
 
 // NewAction generates an action to use in tests
 func NewAction() models.Action {
+	now := time.Now().UTC()
 	return models.Action{
+		ID:             uuid.New(),
 		IntakeID:       nil,
 		ActionType:     models.ActionTypeSUBMITINTAKE,
 		ActorName:      "Fake Name",
 		ActorEmail:     "fake@test.com",
 		ActorEUAUserID: "ABCD",
 		Feedback:       null.StringFrom("Test Feedback"),
+		CreatedAt:      &now,
 	}
 }

--- a/pkg/testhelpers/business_case.go
+++ b/pkg/testhelpers/business_case.go
@@ -1,6 +1,8 @@
 package testhelpers
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/guregu/null"
 
@@ -233,6 +235,7 @@ func NewValidLifecycleCosts(id *uuid.UUID) models.EstimatedLifecycleCosts {
 
 // NewBusinessCase allows us to generate a business case for tests
 func NewBusinessCase() models.BusinessCase {
+	now := time.Now().UTC()
 	year2 := models.LifecycleCostYear2
 	return models.BusinessCase{
 		ID:                              uuid.New(),
@@ -284,5 +287,7 @@ func NewBusinessCase() models.BusinessCase {
 		},
 		InitialSubmittedAt: nil,
 		LastSubmittedAt:    nil,
+		CreatedAt:          &now,
+		UpdatedAt:          &now,
 	}
 }

--- a/pkg/testhelpers/grt_feedback.go
+++ b/pkg/testhelpers/grt_feedback.go
@@ -1,0 +1,21 @@
+package testhelpers
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+// NewGRTFeedback generates a feedback to use in tests
+func NewGRTFeedback() models.GRTFeedback {
+	now := time.Now().UTC()
+	return models.GRTFeedback{
+		ID:           uuid.New(),
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+		FeedbackType: models.GRTFeedbackTypeGRB,
+		Feedback:     "Fake Feedback",
+	}
+}

--- a/pkg/testhelpers/note.go
+++ b/pkg/testhelpers/note.go
@@ -1,0 +1,22 @@
+package testhelpers
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/guregu/null"
+
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+// NewNote generates a note to use in tests
+func NewNote() models.Note {
+	now := time.Now().UTC()
+	return models.Note{
+		ID:          uuid.New(),
+		CreatedAt:   &now,
+		AuthorEUAID: "ABCDE",
+		AuthorName:  null.StringFrom("Fake Name"),
+		Content:     null.StringFrom("Fake Content"),
+	}
+}


### PR DESCRIPTION
# ES-525 (Previously EASI-1134)

Changes proposed in this pull request:

- this change is mostly the annoying bookkeeping of moving information (~"translating") from EASI internal representation over to the generated code representation that gets sent across the wire
- also added some tests, taking advantage of the validations provided by the generated code... (And actually our EASI models actually do a full round-trip into a JSON representation and come back out the other side to be validated!) This at least helps to make sure we that what we send is structurally in agreement with the Swagger spec.
- as of this PR, validation of the payload is currently in the active path, but I anticipate hiding that behind a feature flag in near-future PRs
