### PR TITLE
make PageHeading aria-live polite

### DIFF
--- a/src/components/PageHeading/__snapshots__/index.test.tsx.snap
+++ b/src/components/PageHeading/__snapshots__/index.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Page heading component matches the snapshot 1`] = `
 <h1
+  aria-live="polite"
   className="easi-h1"
   tabIndex={-1}
 >

--- a/src/components/PageHeading/index.tsx
+++ b/src/components/PageHeading/index.tsx
@@ -30,7 +30,13 @@ const PageHeading = ({
   }, []);
 
   return (
-    <Component className={classes} tabIndex={-1} ref={headingRef} {...props}>
+    <Component
+      className={classes}
+      tabIndex={-1}
+      ref={headingRef}
+      aria-live="polite"
+      {...props}
+    >
       {children}
     </Component>
   );

--- a/src/views/BusinessCase/Confirmation/__snapshots__/index.test.tsx.snap
+++ b/src/views/BusinessCase/Confirmation/__snapshots__/index.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`The Business Case Confirmation page matches the snapshot 1`] = `
 >
   <div>
     <h1
+      aria-live="polite"
       className="easi-h1"
       tabIndex={-1}
     >

--- a/src/views/GovernanceOverview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceOverview/__snapshots__/index.test.tsx.snap
@@ -279,6 +279,7 @@ exports[`The governance overview page matches the snapshot 1`] = `
       </span>
     </a>
     <h1
+      aria-live="polite"
       className="easi-h1"
       tabIndex={-1}
     >

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`The GRT business case review matches the snapshot 1`] = `
 <div>
   <h1
+    aria-live="polite"
     className="easi-h1 margin-top-0"
     tabIndex={-1}
   >

--- a/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`The GRT intake review view matches the snapshot 1`] = `
 Array [
   <div>
     <h1
+      aria-live="polite"
       className="easi-h1 margin-top-0"
       tabIndex={-1}
     >

--- a/src/views/NotFound/__snapshots__/index.test.tsx.snap
+++ b/src/views/NotFound/__snapshots__/index.test.tsx.snap
@@ -246,6 +246,7 @@ exports[`The Not Found Page matches the snapshot 1`] = `
       className="margin-y-7"
     >
       <h1
+        aria-live="polite"
         className="easi-h1"
         tabIndex={-1}
       >

--- a/src/views/TermsAndConditions/__snapshots__/index.test.tsx.snap
+++ b/src/views/TermsAndConditions/__snapshots__/index.test.tsx.snap
@@ -243,6 +243,7 @@ exports[`The Terms & Conditions page matches the snapshot 1`] = `
     tabIndex={-1}
   >
     <h1
+      aria-live="polite"
       className="easi-h1"
       tabIndex={-1}
     >


### PR DESCRIPTION
This PR adds the attribute `aria-live="polite"`.

Because this component steals focus on load (to indicate the page has changed), it cuts off whatever was previously being read. The `aria-live="polite"` will allow the previous reading to be completed before the heading reads.

For example, while confirmation notifications/alerts are being read, the `PageHeading` steals focus and cuts off the notification. We want the notification to finish reading before reading the `PageHeading`.
