### PR TITLE
LCID validation fixes

### DIFF
--- a/src/validations/actionSchema.ts
+++ b/src/validations/actionSchema.ts
@@ -5,13 +5,6 @@ export const actionSchema = Yup.object().shape({
 });
 
 export const lifecycleIdSchema = Yup.object().shape({
-  lifecycleId: Yup.string()
-    .trim()
-    .nullable()
-    .matches(
-      /^[A-Za-z]?[0-9]{6}$/,
-      'Must be 6 digits with optional preceding letter'
-    ),
   expirationDateDay: Yup.string()
     .trim()
     .length(2)
@@ -26,7 +19,18 @@ export const lifecycleIdSchema = Yup.object().shape({
     .required('Please include a year'),
   scope: Yup.string().trim().required('Please include a scope'),
   nextSteps: Yup.string().trim(),
-  feedback: Yup.string().trim().required('Please fill out email')
+  feedback: Yup.string().trim().required('Please fill out email'),
+  newLifecycleId: Yup.boolean().required('Choose the type of Lifecycle ID'),
+  lifecycleId: Yup.string().when('newLifecycleId', {
+    is: false,
+    then: Yup.string()
+      .trim()
+      .matches(
+        /^[A-Za-z]?[0-9]{6}$/,
+        'Must be 6 digits with optional preceding letter'
+      )
+      .required('Please enter the existing Lifecycle ID')
+  })
 });
 
 export const rejectIntakeSchema = Yup.object().shape({

--- a/src/validations/actionSchema.ts
+++ b/src/validations/actionSchema.ts
@@ -20,7 +20,9 @@ export const lifecycleIdSchema = Yup.object().shape({
   scope: Yup.string().trim().required('Please include a scope'),
   nextSteps: Yup.string().trim().required('Please fill out next steps'),
   feedback: Yup.string().trim().required('Please fill out email'),
-  newLifecycleId: Yup.boolean().required('Choose the type of Lifecycle ID'),
+  newLifecycleId: Yup.boolean().required(
+    'Choose if you need a new Lifecycle ID or if you will use an existing Lifecycle ID'
+  ),
   lifecycleId: Yup.string().when('newLifecycleId', {
     is: false,
     then: Yup.string()

--- a/src/validations/actionSchema.ts
+++ b/src/validations/actionSchema.ts
@@ -18,7 +18,7 @@ export const lifecycleIdSchema = Yup.object().shape({
     .length(4)
     .required('Please include a year'),
   scope: Yup.string().trim().required('Please include a scope'),
-  nextSteps: Yup.string().trim(),
+  nextSteps: Yup.string().trim().required('Please fill out next steps'),
   feedback: Yup.string().trim().required('Please fill out email'),
   newLifecycleId: Yup.boolean().required('Choose the type of Lifecycle ID'),
   lifecycleId: Yup.string().when('newLifecycleId', {

--- a/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
@@ -42,7 +42,8 @@ const IssueLifecycleId = () => {
     lifecycleId: '',
     expirationDateDay: '',
     expirationDateMonth: '',
-    expirationDateYear: ''
+    expirationDateYear: '',
+    newLifecycleId: undefined
   };
 
   const onSubmit = (values: SubmitLifecycleIdForm) => {


### PR DESCRIPTION
Changes proposed in this pull request:

- Require that users select one of the options when issuing a lifecycle id
![Screen Shot 2021-04-08 at 2 10 32 PM](https://user-images.githubusercontent.com/3331/114083228-54b97280-9874-11eb-9070-40a95b41a57b.png)

- Require that an LCID is entered when using an existing one is selected
![Screen Shot 2021-04-07 at 3 15 38 PM](https://user-images.githubusercontent.com/3331/113933385-21b2a880-97ba-11eb-9deb-3f4ecc6f5a25.png)
- Add a validation for next steps
![Screen Shot 2021-04-07 at 3 54 52 PM](https://user-images.githubusercontent.com/3331/113933425-2d9e6a80-97ba-11eb-8131-5e670803cc4a.png)

As a part of testing, we should verify that the changes made in #953 are still working.

