### PR TITLE
update parseDate to parseDateInUTC

### DIFF
--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -5,7 +5,7 @@ import {
   GovernanceCollaborationTeam,
   SystemIntakeForm
 } from 'types/systemIntake';
-import { formatContractDate, formatDate, parseDate } from 'utils/date';
+import { formatContractDate, formatDate, parseDateInUTC } from 'utils/date';
 
 // On the frontend, the field is now "requestName", but the backend API
 // has it as "projectName". This was an update from design.
@@ -252,8 +252,8 @@ export const prepareSystemIntakeForApp = (
     lcidScope: systemIntake.lcidScope || '',
     decisionNextSteps: systemIntake.decisionNextSteps || '',
     rejectionReason: systemIntake.rejectionReason || '',
-    grtDate: systemIntake.grtDate ? parseDate(systemIntake.grtDate) : null,
-    grbDate: systemIntake.grbDate ? parseDate(systemIntake.grbDate) : null,
+    grtDate: systemIntake.grtDate ? parseDateInUTC(systemIntake.grtDate) : null,
+    grbDate: systemIntake.grbDate ? parseDateInUTC(systemIntake.grbDate) : null,
     adminLead: systemIntake.adminLead || '',
     lastAdminNote: systemIntake.lastAdminNoteContent
       ? {

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -4,24 +4,24 @@ import {
   formatContractDate,
   formatDate,
   getFiscalYear,
-  parseDate
+  parseDateInUTC
 } from './date';
 
-describe('parseDate', () => {
+describe('parseDateInUTC', () => {
   it('converts a date from an ISO string to a luxon datetime', () => {
     const date = '2022-10-22T00:00:00Z';
-    const parsedDate: any = parseDate(date);
+    const parsedDate: any = parseDateInUTC(date);
     expect(parsedDate instanceof DateTime).toBeTruthy();
   });
 
   it('converts dates from the utc timezone instead of local', () => {
     const date = '2022-10-22T00:00:00Z';
-    expect(parseDate(date).day).toEqual(22);
+    expect(parseDateInUTC(date).day).toEqual(22);
   });
 
   it('converts ISO string with offset to utc', () => {
     const date = '2022-10-22T00:00:00+07:00';
-    expect(parseDate(date).day).toEqual(21);
+    expect(parseDateInUTC(date).day).toEqual(21);
   });
 });
 

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -8,15 +8,20 @@ import {
 } from './date';
 
 describe('parseDate', () => {
-  const date = '2022-10-22T00:00:00Z';
-
   it('converts a date from an ISO string to a luxon datetime', () => {
+    const date = '2022-10-22T00:00:00Z';
     const parsedDate: any = parseDate(date);
     expect(parsedDate instanceof DateTime).toBeTruthy();
   });
 
   it('converts dates from the utc timezone instead of local', () => {
+    const date = '2022-10-22T00:00:00Z';
     expect(parseDate(date).day).toEqual(22);
+  });
+
+  it('converts ISO string with offset to utc', () => {
+    const date = '2022-10-22T00:00:00+07:00';
+    expect(parseDate(date).day).toEqual(21);
   });
 });
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,6 +1,11 @@
 import { DateTime } from 'luxon';
 
-export const parseDate = (date: string) =>
+/**
+ * Parsing date as if you are in UTC
+ * @param date ISO string
+ * @returns DateTime
+ */
+export const parseDateInUTC = (date: string) =>
   DateTime.fromISO(date, { zone: 'utc' });
 
 export const formatDate = (date: string | DateTime) => {

--- a/src/views/GovernanceReviewTeam/Dates/index.tsx
+++ b/src/views/GovernanceReviewTeam/Dates/index.tsx
@@ -20,7 +20,7 @@ import Label from 'components/shared/Label';
 import TextField from 'components/shared/TextField';
 import { AnythingWrongSurvey } from 'components/Survey';
 import { SubmitDatesForm } from 'types/systemIntake';
-import { parseDate } from 'utils/date';
+import { parseDateInUTC } from 'utils/date';
 import flattenErrors from 'utils/flattenErrors';
 import { DateValidationSchema } from 'validations/systemIntakeSchema';
 
@@ -36,8 +36,8 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntake }) => {
   });
 
   const { grtDate, grbDate } = systemIntake;
-  const parsedGrbDate = parseDate(grbDate);
-  const parsedGrtDate = parseDate(grtDate);
+  const parsedGrbDate = parseDateInUTC(grbDate);
+  const parsedGrtDate = parseDateInUTC(grtDate);
 
   // TODO: Fix Text Field so we don't have to set initial empty values
   const initialValues: SubmitDatesForm = {


### PR DESCRIPTION
I found this naming more descriptive and it'll help differentiate which/when to use. Open to feedback.

Additionally, I added an extra test. It's possible that the ISO string that's put into `parseDateInUTC` will have an offset. I want to make sure that it's captured behavior. If it shouldn't be like that, we need to make changes accordingly.