### PR TITLE
add scroll to top when a user submits in case of validation errors

### DIFF
--- a/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
@@ -41,7 +41,7 @@ const Create = () => {
   });
 
   const [mutate, mutationResult] = useMutation(CreateAccessibilityRequestQuery);
-  const handleSubmit = (values: AccessibilityRequestForm) => {
+  const handleSubmitForm = (values: AccessibilityRequestForm) => {
     mutate({
       variables: {
         input: {
@@ -86,14 +86,14 @@ const Create = () => {
       <PageHeading>{t('newRequestForm.heading')}</PageHeading>
       <Formik
         initialValues={initialAccessibilityRequestFormData}
-        onSubmit={handleSubmit}
+        onSubmit={handleSubmitForm}
         validationSchema={accessibilitySchema.requestForm}
         validateOnBlur={false}
         validateOnChange={false}
         validateOnMount={false}
       >
         {(formikProps: FormikProps<AccessibilityRequestForm>) => {
-          const { errors, setFieldValue } = formikProps;
+          const { errors, setFieldValue, handleSubmit } = formikProps;
           const flatErrors = flattenErrors(errors);
           return (
             <>
@@ -106,7 +106,12 @@ const Create = () => {
                 </ErrorAlert>
               )}
               <div className="margin-bottom-7">
-                <FormikForm>
+                <FormikForm
+                  onSubmit={e => {
+                    handleSubmit(e);
+                    window.scrollTo(0, 0);
+                  }}
+                >
                   {!loading && (
                     <FieldGroup
                       scrollElement="intakeId"

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -144,7 +144,7 @@ const New = () => {
         validateOnMount={false}
       >
         {(formikProps: FormikProps<FileUploadForm>) => {
-          const { errors, setFieldValue, values } = formikProps;
+          const { errors, setFieldValue, values, handleSubmit } = formikProps;
           const flatErrors = flattenErrors(errors);
           return (
             <>
@@ -169,7 +169,13 @@ const New = () => {
                 Upload a document to {data?.accessibilityRequest?.name}
               </PageHeading>
               <div className="grid-col-9">
-                <Form onSubmit={formikProps.handleSubmit} large>
+                <Form
+                  onSubmit={e => {
+                    handleSubmit(e);
+                    window.scrollTo(0, 0);
+                  }}
+                  large
+                >
                   <Label htmlFor="FileUpload-File">
                     Choose a document to upload
                   </Label>

--- a/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
@@ -88,7 +88,7 @@ const IssueLifecycleId = () => {
       validateOnMount={false}
     >
       {(formikProps: FormikProps<SubmitLifecycleIdForm>) => {
-        const { errors, setFieldValue, values } = formikProps;
+        const { errors, setFieldValue, values, handleSubmit } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -124,7 +124,12 @@ const IssueLifecycleId = () => {
               <Link to={backLink}>Change</Link>
             </p>
             <div className="tablet:grid-col-9 margin-bottom-7">
-              <Form>
+              <Form
+                onSubmit={e => {
+                  handleSubmit(e);
+                  window.scrollTo(0, 0);
+                }}
+              >
                 <FieldGroup
                   scrollElement="newLifecycleId"
                   error={!!flatErrors.newLifecycleId}

--- a/src/views/GovernanceReviewTeam/Actions/ProvideGRTFeedbackToBusinessOwner.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ProvideGRTFeedbackToBusinessOwner.tsx
@@ -65,7 +65,7 @@ const ProvideGRTFeedbackToBusinessOwner = ({
       validateOnMount={false}
     >
       {(formikProps: FormikProps<ProvideGRTFeedbackForm>) => {
-        const { errors } = formikProps;
+        const { errors, handleSubmit } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -93,7 +93,12 @@ const ProvideGRTFeedbackToBusinessOwner = ({
               <Link to={backLink}>{t('submitAction.backLink')}</Link>
             </p>
             <div className="tablet:grid-col-9 margin-bottom-7">
-              <Form>
+              <Form
+                onSubmit={e => {
+                  handleSubmit(e);
+                  window.scrollTo(0, 0);
+                }}
+              >
                 <FieldGroup
                   scrollElement="grtFeedback"
                   error={!!flatErrors.grtFeedback}

--- a/src/views/GovernanceReviewTeam/Actions/ProvideGRTRecommendationsToGRB.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ProvideGRTRecommendationsToGRB.tsx
@@ -60,7 +60,7 @@ const ProvideGRTRecommendationsToGRB = () => {
       validateOnMount={false}
     >
       {(formikProps: FormikProps<ProvideGRTFeedbackForm>) => {
-        const { errors } = formikProps;
+        const { errors, handleSubmit } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -88,7 +88,12 @@ const ProvideGRTRecommendationsToGRB = () => {
               <Link to={backLink}>{t('submitAction.backLink')}</Link>
             </p>
             <div className="tablet:grid-col-9 margin-bottom-7">
-              <Form>
+              <Form
+                onSubmit={e => {
+                  handleSubmit(e);
+                  window.scrollTo(0, 0);
+                }}
+              >
                 <FieldGroup
                   scrollElement="grtFeedback"
                   error={!!flatErrors.grtFeedback}

--- a/src/views/GovernanceReviewTeam/Actions/RejectIntake.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/RejectIntake.tsx
@@ -70,7 +70,7 @@ const RejectIntake = () => {
       validateOnMount={false}
     >
       {(formikProps: FormikProps<RejectIntakeForm>) => {
-        const { errors } = formikProps;
+        const { errors, handleSubmit } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -106,7 +106,12 @@ const RejectIntake = () => {
               <Link to={backLink}>{t('rejectIntake.backLink')}</Link>
             </p>
             <div className="tablet:grid-col-9 margin-bottom-7">
-              <Form>
+              <Form
+                onSubmit={e => {
+                  handleSubmit(e);
+                  window.scrollTo(0, 0);
+                }}
+              >
                 <FieldGroup scrollElement="reason" error={!!flatErrors.reason}>
                   <Label htmlFor="RejectIntakeForm-Reason">
                     {t('rejectIntake.reasonLabel')}

--- a/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
@@ -64,7 +64,7 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
       validateOnMount={false}
     >
       {(formikProps: FormikProps<ActionForm>) => {
-        const { errors } = formikProps;
+        const { errors, handleSubmit } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -100,7 +100,12 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
               <Link to={backLink}>{t('submitAction.backLink')}</Link>
             </p>
             <div className="tablet:grid-col-9 margin-bottom-7">
-              <Form>
+              <Form
+                onSubmit={e => {
+                  handleSubmit(e);
+                  window.scrollTo(0, 0);
+                }}
+              >
                 <FieldGroup
                   scrollElement="feedback"
                   error={!!flatErrors.feedback}

--- a/src/views/GovernanceReviewTeam/Dates/index.tsx
+++ b/src/views/GovernanceReviewTeam/Dates/index.tsx
@@ -96,7 +96,7 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntake }) => {
       validateOnMount={false}
     >
       {(formikProps: FormikProps<SubmitDatesForm>) => {
-        const { errors } = formikProps;
+        const { errors, handleSubmit } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -128,7 +128,12 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntake }) => {
             <PageHeading>{t('governanceReviewTeam:dates.heading')}</PageHeading>
             <h2>{t('governanceReviewTeam:dates.subheading')}</h2>
             <div className="tablet:grid-col-9 margin-bottom-7">
-              <Form>
+              <Form
+                onSubmit={e => {
+                  handleSubmit(e);
+                  window.scrollTo(0, 0);
+                }}
+              >
                 {/* GRT Date Fields */}
                 <FieldGroup
                   error={

--- a/src/views/GovernanceReviewTeam/Notes/index.tsx
+++ b/src/views/GovernanceReviewTeam/Notes/index.tsx
@@ -163,7 +163,7 @@ const Notes = () => {
       <PageHeading>{t('notes.heading')}</PageHeading>
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         {(formikProps: FormikProps<NoteForm>) => {
-          const { values } = formikProps;
+          const { values, handleSubmit } = formikProps;
           return (
             <div className="tablet:grid-col-9 margin-bottom-7">
               {mutationResult && mutationResult.error && (
@@ -174,7 +174,12 @@ const Notes = () => {
                   />
                 </ErrorAlert>
               )}
-              <Form>
+              <Form
+                onSubmit={e => {
+                  handleSubmit(e);
+                  window.scrollTo(0, 0);
+                }}
+              >
                 <FieldGroup>
                   <Label htmlFor="GovernanceReviewTeam-Note">
                     {t('notes.addNote')}

--- a/src/views/RequestTypeForm/index.tsx
+++ b/src/views/RequestTypeForm/index.tsx
@@ -105,7 +105,7 @@ const RequestTypeForm = () => {
           validateOnMount={false}
         >
           {(formikProps: FormikProps<{ requestType: string }>) => {
-            const { values, errors } = formikProps;
+            const { values, errors, handleSubmit } = formikProps;
             const flatErrors = flattenErrors(errors);
             return (
               <>
@@ -126,7 +126,12 @@ const RequestTypeForm = () => {
                     })}
                   </ErrorAlert>
                 )}
-                <Form>
+                <Form
+                  onSubmit={e => {
+                    handleSubmit(e);
+                    window.scrollTo(0, 0);
+                  }}
+                >
                   <FieldGroup
                     error={!!flatErrors.requestType}
                     scrollElement="requestType"

--- a/src/views/TestDate/index.tsx
+++ b/src/views/TestDate/index.tsx
@@ -98,7 +98,7 @@ const TestDate = () => {
       validateOnMount={false}
     >
       {(formikProps: FormikProps<TestDateForm>) => {
-        const { errors, setFieldValue, values } = formikProps;
+        const { errors, setFieldValue, values, handleSubmit } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -134,7 +134,12 @@ const TestDate = () => {
             </PageHeading>
             <div className="grid-row grid-gap-lg">
               <div className="grid-col-9">
-                <Form>
+                <Form
+                  onSubmit={e => {
+                    handleSubmit(e);
+                    window.scrollTo(0, 0);
+                  }}
+                >
                   <FieldGroup error={!!flatErrors.testType}>
                     <fieldset className="usa-fieldset">
                       <legend className="usa-label margin-bottom-1">


### PR DESCRIPTION
This PR resolves issues with some forms not scrolling to top when there are validation errors.

By default, `Form` from Formik, runs `formikProps.handleSubmit`, which is the `onSubmit` function that's passed into `<Formik />`. In addition to that, I added a `window.scrollTo(0, 0)` to scroll back to the top.
