### PR TITLE
Remove header from modal

### DIFF
--- a/src/components/Modal/index.scss
+++ b/src/components/Modal/index.scss
@@ -27,24 +27,18 @@
     }
   }
 
-  &__header {
-    display: flex;
-    justify-content: space-between;
-    padding: 10px 35px;
-    align-items: center;
-    background-color: #000;
-    color: #fff;
-  }
-
   &__x-button {
+    display: block;
+    margin: 1rem 1rem 1rem auto;
     padding: 0;
     background: none;
     border: 0;
-    font-size: 26px;
-    color: #fff;
+    font-size: 1.5rem;
+    line-height: 1.5rem;
+    color: #000;
   }
 
   &__body {
-    padding: 35px;
+    padding: 0 2rem 2rem;
   }
 }

--- a/src/components/Modal/index.scss
+++ b/src/components/Modal/index.scss
@@ -36,6 +36,10 @@
     font-size: 1.5rem;
     line-height: 1.5rem;
     color: #000;
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 
   &__body {

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -5,20 +5,13 @@ import noScroll from 'no-scroll';
 import './index.scss';
 
 type ModalProps = {
-  title: string;
   children: ReactNode | ReactNodeArray;
   isOpen: boolean;
   openModal?: () => void;
   closeModal: () => void;
 };
 
-const Modal = ({
-  title,
-  children,
-  isOpen,
-  openModal,
-  closeModal
-}: ModalProps) => {
+const Modal = ({ children, isOpen, openModal, closeModal }: ModalProps) => {
   const handleOpenModal = () => {
     noScroll.on();
     if (openModal) {
@@ -37,17 +30,14 @@ const Modal = ({
       shouldCloseOnOverlayClick={false}
       appElement={document.getElementById('root')!}
     >
-      <div className="easi-modal__header">
-        <div className="easi-modal__title">{title}</div>
-        <button
-          type="button"
-          className="easi-modal__x-button"
-          aria-label="Close Modal"
-          onClick={closeModal}
-        >
-          <i className="fa fa-times" />
-        </button>
-      </div>
+      <button
+        type="button"
+        className="easi-modal__x-button"
+        aria-label="Close Modal"
+        onClick={closeModal}
+      >
+        <i className="fa fa-times" />
+      </button>
       <div className="easi-modal__body">{children}</div>
     </ReactModal>
   );

--- a/src/i18n/en-US/governanceReviewTeam.ts
+++ b/src/i18n/en-US/governanceReviewTeam.ts
@@ -181,7 +181,6 @@ const governanceReviewTeam = {
   },
   adminLeads: {
     assignModal: {
-      title: 'EASi',
       header: 'Choose an Admin Lead for {{requestName}}',
       save: 'Save',
       noChanges: "Don't make changes and return to request page"

--- a/src/i18n/en-US/taskList.ts
+++ b/src/i18n/en-US/taskList.ts
@@ -1,6 +1,5 @@
 const taskList = {
   withdraw_modal: {
-    title: 'EASi',
     header: 'Are you sure you want to remove your request?',
     warning: 'You will lose any information you have filled in.',
     confirm: 'Remove request',

--- a/src/i18n/en-US/taskList.ts
+++ b/src/i18n/en-US/taskList.ts
@@ -1,6 +1,6 @@
 const taskList = {
   withdraw_modal: {
-    header: 'Are you sure you want to remove your request?',
+    header: 'Confirm you want to remove {{requestName}}.',
     warning: 'You will lose any information you have filled in.',
     confirm: 'Remove request',
     cancel: 'Cancel',

--- a/src/views/GovernanceReviewTeam/Summary/index.tsx
+++ b/src/views/GovernanceReviewTeam/Summary/index.tsx
@@ -161,7 +161,6 @@ const RequestSummary = ({ intake }: { intake: SystemIntake }) => {
                 {t('governanceReviewTeam:adminLeads.changeLead')}
               </Button>
               <Modal
-                title={t('governanceReviewTeam:adminLeads:assignModal.title')}
                 isOpen={isModalOpen}
                 closeModal={() => {
                   setModalOpen(false);

--- a/src/views/GovernanceTaskList/SideNavActions/index.test.tsx
+++ b/src/views/GovernanceTaskList/SideNavActions/index.test.tsx
@@ -3,12 +3,13 @@ import { Button, Link } from '@trussworks/react-uswds';
 import { shallow } from 'enzyme';
 
 import Modal from 'components/Modal';
+import { initialSystemIntakeForm } from 'data/systemIntake';
 
 import SideNavActions from './index';
 
 const renderComponent = () => {
   return shallow(
-    <SideNavActions intakeStatus="INTAKE_DRAFT" archiveIntake={() => {}} />
+    <SideNavActions intake={initialSystemIntakeForm} archiveIntake={() => {}} />
   );
 };
 

--- a/src/views/GovernanceTaskList/SideNavActions/index.tsx
+++ b/src/views/GovernanceTaskList/SideNavActions/index.tsx
@@ -5,20 +5,17 @@ import { Button, Link as UswdsLink } from '@trussworks/react-uswds';
 
 import Modal from 'components/Modal';
 import PageHeading from 'components/PageHeading';
-import { SystemIntakeStatus } from 'types/systemIntake';
+import { SystemIntakeForm } from 'types/systemIntake';
 import { isIntakeOpen } from 'utils/systemIntake';
 
 import './index.scss';
 
 type SideNavActionsProps = {
-  intakeStatus: SystemIntakeStatus;
+  intake: SystemIntakeForm;
   archiveIntake: () => void;
 };
 
-const SideNavActions = ({
-  intakeStatus,
-  archiveIntake
-}: SideNavActionsProps) => {
+const SideNavActions = ({ intake, archiveIntake }: SideNavActionsProps) => {
   const { t } = useTranslation();
   const [isModalOpen, setModalOpen] = useState(false);
 
@@ -27,7 +24,7 @@ const SideNavActions = ({
       <div className="grid-col margin-top-105">
         <Link to="/">Save & Exit</Link>
       </div>
-      {isIntakeOpen(intakeStatus) && (
+      {isIntakeOpen(intake.status) && (
         <div className="grid-col margin-top-2">
           <Button
             className="line-height-body-5 test-withdraw-request"
@@ -39,7 +36,9 @@ const SideNavActions = ({
           </Button>
           <Modal isOpen={isModalOpen} closeModal={() => setModalOpen(false)}>
             <PageHeading headingLevel="h2" className="margin-top-0">
-              {t('taskList:withdraw_modal:header')}
+              {t('taskList:withdraw_modal:header', {
+                requestName: intake.requestName
+              })}
             </PageHeading>
             <p>{t('taskList:withdraw_modal:warning')}</p>
             <Button

--- a/src/views/GovernanceTaskList/SideNavActions/index.tsx
+++ b/src/views/GovernanceTaskList/SideNavActions/index.tsx
@@ -37,11 +37,7 @@ const SideNavActions = ({
           >
             Remove your request to add a new system
           </Button>
-          <Modal
-            title={t('taskList:withdraw_modal:title')}
-            isOpen={isModalOpen}
-            closeModal={() => setModalOpen(false)}
-          >
+          <Modal isOpen={isModalOpen} closeModal={() => setModalOpen(false)}>
             <PageHeading headingLevel="h2" className="margin-top-0">
               {t('taskList:withdraw_modal:header')}
             </PageHeading>

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -265,7 +265,7 @@ const GovernanceTaskList = () => {
           <div className="tablet:grid-col-1" />
           <div className="tablet:grid-col-2">
             <SideNavActions
-              intakeStatus={systemIntake.status}
+              intake={systemIntake}
               archiveIntake={archiveIntake}
             />
           </div>

--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -131,7 +131,7 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
 
   return (
     <>
-      <Modal title="EASi" isOpen={isModalOpen} closeModal={handleModalExit}>
+      <Modal isOpen={isModalOpen} closeModal={handleModalExit}>
         <h3
           className="margin-top-0"
           role="timer"


### PR DESCRIPTION
# ES-439

This PR:
- removes header from all modals (timeout, admin lead, and withdraw request)
- updates styling
- remove unnecessary text from i18n
- tested for accessibility