### PR TITLE
Modified wording of cost increase question in intake form

### DIFF
--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -304,14 +304,15 @@ const ContractDetails = ({
                       aria-describedby="IntakeForm-IncreasedCostsHelp"
                     />
                     {values.costs.isExpectingIncrease === 'YES' && (
-                      <div className="width-mobile margin-top-neg-2 margin-left-4 margin-bottom-1">
+                      <div className="width-mobile-lg margin-top-neg-2 margin-left-4 margin-bottom-1">
                         <FieldGroup
                           scrollElement="costs.expectedIncreaseAmount"
                           error={!!flatErrors['costs.expectedIncreaseAmount']}
                         >
                           <Label htmlFor="IntakeForm-CostsExpectedIncrease">
                             Approximately how much do you expect the cost to
-                            increase?
+                            increase over what you are currently spending to
+                            meet your business need?
                           </Label>
                           <FieldErrorMsg>
                             {flatErrors['costs.expectedIncreaseAmount']}


### PR DESCRIPTION
Changes proposed in this pull request:

- Modified wording of cost increase sub question (only appears when 'yes' is selected) to be more clear about expected answer
