### PR TITLE
add proper props to associate label with the combo box

### DIFF
--- a/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
@@ -122,8 +122,11 @@ const Create = () => {
                       </Label>
                       <FieldErrorMsg>{flatErrors.intakeId}</FieldErrorMsg>
                       <ComboBox
+                        id="508Request-IntakeComboBox"
                         name="intakeId"
-                        id="508Request-IntakeId"
+                        inputProps={{
+                          id: '508Request-IntakeId'
+                        }}
                         options={projectComboBoxOptions}
                         onChange={(intakeId: any) => {
                           const selectedSystem = systems[intakeId];

--- a/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
@@ -105,6 +105,23 @@ const Create = () => {
                   />
                 </ErrorAlert>
               )}
+              {Object.keys(errors).length > 0 && (
+                <ErrorAlert
+                  testId="508-request-errors"
+                  classNames="margin-bottom-4 margin-top-4"
+                  heading="There is a problem"
+                >
+                  {Object.keys(flatErrors).map(key => {
+                    return (
+                      <ErrorAlertMessage
+                        key={`Error.${key}`}
+                        errorKey={key}
+                        message={flatErrors[key]}
+                      />
+                    );
+                  })}
+                </ErrorAlert>
+              )}
               <div className="margin-bottom-7">
                 <FormikForm
                   onSubmit={e => {
@@ -123,9 +140,10 @@ const Create = () => {
                       <FieldErrorMsg>{flatErrors.intakeId}</FieldErrorMsg>
                       <ComboBox
                         id="508Request-IntakeComboBox"
-                        name="intakeId"
+                        name="intakeComboBox"
                         inputProps={{
-                          id: '508Request-IntakeId'
+                          id: '508Request-IntakeId',
+                          name: 'intakeId'
                         }}
                         options={projectComboBoxOptions}
                         onChange={(intakeId: any) => {


### PR DESCRIPTION
# ES-443

This PR adds proper props to `ComboBox` to associate the field label with the field.
The `id` prop doesn't pass to the element we thought it did. So instead we need to make sure it's a part of the `inputProps`.

## Reviewer Notes

- [ ] Screen Reader review (VoiceOver is okay)

## Code Review Verification Steps

- [ ] User-facing changes have been tested with voice-over
- [ ] User-facing changes have been reviewed by design
- [ ] Acceptance criteria has been met, or will be met by a future PR
- Any new migrations/schema changes:
  - [ ] Follow guidelines for zero-downtime deploys
  - [ ] Have been deployed to the remote dev environment via CI
