### PR TITLE
Improve accessibility of the requests table

### DIFF
--- a/src/components/AccessibilityRequestsTable/index.scss
+++ b/src/components/AccessibilityRequestsTable/index.scss
@@ -1,0 +1,11 @@
+.accessibility-requests-table {
+    .caret {
+        width: 12px;
+        &.fa-caret-up {
+            vertical-align: 0;
+       }
+        &.fa-caret-down {
+            vertical-align: -8%;
+       }
+    }
+}

--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -11,6 +11,7 @@ import { GetAccessibilityRequests_accessibilityRequests_edges_node as Accessibil
 
 import { formatDate } from 'utils/date';
 
+import './index.scss';
 // import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
 
 type AccessibilityRequestsTableProps = {
@@ -140,8 +141,8 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
 
   const getHeaderSortIcon = (isDesc: boolean | undefined) => {
     return classnames('margin-left-1', {
-      'fa fa-caret-down': isDesc,
-      'fa fa-caret-up': !isDesc
+      'fa fa-caret-down fa-lg caret': isDesc,
+      'fa fa-caret-up fa-lg caret': !isDesc
     });
   };
 
@@ -159,55 +160,85 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
   };
 
   return (
-    <Table bordered={false} {...getTableProps()} fullWidth>
-      <caption className="usa-sr-only">{t('requestTable.caption')}</caption>
-      <thead>
-        {headerGroups.map(headerGroup => (
-          <tr {...headerGroup.getHeaderGroupProps()}>
-            {headerGroup.headers.map(column => (
-              <th
-                {...column.getHeaderProps(column.getSortByToggleProps())}
-                aria-sort={getColumnSortStatus(column)}
-                style={{ whiteSpace: 'nowrap' }}
-              >
-                {column.render('Header')}
-                {column.isSorted && (
-                  <span className={getHeaderSortIcon(column.isSortedDesc)} />
-                )}
-              </th>
-            ))}
-          </tr>
-        ))}
-      </thead>
-      <tbody {...getTableBodyProps()}>
-        {rows.map(row => {
-          prepareRow(row);
-          return (
-            <tr {...row.getRowProps()}>
-              {row.cells.map((cell, i) => {
-                if (i === 0) {
-                  return (
-                    <th
-                      {...cell.getCellProps()}
-                      scope="row"
-                      style={{ maxWidth: '16rem' }}
-                    >
-                      {cell.render('Cell')}
-                    </th>
-                  );
-                }
-                return (
-                  <td {...cell.getCellProps()} style={{ maxWidth: '16rem' }}>
-                    {cell.render('Cell')}
-                  </td>
-                );
-              })}
+    <div className="accessibility-requests-table">
+      <Table bordered={false} {...getTableProps()} fullWidth>
+        <caption className="usa-sr-only">{t('requestTable.caption')}</caption>
+        <thead>
+          {headerGroups.map(headerGroup => (
+            <tr {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map(column => (
+                <th
+                  {...column.getHeaderProps()}
+                  aria-sort={getColumnSortStatus(column)}
+                  style={{ whiteSpace: 'nowrap' }}
+                  scope="col"
+                >
+                  <button
+                    className="usa-button usa-button--unstyled"
+                    type="button"
+                    {...column.getSortByToggleProps()}
+                  >
+                    {column.render('Header')}
+                    {column.isSorted && (
+                      <span
+                        className={getHeaderSortIcon(column.isSortedDesc)}
+                      />
+                    )}
+                    {!column.isSorted && (
+                      <span className="margin-left-1 fa fa-sort caret" />
+                    )}
+                  </button>
+                </th>
+              ))}
             </tr>
-          );
-        })}
-      </tbody>
-    </Table>
+          ))}
+        </thead>
+        <tbody {...getTableBodyProps()}>
+          {rows.map(row => {
+            prepareRow(row);
+            return (
+              <tr {...row.getRowProps()}>
+                {row.cells.map((cell, i) => {
+                  if (i === 0) {
+                    return (
+                      <th
+                        {...cell.getCellProps()}
+                        scope="row"
+                        style={{ maxWidth: '16rem' }}
+                      >
+                        {cell.render('Cell')}
+                      </th>
+                    );
+                  }
+                  return (
+                    <td {...cell.getCellProps()} style={{ maxWidth: '16rem' }}>
+                      {cell.render('Cell')}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </Table>
+      <div
+        className="usa-sr-only usa-table__announcement-region"
+        aria-live="polite"
+      >
+        {currentTableSortDescription(headerGroups[0])}
+      </div>
+    </div>
   );
+};
+
+const currentTableSortDescription = headerGroup => {
+  const sortedHeader = headerGroup.headers.find(header => header.isSorted);
+
+  if (sortedHeader) {
+    const direction = sortedHeader.isSortedDesc ? 'descending' : 'ascending';
+    return `Requests table sorted by ${sortedHeader.Header} ${direction}`;
+  }
+  return 'Requests table reset to default sort order';
 };
 
 export default AccessibilityRequestsTable;


### PR DESCRIPTION
# ES-436

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

## Changes proposed in this pull request

- Column headers are now buttons, which is semantically an improvement since they are controls (you can click on them to do things).
- Add carets to all column headers. The currently sorting column's carets are shown larger so they are more visually distinct.
- Add an audio description of the table's sorting that is read to the user whenever the sort changes.

There is some duplication in what is read out to users still, but I think this is unavoidable to maximize compatibility since not all assistive tech will automatically read out the values of `aria-sort`. We should run this by Mario and get his take on this since we're mostly targeting JAWS and its behavior might be something we can rely on in this app.

## Code Review Verification Steps

- [x] User-facing changes have been tested with voice-over
- [x] User-facing changes have been reviewed by design
- [x] Acceptance criteria has been met, or will be met by a future PR

## Screenshots

https://user-images.githubusercontent.com/3331/115604306-d662c480-a2a6-11eb-88e2-b5125d3433fb.mov


