### PR TITLE
Add task to check and configure hosts file

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -121,3 +121,4 @@ repurpose
 Alfabet
 booleans
 enums
+hostname

--- a/README.md
+++ b/README.md
@@ -384,6 +384,10 @@ export MINIO_ACCESS_KEY='minioadmin'
 export MINIO_SECRET_KEY='minioadmin'
 ```
 
+The container is accessed from the browser using the hostname 'minio'. To make
+this work, run `scripts/dev hosts:check` and press enter to setup this hostname
+on your machine.
+
 ### Setup: Prince XML Lambda
 
 EASi runs [Prince XML](https://www.princexml.com/) as a Lambda function to

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,7 +24,7 @@ services:
     environment:
       - MINIO_ACCESS_KEY=minioadmin
       - MINIO_SECRET_KEY=minioadmin
-      - MINIO_ADDRESS=http://localhost:9000
+      - MINIO_ADDRESS=http://minio:9000
   easi_client:
     build:
       context: .

--- a/scripts/dev
+++ b/scripts/dev
@@ -42,6 +42,15 @@ needs "gotest", install_with: "go get -u github.com/rakyll/gotest"
 needs "goimports", install_with: "go get -u golang.org/x/tools/cmd/goimports"
 needs "ulimit"
 
+# Gracefully handle folks trying to explore using common help flags
+["--help", "-help", "--h", "-h"].each do |flag|
+  if ARGV == [flag]
+    puts "** Showing the available tasks. If you really want to see rake's command line options, use rake --help. **"
+    puts
+    ARGV.delete(flag)
+  end
+end
+
 Rake.application.init("scripts/dev")
 
 def ask?(question)

--- a/scripts/dev
+++ b/scripts/dev
@@ -44,10 +44,14 @@ needs "ulimit"
 
 Rake.application.init("scripts/dev")
 
-def ask_to_install(executable, install_with)
-  puts "Do you want to install it? (Y/n)"
+def ask?(question)
+  puts question
   response = STDIN.getch
-  if ["y", "Y", "\r"].include?(response)
+  ["y", "Y", "\r"].include?(response)
+end
+
+def ask_to_install(executable, install_with)
+  if ask?("Do you want to install it? (Y/n)")
     sh install_with
     check_bin(executable)
     # TODO let the user know that their path is not configured correctly
@@ -68,6 +72,7 @@ task :prereqs do
   @needed.each do |executable, install_with|
     check_bin(executable, install_with: install_with)
   end
+  Rake::Task["hosts:check"].invoke
 end
 
 task :consume_args do |t, args|
@@ -168,6 +173,31 @@ task :reset => :up do
 
   # The backend may have lost its database connection
   sh("docker-compose restart easi", verbose: true) 
+end
+
+namespace :hosts do
+  desc "Verify that hosts for local development are configured"
+  task :check do
+    lookup = `dscacheutil -q host -a name minio`.strip
+    if lookup.size == 0 && ask?("host minio can't be resolved. Do you want to configure it now? (Y/n)")
+      Rake::Task["hosts:install"].invoke
+
+      Rake::Task["hosts:install"].reenable
+      Rake::Task["hosts:check"].invoke
+    elsif lookup.include?("ip_address: 127.0.0.1")
+      puts "Host 'minio' is resolving correctly."
+    else
+      puts "Host 'minio' resolved, but not to the correct IP:"
+      puts lookup
+      exit(1)
+    end
+  end
+
+  task :install do
+    sh("echo '127.0.0.1 minio' | sudo tee -a /etc/hosts") &&
+      sh("sudo killall -HUP mDNSResponder") &&
+      sh("sudo dscacheutil -flushcache")
+  end
 end
 
 namespace :db do

--- a/scripts/dev
+++ b/scripts/dev
@@ -188,7 +188,7 @@ namespace :hosts do
   desc "Verify that hosts for local development are configured"
   task :check do
     lookup = `dscacheutil -q host -a name minio`.strip
-    if lookup.size == 0 && ask?("host minio can't be resolved. Do you want to configure it now? (Y/n)")
+    if lookup.size == 0 && ask?("Host 'minio' can't be resolved. Do you want to configure it now? (Y/n)")
       Rake::Task["hosts:install"].invoke
 
       Rake::Task["hosts:install"].reenable


### PR DESCRIPTION
## Changes proposed in this pull request

- Changes the default URL for local MinIO to `http://minio:9000`
- Add a task to `scripts/dev` to verify and optionally setup the `minio` host on a user's machine.

## Verification

Run `scripts/dev hosts:check` and hit enter once. You should see the following if you haven't configured the minio host yet:

```console
$ scripts/dev hosts:check
host minio can't be resolved. Do you want to configure it now? (Y/n)
echo '127.0.0.1 minio' | sudo tee -a /etc/hosts
127.0.0.1 minio
sudo killall -HUP mDNSResponder
sudo dscacheutil -flushcache
Host 'minio' is resolving correctly.
```

If you have configured the minio host, you should see this:

```console
$ scripts/dev hosts:check
Host 'minio' is resolving correctly.
```