### PR TITLE
update useConfirmationText hook to return an object

### DIFF
--- a/src/components/AccessibilityDocumentsList/index.tsx
+++ b/src/components/AccessibilityDocumentsList/index.tsx
@@ -11,6 +11,7 @@ import {
 
 import Modal from 'components/Modal';
 import PageHeading from 'components/PageHeading';
+import useConfirmationText from 'hooks/useConfirmationText';
 import {
   AccessibilityRequestDocumentCommonType,
   AccessibilityRequestDocumentStatus
@@ -40,6 +41,7 @@ const AccessibilityDocumentsList = ({
   requestName,
   refetchRequest
 }: DocumentsListProps) => {
+  const { setConfirmationText } = useConfirmationText();
   const { t } = useTranslation('accessibility');
   const [
     documentWithModalOpen,
@@ -70,8 +72,11 @@ const AccessibilityDocumentsList = ({
           id
         }
       }
-    }).then(refetchRequest);
-    setDocumentWithModalOpen(null);
+    }).then(() => {
+      refetchRequest();
+      setDocumentWithModalOpen(null);
+      setConfirmationText('its done');
+    });
   };
 
   const columns = useMemo<Column<Document>[]>(() => {
@@ -125,7 +130,7 @@ const AccessibilityDocumentsList = ({
                   closeModal={() => setDocumentWithModalOpen(null)}
                 >
                   <PageHeading
-                    headingLevel="h1"
+                    headingLevel="h2"
                     className="line-height-heading-2 margin-bottom-2"
                   >
                     {t('documentTable.modal.header', {

--- a/src/hooks/useConfirmationText.ts
+++ b/src/hooks/useConfirmationText.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 // useConfirmationText is a hook used to get the confirmation text
@@ -10,7 +10,10 @@ import { useHistory, useLocation } from 'react-router-dom';
 // or
 // const location = { pathname: '/some/url', state: { confirmationText: 'Confirmed' }};
 // <Link to={location} />
-function useConfirmationText() {
+function useConfirmationText(): {
+  confirmationText: string;
+  setConfirmationText: React.Dispatch<React.SetStateAction<string>>;
+} {
   const location = useLocation<any>();
   const history = useHistory();
   const [confirmationText, setConfirmationText] = useState('');
@@ -30,7 +33,7 @@ function useConfirmationText() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [history.location.pathname]);
 
-  return confirmationText;
+  return { confirmationText, setConfirmationText };
 }
 
 export default useConfirmationText;

--- a/src/views/Accessibility/index.tsx
+++ b/src/views/Accessibility/index.tsx
@@ -28,7 +28,7 @@ const Accessibility = () => {
   const flags = useFlags();
 
   const { t } = useTranslation('accessibility');
-  const confirmationText = useConfirmationText();
+  const { confirmationText } = useConfirmationText();
 
   const NewRequest = (
     <SecureRoute path="/508/requests/new" exact component={Create} />

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -23,7 +23,7 @@ const Home = () => {
   const userGroups = useSelector((state: AppState) => state.auth.groups);
   const isUserSet = useSelector((state: AppState) => state.auth.isUserSet);
   const flags = useFlags();
-  const confirmationText = useConfirmationText();
+  const { confirmationText } = useConfirmationText();
 
   const renderView = () => {
     if (isUserSet) {


### PR DESCRIPTION
# ES-563

## Changes proposed in this pull request

- update `useConfirmationText` to return an `object`
    - it returns an object with keys `confirmationText` and `setConfirmationText`
- update other use cases of `useConfirmationText` to support API changes
- update remove document modal to have `h2` heading
## Reviewer Notes

- Make sure that confirmation text only shows/hides when necessary.
- Trigger confirmation messages, click buttons, navigate pages, etc.

## Code Review Verification Steps

- [ ] User-facing changes have been tested with voice-over
- [ ] User-facing changes have been reviewed by design
- [ ] Acceptance criteria has been met, or will be met by a future PR
- Any new migrations/schema changes:
  - [ ] Follow guidelines for zero-downtime deploys
  - [ ] Have been deployed to the remote dev environment via CI


**I haven't been able to fully test this because of local environment blockers**