### PR TITLE
Attach EUA ID directly to 508 requests

### DIFF
--- a/cmd/devdata/main.go
+++ b/cmd/devdata/main.go
@@ -242,8 +242,9 @@ func makeAccessibilityRequest(name string, store *storage.Store) {
 	must(store.UpdateSystemIntake(ctx, &intake)) // required to set lifecycle id
 
 	must(store.CreateAccessibilityRequest(ctx, &models.AccessibilityRequest{
-		Name:     fmt.Sprintf("%s v2", name),
-		IntakeID: intake.ID,
+		Name:      fmt.Sprintf("%s v2", name),
+		IntakeID:  intake.ID,
+		EUAUserID: "ABCD",
 	}))
 }
 

--- a/migrations/V78__Add_508_EUA.sql
+++ b/migrations/V78__Add_508_EUA.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accessibility_requests ADD COLUMN eua_user_id TEXT NOT NULL DEFAULT '0000' CHECK (eua_user_id ~ '^[A-Z0-9]{4}$');

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -307,8 +307,9 @@ func (r *mutationResolver) AddGRTFeedbackAndRequestBusinessCase(ctx context.Cont
 
 func (r *mutationResolver) CreateAccessibilityRequest(ctx context.Context, input model.CreateAccessibilityRequestInput) (*model.CreateAccessibilityRequestPayload, error) {
 	request, err := r.store.CreateAccessibilityRequest(ctx, &models.AccessibilityRequest{
-		Name:     input.Name,
-		IntakeID: input.IntakeID,
+		EUAUserID: appcontext.Principal(ctx).ID(),
+		Name:      input.Name,
+		IntakeID:  input.IntakeID,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/graph/schema.resolvers_accessibility_request_test.go
+++ b/pkg/graph/schema.resolvers_accessibility_request_test.go
@@ -31,7 +31,8 @@ func (s GraphQLTestSuite) TestAccessibilityRequestQuery() {
 	s.NoError(updateErr)
 
 	accessibilityRequest, requestErr := s.store.CreateAccessibilityRequest(ctx, &models.AccessibilityRequest{
-		IntakeID: intake.ID,
+		IntakeID:  intake.ID,
+		EUAUserID: "ABCD",
 	})
 	s.NoError(requestErr)
 
@@ -135,7 +136,8 @@ func (s GraphQLTestSuite) TestAccessibilityRequestVirusStatusQuery() {
 	s.NoError(updateErr)
 
 	accessibilityRequest, requestErr := s.store.CreateAccessibilityRequest(ctx, &models.AccessibilityRequest{
-		IntakeID: intake.ID,
+		IntakeID:  intake.ID,
+		EUAUserID: "ABCD",
 	})
 	s.NoError(requestErr)
 
@@ -236,7 +238,8 @@ func (s GraphQLTestSuite) TestCreateAccessibilityRequestDocumentMutation() {
 	s.NoError(updateErr)
 
 	accessibilityRequest, requestErr := s.store.CreateAccessibilityRequest(ctx, &models.AccessibilityRequest{
-		IntakeID: intake.ID,
+		IntakeID:  intake.ID,
+		EUAUserID: "ABCD",
 	})
 	s.NoError(requestErr)
 

--- a/pkg/models/accessibility_request.go
+++ b/pkg/models/accessibility_request.go
@@ -13,4 +13,5 @@ type AccessibilityRequest struct {
 	IntakeID  uuid.UUID  `db:"intake_id"`
 	CreatedAt *time.Time `db:"created_at" gqlgen:"submittedAt"`
 	UpdatedAt *time.Time `db:"updated_at"`
+	EUAUserID string     `json:"euaUserId" db:"eua_user_id"`
 }

--- a/pkg/storage/accessibility_request.go
+++ b/pkg/storage/accessibility_request.go
@@ -31,14 +31,16 @@ func (s *Store) CreateAccessibilityRequest(ctx context.Context, request *models.
 			name,
 			intake_id,
 			created_at,
-			updated_at
+			updated_at,
+			eua_user_id
 		)
 		VALUES (
 			:id,
 			:name,
 			:intake_id,
 		    :created_at,
-			:updated_at
+			:updated_at,
+			:eua_user_id
 		)`
 	_, err := s.db.NamedExec(
 		createRequestSQL,

--- a/pkg/testhelpers/accessibility_request.go
+++ b/pkg/testhelpers/accessibility_request.go
@@ -9,7 +9,8 @@ import (
 // NewAccessibilityRequest generates an test date to use in tests
 func NewAccessibilityRequest(intakeID uuid.UUID) models.AccessibilityRequest {
 	return models.AccessibilityRequest{
-		IntakeID: intakeID,
-		Name:     "My Accessibility Request",
+		IntakeID:  intakeID,
+		Name:      "My Accessibility Request",
+		EUAUserID: RandomEUAID(),
 	}
 }


### PR DESCRIPTION
# ES-532

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

## Changes proposed in this pull request

- Adds EUA ID of 508 request creator to object in database

## Reviewer Notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

Add an accessibility request. Check your EUA ID appears in the database in the accessibility request. 

## Code Review Verification Steps

- [ ] Acceptance criteria has been met, or will be met by a future PR
- Any new migrations/schema changes:
  - [ ] Follow guidelines for zero-downtime deploys
  - [ ] Have been deployed to the remote dev environment via CI