### PR TITLE
consolidate props passed to TestDateCard

### DIFF
--- a/src/components/TestDateCard/index.test.tsx
+++ b/src/components/TestDateCard/index.test.tsx
@@ -5,19 +5,23 @@ import { mount, shallow } from 'enzyme';
 import { DateTime } from 'luxon';
 
 import TestDateCard from 'components/TestDateCard';
+import { TestDateTestType } from 'types/graphql-global-types';
 
 const renderComponent = (score: number | null) => {
   return mount(
     <MemoryRouter>
       <MockedProvider>
         <TestDateCard
-          date={DateTime.local().toISO()}
-          type="INITIAL"
+          testDate={{
+            __typename: 'TestDate',
+            id: 'ID',
+            date: DateTime.local().toISO(),
+            testType: TestDateTestType.INITIAL,
+            score
+          }}
           testIndex={1}
-          score={score}
           requestId="Request ID"
           requestName="Initial Request"
-          id="ID"
           refetchRequest={() => 0}
         />
       </MockedProvider>
@@ -30,13 +34,16 @@ describe('The Test Date Card component', () => {
     shallow(
       <MockedProvider>
         <TestDateCard
-          date={DateTime.local().toISO()}
-          type="INITIAL"
+          testDate={{
+            __typename: 'TestDate',
+            id: 'ID',
+            date: DateTime.local().toISO(),
+            testType: TestDateTestType.INITIAL,
+            score: 0
+          }}
           testIndex={1}
-          score={0}
           requestId="Request ID"
           requestName="Initial Request"
-          id="ID"
           refetchRequest={() => 0}
         />
       </MockedProvider>

--- a/src/components/TestDateCard/index.tsx
+++ b/src/components/TestDateCard/index.tsx
@@ -5,33 +5,29 @@ import { useMutation } from '@apollo/client';
 import { Button, Link as UswdsLink } from '@trussworks/react-uswds';
 import DeleteTestDateQuery from 'queries/DeleteTestDateQuery';
 import { DeleteTestDate } from 'queries/types/DeleteTestDate';
+import { GetAccessibilityRequest_accessibilityRequest_testDates as TestDateType } from 'queries/types/GetAccessibilityRequest';
 
 import Modal from 'components/Modal';
 import PageHeading from 'components/PageHeading';
 import { formatDate } from 'utils/date';
 
 type TestDateCardProps = {
-  date: string; // ISO string
-  type: 'INITIAL' | 'REMEDIATION';
+  testDate: TestDateType;
   testIndex: number;
-  score: number | null; // A whole number representing tenths of a percent
   requestId: string;
   requestName: string;
-  id: string;
   refetchRequest: () => any;
 };
 
 const TestDateCard = ({
-  date,
-  type,
+  testDate,
   testIndex,
-  score,
   requestId,
   requestName,
-  id,
   refetchRequest
 }: TestDateCardProps) => {
   const { t } = useTranslation('accessibility');
+  const { id, testType, date, score } = testDate;
 
   const [deleteTestDateMutation] = useMutation<DeleteTestDate>(
     DeleteTestDateQuery,
@@ -67,7 +63,7 @@ const TestDateCard = ({
   return (
     <div className="bg-gray-10 padding-2 line-height-body-4 margin-bottom-2">
       <div className="text-bold margin-bottom-1">
-        Test {testIndex}: {type === 'INITIAL' ? 'Initial' : 'Remediation'}
+        Test {testIndex}: {testType === 'INITIAL' ? 'Initial' : 'Remediation'}
       </div>
       <div className="margin-bottom-1">
         <div className="display-inline-block margin-right-2">
@@ -84,14 +80,14 @@ const TestDateCard = ({
         <UswdsLink
           asCustom={Link}
           to={`/508/requests/${requestId}/test-date/${id}`}
-          aria-label={`Edit test ${testIndex} ${type}`}
+          aria-label={`Edit test ${testIndex} ${testType}`}
         >
           Edit
         </UswdsLink>
         <Button
           className="margin-left-1"
           type="button"
-          aria-label={`Remove test ${testIndex} ${type}`}
+          aria-label={`Remove test ${testIndex} ${testType}`}
           unstyled
           onClick={() => {
             setRemoveTestDateModalOpen(true);
@@ -100,7 +96,6 @@ const TestDateCard = ({
           Remove
         </Button>
         <Modal
-          title="Title"
           isOpen={isRemoveTestDateModalOpen}
           closeModal={() => {
             setRemoveTestDateModalOpen(false);
@@ -109,7 +104,7 @@ const TestDateCard = ({
           <PageHeading headingLevel="h2" className="margin-top-0">
             {t('removeTestDate.modalHeader', {
               testNumber: testIndex,
-              testType: type,
+              testType,
               testDate: formatDate(date),
               requestName
             })}

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -97,11 +97,8 @@ const AccessibilityRequestDetailPage = () => {
                 .map((testDate, index) => (
                   <TestDateCard
                     key={testDate.id}
-                    date={testDate.date}
-                    type={testDate.testType}
+                    testDate={testDate}
                     testIndex={index + 1}
-                    score={testDate.score}
-                    id={testDate.id}
                     requestName={requestName}
                     requestId={accessibilityRequestId}
                     refetchRequest={refetch}


### PR DESCRIPTION
This PR simplifies the props that are passed to `TestDateCard`. Previously, it was passing each individual piece of data that comes from a test date.

Since test dates are returned as an object, we can just pass the entire object to `TestDateCard` since every value is being used.