### PR TITLE
ES-574 Add entrypoint to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,3 +42,7 @@ RUN update-ca-certificates
 
 RUN adduser -D -H easi
 USER easi
+
+ENTRYPOINT ["/easi/easi"]
+
+CMD ["serve"]

--- a/docker-compose.circleci.yml
+++ b/docker-compose.circleci.yml
@@ -9,7 +9,6 @@ services:
       - EMAIL_TEMPLATE_DIR=/easi/templates
       - SERVER_CERT
       - SERVER_KEY
-    entrypoint: ['/easi/easi', 'serve']
   easi_client:
     build:
       context: .

--- a/docker-compose.cypress_local.yml
+++ b/docker-compose.cypress_local.yml
@@ -20,7 +20,6 @@ services:
       - EMAIL_TEMPLATE_DIR=/easi/templates
     ports:
       - 8080:8080
-    entrypoint: ['/easi/easi', 'serve']
   easi_client:
     build:
       context: .


### PR DESCRIPTION
# ES-574

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

## Changes proposed in this pull request

- Add an entrypoint to the main app's Dockerfile and remove it from the docker-compose files. This will eliminate duplication and also allow us to remove the entrypoint from the deployed app's task definition (another point of duplication). I'm leaving the easi entrypoint in https://github.com/CMSgov/easi-app/blob/master/docker-compose.override.yml as-is since that particular docker-compose file uses an earlier stage in the Dockerfile's multi-stage build, and it's not impacted by this change.

## Reviewer Notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## Code Review Verification Steps

- [ ] User-facing changes have been tested with voice-over
- [ ] User-facing changes have been reviewed by design
- [ ] Acceptance criteria has been met, or will be met by a future PR
- Any new migrations/schema changes:
  - [ ] Follow guidelines for zero-downtime deploys
  - [ ] Have been deployed to the remote dev environment via CI

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
