### PR TITLE
Disable edit/remove test date card for business owners

### DIFF
--- a/src/components/TestDateCard/index.test.tsx
+++ b/src/components/TestDateCard/index.test.tsx
@@ -3,35 +3,14 @@ import { MemoryRouter } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { mount, shallow } from 'enzyme';
 import { DateTime } from 'luxon';
+import { GetAccessibilityRequest_accessibilityRequest_testDates as TestDateType } from 'queries/types/GetAccessibilityRequest';
 
 import TestDateCard from 'components/TestDateCard';
 import { TestDateTestType } from 'types/graphql-global-types';
 
-const renderComponent = (score: number | null) => {
+const renderComponent = (customProps?: any) => {
   return mount(
     <MemoryRouter>
-      <MockedProvider>
-        <TestDateCard
-          testDate={{
-            __typename: 'TestDate',
-            id: 'ID',
-            date: DateTime.local().toISO(),
-            testType: TestDateTestType.INITIAL,
-            score
-          }}
-          testIndex={1}
-          requestId="Request ID"
-          requestName="Initial Request"
-          refetchRequest={() => 0}
-        />
-      </MockedProvider>
-    </MemoryRouter>
-  );
-};
-
-describe('The Test Date Card component', () => {
-  it('renders without crashing', () => {
-    shallow(
       <MockedProvider>
         <TestDateCard
           testDate={{
@@ -44,25 +23,101 @@ describe('The Test Date Card component', () => {
           testIndex={1}
           requestId="Request ID"
           requestName="Initial Request"
-          refetchRequest={() => 0}
+          id="ID"
+          isEditableDeletable
+          refetchRequest={jest.fn()}
+          {...customProps}
+        />
+      </MockedProvider>
+    </MemoryRouter>
+  );
+};
+
+describe('The Test Date Card component', () => {
+  const mockTestDate: TestDateType = {
+    __typename: 'TestDate',
+    id: 'ID',
+    date: DateTime.local().toISO(),
+    testType: TestDateTestType.INITIAL,
+    score: 0
+  };
+
+  it('renders without crashing', () => {
+    shallow(
+      <MockedProvider>
+        <TestDateCard
+          testDate={mockTestDate}
+          testIndex={1}
+          requestId="Request ID"
+          requestName="Initial Request"
+          id="ID"
+          isEditableDeletable
+          refetchRequest={jest.fn()}
         />
       </MockedProvider>
     );
   });
 
+  describe('edit', () => {
+    it('renders edit link', () => {
+      const component = renderComponent();
+      expect(
+        component.find('[data-testid="test-date-edit-link"]').exists()
+      ).toEqual(true);
+    });
+
+    it('hides edit link', () => {
+      const component = renderComponent({ isEditableDeletable: false });
+      expect(
+        component.find('[data-testid="test-date-delete-button"]').exists()
+      ).toEqual(false);
+    });
+  });
+
+  describe('delete', () => {
+    it('renders delete button', () => {
+      const component = renderComponent();
+      expect(
+        component.find('[data-testid="test-date-delete-button"]').exists()
+      ).toEqual(true);
+    });
+
+    it('hides delete button', () => {
+      const component = renderComponent({ isEditableDeletable: false });
+      expect(
+        component.find('[data-testid="test-date-delete-button"]').exists()
+      ).toEqual(false);
+    });
+  });
+
   describe('test score', () => {
     it('renders score', () => {
-      const component = renderComponent(1000);
+      const component = renderComponent({
+        testDate: {
+          ...mockTestDate,
+          score: 1000
+        }
+      });
       expect(component.find('[data-testid="score"]').text()).toEqual('100.0%');
     });
 
     it('renders a score of 0', () => {
-      const component = renderComponent(0);
+      const component = renderComponent({
+        testDate: {
+          ...mockTestDate,
+          score: 0
+        }
+      });
       expect(component.find('[data-testid="score"]').text()).toEqual('0%');
     });
 
     it('renders score not added', () => {
-      const component = renderComponent(null);
+      const component = renderComponent({
+        testDate: {
+          ...mockTestDate,
+          score: null
+        }
+      });
       expect(component.find('[data-testid="score"]').text()).toEqual(
         'Score not added'
       );

--- a/src/components/TestDateCard/index.tsx
+++ b/src/components/TestDateCard/index.tsx
@@ -16,6 +16,8 @@ type TestDateCardProps = {
   testIndex: number;
   requestId: string;
   requestName: string;
+  id: string;
+  isEditableDeletable: boolean;
   refetchRequest: () => any;
 };
 
@@ -24,6 +26,7 @@ const TestDateCard = ({
   testIndex,
   requestId,
   requestName,
+  isEditableDeletable,
   refetchRequest
 }: TestDateCardProps) => {
   const { t } = useTranslation('accessibility');
@@ -76,61 +79,66 @@ const TestDateCard = ({
           {testScore()}
         </div>
       </div>
-      <div>
-        <UswdsLink
-          asCustom={Link}
-          to={`/508/requests/${requestId}/test-date/${id}`}
-          aria-label={`Edit test ${testIndex} ${testType}`}
-        >
-          Edit
-        </UswdsLink>
-        <Button
-          className="margin-left-1"
-          type="button"
-          aria-label={`Remove test ${testIndex} ${testType}`}
-          unstyled
-          onClick={() => {
-            setRemoveTestDateModalOpen(true);
-          }}
-        >
-          Remove
-        </Button>
-        <Modal
-          isOpen={isRemoveTestDateModalOpen}
-          closeModal={() => {
-            setRemoveTestDateModalOpen(false);
-          }}
-        >
-          <PageHeading headingLevel="h2" className="margin-top-0">
-            {t('removeTestDate.modalHeader', {
-              testNumber: testIndex,
-              testType,
-              testDate: formatDate(date),
-              requestName
-            })}
-          </PageHeading>
-          <p>{t('removeTestDate.modalText')}</p>
-          <Button
-            type="button"
-            className="margin-right-4"
-            onClick={() => {
-              deleteTestDate();
-              setRemoveTestDateModalOpen(false);
-            }}
+
+      {isEditableDeletable && (
+        <div>
+          <UswdsLink
+            asCustom={Link}
+            to={`/508/requests/${requestId}/test-date/${id}`}
+            aria-label={`Edit test ${testIndex} ${testType}`}
+            data-testid="test-date-edit-link"
           >
-            {t('removeTestDate.modalRemoveButton')}
-          </Button>
+            Edit
+          </UswdsLink>
           <Button
+            className="margin-left-1"
             type="button"
+            aria-label={`Remove test ${testIndex} ${testType}`}
             unstyled
             onClick={() => {
+              setRemoveTestDateModalOpen(true);
+            }}
+            data-testid="test-date-delete-button"
+          >
+            Remove
+          </Button>
+          <Modal
+            isOpen={isRemoveTestDateModalOpen}
+            closeModal={() => {
               setRemoveTestDateModalOpen(false);
             }}
           >
-            {t('removeTestDate.modalCancelButton')}
-          </Button>
-        </Modal>
-      </div>
+            <PageHeading headingLevel="h2" className="margin-top-0">
+              {t('removeTestDate.modalHeader', {
+                testNumber: testIndex,
+                testType,
+                testDate: formatDate(date),
+                requestName
+              })}
+            </PageHeading>
+            <p>{t('removeTestDate.modalText')}</p>
+            <Button
+              type="button"
+              className="margin-right-4"
+              onClick={() => {
+                deleteTestDate();
+                setRemoveTestDateModalOpen(false);
+              }}
+            >
+              {t('removeTestDate.modalRemoveButton')}
+            </Button>
+            <Button
+              type="button"
+              unstyled
+              onClick={() => {
+                setRemoveTestDateModalOpen(false);
+              }}
+            >
+              {t('removeTestDate.modalCancelButton')}
+            </Button>
+          </Modal>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/TestDateCard/index.tsx
+++ b/src/components/TestDateCard/index.tsx
@@ -17,7 +17,7 @@ type TestDateCardProps = {
   requestId: string;
   requestName: string;
   id: string;
-  isEditableDeletable: boolean;
+  isEditableDeletable?: boolean;
   refetchRequest: () => any;
 };
 
@@ -26,7 +26,7 @@ const TestDateCard = ({
   testIndex,
   requestId,
   requestName,
-  isEditableDeletable,
+  isEditableDeletable = true,
   refetchRequest
 }: TestDateCardProps) => {
   const { t } = useTranslation('accessibility');

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 import { Link, useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import { Link as UswdsLink } from '@trussworks/react-uswds';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 import { DateTime } from 'luxon';
 import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
 import {
@@ -13,17 +15,13 @@ import {
 import AccessibilityDocumentsList from 'components/AccessibilityDocumentsList';
 import PageHeading from 'components/PageHeading';
 import TestDateCard from 'components/TestDateCard';
+import { AppState } from 'reducers/rootReducer';
 import { formatDate } from 'utils/date';
+import user from 'utils/user';
 
 import './index.scss';
 
-type AccessibilityRequestDetailPageProps = {
-  isAccessibilityTeam: boolean;
-};
-
-const AccessibilityRequestDetailPage = ({
-  isAccessibilityTeam
-}: AccessibilityRequestDetailPageProps) => {
+const AccessibilityRequestDetailPage = () => {
   const { t } = useTranslation('accessibility');
   const { accessibilityRequestId } = useParams<{
     accessibilityRequestId: string;
@@ -47,6 +45,10 @@ const AccessibilityRequestDetailPage = ({
     data?.accessibilityRequest?.system?.businessOwner?.component;
   const documents = data?.accessibilityRequest?.documents || [];
   const testDates = data?.accessibilityRequest?.testDates || [];
+
+  const flags = useFlags();
+  const userGroups = useSelector((state: AppState) => state.auth.groups);
+  const isAccessibilityTeam = user.isAccessibilityTeam(userGroups, flags);
 
   if (loading) {
     return <div>Loading</div>;

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -113,13 +113,15 @@ const AccessibilityRequestDetailPage = () => {
                     refetchRequest={refetch}
                   />
                 ))}
-              <Link
-                to={`/508/requests/${accessibilityRequestId}/test-date`}
-                className="margin-bottom-3 display-block"
-                aria-label="Add a test date"
-              >
-                Add a date
-              </Link>
+              {isAccessibilityTeam && (
+                <Link
+                  to={`/508/requests/${accessibilityRequestId}/test-date`}
+                  className="margin-bottom-3 display-block"
+                  aria-label="Add a test date"
+                >
+                  Add a date
+                </Link>
+              )}
             </div>
             <div className="accessibility-request__other-details">
               <h3>{t('requestDetails.other')}</h3>

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -17,7 +17,13 @@ import { formatDate } from 'utils/date';
 
 import './index.scss';
 
-const AccessibilityRequestDetailPage = () => {
+type AccessibilityRequestDetailPageProps = {
+  isAccessibilityTeam: boolean;
+};
+
+const AccessibilityRequestDetailPage = ({
+  isAccessibilityTeam
+}: AccessibilityRequestDetailPageProps) => {
   const { t } = useTranslation('accessibility');
   const { accessibilityRequestId } = useParams<{
     accessibilityRequestId: string;
@@ -101,6 +107,7 @@ const AccessibilityRequestDetailPage = () => {
                     testIndex={index + 1}
                     requestName={requestName}
                     requestId={accessibilityRequestId}
+                    isEditableDeletable={isAccessibilityTeam}
                     refetchRequest={refetch}
                   />
                 ))}

--- a/src/views/Accessibility/index.tsx
+++ b/src/views/Accessibility/index.tsx
@@ -57,9 +57,7 @@ const Accessibility = () => {
   const RequestDetails = (
     <SecureRoute
       path="/508/requests/:accessibilityRequestId"
-      render={() => {
-        return <AccessibilityRequestDetailPage />;
-      }}
+      component={AccessibilityRequestDetailPage}
     />
   );
   const Default = <Route path="*" component={NotFoundPartial} />;

--- a/src/views/Accessibility/index.tsx
+++ b/src/views/Accessibility/index.tsx
@@ -57,7 +57,13 @@ const Accessibility = () => {
   const RequestDetails = (
     <SecureRoute
       path="/508/requests/:accessibilityRequestId"
-      component={AccessibilityRequestDetailPage}
+      render={() => {
+        return (
+          <AccessibilityRequestDetailPage
+            isAccessibilityTeam={user.isAccessibilityTeam(userGroups, flags)}
+          />
+        );
+      }}
     />
   );
   const Default = <Route path="*" component={NotFoundPartial} />;

--- a/src/views/Accessibility/index.tsx
+++ b/src/views/Accessibility/index.tsx
@@ -58,11 +58,7 @@ const Accessibility = () => {
     <SecureRoute
       path="/508/requests/:accessibilityRequestId"
       render={() => {
-        return (
-          <AccessibilityRequestDetailPage
-            isAccessibilityTeam={user.isAccessibilityTeam(userGroups, flags)}
-          />
-        );
+        return <AccessibilityRequestDetailPage />;
       }}
     />
   );


### PR DESCRIPTION
# ES-496

This PR disables the ability for business owners to edit/remove test dates for business owners. Only the 508/accessibility team is able to edit/remove test dates.

## Changes proposed in this pull request

This PR **ONLY** does frontend work to hide the edit/remove buttons. I've verified that users **NEED** 508 job codes to perform those actions. Anybody that doesn't have those job codes can't edit/remove test dates.

Minor note: If a business owner _somehow_ attempts to edit/remove a test date (without proper job codes), the request will resolve 200, but nothing will actually happen. I'm not sure if we want to do anything more, but that's how it works now.

## Reviewer Notes

Standard code review, but it'd be helpful to add request dates, edit, and remove them. A sample run through can look like:

Business Owner (No job codes)
1. Add 508 Request. You can manually navigate to `/508/requests/new`
2. Add test date
3. Verify that the test date card does not have edit/remove buttons
4. Logout

508 User/Tester
1. Login as a 508 user/tester with appropriate job codes.
2. Find the 508 request you just created
3. Verify that the test date card has edit/remove buttons
4. Update the test date details (e.g date, type, score, etc) and verify that they've been update
5. Remove and verify it's been removed

## Code Review Verification Steps

- [ ] User-facing changes have been tested with voice-over
- [ ] User-facing changes have been reviewed by design
- [ ] Acceptance criteria has been met, or will be met by a future PR
