### PR TITLE
ES-551: Validate test score

### DIFF
--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -51,6 +51,7 @@ const accessibility = {
     testTypeHeader: 'What type of test?',
     dateHeader: 'Test date',
     dateHelpText: 'For example: 4 28 2020',
+    scoreHelpText: 'The test score must be a number between 0 and 100',
     scoreHeader: 'Does this test have a score?',
     scoreValueHeader: 'Test Score',
     scoreValueSRHelpText: 'Enter the test score without the percentage symbol',

--- a/src/validations/testDateSchema.test.ts
+++ b/src/validations/testDateSchema.test.ts
@@ -1,0 +1,29 @@
+import { TestDateValidationSchema } from './testDateSchema';
+
+describe('test date validation', () => {
+  ['101.1', '234', '1000000', '-1', '-0.1'].forEach(value => {
+    it(`requires a score to be a number within 0 and 100: ${value}`, async () => {
+      const result = await TestDateValidationSchema.validateAt('score', {
+        score: { isPresent: true, value }
+      }).catch(err => {
+        return err;
+      });
+
+      expect(result.errors).toEqual([
+        'The test score must be no less than 0 and no more than 100'
+      ]);
+    });
+
+    ['0', '1', '55', '56.78', '100'].forEach(valid => {
+      it(`accepts a valid test score: ${valid}`, async () => {
+        const result = await TestDateValidationSchema.validateAt('score', {
+          score: { isPresent: true, value: valid }
+        }).catch(err => {
+          return err;
+        });
+
+        expect(result.errors).toBeUndefined();
+      });
+    });
+  });
+});

--- a/src/validations/testDateSchema.ts
+++ b/src/validations/testDateSchema.ts
@@ -38,6 +38,14 @@ export const TestDateValidationSchema: any = Yup.object().shape({
         .trim()
         .required('Enter a test score')
         .matches(scoreRegex, 'The test score must be a number, like 85.5')
+        .test(
+          'score',
+          'The test score must be no less than 0 and no more than 100',
+          number => {
+            const float = parseFloat(number);
+            return float >= 0 && float <= 100;
+          }
+        )
     })
   })
 });

--- a/src/views/TestDate/Form.tsx
+++ b/src/views/TestDate/Form.tsx
@@ -237,7 +237,7 @@ const TestDateForm = ({
                             <FieldErrorMsg>
                               {flatErrors['score.value']}
                             </FieldErrorMsg>
-                            <div className="display-flex">
+                            <div className="display-flex margin-bottom-1">
                               <div className="width-10">
                                 <Field
                                   as={TextField}
@@ -246,12 +246,16 @@ const TestDateForm = ({
                                   id="TestDate-ScoreValue"
                                   maxLength={4}
                                   name="score.value"
+                                  aria-describedby="TestDate-ScoreValueHelpText"
                                 />
                               </div>
                               <div className="bg-black text-white width-5 display-flex flex-justify-center flex-align-center">
                                 <span className="text-bold">%</span>
                               </div>
                             </div>
+                            <HelpText id="TestDate-ScoreValueHelpText">
+                              {t('testDateForm.scoreHelpText')}
+                            </HelpText>
                           </FieldGroup>
                         </div>
                       )}


### PR DESCRIPTION
# ES-551

## Changes proposed in this pull request

- The test score for a test date, if entered, must be between 0 and 100 (inclusive).
- We added help text associated with the input to make this information available before a user encounters a validation error.

I added a unit test for the test date validation code. We don't have a pattern for this yet in the app.

These changes have been tested using only a keyboard and using JAWS.

## Code Review Verification Steps

- [ ] User-facing changes have been tested with voice-over
- [ ] User-facing changes have been reviewed by design
- [ ] Acceptance criteria has been met, or will be met by a future PR

## Screenshots

![Screen Shot 2021-05-04 at 1 37 58 PM](https://user-images.githubusercontent.com/3331/117053113-319caa00-acde-11eb-9fb9-0ec506b08d83.png)
![Screen Shot 2021-05-04 at 1 38 18 PM](https://user-images.githubusercontent.com/3331/117053139-3a8d7b80-acde-11eb-8652-b66201682ceb.png)

