### PR TITLE
Removed legacy SharePoint intake form link on home page

### DIFF
--- a/src/i18n/en-US/home.ts
+++ b/src/i18n/en-US/home.ts
@@ -2,8 +2,6 @@ const home = {
   title: 'Welcome to EASi',
   subtitle:
     'You can use EASi to go through the set of steps needed to get a Lifecycle ID from the Governance Review Board (GRB).',
-  easiInfo:
-    "Use this process only if you'd like to add a new system, service or make major changes and upgrades to an existing one. For all other requests, please use the <1>alternative request form</1>.",
   startNow: 'Start now',
   signIn: 'Sign in to start',
   accessibility: {

--- a/src/views/Home/WelcomeText.tsx
+++ b/src/views/Home/WelcomeText.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { useOktaAuth } from '@okta/okta-react';
 import { Link as UswdsLink } from '@trussworks/react-uswds';
 
 import PageHeading from 'components/PageHeading';
-import PlainInfo from 'components/PlainInfo';
 
 const WelcomeText = () => {
   const { t } = useTranslation();
@@ -14,23 +13,9 @@ const WelcomeText = () => {
   return (
     <div className="tablet:grid-col-9">
       <PageHeading>{t('home:title')}</PageHeading>
-      <p className="line-height-body-5 font-body-lg text-light">
+      <p className="line-height-body-5 font-body-lg text-light margin-bottom-6">
         {t('home:subtitle')}
       </p>
-      <div className="margin-bottom-6">
-        <PlainInfo>
-          <Trans i18nKey="home:easiInfo">
-            zeroIndex
-            <a
-              href="https://share.cms.gov/Office/OIT/CIOCorner/Lists/Intake/NewForm.aspx"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              localeLink
-            </a>
-          </Trans>
-        </PlainInfo>
-      </div>
       {authState.isAuthenticated ? (
         <UswdsLink
           className="usa-button"


### PR DESCRIPTION
# EASI-1174

## Changes proposed in this pull request

- Removed help text / alert on home page that would direct users to the legacy SharePoint intake form

## Reviewer Notes

- This is one of the PRs to allow the governance team to make a full transition to EASi

## Code Review Verification Steps

- [ ] User-facing changes have been tested with voice-over
- [ ] User-facing changes have been reviewed by design
- [ ] Acceptance criteria has been met, or will be met by a future PR
- Any new migrations/schema changes:
  - [ ] Follow guidelines for zero-downtime deploys
  - [ ] Have been deployed to the remote dev environment via CI
