### PR TITLE
Modified wording of cost increase question

### DIFF
--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -282,7 +282,8 @@ const ContractDetails = ({
                 >
                   <fieldset className="usa-fieldset margin-top-4">
                     <legend className="usa-label margin-bottom-1">
-                      Do you expect costs for this request to increase?
+                      Do the costs for this request exceed what you are
+                      currently spending to meet your business need?
                     </legend>
                     <HelpText
                       id="IntakeForm-IncreasedCostsHelp"
@@ -309,11 +310,17 @@ const ContractDetails = ({
                           scrollElement="costs.expectedIncreaseAmount"
                           error={!!flatErrors['costs.expectedIncreaseAmount']}
                         >
-                          <Label htmlFor="IntakeForm-CostsExpectedIncrease">
+                          <Label
+                            htmlFor="IntakeForm-CostsExpectedIncrease"
+                            className="margin-bottom-1"
+                          >
                             Approximately how much do you expect the cost to
-                            increase over what you are currently spending to
-                            meet your business need?
+                            increase?
                           </Label>
+                          <HelpText id="IntakeForm-ExpectedIncreaseHelp">
+                            Compare the first year of new contract spending to
+                            current annual spending
+                          </HelpText>
                           <FieldErrorMsg>
                             {flatErrors['costs.expectedIncreaseAmount']}
                           </FieldErrorMsg>
@@ -323,6 +330,7 @@ const ContractDetails = ({
                             error={!!flatErrors['costs.expectedIncreaseAmount']}
                             id="IntakeForm-CostsExpectedIncrease"
                             name="costs.expectedIncreaseAmount"
+                            aria-describedby="IntakeForm-ExpectedIncreaseHelp"
                             maxLength={100}
                           />
                         </FieldGroup>


### PR DESCRIPTION
# EASI-1175

## Changes proposed in this pull request

- Changed wording of intake cost increase question to be more specific about expected answers
- Added help text to expected increase question

## Reviewer Notes

- This is one of the PRs to allow the governance team to make a full transition to EASi

- Question for reviewer(s): I only changed the wording on the actual form itself, do we want to change the wording in the other places? (i.e. "Do you expect costs for this request to increase?" in components/SystemIntakeReview/index.tsx)

## Code Review Verification Steps

- [ ] User-facing changes have been tested with voice-over
- [ ] User-facing changes have been reviewed by design
- [ ] Acceptance criteria has been met, or will be met by a future PR
- Any new migrations/schema changes:
  - [ ] Follow guidelines for zero-downtime deploys
  - [ ] Have been deployed to the remote dev environment via CI
