### PR TITLE
fix focus when closing remove document modal

### DIFF
--- a/src/components/AccessibilityDocumentsList/index.tsx
+++ b/src/components/AccessibilityDocumentsList/index.tsx
@@ -41,10 +41,7 @@ const AccessibilityDocumentsList = ({
   refetchRequest
 }: DocumentsListProps) => {
   const { t } = useTranslation('accessibility');
-  const [
-    documentWithModalOpen,
-    setDocumentWithModalOpen
-  ] = useState<Document | null>(null);
+  const [document, setDocument] = useState<Document | null>(null);
 
   const getDocType = (documentType: {
     commonType: AccessibilityRequestDocumentCommonType;
@@ -71,7 +68,7 @@ const AccessibilityDocumentsList = ({
         }
       }
     }).then(refetchRequest);
-    setDocumentWithModalOpen(null);
+    setDocument(null);
   };
 
   const columns = useMemo<Column<Document>[]>(() => {
@@ -116,40 +113,10 @@ const AccessibilityDocumentsList = ({
                   aria-label={`Remove ${getDocType(row.original.documentType)}`}
                   type="button"
                   unstyled
-                  onClick={() => setDocumentWithModalOpen(row.original)}
+                  onClick={() => setDocument(row.original)}
                 >
                   {t('documentTable.remove')}
                 </Button>
-                <Modal
-                  isOpen={documentWithModalOpen === row.original}
-                  closeModal={() => setDocumentWithModalOpen(null)}
-                >
-                  <PageHeading
-                    headingLevel="h1"
-                    className="line-height-heading-2 margin-bottom-2"
-                  >
-                    {t('documentTable.modal.header', {
-                      name: getDocType(row.original.documentType)
-                    })}
-                  </PageHeading>
-                  <span>{t('documentTable.modal.warning')}</span>
-                  <div className="display-flex margin-top-2">
-                    <Button
-                      type="button"
-                      className="margin-right-5"
-                      onClick={() => submitDelete(row.original.id)}
-                    >
-                      {t('documentTable.modal.proceedButton')}
-                    </Button>
-                    <Button
-                      type="button"
-                      unstyled
-                      onClick={() => setDocumentWithModalOpen(null)}
-                    >
-                      {t('documentTable.modal.declineButton')}
-                    </Button>
-                  </div>
-                </Modal>
               </>
             )}
             {row.original.status === 'UNAVAILABLE' && (
@@ -158,16 +125,12 @@ const AccessibilityDocumentsList = ({
                 Document failed virus scan
               </>
             )}
-            {/* <UswdsLink asCustom={Link} to="#" className="margin-left-2">
-              {t('documentTable.remove')}
-            </UswdsLink>
-            <span className="usa-sr-only">{row.original.name}</span> */}
           </>
         )
       }
     ];
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [documentWithModalOpen]);
+  }, []);
 
   const {
     getTableProps,
@@ -189,53 +152,82 @@ const AccessibilityDocumentsList = ({
   }
 
   return (
-    <Table bordered={false} {...getTableProps()} fullWidth>
-      <caption className="usa-sr-only">
-        {`${t('documentTable.caption')} ${requestName}`}
-      </caption>
-      <thead>
-        {headerGroups.map(headerGroup => (
-          <tr {...headerGroup.getHeaderGroupProps()}>
-            {headerGroup.headers.map(column => (
-              <th
-                {...column.getHeaderProps()}
-                style={{ whiteSpace: 'nowrap', width: column.width }}
-                scope="col"
-              >
-                {column.render('Header')}
-              </th>
-            ))}
-          </tr>
-        ))}
-      </thead>
-      <tbody {...getTableBodyProps()}>
-        {rows.map(row => {
-          prepareRow(row);
-          return (
-            <tr {...row.getRowProps()}>
-              {row.cells.map((cell, i) => {
-                if (i === 0) {
-                  return (
-                    <th
-                      {...cell.getCellProps()}
-                      scope="row"
-                      style={{ maxWidth: '16rem' }}
-                    >
-                      {cell.render('Cell')}
-                    </th>
-                  );
-                }
-                return (
-                  <td {...cell.getCellProps()} style={{ maxWidth: '16rem' }}>
-                    {cell.render('Cell')}
-                  </td>
-                );
-              })}
+    <>
+      <Table bordered={false} {...getTableProps()} fullWidth>
+        <caption className="usa-sr-only">
+          {`${t('documentTable.caption')} ${requestName}`}
+        </caption>
+        <thead>
+          {headerGroups.map(headerGroup => (
+            <tr {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map(column => (
+                <th
+                  {...column.getHeaderProps()}
+                  style={{ whiteSpace: 'nowrap', width: column.width }}
+                  scope="col"
+                >
+                  {column.render('Header')}
+                </th>
+              ))}
             </tr>
-          );
-        })}
-      </tbody>
-    </Table>
+          ))}
+        </thead>
+        <tbody {...getTableBodyProps()}>
+          {rows.map(row => {
+            prepareRow(row);
+            return (
+              <tr {...row.getRowProps()}>
+                {row.cells.map((cell, i) => {
+                  if (i === 0) {
+                    return (
+                      <th
+                        {...cell.getCellProps()}
+                        scope="row"
+                        style={{ maxWidth: '16rem' }}
+                      >
+                        {cell.render('Cell')}
+                      </th>
+                    );
+                  }
+                  return (
+                    <td {...cell.getCellProps()} style={{ maxWidth: '16rem' }}>
+                      {cell.render('Cell')}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </Table>
+      <Modal isOpen={!!document} closeModal={() => setDocument(null)}>
+        {document && (
+          <>
+            <PageHeading
+              headingLevel="h2"
+              className="margin-top-0 line-height-heading-2 margin-bottom-2"
+            >
+              {t('documentTable.modal.header', {
+                name: getDocType(document.documentType)
+              })}
+            </PageHeading>
+            <span>{t('documentTable.modal.warning')}</span>
+            <div className="display-flex margin-top-2">
+              <Button
+                type="button"
+                className="margin-right-5"
+                onClick={() => submitDelete(document.id)}
+              >
+                {t('documentTable.modal.proceedButton')}
+              </Button>
+              <Button type="button" unstyled onClick={() => setDocument(null)}>
+                {t('documentTable.modal.declineButton')}
+              </Button>
+            </div>
+          </>
+        )}
+      </Modal>
+    </>
   );
 };
 


### PR DESCRIPTION
# ES-588

This PR fixes the loss of focus bug when a user closes the "Remove Document" modal.

The diff is messy so here's what happened in the render:
- Move `Modal` from the table columns in to the actual `render` of the component
    - This made me wrap render with a React Fragment, which caused a big diff.
- Because the `Modal` is no longer in the `columns`, we don't need to have a dependency array in the `useEffect` to force re-render
- 
## Code Review Verification Steps

- [ ] User-facing changes have been tested with voice-over
- [ ] User-facing changes have been reviewed by design
- [ ] Acceptance criteria has been met, or will be met by a future PR
