### PR TITLE
Don't escape the requestName when interpolating.

### DIFF
--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -43,18 +43,18 @@ const accessibility = {
     other: 'Other request details',
     remove: 'Remove this request from EASi',
     modal: {
-      header: 'Confirm you want to remove {{requestName}}?',
+      header: 'Confirm you want to remove {{-requestName}}?',
       subhead:
         'You will not be able to access this request and its documents after it is removed.',
       confirm: 'Remove request',
       cancel: 'Keep request'
     },
-    removeConfirmationText: '{{requestName}} successfully removed'
+    removeConfirmationText: '{{-requestName}} successfully removed'
   },
   testDateForm: {
     header: {
-      create: 'Add a test date for {{requestName}}',
-      update: 'Update a test date for {{requestName}}'
+      create: 'Add a test date for {{-requestName}}',
+      update: 'Update a test date for {{-requestName}}'
     },
     testTypeHeader: 'What type of test?',
     dateHeader: 'Test date',
@@ -77,11 +77,11 @@ const accessibility = {
   },
   removeTestDate: {
     modalHeader:
-      'Confirm you want to remove Test {{testNumber}} {{testType}}, {{testDate}} from {{requestName}}',
+      'Confirm you want to remove Test {{testNumber}} {{testType}}, {{testDate}} from {{-requestName}}',
     modalText: 'This test date and score will be removed from the request page',
     modalRemoveButton: 'Remove test date',
     modalCancelButton: 'Keep test date',
-    confirmation: '{{date}} test date was removed from {{requestName}} page'
+    confirmation: '{{date}} test date was removed from {{-requestName}} page'
   },
   newRequestForm: {
     heading: 'Add a new request',
@@ -108,7 +108,7 @@ const accessibility = {
     info:
       'A request for 508 testing will be added to the list of 508 requests. An email will be sent to the Business Owner and the 508 team stating that a request has been added to the system.',
     submitBtn: 'Add a new request',
-    confirmation: '{{requestName}} was added to the 508 requests page'
+    confirmation: '{{-requestName}} was added to the 508 requests page'
   },
   documentType: {
     awardedVpat: 'Awarded VPAT',

--- a/src/i18n/en-US/governanceReviewTeam.ts
+++ b/src/i18n/en-US/governanceReviewTeam.ts
@@ -181,7 +181,7 @@ const governanceReviewTeam = {
   },
   adminLeads: {
     assignModal: {
-      header: 'Choose an Admin Lead for {{requestName}}',
+      header: 'Choose an Admin Lead for {{-requestName}}',
       save: 'Save',
       noChanges: "Don't make changes and return to request page"
     },

--- a/src/i18n/en-US/taskList.ts
+++ b/src/i18n/en-US/taskList.ts
@@ -1,10 +1,10 @@
 const taskList = {
   withdraw_modal: {
-    header: 'Confirm you want to remove {{requestName}}.',
+    header: 'Confirm you want to remove {{-requestName}}.',
     warning: 'You will lose any information you have filled in.',
     confirm: 'Remove request',
     cancel: 'Cancel',
-    confirmationText_name: 'The request for {{requestName}} has been removed',
+    confirmationText_name: 'The request for {{-requestName}} has been removed',
     confirmationText_noName: 'The request has been removed'
   },
   decision: {


### PR DESCRIPTION
# ES-561

Our internationalization library, [react-18next](https://react.i18next.com), performs HTML escaping by default when interpolating values. This is causing some issues where we are displaying interpolated internationalized copy in the UI, as the resulting values are not interpreted as HTML by React but as literal text. This leads to results like this:

![Screen Shot 2021-05-06 at 3 47 16 PM](https://user-images.githubusercontent.com/3331/117365862-8b8ba400-ae85-11eb-95db-d801cce79ba0.png)

There are [two ways](https://www.i18next.com/translation-function/interpolation#unescape) to disable the auto escaping, and I chose to modify the strings we use for interpolation so that it could be done just for that value and not for the entire string.

## Changes proposed in this pull request

- Update any i18n text that interpolates a request name to not perform HTML escaping of that value.

## Reviewer Notes

If you want to try it out, create a 508 request with a name that includes `'"<>` and then look at the success message that is displayed after creation. You want to make sure that the exact value you entered in the form is displayed on the screen:

<img width="471" alt="Screen Shot 2021-05-06 at 4 12 21 PM" src="https://user-images.githubusercontent.com/3331/117367793-3dc46b00-ae88-11eb-9848-2842593724d3.png">

## Code Review Verification Steps

- [ ] User-facing changes have been tested with voice-over
- [ ] User-facing changes have been reviewed by design
- [ ] Acceptance criteria has been met, or will be met by a future PR