### PR TITLE
Add additional context to document file input

### DIFF
--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -196,11 +196,19 @@ const New = () => {
                       as={FileUpload}
                       id="FileUpload-File"
                       name="file"
+                      ariaDescribedBy="FileUpload-Description"
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                         onChange(e);
                         setFieldValue('file', e.currentTarget?.files?.[0]);
                       }}
                     />
+                    <div
+                      id="FileUpload-Description"
+                      className="sr-only"
+                      tabIndex={-1}
+                    >
+                      Activate to select a file.
+                    </div>
                   </FieldGroup>
                   {values.file && (
                     <FieldGroup

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -207,7 +207,7 @@ const New = () => {
                       className="sr-only"
                       tabIndex={-1}
                     >
-                      Activate to select a file.
+                      Select a file.
                     </div>
                   </FieldGroup>
                   {values.file && (


### PR DESCRIPTION
The file input previous was ambiguously announced by JAWS. Listen and ask yourself which button does what:

https://user-images.githubusercontent.com/3331/117707358-1cb78f00-b194-11eb-8756-68b60be65d49.mov

## Changes proposed in this pull request

- Add additional context that is announced when the file input is tabbed into:

https://user-images.githubusercontent.com/3331/117707414-2fca5f00-b194-11eb-8c2b-bf3037968875.mov

## Code Review Verification Steps

- [x] User-facing changes have been tested with JAWS
- [x] User-facing changes have been reviewed by design