### PR TITLE
update accessibility pages page structure

### DIFF
--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
-import { Button, Link as UswdsLink } from '@trussworks/react-uswds';
+import { Alert, Button, Link as UswdsLink } from '@trussworks/react-uswds';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 import { DateTime } from 'luxon';
 import { DeleteAccessibilityRequestQuery } from 'queries/AccessibilityRequestQueries';
@@ -20,6 +20,7 @@ import {
 import AccessibilityDocumentsList from 'components/AccessibilityDocumentsList';
 import Modal from 'components/Modal';
 import PageHeading from 'components/PageHeading';
+import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import TestDateCard from 'components/TestDateCard';
 import useMessage from 'hooks/useMessage';
 import { AppState } from 'reducers/rootReducer';
@@ -32,7 +33,8 @@ import './index.scss';
 const AccessibilityRequestDetailPage = () => {
   const { t } = useTranslation('accessibility');
   const [isModalOpen, setModalOpen] = useState(false);
-  const { showMessage, showMessageOnNextPage } = useMessage();
+  const { message, showMessage, showMessageOnNextPage } = useMessage();
+
   const history = useHistory();
   const { accessibilityRequestId } = useParams<{
     accessibilityRequestId: string;
@@ -69,6 +71,7 @@ const AccessibilityRequestDetailPage = () => {
         }
       }
     }).then(response => {
+      console.log(response.errors);
       if (response.errors && response.errors.length === 0) {
         showMessageOnNextPage(
           t('requestDetails.removeConfirmationText', {
@@ -89,7 +92,11 @@ const AccessibilityRequestDetailPage = () => {
   }
 
   if (!data) {
-    return <NotFoundPartial />;
+    return (
+      <div className="grid-container">
+        <NotFoundPartial />
+      </div>
+    );
   }
 
   // What type of errors can we get/return?
@@ -100,120 +107,133 @@ const AccessibilityRequestDetailPage = () => {
 
   return (
     <>
-      <PageHeading>{requestName}</PageHeading>
-      <div className="grid-row grid-gap-lg">
-        <div className="grid-col-9">
-          <h2 className="margin-top-0">
-            {t('requestDetails.documents.label')}
-          </h2>
-          <UswdsLink
-            className="usa-button"
-            variant="unstyled"
-            asCustom={Link}
-            to={`/508/requests/${accessibilityRequestId}/documents/new`}
-          >
-            {t('requestDetails.documentUpload')}
-          </UswdsLink>
-          <div className="margin-top-6">
-            <AccessibilityDocumentsList
-              documents={documents}
-              requestName={requestName}
-              setConfirmationText={showMessage}
-              refetchRequest={refetch}
-            />
-          </div>
-        </div>
-        <div className="grid-col-3">
-          <div className="accessibility-request__side-nav">
-            <div>
-              <h2 className="margin-top-2 margin-bottom-3">
-                Test Dates and Scores
-              </h2>
-              {[...testDates]
-                .sort(
-                  (a, b) =>
-                    DateTime.fromISO(a.date).toMillis() -
-                    DateTime.fromISO(b.date).toMillis()
-                )
-                .map((testDate, index) => (
-                  <TestDateCard
-                    key={testDate.id}
-                    testDate={testDate}
-                    testIndex={index + 1}
-                    requestName={requestName}
-                    requestId={accessibilityRequestId}
-                    isEditableDeletable={isAccessibilityTeam}
-                    refetchRequest={refetch}
-                    setConfirmationText={showMessage}
-                  />
-                ))}
-              {isAccessibilityTeam && (
-                <Link
-                  to={`/508/requests/${accessibilityRequestId}/test-date`}
-                  className="margin-bottom-3 display-block"
-                  aria-label="Add a test date"
-                >
-                  Add a date
-                </Link>
-              )}
-            </div>
-            <div className="accessibility-request__other-details">
-              <h3>{t('requestDetails.other')}</h3>
-              <dl>
-                <dt className="margin-bottom-1">
-                  {t('intake:fields.submissionDate')}
-                </dt>
-                <dd className="margin-0 margin-bottom-2">
-                  {formatDate(submittedAt)}
-                </dd>
-                <dt className="margin-bottom-1">
-                  {t('intake:fields.businessOwner')}
-                </dt>
-                <dd className="margin-0 margin-bottom-2">
-                  {businessOwnerName}, {businessOwnerComponent}
-                </dd>
-                <dt className="margin-bottom-1">
-                  {t('intake:fields:projectName')}
-                </dt>
-                <dd className="margin-0 margin-bottom-3">{systemName}</dd>
-                <dt className="margin-bottom-1">{t('intake:lifecycleId')}</dt>
-                <dd className="margin-0 margin-bottom-3">{lcid}</dd>
-              </dl>
-            </div>
-            <button
-              type="button"
-              className="accessibility-request__remove-request"
-              onClick={() => setModalOpen(true)}
+      <SecondaryNav>
+        <NavLink to="/">{t('tabs.accessibilityRequests')}</NavLink>
+      </SecondaryNav>
+      <div className="grid-container">
+        {message && (
+          <Alert className="margin-top-4" type="success" role="alert">
+            {message}
+          </Alert>
+        )}
+        <PageHeading>{requestName}</PageHeading>
+        <div className="grid-row grid-gap-lg">
+          <div className="grid-col-9">
+            <h2 className="margin-top-0">
+              {t('requestDetails.documents.label')}
+            </h2>
+            <UswdsLink
+              className="usa-button"
+              variant="unstyled"
+              asCustom={Link}
+              to={`/508/requests/${accessibilityRequestId}/documents/new`}
             >
-              {t('requestDetails.remove')}
-            </button>
-            <Modal isOpen={isModalOpen} closeModal={() => setModalOpen(false)}>
-              <PageHeading
-                headingLevel="h1"
-                className="line-height-heading-2 margin-bottom-2"
-              >
-                {t('requestDetails.modal.header', {
-                  requestName
-                })}
-              </PageHeading>
-              <span>{t('requestDetails.modal.subhead')}</span>
-              <div className="display-flex margin-top-2">
-                <Button
-                  type="button"
-                  className="margin-right-5"
-                  onClick={removeRequest}
-                >
-                  {t('requestDetails.modal.confirm')}
-                </Button>
-                <Button
-                  type="button"
-                  unstyled
-                  onClick={() => setModalOpen(false)}
-                >
-                  {t('requestDetails.modal.cancel')}
-                </Button>
+              {t('requestDetails.documentUpload')}
+            </UswdsLink>
+            <div className="margin-top-6">
+              <AccessibilityDocumentsList
+                documents={documents}
+                requestName={requestName}
+                setConfirmationText={showMessage}
+                refetchRequest={refetch}
+              />
+            </div>
+          </div>
+          <div className="grid-col-3">
+            <div className="accessibility-request__side-nav">
+              <div>
+                <h2 className="margin-top-2 margin-bottom-3">
+                  Test Dates and Scores
+                </h2>
+                {[...testDates]
+                  .sort(
+                    (a, b) =>
+                      DateTime.fromISO(a.date).toMillis() -
+                      DateTime.fromISO(b.date).toMillis()
+                  )
+                  .map((testDate, index) => (
+                    <TestDateCard
+                      key={testDate.id}
+                      testDate={testDate}
+                      testIndex={index + 1}
+                      requestName={requestName}
+                      requestId={accessibilityRequestId}
+                      isEditableDeletable={isAccessibilityTeam}
+                      refetchRequest={refetch}
+                      setConfirmationText={showMessage}
+                    />
+                  ))}
+                {isAccessibilityTeam && (
+                  <Link
+                    to={`/508/requests/${accessibilityRequestId}/test-date`}
+                    className="margin-bottom-3 display-block"
+                    aria-label="Add a test date"
+                  >
+                    Add a date
+                  </Link>
+                )}
               </div>
-            </Modal>
+              <div className="accessibility-request__other-details">
+                <h3>{t('requestDetails.other')}</h3>
+                <dl>
+                  <dt className="margin-bottom-1">
+                    {t('intake:fields.submissionDate')}
+                  </dt>
+                  <dd className="margin-0 margin-bottom-2">
+                    {formatDate(submittedAt)}
+                  </dd>
+                  <dt className="margin-bottom-1">
+                    {t('intake:fields.businessOwner')}
+                  </dt>
+                  <dd className="margin-0 margin-bottom-2">
+                    {businessOwnerName}, {businessOwnerComponent}
+                  </dd>
+                  <dt className="margin-bottom-1">
+                    {t('intake:fields:projectName')}
+                  </dt>
+                  <dd className="margin-0 margin-bottom-3">{systemName}</dd>
+                  <dt className="margin-bottom-1">{t('intake:lifecycleId')}</dt>
+                  <dd className="margin-0 margin-bottom-3">{lcid}</dd>
+                </dl>
+              </div>
+              <button
+                type="button"
+                className="accessibility-request__remove-request"
+                onClick={() => setModalOpen(true)}
+              >
+                {t('requestDetails.remove')}
+              </button>
+              <Modal
+                isOpen={isModalOpen}
+                closeModal={() => setModalOpen(false)}
+              >
+                <PageHeading
+                  headingLevel="h2"
+                  className="margin-top-0 line-height-heading-2 margin-bottom-2"
+                >
+                  {t('requestDetails.modal.header', {
+                    requestName
+                  })}
+                </PageHeading>
+                <span>{t('requestDetails.modal.subhead')}</span>
+                <div className="display-flex margin-top-2">
+                  <Button
+                    type="button"
+                    className="margin-right-5"
+                    onClick={removeRequest}
+                  >
+                    {t('requestDetails.modal.confirm')}
+                  </Button>
+                  <Button
+                    type="button"
+                    unstyled
+                    onClick={() => setModalOpen(false)}
+                  >
+                    {t('requestDetails.modal.cancel')}
+                  </Button>
+                </div>
+              </Modal>
+            </div>
           </div>
         </div>
       </div>

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -71,8 +71,7 @@ const AccessibilityRequestDetailPage = () => {
         }
       }
     }).then(response => {
-      console.log(response.errors);
-      if (response.errors && response.errors.length === 0) {
+      if (!response.errors) {
         showMessageOnNextPage(
           t('requestDetails.removeConfirmationText', {
             requestName

--- a/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
@@ -24,6 +24,7 @@ import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
+import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import TextField from 'components/shared/TextField';
 import { initialAccessibilityRequestFormData } from 'data/accessibility';
 import useMessage from 'hooks/useMessage';
@@ -87,160 +88,169 @@ const Create = () => {
 
   return (
     <>
-      <PageHeading>{t('newRequestForm.heading')}</PageHeading>
-      <Formik
-        initialValues={initialAccessibilityRequestFormData}
-        onSubmit={handleSubmitForm}
-        validationSchema={accessibilitySchema.requestForm}
-        validateOnBlur={false}
-        validateOnChange={false}
-        validateOnMount={false}
-      >
-        {(formikProps: FormikProps<AccessibilityRequestForm>) => {
-          const { errors, setFieldValue, handleSubmit } = formikProps;
-          const flatErrors = flattenErrors(errors);
-          return (
-            <>
-              {mutationResult.error && (
-                <ErrorAlert heading="System error">
-                  <ErrorAlertMessage
-                    message={mutationResult.error.message}
-                    errorKey="system"
-                  />
-                </ErrorAlert>
-              )}
-              {Object.keys(errors).length > 0 && (
-                <ErrorAlert
-                  testId="508-request-errors"
-                  classNames="margin-bottom-4 margin-top-4"
-                  heading="There is a problem"
-                >
-                  {Object.keys(flatErrors).map(key => {
-                    return (
-                      <ErrorAlertMessage
-                        key={`Error.${key}`}
-                        errorKey={key}
-                        message={flatErrors[key]}
-                      />
-                    );
-                  })}
-                </ErrorAlert>
-              )}
-              <div className="margin-bottom-7">
-                <FormikForm
-                  onSubmit={e => {
-                    handleSubmit(e);
-                    window.scrollTo(0, 0);
-                  }}
-                >
-                  {!loading && (
-                    <FieldGroup
-                      scrollElement="intakeId"
-                      error={!!flatErrors.intakeId}
-                    >
-                      <Label htmlFor="508Request-IntakeId">
-                        {t('newRequestForm.fields.project.label')}
+      <SecondaryNav>
+        <NavLink to="/">{t('tabs.accessibilityRequests')}</NavLink>
+      </SecondaryNav>
+      <div className="grid-container">
+        <PageHeading>{t('newRequestForm.heading')}</PageHeading>
+        <Formik
+          initialValues={initialAccessibilityRequestFormData}
+          onSubmit={handleSubmitForm}
+          validationSchema={accessibilitySchema.requestForm}
+          validateOnBlur={false}
+          validateOnChange={false}
+          validateOnMount={false}
+        >
+          {(formikProps: FormikProps<AccessibilityRequestForm>) => {
+            const { errors, setFieldValue, handleSubmit } = formikProps;
+            const flatErrors = flattenErrors(errors);
+            return (
+              <>
+                {mutationResult.error && (
+                  <ErrorAlert heading="System error">
+                    <ErrorAlertMessage
+                      message={mutationResult.error.message}
+                      errorKey="system"
+                    />
+                  </ErrorAlert>
+                )}
+                {Object.keys(errors).length > 0 && (
+                  <ErrorAlert
+                    testId="508-request-errors"
+                    classNames="margin-bottom-4 margin-top-4"
+                    heading="There is a problem"
+                  >
+                    {Object.keys(flatErrors).map(key => {
+                      return (
+                        <ErrorAlertMessage
+                          key={`Error.${key}`}
+                          errorKey={key}
+                          message={flatErrors[key]}
+                        />
+                      );
+                    })}
+                  </ErrorAlert>
+                )}
+                <div className="margin-bottom-7">
+                  <FormikForm
+                    onSubmit={e => {
+                      handleSubmit(e);
+                      window.scrollTo(0, 0);
+                    }}
+                  >
+                    {!loading && (
+                      <FieldGroup
+                        scrollElement="intakeId"
+                        error={!!flatErrors.intakeId}
+                      >
+                        <Label htmlFor="508Request-IntakeId">
+                          {t('newRequestForm.fields.project.label')}
+                        </Label>
+                        <FieldErrorMsg>{flatErrors.intakeId}</FieldErrorMsg>
+                        <ComboBox
+                          id="508Request-IntakeComboBox"
+                          name="intakeComboBox"
+                          inputProps={{
+                            id: '508Request-IntakeId',
+                            name: 'intakeId'
+                          }}
+                          options={projectComboBoxOptions}
+                          onChange={(intakeId: any) => {
+                            const selectedSystem = systems[intakeId];
+                            if (selectedSystem) {
+                              setFieldValue('intakeId', intakeId || '');
+                              setFieldValue(
+                                'businessOwner.name',
+                                selectedSystem.businessOwner.name || ''
+                              );
+                              setFieldValue(
+                                'businessOwner.component',
+                                selectedSystem.businessOwner.component || ''
+                              );
+                            }
+                          }}
+                        />
+                      </FieldGroup>
+                    )}
+
+                    <FieldGroup scrollElement="requester.name">
+                      <Label htmlFor="508Request-BusinessOwnerName">
+                        {t('newRequestForm.fields.businessOwnerName.label')}
                       </Label>
-                      <FieldErrorMsg>{flatErrors.intakeId}</FieldErrorMsg>
-                      <ComboBox
-                        id="508Request-IntakeComboBox"
-                        name="intakeComboBox"
-                        inputProps={{
-                          id: '508Request-IntakeId',
-                          name: 'intakeId'
-                        }}
-                        options={projectComboBoxOptions}
-                        onChange={(intakeId: any) => {
-                          const selectedSystem = systems[intakeId];
-                          if (selectedSystem) {
-                            setFieldValue('intakeId', intakeId || '');
-                            setFieldValue(
-                              'businessOwner.name',
-                              selectedSystem.businessOwner.name || ''
-                            );
-                            setFieldValue(
-                              'businessOwner.component',
-                              selectedSystem.businessOwner.component || ''
-                            );
-                          }
-                        }}
+                      <HelpText
+                        id="508Request-BusinessOwnerNameHelp"
+                        className="usa-sr-only"
+                      >
+                        {t('newRequestForm.fields.businessOwnerName.help')}
+                      </HelpText>
+                      <FormikField
+                        as={TextField}
+                        id="508Request-BusinessOwnerName"
+                        name="businessOwner.name"
+                        aria-describedby="508Request-BusinessOwnerNameHelp"
+                        disabled
                       />
                     </FieldGroup>
-                  )}
 
-                  <FieldGroup scrollElement="requester.name">
-                    <Label htmlFor="508Request-BusinessOwnerName">
-                      {t('newRequestForm.fields.businessOwnerName.label')}
-                    </Label>
-                    <HelpText
-                      id="508Request-BusinessOwnerNameHelp"
-                      className="usa-sr-only"
-                    >
-                      {t('newRequestForm.fields.businessOwnerName.help')}
-                    </HelpText>
-                    <FormikField
-                      as={TextField}
-                      id="508Request-BusinessOwnerName"
-                      name="businessOwner.name"
-                      aria-describedby="508Request-BusinessOwnerNameHelp"
-                      disabled
-                    />
-                  </FieldGroup>
-
-                  <FieldGroup scrollElement="businessOwner.component">
-                    <Label htmlFor="508Form-BusinessOwnerComponent">
-                      {t('newRequestForm.fields.businessOwnerComponent.label')}
-                    </Label>
-                    <HelpText
-                      id="508Request-BusinessOwnerComponentHelp"
-                      className="usa-sr-only"
-                    >
-                      {t('newRequestForm.fields.businessOwnerComponent.help')}
-                    </HelpText>
-                    <FormikField
-                      as={TextField}
-                      id="508Form-BusinessOwnerComponent"
-                      name="businessOwner.component"
-                      aria-describedby="508Request-BusinessOwnerComponentHelp"
-                      disabled
-                    />
-                  </FieldGroup>
-                  <FieldGroup
-                    scrollElement="requestName"
-                    error={!!flatErrors.requestName}
-                  >
-                    <Label htmlFor="508Request-RequestName">
-                      {t('newRequestForm.fields.requestName.label')}
-                    </Label>
-                    <HelpText
-                      id="508Request-RequestNameHelp"
-                      className="margin-top-1"
-                    >
-                      {t('newRequestForm.fields.requestName.help')}
-                    </HelpText>
-                    <FieldErrorMsg>{flatErrors.requestName}</FieldErrorMsg>
-                    <FormikField
-                      as={TextField}
+                    <FieldGroup scrollElement="businessOwner.component">
+                      <Label htmlFor="508Form-BusinessOwnerComponent">
+                        {t(
+                          'newRequestForm.fields.businessOwnerComponent.label'
+                        )}
+                      </Label>
+                      <HelpText
+                        id="508Request-BusinessOwnerComponentHelp"
+                        className="usa-sr-only"
+                      >
+                        {t('newRequestForm.fields.businessOwnerComponent.help')}
+                      </HelpText>
+                      <FormikField
+                        as={TextField}
+                        id="508Form-BusinessOwnerComponent"
+                        name="businessOwner.component"
+                        aria-describedby="508Request-BusinessOwnerComponentHelp"
+                        disabled
+                      />
+                    </FieldGroup>
+                    <FieldGroup
+                      scrollElement="requestName"
                       error={!!flatErrors.requestName}
-                      id="508Request-RequestName"
-                      maxLength={50}
-                      name="requestName"
-                      aria-describedby="508Request-RequestNameHelp"
-                    />
-                  </FieldGroup>
+                    >
+                      <Label htmlFor="508Request-RequestName">
+                        {t('newRequestForm.fields.requestName.label')}
+                      </Label>
+                      <HelpText
+                        id="508Request-RequestNameHelp"
+                        className="margin-top-1"
+                      >
+                        {t('newRequestForm.fields.requestName.help')}
+                      </HelpText>
+                      <FieldErrorMsg>{flatErrors.requestName}</FieldErrorMsg>
+                      <FormikField
+                        as={TextField}
+                        error={!!flatErrors.requestName}
+                        id="508Request-RequestName"
+                        maxLength={50}
+                        name="requestName"
+                        aria-describedby="508Request-RequestNameHelp"
+                      />
+                    </FieldGroup>
 
-                  <div className="tablet:grid-col-8">
-                    <div className="margin-top-6 margin-bottom-2">
-                      <PlainInfo>{t('newRequestForm.info')}</PlainInfo>
+                    <div className="tablet:grid-col-8">
+                      <div className="margin-top-6 margin-bottom-2">
+                        <PlainInfo>{t('newRequestForm.info')}</PlainInfo>
+                      </div>
                     </div>
-                  </div>
-                  <Button type="submit">{t('newRequestForm.submitBtn')}</Button>
-                </FormikForm>
-              </div>
-            </>
-          );
-        }}
-      </Formik>
+                    <Button type="submit">
+                      {t('newRequestForm.submitBtn')}
+                    </Button>
+                  </FormikForm>
+                </div>
+              </>
+            );
+          }}
+        </Formik>
+      </div>
     </>
   );
 };

--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import { Button, Label } from '@trussworks/react-uswds';
@@ -21,6 +22,7 @@ import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import { RadioField } from 'components/shared/RadioField';
+import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import TextField from 'components/shared/TextField';
 import { useMessage } from 'hooks/useMessage';
 import { FileUploadForm } from 'types/files';
@@ -31,6 +33,8 @@ import { DocumentUploadValidationSchema } from 'validations/documentUploadSchema
 
 const New = () => {
   const history = useHistory();
+  const { t } = useTranslation('accessibility');
+
   const { showMessageOnNextPage } = useMessage();
 
   const { accessibilityRequestId } = useParams<{
@@ -134,183 +138,189 @@ const New = () => {
 
   return (
     <>
-      <Formik
-        initialValues={{
-          file: null,
-          documentType: {
-            commonType: null,
-            otherType: ''
-          }
-        }}
-        onSubmit={onSubmit}
-        validationSchema={DocumentUploadValidationSchema}
-        validateOnBlur={false}
-        validateOnChange={false}
-        validateOnMount={false}
-      >
-        {(formikProps: FormikProps<FileUploadForm>) => {
-          const { errors, setFieldValue, values, handleSubmit } = formikProps;
-          const flatErrors = flattenErrors(errors);
-          return (
-            <>
-              {Object.keys(errors).length > 0 && (
-                <ErrorAlert
-                  testId="document-upload-errors"
-                  classNames="margin-bottom-4 margin-top-4"
-                  heading="There is a problem"
-                >
-                  {Object.keys(flatErrors).map(key => {
-                    return (
-                      <ErrorAlertMessage
-                        key={`Error.${key}`}
-                        errorKey={key}
-                        message={flatErrors[key]}
-                      />
-                    );
-                  })}
-                </ErrorAlert>
-              )}
-              {createDocumentStatus.error && (
-                <ErrorAlert heading="Error uploading document">
-                  <ErrorAlertMessage
-                    message={createDocumentStatus.error.message}
-                    errorKey="accessibilityRequest"
-                  />
-                </ErrorAlert>
-              )}
-              <PageHeading>
-                Upload a document to {data?.accessibilityRequest?.name}
-              </PageHeading>
-              <div className="grid-col-9">
-                <Form
-                  className="usa-form usa-form--large"
-                  onSubmit={e => {
-                    handleSubmit(e);
-                    window.scrollTo(0, 0);
-                  }}
-                >
-                  <FieldGroup scrollElement="file" error={!!flatErrors.file}>
-                    <Label htmlFor="FileUpload-File">Document Upload</Label>
-                    <FieldErrorMsg>{flatErrors.file}</FieldErrorMsg>
-                    <Field
-                      as={FileUpload}
-                      id="FileUpload-File"
-                      name="file"
-                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                        onChange(e);
-                        setFieldValue('file', e.currentTarget?.files?.[0]);
-                      }}
-                    />
-                  </FieldGroup>
-                  {values.file && (
-                    <FieldGroup
-                      scrollElement="documentType.commonType"
-                      error={!!flatErrors['documentType.commonType']}
-                    >
-                      <fieldset className="usa-fieldset margin-top-4">
-                        <legend className="usa-label margin-bottom-1">
-                          What type of document are you uploading?
-                        </legend>
-                        <FieldErrorMsg>
-                          {flatErrors['documentType.commonType']}
-                        </FieldErrorMsg>
-                        {([
-                          'AWARDED_VPAT',
-                          'TEST_PLAN',
-                          'TESTING_VPAT',
-                          'TEST_RESULTS',
-                          'REMEDIATION_PLAN'
-                        ] as AccessibilityRequestDocumentCommonType[]).map(
-                          commonType => {
-                            return (
-                              <Field
-                                key={`FileUpload-CommonType${commonType}`}
-                                as={RadioField}
-                                checked={
-                                  values.documentType.commonType === commonType
-                                }
-                                id={`FileUpload-CommonType${commonType}`}
-                                name="documentType.commonType"
-                                label={translateDocumentType(commonType)}
-                                onChange={() => {
-                                  setFieldValue(
-                                    'documentType.commonType',
-                                    commonType
-                                  );
-                                  setFieldValue('documentType.otherType', '');
-                                }}
-                                value={commonType}
-                              />
-                            );
-                          }
-                        )}
-                        <Field
-                          as={RadioField}
-                          checked={values.documentType.commonType === 'OTHER'}
-                          id="FileUpload-CommonTypeOTHER"
-                          name="documentType.commonType"
-                          label={translateDocumentType(
-                            AccessibilityRequestDocumentCommonType.OTHER
-                          )}
-                          value="OTHER"
+      <SecondaryNav>
+        <NavLink to="/">{t('tabs.accessibilityRequests')}</NavLink>
+      </SecondaryNav>
+      <div className="grid-container">
+        <Formik
+          initialValues={{
+            file: null,
+            documentType: {
+              commonType: null,
+              otherType: ''
+            }
+          }}
+          onSubmit={onSubmit}
+          validationSchema={DocumentUploadValidationSchema}
+          validateOnBlur={false}
+          validateOnChange={false}
+          validateOnMount={false}
+        >
+          {(formikProps: FormikProps<FileUploadForm>) => {
+            const { errors, setFieldValue, values, handleSubmit } = formikProps;
+            const flatErrors = flattenErrors(errors);
+            return (
+              <>
+                {Object.keys(errors).length > 0 && (
+                  <ErrorAlert
+                    testId="document-upload-errors"
+                    classNames="margin-bottom-4 margin-top-4"
+                    heading="There is a problem"
+                  >
+                    {Object.keys(flatErrors).map(key => {
+                      return (
+                        <ErrorAlertMessage
+                          key={`Error.${key}`}
+                          errorKey={key}
+                          message={flatErrors[key]}
                         />
-                        {values.documentType.commonType === 'OTHER' && (
-                          <div className="width-card-lg margin-left-4 margin-bottom-1">
-                            <FieldGroup
-                              scrollElement="documentType.otherType"
-                              error={!!flatErrors['documentType.otherType']}
-                            >
-                              <Label
-                                htmlFor="FileUpload-OtherType"
-                                className="margin-bottom-1"
-                                style={{ marginTop: '0.5em' }}
-                              >
-                                Document name
-                              </Label>
-                              <FieldErrorMsg>
-                                {flatErrors['documentType.otherType']}
-                              </FieldErrorMsg>
-                              <Field
-                                as={TextField}
-                                error={!!flatErrors['documentType.otherType']}
-                                className="margin-top-0"
-                                id="DocumentType-OtherType"
-                                name="documentType.otherType"
-                              />
-                            </FieldGroup>
-                          </div>
-                        )}
-                      </fieldset>
+                      );
+                    })}
+                  </ErrorAlert>
+                )}
+                {createDocumentStatus.error && (
+                  <ErrorAlert heading="Error uploading document">
+                    <ErrorAlertMessage
+                      message={createDocumentStatus.error.message}
+                      errorKey="accessibilityRequest"
+                    />
+                  </ErrorAlert>
+                )}
+                <PageHeading>
+                  Upload a document to {data?.accessibilityRequest?.name}
+                </PageHeading>
+                <div className="grid-col-9">
+                  <Form
+                    className="usa-form usa-form--large"
+                    onSubmit={e => {
+                      handleSubmit(e);
+                      window.scrollTo(0, 0);
+                    }}
+                  >
+                    <FieldGroup scrollElement="file" error={!!flatErrors.file}>
+                      <Label htmlFor="FileUpload-File">Document Upload</Label>
+                      <FieldErrorMsg>{flatErrors.file}</FieldErrorMsg>
+                      <Field
+                        as={FileUpload}
+                        id="FileUpload-File"
+                        name="file"
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                          onChange(e);
+                          setFieldValue('file', e.currentTarget?.files?.[0]);
+                        }}
+                      />
                     </FieldGroup>
-                  )}
-                  <div className="padding-top-2">
-                    <p>
-                      To keep CMS safe, documents are scanned for viruses after
-                      uploading. If something goes wrong, we&apos;ll let you
-                      know.
-                    </p>
-                    <Button
-                      type="submit"
-                      disabled={
-                        generateURLStatus.loading ||
-                        createDocumentStatus.loading
-                      }
-                    >
-                      Upload document
-                    </Button>
-                  </div>
-                </Form>
-              </div>
-            </>
-          );
-        }}
-      </Formik>
+                    {values.file && (
+                      <FieldGroup
+                        scrollElement="documentType.commonType"
+                        error={!!flatErrors['documentType.commonType']}
+                      >
+                        <fieldset className="usa-fieldset margin-top-4">
+                          <legend className="usa-label margin-bottom-1">
+                            What type of document are you uploading?
+                          </legend>
+                          <FieldErrorMsg>
+                            {flatErrors['documentType.commonType']}
+                          </FieldErrorMsg>
+                          {([
+                            'AWARDED_VPAT',
+                            'TEST_PLAN',
+                            'TESTING_VPAT',
+                            'TEST_RESULTS',
+                            'REMEDIATION_PLAN'
+                          ] as AccessibilityRequestDocumentCommonType[]).map(
+                            commonType => {
+                              return (
+                                <Field
+                                  key={`FileUpload-CommonType${commonType}`}
+                                  as={RadioField}
+                                  checked={
+                                    values.documentType.commonType ===
+                                    commonType
+                                  }
+                                  id={`FileUpload-CommonType${commonType}`}
+                                  name="documentType.commonType"
+                                  label={translateDocumentType(commonType)}
+                                  onChange={() => {
+                                    setFieldValue(
+                                      'documentType.commonType',
+                                      commonType
+                                    );
+                                    setFieldValue('documentType.otherType', '');
+                                  }}
+                                  value={commonType}
+                                />
+                              );
+                            }
+                          )}
+                          <Field
+                            as={RadioField}
+                            checked={values.documentType.commonType === 'OTHER'}
+                            id="FileUpload-CommonTypeOTHER"
+                            name="documentType.commonType"
+                            label={translateDocumentType(
+                              AccessibilityRequestDocumentCommonType.OTHER
+                            )}
+                            value="OTHER"
+                          />
+                          {values.documentType.commonType === 'OTHER' && (
+                            <div className="width-card-lg margin-left-4 margin-bottom-1">
+                              <FieldGroup
+                                scrollElement="documentType.otherType"
+                                error={!!flatErrors['documentType.otherType']}
+                              >
+                                <Label
+                                  htmlFor="FileUpload-OtherType"
+                                  className="margin-bottom-1"
+                                  style={{ marginTop: '0.5em' }}
+                                >
+                                  Document name
+                                </Label>
+                                <FieldErrorMsg>
+                                  {flatErrors['documentType.otherType']}
+                                </FieldErrorMsg>
+                                <Field
+                                  as={TextField}
+                                  error={!!flatErrors['documentType.otherType']}
+                                  className="margin-top-0"
+                                  id="DocumentType-OtherType"
+                                  name="documentType.otherType"
+                                />
+                              </FieldGroup>
+                            </div>
+                          )}
+                        </fieldset>
+                      </FieldGroup>
+                    )}
+                    <div className="padding-top-2">
+                      <p>
+                        To keep CMS safe, documents are scanned for viruses
+                        after uploading. If something goes wrong, we&apos;ll let
+                        you know.
+                      </p>
+                      <Button
+                        type="submit"
+                        disabled={
+                          generateURLStatus.loading ||
+                          createDocumentStatus.loading
+                        }
+                      >
+                        Upload document
+                      </Button>
+                    </div>
+                  </Form>
+                </div>
+              </>
+            );
+          }}
+        </Formik>
 
-      <p className="padding-top-2">
-        <Link to={`/508/requests/${accessibilityRequestId}`}>
-          Don&apos;t upload and return to request page
-        </Link>
-      </p>
+        <p className="padding-top-2">
+          <Link to={`/508/requests/${accessibilityRequestId}`}>
+            Don&apos;t upload and return to request page
+          </Link>
+        </p>
+      </div>
     </>
   );
 };

--- a/src/views/Accessibility/AccessibiltyRequest/List/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/List/index.tsx
@@ -2,15 +2,19 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
-import { Link as UswdsLink } from '@trussworks/react-uswds';
+import { Alert, Link as UswdsLink } from '@trussworks/react-uswds';
 import GetAccessibilityRequestsQuery from 'queries/GetAccessibilityRequestsQuery';
 import { GetAccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
 
 import AccessibilityRequestsTable from 'components/AccessibilityRequestsTable';
 import PageHeading from 'components/PageHeading';
+import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
+import useMessage from 'hooks/useMessage';
 
 const List = () => {
   const { t } = useTranslation('home');
+  const { message } = useMessage();
+
   const { loading, error, data } = useQuery<GetAccessibilityRequests>(
     GetAccessibilityRequestsQuery,
     {
@@ -37,20 +41,32 @@ const List = () => {
     });
 
   return (
-    <div className="grid-container">
-      <div className="display-flex flex-justify flex-wrap">
-        <PageHeading>{t('accessibility.heading')}</PageHeading>
-        <UswdsLink
-          asCustom={Link}
-          className="usa-button flex-align-self-center"
-          variant="unstyled"
-          to="/508/requests/new"
-        >
-          {t('accessibility.newRequest')}
-        </UswdsLink>
+    <>
+      <SecondaryNav>
+        <NavLink to="/">
+          {t('accessibility:tabs.accessibilityRequests')}
+        </NavLink>
+      </SecondaryNav>
+      <div className="grid-container">
+        {message && (
+          <Alert className="margin-top-4" type="success" role="alert">
+            {message}
+          </Alert>
+        )}
+        <div className="display-flex flex-justify flex-wrap">
+          <PageHeading>{t('accessibility.heading')}</PageHeading>
+          <UswdsLink
+            asCustom={Link}
+            className="usa-button flex-align-self-center"
+            variant="unstyled"
+            to="/508/requests/new"
+          >
+            {t('accessibility.newRequest')}
+          </UswdsLink>
+        </div>
+        <AccessibilityRequestsTable requests={requests || []} />
       </div>
-      <AccessibilityRequestsTable requests={requests || []} />
-    </div>
+    </>
   );
 };
 

--- a/src/views/Accessibility/index.tsx
+++ b/src/views/Accessibility/index.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import { SecureRoute } from '@okta/okta-react';
-import { Alert } from '@trussworks/react-uswds';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import Footer from 'components/Footer';
 import Header from 'components/Header';
 import MainContent from 'components/MainContent';
 import PageWrapper from 'components/PageWrapper';
-import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
-import { useMessage } from 'hooks/useMessage';
 import { AppState } from 'reducers/rootReducer';
 import user from 'utils/user';
 import AccessibilityRequestDetailPage from 'views/Accessibility/AccessibilityRequestDetailPage';
@@ -67,29 +63,20 @@ const RequestDetails = (
   />
 );
 
-const Default = (
-  <Route key="508-not-found" path="*" component={NotFoundPartial} />
+const NotFound = () => (
+  <div className="grid-container">
+    <NotFoundPartial />
+  </div>
 );
 
-const PageTemplate = ({ children }: { children: React.ReactNode }) => {
-  const { t } = useTranslation('accessibility');
-  const { message } = useMessage();
+const Default = <Route path="*" key="508-not-found" component={NotFound} />;
 
+const PageTemplate = ({ children }: { children: React.ReactNode }) => {
   return (
     <PageWrapper>
       <Header />
       <MainContent className="margin-bottom-5">
-        <SecondaryNav>
-          <NavLink to="/">{t('tabs.accessibilityRequests')}</NavLink>
-        </SecondaryNav>
-        <div className="grid-container">
-          {message && (
-            <Alert className="margin-top-4" type="success" role="alert">
-              {message}
-            </Alert>
-          )}
-          <Switch>{children}</Switch>
-        </div>
+        <Switch>{children}</Switch>
       </MainContent>
       <Footer />
     </PageWrapper>

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -33,6 +33,13 @@ const Home = () => {
           // Changed GRT table from grid-container to just slight margins. This is take up
           // entire screen to better fit the more expansive data in the table.
           <div className="padding-x-4">
+            {message && (
+              <div className="grid-container margin-top-6">
+                <Alert type="success" slim role="alert">
+                  {message}
+                </Alert>
+              </div>
+            )}
             <RequestRepository />
           </div>
         );
@@ -45,6 +52,13 @@ const Home = () => {
       if (user.isBasicUser(userGroups)) {
         return (
           <div className="grid-container">
+            {message && (
+              <div className="grid-container margin-top-6">
+                <Alert type="success" slim role="alert">
+                  {message}
+                </Alert>
+              </div>
+            )}
             <div className="margin-y-6">
               <SystemIntakeBanners />
             </div>
@@ -63,16 +77,7 @@ const Home = () => {
   return (
     <PageWrapper>
       <Header />
-      <MainContent className="margin-bottom-5">
-        {message && (
-          <div className="grid-container margin-top-6">
-            <Alert type="success" slim role="alert">
-              {message}
-            </Alert>
-          </div>
-        )}
-        {renderView()}
-      </MainContent>
+      <MainContent className="margin-bottom-5">{renderView()}</MainContent>
       <Footer />
     </PageWrapper>
   );

--- a/src/views/TestDate/NewTestDate.tsx
+++ b/src/views/TestDate/NewTestDate.tsx
@@ -9,6 +9,7 @@ import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
 import { CreateTestDate } from 'queries/types/CreateTestDate';
 import { GetAccessibilityRequest } from 'queries/types/GetAccessibilityRequest';
 
+import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import { useMessage } from 'hooks/useMessage';
 import { TestDateFormType } from 'types/accessibility';
 import { formatDate } from 'utils/date';
@@ -89,19 +90,24 @@ const NewTestDate = () => {
 
   return (
     <>
-      {message && (
-        <Alert className="margin-top-4" type="success" role="alert">
-          {message}
-        </Alert>
-      )}
-      <Form
-        initialValues={initialValues}
-        onSubmit={onSubmit}
-        error={mutateResult.error}
-        requestName={data?.accessibilityRequest?.name || ''}
-        requestId={accessibilityRequestId}
-        formType="create"
-      />
+      <SecondaryNav>
+        <NavLink to="/">{t('tabs.accessibilityRequests')}</NavLink>
+      </SecondaryNav>
+      <div className="grid-container">
+        {message && (
+          <Alert className="margin-top-4" type="success" role="alert">
+            {message}
+          </Alert>
+        )}
+        <Form
+          initialValues={initialValues}
+          onSubmit={onSubmit}
+          error={mutateResult.error}
+          requestName={data?.accessibilityRequest?.name || ''}
+          requestId={accessibilityRequestId}
+          formType="create"
+        />
+      </div>
     </>
   );
 };

--- a/src/views/TestDate/UpdateTestDate.tsx
+++ b/src/views/TestDate/UpdateTestDate.tsx
@@ -11,16 +11,19 @@ import {
 import { UpdateTestDate } from 'queries/types/UpdateTestDate';
 import UpdateTestDateQuery from 'queries/UpdateTestDateQuery';
 
-import useMessage from 'hooks/useMessage';
+import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
+import { useMessage } from 'hooks/useMessage';
 import { TestDateFormType } from 'types/accessibility';
 import { formatDate } from 'utils/date';
 
-import Form from './Form';
+import TestDateForm from './Form';
 
 import './styles.scss';
 
 const TestDate = () => {
   const { t } = useTranslation('accessibility');
+  const { showMessageOnNextPage } = useMessage();
+
   const { accessibilityRequestId, testDateId } = useParams<{
     accessibilityRequestId: string;
     testDateId: string;
@@ -40,11 +43,17 @@ const TestDate = () => {
     }
   );
   const history = useHistory();
-  const { showMessageOnNextPage } = useMessage();
 
-  const test: TestDateType = data?.accessibilityRequest?.testDates.find(
+  const test:
+    | TestDateType
+    | undefined = data?.accessibilityRequest?.testDates.find(
     date => date.id === testDateId
   );
+
+  if (!test) {
+    throw new TypeError('TypeError: test does not exist');
+  }
+
   const testDate = DateTime.fromISO(test?.date);
   const initialValues: TestDateFormType = {
     dateMonth: String(testDate.month),
@@ -66,7 +75,7 @@ const TestDate = () => {
     const hasScore = values.score.isPresent;
     const score = values.score.value;
 
-    const confirmation = `
+    const confirmationText = `
       ${t('testDateForm.confirmation.date', { date: formatDate(date) })}
       ${hasScore ? t('testDateForm.confirmation.score', { score }) : ''}
       ${t('testDateForm.confirmation.update')}
@@ -82,7 +91,7 @@ const TestDate = () => {
         }
       }
     }).then(() => {
-      showMessageOnNextPage(confirmation);
+      showMessageOnNextPage(confirmationText);
       history.push(`/508/requests/${accessibilityRequestId}`);
     });
   };
@@ -93,14 +102,19 @@ const TestDate = () => {
 
   return (
     <>
-      <Form
-        initialValues={initialValues}
-        onSubmit={onSubmit}
-        error={mutateResult.error}
-        requestName={data?.accessibilityRequest?.name}
-        requestId={accessibilityRequestId}
-        formType="update"
-      />
+      <SecondaryNav>
+        <NavLink to="/">{t('tabs.accessibilityRequests')}</NavLink>
+      </SecondaryNav>
+      <div className="grid-container">
+        <TestDateForm
+          initialValues={initialValues}
+          onSubmit={onSubmit}
+          error={mutateResult.error}
+          requestName={data?.accessibilityRequest?.name || ''}
+          requestId={accessibilityRequestId}
+          formType="update"
+        />
+      </div>
     </>
   );
 };


### PR DESCRIPTION
# ES-000

This PR updates the page structure for accessibility pages

- Remove `SecondaryNav` from "template" and put it in each individual accessibility page
    - the `SecondaryNav` doesn't appear on the 508 overview page and probably shouldn't appear on the 404 page
- move `.grid-container` from `Accessibility/index.tsx` to each individual accessibility page
    - this causes the massive diff

## Reviewer Notes

- Click through 508 pages
- Make sure "secondary nav" border bottom spans full width
- confirmation messages display under the secondary nav (if applicable) and above the rest of the "main content"

## Code Review Verification Steps

- [ ] User-facing changes have been tested with voice-over
- [ ] User-facing changes have been reviewed by design
- [ ] Acceptance criteria has been met, or will be met by a future PR

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
