### PR TITLE
Request type form changes

### DIFF
--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -114,7 +114,7 @@ const intake = {
     heading: 'Make a System Request',
     subheading: 'What is this request for?',
     info:
-      'If you are unsure or do not see an option for your use-case, send an email to the <1>IT Navigator Mailbox</1> and a navigator will get back to you.',
+      'If you are not sure send an email to the <1>IT Navigator Mailbox</1> describing your request and a navigator will get back to you.',
     fields: {
       addNewSystem: 'Add a new system',
       majorChanges: 'Major changes or upgrades to an existing system',

--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -111,7 +111,7 @@ const intake = {
     adminLead: 'Admin Lead'
   },
   requestTypeForm: {
-    heading: 'Make a System Request',
+    heading: 'Make a Request',
     subheading: 'What is this request for?',
     info:
       'If you are not sure send an email to the <1>IT Navigator Mailbox</1> describing your request and a navigator will get back to you.',

--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -114,7 +114,7 @@ const intake = {
     heading: 'Make a System Request',
     subheading: 'What is this request for?',
     info:
-      'If you are unsure or do not see an option for your use-case, mark "I\'m not sure" and someone from the Governance Team will assist you',
+      'If you are unsure or do not see an option for your use-case, send an email to the <1>IT Navigator Mailbox</1> and a navigator will get back to you.',
     fields: {
       addNewSystem: 'Add a new system',
       majorChanges: 'Major changes or upgrades to an existing system',

--- a/src/views/RequestTypeForm/index.tsx
+++ b/src/views/RequestTypeForm/index.tsx
@@ -92,7 +92,7 @@ const RequestTypeForm = () => {
             <Link to="/">Home</Link>
             <i className="fa fa-angle-right margin-x-05" aria-hidden />
           </li>
-          <li aria-current="location">Make a system request</li>
+          <li aria-current="location">Make a request</li>
         </BreadcrumbNav>
         <h1 className="font-heading-2xl margin-top-4">
           {t('requestTypeForm.heading')}

--- a/src/views/RequestTypeForm/index.tsx
+++ b/src/views/RequestTypeForm/index.tsx
@@ -136,21 +136,9 @@ const RequestTypeForm = () => {
                       className="usa-fieldset"
                       aria-describedby="RequestType-HelpText"
                     >
-                      <legend className="font-heading-xl">
+                      <legend className="font-heading-xl margin-bottom-4">
                         {t('requestTypeForm.subheading')}
                       </legend>
-                      <HelpText
-                        id="RequestType-HelpText"
-                        className="margin-bottom-4"
-                      >
-                        <Trans i18nKey="intake:requestTypeForm.info">
-                          indexZero
-                          <UswdsLink href="mailto:NavigatorInquiries@cms.hhs.gov">
-                            navigatorEmailLink
-                          </UswdsLink>
-                          indexTwo
-                        </Trans>
-                      </HelpText>
                       <Field
                         as={RadioField}
                         id="RequestType-NewSystem"
@@ -204,7 +192,16 @@ const RequestTypeForm = () => {
                       ))}
                     </ul>
                   </CollapsableLink>
-                  <Button className="margin-top-5" type="submit">
+                  <HelpText id="RequestType-HelpText" className="margin-top-4">
+                    <Trans i18nKey="intake:requestTypeForm.info">
+                      indexZero
+                      <UswdsLink href="mailto:NavigatorInquiries@cms.hhs.gov">
+                        navigatorEmailLink
+                      </UswdsLink>
+                      indexTwo
+                    </Trans>
+                  </HelpText>
+                  <Button className="margin-top-5 display-block" type="submit">
                     Continue
                   </Button>
                 </Form>

--- a/src/views/RequestTypeForm/index.tsx
+++ b/src/views/RequestTypeForm/index.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link, useHistory } from 'react-router-dom';
 import { useOktaAuth } from '@okta/okta-react';
-import { Button } from '@trussworks/react-uswds';
+import { Button, Link as UswdsLink } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 
 import BreadcrumbNav from 'components/BreadcrumbNav';
@@ -143,7 +143,13 @@ const RequestTypeForm = () => {
                         id="RequestType-HelpText"
                         className="margin-bottom-4"
                       >
-                        {t('requestTypeForm.info')}
+                        <Trans i18nKey="intake:requestTypeForm.info">
+                          indexZero
+                          <UswdsLink href="mailto:NavigatorInquiries@cms.hhs.gov">
+                            navigatorEmailLink
+                          </UswdsLink>
+                          indexTwo
+                        </Trans>
                       </HelpText>
                       <Field
                         as={RadioField}


### PR DESCRIPTION
# EASI-1173

## Changes proposed in this pull request

- Modified help text in request type form to replace 'im not sure' text with link to navigator mailbox
- Moved help text from underneath "What is this request for?" to be below the various options
- Changed "Make a System Request" to "Make a Request"

## Reviewer Notes

- This is the last of the three changes requested by the governance team so that they can fully switch over to using EASi and retire the legacy SharePoint form


## Code Review Verification Steps

- [ ] User-facing changes have been tested with voice-over
- [ ] User-facing changes have been reviewed by design
- [ ] Acceptance criteria has been met, or will be met by a future PR
- Any new migrations/schema changes:
  - [ ] Follow guidelines for zero-downtime deploys
  - [ ] Have been deployed to the remote dev environment via CI

## Screenshots

**Before:**
![image](https://user-images.githubusercontent.com/68014929/117728555-9b71f380-b1b7-11eb-8604-3dd5593a437c.png)

**After:**
![image](https://user-images.githubusercontent.com/68014929/117715888-e2a3b880-b1a6-11eb-839c-a7c67e807bbd.png)

