### PR TITLE
move delete test date mutation into 508 request details view

### DIFF
--- a/src/components/TestDateCard/index.test.tsx
+++ b/src/components/TestDateCard/index.test.tsx
@@ -24,8 +24,7 @@ const renderComponent = (customProps?: any) => {
           requestId="Request ID"
           requestName="Initial Request"
           isEditableDeletable
-          refetchRequest={jest.fn()}
-          setConfirmationText={jest.fn()}
+          handleDeleteTestDate={jest.fn()}
           {...customProps}
         />
       </MockedProvider>
@@ -51,8 +50,7 @@ describe('The Test Date Card component', () => {
           requestId="Request ID"
           requestName="Initial Request"
           isEditableDeletable
-          refetchRequest={jest.fn()}
-          setConfirmationText={jest.fn()}
+          handleDeleteTestDate={jest.fn()}
         />
       </MockedProvider>
     );

--- a/src/components/TestDateCard/index.tsx
+++ b/src/components/TestDateCard/index.tsx
@@ -1,67 +1,29 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { useMutation } from '@apollo/client';
 import { Button, Link as UswdsLink } from '@trussworks/react-uswds';
-import DeleteTestDateQuery from 'queries/DeleteTestDateQuery';
-import { DeleteTestDate } from 'queries/types/DeleteTestDate';
 import { GetAccessibilityRequest_accessibilityRequest_testDates as TestDateType } from 'queries/types/GetAccessibilityRequest';
 
-import Modal from 'components/Modal';
-import PageHeading from 'components/PageHeading';
+import { translateTestType } from 'utils/accessibilityRequest';
 import { formatDate } from 'utils/date';
 
 type TestDateCardProps = {
   testDate: TestDateType;
   testIndex: number;
   requestId: string;
-  requestName: string;
   isEditableDeletable?: boolean;
-  refetchRequest: () => any;
-  setConfirmationText: (text: string) => void;
+  handleDeleteTestDate: (testDate: TestDateType) => void;
 };
 
 const TestDateCard = ({
   testDate,
   testIndex,
   requestId,
-  requestName,
-  refetchRequest,
-  setConfirmationText,
-  isEditableDeletable = true
+  isEditableDeletable = true,
+  handleDeleteTestDate
 }: TestDateCardProps) => {
-  const { t } = useTranslation('accessibility');
+  const { t } = useTranslation();
   const { id, testType, date, score } = testDate;
-
-  const [deleteTestDateMutation] = useMutation<DeleteTestDate>(
-    DeleteTestDateQuery,
-    {
-      errorPolicy: 'all'
-    }
-  );
-
-  const [isRemoveTestDateModalOpen, setRemoveTestDateModalOpen] = useState(
-    false
-  );
-
-  const deleteTestDate = () => {
-    deleteTestDateMutation({
-      variables: {
-        input: {
-          id
-        }
-      }
-    }).then(() => {
-      refetchRequest();
-      setRemoveTestDateModalOpen(false);
-      setConfirmationText(
-        t('removeTestDate.confirmation', {
-          date: formatDate(date),
-          requestName
-        })
-      );
-    });
-  };
 
   const testScore = () => {
     if (score === 0) {
@@ -73,7 +35,7 @@ const TestDateCard = ({
   return (
     <div className="bg-gray-10 padding-2 line-height-body-4 margin-bottom-2">
       <div className="text-bold margin-bottom-1">
-        Test {testIndex}: {testType === 'INITIAL' ? 'Initial' : 'Remediation'}
+        {`Test ${testIndex}: ${translateTestType(testType)}`}
       </div>
       <div className="margin-bottom-1">
         <div className="display-inline-block margin-right-2">
@@ -95,53 +57,18 @@ const TestDateCard = ({
             aria-label={`Edit test ${testIndex} ${testType}`}
             data-testid="test-date-edit-link"
           >
-            Edit
+            {t('general:edit')}
           </UswdsLink>
           <Button
             className="margin-left-1"
             type="button"
-            onClick={deleteTestDate}
+            onClick={() => handleDeleteTestDate(testDate)}
             aria-label={`Remove test ${testIndex} ${testType}`}
             unstyled
             data-testid="test-date-delete-button"
           >
-            Remove
+            {t('general:remove')}
           </Button>
-          <Modal
-            isOpen={isRemoveTestDateModalOpen}
-            closeModal={() => {
-              setRemoveTestDateModalOpen(false);
-            }}
-          >
-            <PageHeading headingLevel="h2" className="margin-top-0">
-              {t('removeTestDate.modalHeader', {
-                testNumber: testIndex,
-                testType,
-                testDate: formatDate(date),
-                requestName
-              })}
-            </PageHeading>
-            <p>{t('removeTestDate.modalText')}</p>
-            <Button
-              type="button"
-              className="margin-right-4"
-              onClick={() => {
-                deleteTestDate();
-                setRemoveTestDateModalOpen(false);
-              }}
-            >
-              {t('removeTestDate.modalRemoveButton')}
-            </Button>
-            <Button
-              type="button"
-              unstyled
-              onClick={() => {
-                setRemoveTestDateModalOpen(false);
-              }}
-            >
-              {t('removeTestDate.modalCancelButton')}
-            </Button>
-          </Modal>
         </div>
       )}
     </div>

--- a/src/components/TestDateCard/index.tsx
+++ b/src/components/TestDateCard/index.tsx
@@ -1,15 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { Button, Link as UswdsLink } from '@trussworks/react-uswds';
 import { GetAccessibilityRequest_accessibilityRequest_testDates as TestDateType } from 'queries/types/GetAccessibilityRequest';
 
+import Modal from 'components/Modal';
+import PageHeading from 'components/PageHeading';
 import { translateTestType } from 'utils/accessibilityRequest';
 import { formatDate } from 'utils/date';
 
 type TestDateCardProps = {
   testDate: TestDateType;
   testIndex: number;
+  requestName: string;
   requestId: string;
   isEditableDeletable?: boolean;
   handleDeleteTestDate: (testDate: TestDateType) => void;
@@ -18,11 +21,15 @@ type TestDateCardProps = {
 const TestDateCard = ({
   testDate,
   testIndex,
+  requestName,
   requestId,
   isEditableDeletable = true,
   handleDeleteTestDate
 }: TestDateCardProps) => {
-  const { t } = useTranslation();
+  const [isRemoveTestDateModalOpen, setIsRemoveTestDateModalOpen] = useState(
+    false
+  );
+  const { t } = useTranslation('accessibility');
   const { id, testType, date, score } = testDate;
 
   const testScore = () => {
@@ -62,7 +69,7 @@ const TestDateCard = ({
           <Button
             className="margin-left-1"
             type="button"
-            onClick={() => handleDeleteTestDate(testDate)}
+            onClick={() => setIsRemoveTestDateModalOpen(true)}
             aria-label={`Remove test ${testIndex} ${testType}`}
             unstyled
             data-testid="test-date-delete-button"
@@ -71,6 +78,40 @@ const TestDateCard = ({
           </Button>
         </div>
       )}
+      <Modal
+        isOpen={isRemoveTestDateModalOpen}
+        closeModal={() => {
+          setIsRemoveTestDateModalOpen(false);
+        }}
+      >
+        <PageHeading headingLevel="h2" className="margin-top-0">
+          {t('removeTestDate.modalHeader', {
+            testNumber: testIndex,
+            testType: translateTestType(testDate.testType),
+            testDate: formatDate(testDate.date),
+            requestName
+          })}
+        </PageHeading>
+        <p>{t('removeTestDate.modalText')}</p>
+        <Button
+          type="button"
+          className="margin-right-4"
+          onClick={() => {
+            handleDeleteTestDate(testDate);
+          }}
+        >
+          {t('removeTestDate.modalRemoveButton')}
+        </Button>
+        <Button
+          type="button"
+          unstyled
+          onClick={() => {
+            setIsRemoveTestDateModalOpen(false);
+          }}
+        >
+          {t('removeTestDate.modalCancelButton')}
+        </Button>
+      </Modal>
     </div>
   );
 };

--- a/src/components/TestDateCard/index.tsx
+++ b/src/components/TestDateCard/index.tsx
@@ -12,8 +12,8 @@ import { formatDate } from 'utils/date';
 type TestDateCardProps = {
   testDate: TestDateType;
   testIndex: number;
-  requestName: string;
   requestId: string;
+  requestName: string;
   isEditableDeletable?: boolean;
   handleDeleteTestDate: (testDate: TestDateType) => void;
 };
@@ -21,8 +21,8 @@ type TestDateCardProps = {
 const TestDateCard = ({
   testDate,
   testIndex,
-  requestName,
   requestId,
+  requestName,
   isEditableDeletable = true,
   handleDeleteTestDate
 }: TestDateCardProps) => {
@@ -76,42 +76,42 @@ const TestDateCard = ({
           >
             {t('general:remove')}
           </Button>
+          <Modal
+            isOpen={isRemoveTestDateModalOpen}
+            closeModal={() => {
+              setIsRemoveTestDateModalOpen(false);
+            }}
+          >
+            <PageHeading headingLevel="h2" className="margin-top-0">
+              {t('removeTestDate.modalHeader', {
+                testNumber: testIndex,
+                testType: translateTestType(testDate.testType),
+                testDate: formatDate(testDate.date),
+                requestName
+              })}
+            </PageHeading>
+            <p>{t('removeTestDate.modalText')}</p>
+            <Button
+              type="button"
+              className="margin-right-4"
+              onClick={() => {
+                handleDeleteTestDate(testDate);
+              }}
+            >
+              {t('removeTestDate.modalRemoveButton')}
+            </Button>
+            <Button
+              type="button"
+              unstyled
+              onClick={() => {
+                setIsRemoveTestDateModalOpen(false);
+              }}
+            >
+              {t('removeTestDate.modalCancelButton')}
+            </Button>
+          </Modal>
         </div>
       )}
-      <Modal
-        isOpen={isRemoveTestDateModalOpen}
-        closeModal={() => {
-          setIsRemoveTestDateModalOpen(false);
-        }}
-      >
-        <PageHeading headingLevel="h2" className="margin-top-0">
-          {t('removeTestDate.modalHeader', {
-            testNumber: testIndex,
-            testType: translateTestType(testDate.testType),
-            testDate: formatDate(testDate.date),
-            requestName
-          })}
-        </PageHeading>
-        <p>{t('removeTestDate.modalText')}</p>
-        <Button
-          type="button"
-          className="margin-right-4"
-          onClick={() => {
-            handleDeleteTestDate(testDate);
-          }}
-        >
-          {t('removeTestDate.modalRemoveButton')}
-        </Button>
-        <Button
-          type="button"
-          unstyled
-          onClick={() => {
-            setIsRemoveTestDateModalOpen(false);
-          }}
-        >
-          {t('removeTestDate.modalCancelButton')}
-        </Button>
-      </Modal>
     </div>
   );
 };

--- a/src/components/TestDateCard/index.tsx
+++ b/src/components/TestDateCard/index.tsx
@@ -85,8 +85,8 @@ const TestDateCard = ({
             <PageHeading headingLevel="h2" className="margin-top-0">
               {t('removeTestDate.modalHeader', {
                 testNumber: testIndex,
-                testType: translateTestType(testDate.testType),
-                testDate: formatDate(testDate.date),
+                testType: translateTestType(testType),
+                testDate: formatDate(date),
                 requestName
               })}
             </PageHeading>

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -79,7 +79,7 @@ const accessibility = {
   },
   removeTestDate: {
     modalHeader:
-      'Confirm you want to remove {{testType}}, {{testDate}} from {{-requestName}}',
+      'Confirm you want to remove Test {{testNumber}} {{testType}}, {{testDate}} from {{-requestName}}',
     modalText: 'This test date and score will be removed from the request page',
     modalRemoveButton: 'Remove test date',
     modalCancelButton: 'Keep test date',

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -73,11 +73,13 @@ const accessibility = {
       score: ' with score {{score}}%',
       create: ' was added',
       update: ' was updated'
-    }
+    },
+    inital: 'Initial',
+    remediation: 'Remediation'
   },
   removeTestDate: {
     modalHeader:
-      'Confirm you want to remove Test {{testNumber}} {{testType}}, {{testDate}} from {{-requestName}}',
+      'Confirm you want to remove {{testType}}, {{testDate}} from {{-requestName}}',
     modalText: 'This test date and score will be removed from the request page',
     modalRemoveButton: 'Remove test date',
     modalCancelButton: 'Keep test date',

--- a/src/i18n/en-US/general.ts
+++ b/src/i18n/en-US/general.ts
@@ -11,7 +11,9 @@ const general = {
     improvement: 'Help us improve EASi',
     whatYouThink: 'Tell us what you think of this service (opens in a new tab)',
     anythingWrong: 'Is there anything wrong on this page? (opens in a new tab)'
-  }
+  },
+  edit: 'Edit',
+  remove: 'Remove'
 };
 
 export default general;

--- a/src/utils/accessibilityRequest.ts
+++ b/src/utils/accessibilityRequest.ts
@@ -1,11 +1,13 @@
 import i18next from 'i18next';
 
-import { AccessibilityRequestDocumentCommonType } from 'types/graphql-global-types';
+import {
+  AccessibilityRequestDocumentCommonType,
+  TestDateTestType
+} from 'types/graphql-global-types';
 
 /**
- * Translate the API enum to a human readable string
+ * Translate the document type API enum to a human readable string
  */
-// eslint-disable-next-line import/prefer-default-export
 export const translateDocumentType = (
   commonDocumentType: AccessibilityRequestDocumentCommonType
 ) => {
@@ -22,6 +24,20 @@ export const translateDocumentType = (
       return i18next.t('accessibility:documentType.testingVpat');
     case 'OTHER':
       return i18next.t('accessibility:documentType.other');
+    default:
+      return '';
+  }
+};
+
+/**
+ * Translate the test date type API enum to a human readable string
+ */
+export const translateTestType = (testType: TestDateTestType) => {
+  switch (testType) {
+    case 'INITIAL':
+      return i18next.t('accessibility:testDateForm.inital');
+    case 'REMEDIATION':
+      return i18next.t('accessibility:testDateForm.remediation');
     default:
       return '';
   }

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -27,7 +27,6 @@ import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import TestDateCard from 'components/TestDateCard';
 import useMessage from 'hooks/useMessage';
 import { AppState } from 'reducers/rootReducer';
-import { translateTestType } from 'utils/accessibilityRequest';
 import { formatDate } from 'utils/date';
 import user from 'utils/user';
 import { NotFoundPartial } from 'views/NotFound';
@@ -37,9 +36,6 @@ import './index.scss';
 const AccessibilityRequestDetailPage = () => {
   const { t } = useTranslation('accessibility');
   const [isModalOpen, setModalOpen] = useState(false);
-  const [selectedTestDateForRemoval, setSelectedTestDateForRemoval] = useState<
-    TestDateType | undefined
-  >();
   const { message, showMessage, showMessageOnNextPage } = useMessage();
   const flags = useFlags();
   const history = useHistory();
@@ -95,7 +91,6 @@ const AccessibilityRequestDetailPage = () => {
       }
     }).then(() => {
       refetch();
-      setSelectedTestDateForRemoval(undefined);
       showMessage(
         t('removeTestDate.confirmation', {
           date: formatDate(testDate.date),
@@ -189,9 +184,10 @@ const AccessibilityRequestDetailPage = () => {
                       key={testDate.id}
                       testDate={testDate}
                       testIndex={index + 1}
+                      requestName={requestName}
                       requestId={accessibilityRequestId}
                       isEditableDeletable={isAccessibilityTeam}
-                      handleDeleteTestDate={setSelectedTestDateForRemoval}
+                      handleDeleteTestDate={deleteTestDate}
                     />
                   ))}
                 {isAccessibilityTeam && (
@@ -270,49 +266,6 @@ const AccessibilityRequestDetailPage = () => {
           </div>
         </div>
       </div>
-      <Modal
-        isOpen={!!selectedTestDateForRemoval}
-        closeModal={() => {
-          setSelectedTestDateForRemoval(undefined);
-        }}
-      >
-        {/*
-         * Conditional satisfies Typescript because selectedTestDateForRemoval
-         * can be undefined
-         */}
-        {!!selectedTestDateForRemoval && (
-          <>
-            <PageHeading headingLevel="h2" className="margin-top-0">
-              {t('removeTestDate.modalHeader', {
-                testType: translateTestType(
-                  selectedTestDateForRemoval.testType
-                ),
-                testDate: formatDate(selectedTestDateForRemoval.date),
-                requestName
-              })}
-            </PageHeading>
-            <p>{t('removeTestDate.modalText')}</p>
-            <Button
-              type="button"
-              className="margin-right-4"
-              onClick={() => {
-                deleteTestDate(selectedTestDateForRemoval);
-              }}
-            >
-              {t('removeTestDate.modalRemoveButton')}
-            </Button>
-            <Button
-              type="button"
-              unstyled
-              onClick={() => {
-                setSelectedTestDateForRemoval(undefined);
-              }}
-            >
-              {t('removeTestDate.modalCancelButton')}
-            </Button>
-          </>
-        )}
-      </Modal>
     </>
   );
 };


### PR DESCRIPTION
This is some refactoring work I've been wanting to do.
This PR reorganizes where some of our logic lives, specifically dealing with test dates and the accessibility request detail view. WIth hooks, it's much easier to put logic in lower-level components. I think we've done too much of that. None of this work is set in stone. I'd like feedback and set better patterns to follow moving forward.

- Move delete test date mutation to parent (`AccessibilityRequestDetailPage`)
    - This makes things a bit simpler so we don't need to pass props to handle side effects (refetch and set confirmation text)

## Reviewer Notes

Something I'd like us to be more thoughtful about is where we use the query and mutation hooks. With hooks it's easier to put them anywhere in the component hierarchy. I think this might be problematic if we aren't careful with where we put it. This will also make some components more difficult to test.