### PR TITLE
Configure the app so that it's easy to repro the connection issue

### DIFF
--- a/cmd/devdata/main.go
+++ b/cmd/devdata/main.go
@@ -44,8 +44,10 @@ func main() {
 		panic(storeErr)
 	}
 
-	makeAccessibilityRequest("TACO", store)
-	makeAccessibilityRequest("Big Project", store)
+	for i := 0; i < 20; i++ {
+		makeAccessibilityRequest("TACO", store)
+		makeAccessibilityRequest("Big Project", store)
+	}
 
 	makeSystemIntake("A Completed Intake Form", logger, store, func(i *models.SystemIntake) {
 		i.ID = uuid.MustParse("af7a3924-3ff7-48ec-8a54-b8b4bc95610b")
@@ -227,8 +229,13 @@ func makeBusinessCase(name string, logger *zap.Logger, store *storage.Store, int
 	must(store.CreateBusinessCase(ctx, &businessCase))
 }
 
+var lcid = 0
+
 func makeAccessibilityRequest(name string, store *storage.Store) {
 	ctx := context.Background()
+
+	lifecycleID := fmt.Sprintf("%06d", lcid)
+	lcid = lcid + 1
 
 	intake := models.SystemIntake{
 		Status:                 models.SystemIntakeStatusLCIDISSUED,
@@ -236,7 +243,7 @@ func makeAccessibilityRequest(name string, store *storage.Store) {
 		ProjectName:            null.StringFrom(name),
 		BusinessOwner:          null.StringFrom("Shane Clark"),
 		BusinessOwnerComponent: null.StringFrom("OIT"),
-		LifecycleID:            null.StringFrom("123456"),
+		LifecycleID:            null.StringFrom(lifecycleID),
 	}
 	must(store.CreateSystemIntake(ctx, &intake))
 	must(store.UpdateSystemIntake(ctx, &intake)) // required to set lifecycle id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   db:
     image: postgres:11.10
-    command: ['postgres', '-c', 'log_statement=all']
+    command: ['postgres', '-c', 'log_statement=all', '-c', 'max_connections=15']
     environment:
       - POSTGRES_PASSWORD=mysecretpassword
   db_migrate:

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -55,7 +55,7 @@ func NewStore(
 	if err != nil {
 		return nil, err
 	}
-	db.SetMaxOpenConns(90)
+	db.SetMaxOpenConns(20)
 
 	return &Store{
 		db:        db,


### PR DESCRIPTION
This is part of our ongoing saga of having what appears to be an unbounded number of connections to the database.

## Changes proposed in this pull request

- Configure Postgres to only accept 15 connections in `docker-compose.yml`
- Add a loop to devdata so we have a lot of 508 requests to work with.

## Setup

```sh
$ scripts/dev down
$ scripts/dev up
$ scripts/dev db:seed
```

If you log in there should be 508 requests, and reloading the page once or twice will lead you to:

![image](https://user-images.githubusercontent.com/3331/118287793-6a384280-b499-11eb-93d2-336c36d8b4c3.png)