### PR TITLE
fix multiple document uploads bug

### DIFF
--- a/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Documents/New/index.tsx
@@ -157,7 +157,13 @@ const New = () => {
           validateOnMount={false}
         >
           {(formikProps: FormikProps<FileUploadForm>) => {
-            const { errors, setFieldValue, values, handleSubmit } = formikProps;
+            const {
+              errors,
+              setFieldValue,
+              values,
+              handleSubmit,
+              isSubmitting
+            } = formikProps;
             const flatErrors = flattenErrors(errors);
             return (
               <>
@@ -309,6 +315,7 @@ const New = () => {
                       <Button
                         type="submit"
                         disabled={
+                          isSubmitting ||
                           generateURLStatus.loading ||
                           createDocumentStatus.loading
                         }


### PR DESCRIPTION
# ES-619

This PR fixes the bug where users are able to upload a document multiple times by spamming the enter key or clicking on the submit button multiple times.


## Reviewer Notes

This PR leveraged `isSubmitting` from `formikProps`. My suspicion is that the `axios.put` for the document upload mutation takes a second too long to start. That's what's causing the button to be clicked again before it gets `disabled`. `formikProps.isSubmitting` should be true closer to when the button has been clicked

If this doesn't work, we can use `useState` and set state immediately on the button click.

## Setup
If verifying locally, throttle your network in the chrome dev tools.
1. On 508 request document upload, select a document and it's type
2. Click on upload repeatedly OR focus the button via tab button and spam the enter key.

There should only be **one** of that document uploaded.

## Code Review Verification Steps

**The main change is the timing of when the upload document button is disabled. There should not be any accessibility or design changes to review.**

### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Made it clear which comments need to be addressed before this work is merged
- [x] Considered marking this as accepted even if there are small changes needed
