### PR TITLE
K1m es 500 508 templates

### DIFF
--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -192,19 +192,23 @@ const accessibility = {
             'For each row in the table, indicate the conformance level. There are 5 levels:',
           levels: [
             {
-              'Supports:':
+              name: 'Supports:',
+              description:
                 'The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.',
             },
             {
-              'Partially Supports:':
+              name: 'Partially Supports:',
+              description:
                 'Some functionality of the product does not meet the criterion.',
             },
             {
-              'Does Not Support:':
+              name: 'Does Not Support:',
+              description:
                 'The majority of product functionality does not meet the criterion.',
             },
             {
-              'Not Evaluated:':
+              name: 'Not Evaluated:',
+              description:
                 'The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.',
             },
           ],
@@ -213,6 +217,10 @@ const accessibility = {
           text:
             'After indicating the conformance level, provide a detailed explanation in the ‘Remarks and Evaluation’ column.',
         },
+        downloadVPAT: {
+          heading: 'Download VPAT template',
+
+        }
       },
     },
     testPlanSection: {

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // This is for the CMS 508 project flow
 
 const accessibility = {
@@ -6,7 +7,7 @@ const accessibility = {
     header: {
       actions: 'Actions',
       documentName: 'Document',
-      uploadedAt: 'Upload date'
+      uploadedAt: 'Upload date',
     },
     remove: 'Remove',
     view: 'View',
@@ -15,8 +16,8 @@ const accessibility = {
       warning:
         'You will not be able to access this document after it is removed.',
       proceedButton: 'Remove document',
-      declineButton: 'Keep document'
-    }
+      declineButton: 'Keep document',
+    },
   },
   requestTable: {
     caption: 'List of 508 requests',
@@ -26,18 +27,18 @@ const accessibility = {
       businessOwner: 'Business Owner',
       testDate: 'Test Date',
       pointOfContact: 'Point of Contact',
-      status: 'Status'
+      status: 'Status',
     },
     lastUpdated: 'last updated on',
-    emptyTestDate: 'Not Added'
+    emptyTestDate: 'Not Added',
   },
   tabs: {
-    accessibilityRequests: '508 Requests'
+    accessibilityRequests: '508 Requests',
   },
   requestDetails: {
     documents: {
       label: 'Documents',
-      none: 'No documents added to this request yet.'
+      none: 'No documents added to this request yet.',
     },
     documentUpload: 'Upload a document',
     other: 'Other request details',
@@ -48,14 +49,14 @@ const accessibility = {
       subhead:
         'You will not be able to access this request and its documents after it is removed.',
       confirm: 'Remove request',
-      cancel: 'Keep request'
+      cancel: 'Keep request',
     },
-    removeConfirmationText: '{{-requestName}} successfully removed'
+    removeConfirmationText: '{{-requestName}} successfully removed',
   },
   testDateForm: {
     header: {
       create: 'Add a test date for {{-requestName}}',
-      update: 'Update a test date for {{-requestName}}'
+      update: 'Update a test date for {{-requestName}}',
     },
     testTypeHeader: 'What type of test?',
     dateHeader: 'Test date',
@@ -66,17 +67,17 @@ const accessibility = {
     scoreValueSRHelpText: 'Enter the test score without the percentage symbol',
     submitButton: {
       create: 'Add date',
-      update: 'Update date'
+      update: 'Update date',
     },
     cancel: "Don't add and go back to request page",
     confirmation: {
       date: 'Test date {{date}}',
       score: ' with score {{score}}%',
       create: ' was added',
-      update: ' was updated'
+      update: ' was updated',
     },
     inital: 'Initial',
-    remediation: 'Remediation'
+    remediation: 'Remediation',
   },
   removeTestDate: {
     modalHeader:
@@ -84,34 +85,34 @@ const accessibility = {
     modalText: 'This test date and score will be removed from the request page',
     modalRemoveButton: 'Remove test date',
     modalCancelButton: 'Keep test date',
-    confirmation: '{{date}} test date was removed from {{-requestName}} page'
+    confirmation: '{{date}} test date was removed from {{-requestName}} page',
   },
   newRequestForm: {
     heading: 'Add a new request',
     fields: {
       project: {
-        label: 'Choose the project this request will belong to'
+        label: 'Choose the project this request will belong to',
       },
       businessOwnerName: {
         label: 'Business Owner Name',
         help:
-          'The business owner name field will be automatically filled based on the project you choose'
+          'The business owner name field will be automatically filled based on the project you choose',
       },
       businessOwnerComponent: {
         label: 'Business Owner Component',
         help:
-          'The business owner component field will be automatically filled based on the project you choose'
+          'The business owner component field will be automatically filled based on the project you choose',
       },
       requestName: {
         label: 'Request Name',
         help:
-          'This name will be shown on the Active requests page. For example, ACME 1.3'
-      }
+          'This name will be shown on the Active requests page. For example, ACME 1.3',
+      },
     },
     info:
       'A request for 508 testing will be added to the list of 508 requests. An email will be sent to the Business Owner and the 508 team stating that a request has been added to the system.',
     submitBtn: 'Add a new request',
-    confirmation: '{{-requestName}} was added to the 508 requests page'
+    confirmation: '{{-requestName}} was added to the 508 requests page',
   },
   documentType: {
     awardedVpat: 'Awarded VPAT',
@@ -119,7 +120,7 @@ const accessibility = {
     testPlan: 'Test plan',
     testResults: 'Test results',
     remediationPlan: 'Remediation plan',
-    other: 'Other'
+    other: 'Other',
   },
   testingStepsOverview: {
     heading: 'Steps involved in 508 testing',
@@ -127,19 +128,19 @@ const accessibility = {
       'Here is an overview of the 508 process for testing your application.',
     fillForm: {
       heading: 'Fill the request form in EASi',
-      description: 'Tell the 508 team which application you plan to test.'
+      description: 'Tell the 508 team which application you plan to test.',
     },
     prepareVPAT: {
       heading: 'Prepare and upload the VPAT and Test plan',
       fillOutVPAT:
         'Download and fill the VPAT and Test plan from the templates page. These documents will help the 508 team prepare for testing. Uploaded your completed documents to EASi for the 508 team to review.',
       changesVPAT:
-        'The 508 team will get back to you via email about any changes needed prior to testing.'
+        'The 508 team will get back to you via email about any changes needed prior to testing.',
     },
     testingSession: {
       heading: 'Attend the testing session',
       description:
-        'The 508 team will work with you to schedule a testing session and you will test your application together. Depending on the results, you may need to address any issues and retest.'
+        'The 508 team will work with you to schedule a testing session and you will test your application together. Depending on the results, you may need to address any issues and retest.',
     },
     results: {
       heading: 'Receive results',
@@ -148,19 +149,19 @@ const accessibility = {
         above99: {
           heading: '99% and above',
           description:
-            '508 testing is complete and you can release your application.'
+            '508 testing is complete and you can release your application.',
         },
         interval75: {
           heading: 'Between 99% and 75%',
           description:
-            'You can release your application but you will need fix the issues and retest within a year. You need to submit a remediation plan as a part of retesting.'
+            'You can release your application but you will need fix the issues and retest within a year. You need to submit a remediation plan as a part of retesting.',
         },
         below75: {
           heading: '75% and below',
           description:
-            'You cannot release your application. You need to fix all issues right away and retest.'
-        }
-      }
+            'You cannot release your application. You need to fix all issues right away and retest.',
+        },
+      },
     },
     exception: {
       label: 'What if I need an exception from 508 testing?',
@@ -170,14 +171,71 @@ const accessibility = {
         'National Security System',
         'Software/System acquired by a contractor, or incidental to a contract',
         'Undue Burden for CMS (e.g. - extreme cost)',
-        'Fundamental alteration'
+        'Fundamental alteration',
       ],
       exceptionFineprint:
         'Exceptions are only valid for one release. Future releases will be re-evaluated for additional exceptions.',
       contact:
-        'To apply for an exception or for more information, contact the CMS Section 508 team at <1>CMS_Section508@cms.hhs.gov<1/>.'
-    }
-  }
+        'To apply for an exception or for more information, contact the CMS Section 508 team at <1>CMS_Section508@cms.hhs.gov<1/>.',
+    },
+  },
+  testingTemplates: {
+    heading: 'Templates for 508 testing',
+    vpatSection: {
+      heading: 'Voluntary Product Assessment Template (VPAT)',
+      description:
+        'A VPAT s a document that helps CMS and other government agencxies understand how you will meet the 508 Standards for IT accessibility.',
+      subSection: {
+        heading: 'Tips to complete a VPAT',
+        item1: {
+          text:
+            'For each row in the table, indicate the conformance level. There are 5 levels:',
+          levels: [
+            {
+              'Supports:':
+                'The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.',
+            },
+            {
+              'Partially Supports:':
+                'Some functionality of the product does not meet the criterion.',
+            },
+            {
+              'Does Not Support:':
+                'The majority of product functionality does not meet the criterion.',
+            },
+            {
+              'Not Evaluated:':
+                'The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.',
+            },
+          ],
+        },
+        item2: {
+          text:
+            'After indicating the conformance level, provide a detailed explanation in the ‘Remarks and Evaluation’ column.',
+        },
+      },
+    },
+    testPlanSection: {
+      heading: 'Test Plan',
+      description:
+        'The Test Plan is a document that helps the Section 508 team understand your system and know what areas of your system to test before it goes live. In this document you will provide:',
+      itemsToProvide: [
+        'a description of your system',
+        'information on how to set up and access it',
+        'user scenarios and steps taken to perform actions',
+        'and any other constraints, assumptions or risks',
+      ],
+    },
+    remediationPlanSection: {
+      heading: 'Remediation Plan',
+      description:
+        'The Remediation Plan is a document that helps the Section 508 team understand how you plan to fix the issues that were identified from the 508 test. In this document you will provide:',
+      itemsToProvide: [
+        'solutions for each issue',
+        'when and how you plan to schedule these changes into your project',
+      ],
+    },
+  },
 };
 
 export default accessibility;

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -219,7 +219,17 @@ const accessibility = {
         },
         downloadVPAT: {
           heading: 'Download VPAT template',
-
+          line1: {
+            linkText: 'Download the current VPAT template (opens link in new tab)',
+            otherText: 'from the Information Technology Industry Council (ITI) website.',
+          },
+          line2: {
+            text: 'Do not skip any row in the document. This will result in delays.'
+          },
+          line3: {
+            linkText: 'Watch the tutorial (opens link in a new tab)',
+            otherText: 'on how to fill out a VPAT.',
+          }
         }
       },
     },

--- a/src/views/Accessibility/TestingTemplates/index.scss
+++ b/src/views/Accessibility/TestingTemplates/index.scss
@@ -6,7 +6,8 @@
     list-style-type: none;
     li {
       &:before {
-          content: "- ";
+          content: "-";
+          padding-right: 8px;
       }
     }
   }

--- a/src/views/Accessibility/TestingTemplates/index.scss
+++ b/src/views/Accessibility/TestingTemplates/index.scss
@@ -18,7 +18,7 @@
     background: color($theme-color-info-lighter);
     padding: 24px 18px;
   }
-  &__side-col {
+  &__sidebar {
   border-top: 4px solid $easi-bright-blue;
   }
 }

--- a/src/views/Accessibility/TestingTemplates/index.scss
+++ b/src/views/Accessibility/TestingTemplates/index.scss
@@ -1,0 +1,11 @@
+
+
+.accessibility-testing-templates {
+  &__downloadBox {
+    background: color($theme-color-info-lighter);
+    padding: 24px 18px;
+    h3 {
+    padding-top: 0;
+    }
+  }
+}

--- a/src/views/Accessibility/TestingTemplates/index.scss
+++ b/src/views/Accessibility/TestingTemplates/index.scss
@@ -1,11 +1,23 @@
 
 
 .accessibility-testing-templates {
+  &__table-of-contents {
+    padding-left: 0;
+    list-style-type: none;
+    li {
+      &:before {
+          content: "- ";
+      }
+    }
+  }
+  &__vpat-list, &__test-plan-list, &__remediation-plan-list {
+    padding-left: 20px;
+  }
   &__downloadBox {
     background: color($theme-color-info-lighter);
     padding: 24px 18px;
-    h3 {
-    padding-top: 0;
-    }
+  }
+  &__side-col {
+  border-top: 4px solid $easi-bright-blue;
   }
 }

--- a/src/views/Accessibility/TestingTemplates/index.test.tsx
+++ b/src/views/Accessibility/TestingTemplates/index.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from 'enzyme';
+
+import TestingTemplates from './index';
+
+describe('TestingTemplates', () => {
+  it('renders without crashing', () => {
+    const component = render(<TestingTemplates />);
+    expect(component.length).toBe(1);
+  });
+});

--- a/src/views/Accessibility/TestingTemplates/index.tsx
+++ b/src/views/Accessibility/TestingTemplates/index.tsx
@@ -19,6 +19,13 @@ const TestingTemplates = () => {
     }
   );
 
+  const remediationPlanList: string[] = t(
+    'testingTemplates.remediationPlanSection.itemsToProvide',
+    {
+      returnObjects: true
+    }
+  );
+
   return (
     <div className="grid-container">
       <div className="tablet:grid-col-10">
@@ -68,13 +75,31 @@ const TestingTemplates = () => {
             )}
           </p>
         </div>
-        <h2>{t('testingTemplates.testPlanSection.heading')}</h2>
-        <p>{t('testingTemplates.testPlanSection.description')}</p>
-        <ul>
-          {testPlanList.map(item => (
-            <li>{item}</li>
-          ))}
-        </ul>
+        <div>
+          <h2>{t('testingTemplates.testPlanSection.heading')}</h2>
+          <p>{t('testingTemplates.testPlanSection.description')}</p>
+          <ul>
+            {testPlanList.map(item => (
+              <li>{item}</li>
+            ))}
+          </ul>
+          <h2>{t('testingTemplates.testPlanSection.heading')}</h2>
+          <p>{t('testingTemplates.testPlanSection.description')}</p>
+          <ul>
+            {testPlanList.map(item => (
+              <li>{item}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h2>{t('testingTemplates.remediationPlanSection.heading')}</h2>
+          <p>{t('testingTemplates.remediationPlanSection.description')}</p>
+          <ul>
+            {remediationPlanList.map(item => (
+              <li>{item}</li>
+            ))}
+          </ul>
+        </div>
       </div>
     </div>
   );

--- a/src/views/Accessibility/TestingTemplates/index.tsx
+++ b/src/views/Accessibility/TestingTemplates/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from '@trussworks/react-uswds';
 
 import PageHeading from 'components/PageHeading';
 
@@ -7,6 +8,12 @@ const TestingTemplates = () => {
   const { t } = useTranslation('accessibility');
   const vpatConformanceLevels: { name: string; description: string }[] = t(
     'testingTemplates.vpatSection.subSection.item1.levels',
+    {
+      returnObjects: true
+    }
+  );
+  const testPlanList: string[] = t(
+    'testingTemplates.testPlanSection.itemsToProvide',
     {
       returnObjects: true
     }
@@ -28,6 +35,45 @@ const TestingTemplates = () => {
             </p>
           ))}
           <li>{t('testingTemplates.vpatSection.subSection.item2.text')}</li>
+        </ul>
+        <div>
+          <h3>
+            {t('testingTemplates.vpatSection.subSection.downloadVPAT.heading')}
+          </h3>
+          <p>
+            <Link href="https://www.itic.org/policy/accessibility/vpat">
+              {t(
+                'testingTemplates.vpatSection.subSection.downloadVPAT.line1.linkText'
+              )}
+            </Link>
+            {` `}
+            {t(
+              'testingTemplates.vpatSection.subSection.downloadVPAT.line1.otherText'
+            )}
+          </p>
+          <p>
+            {t(
+              'testingTemplates.vpatSection.subSection.downloadVPAT.line2.text'
+            )}
+          </p>
+          <p>
+            <Link href="https://www.youtube.com/watch?v=kAkSV9xiJ1A">
+              {t(
+                'testingTemplates.vpatSection.subSection.downloadVPAT.line3.linkText'
+              )}
+            </Link>
+            {` `}
+            {t(
+              'testingTemplates.vpatSection.subSection.downloadVPAT.line3.otherText'
+            )}
+          </p>
+        </div>
+        <h2>{t('testingTemplates.testPlanSection.heading')}</h2>
+        <p>{t('testingTemplates.testPlanSection.description')}</p>
+        <ul>
+          {testPlanList.map(item => (
+            <li>{item}</li>
+          ))}
         </ul>
       </div>
     </div>

--- a/src/views/Accessibility/TestingTemplates/index.tsx
+++ b/src/views/Accessibility/TestingTemplates/index.tsx
@@ -4,6 +4,8 @@ import { Link } from '@trussworks/react-uswds';
 
 import PageHeading from 'components/PageHeading';
 
+import './index.scss';
+
 const TestingTemplates = () => {
   const { t } = useTranslation('accessibility');
   const vpatConformanceLevels: { name: string; description: string }[] = t(
@@ -27,7 +29,7 @@ const TestingTemplates = () => {
   );
 
   return (
-    <div className="grid-container">
+    <div className="grid-container accessibility-testing-templates">
       <div className="tablet:grid-col-10">
         <PageHeading>{t('testingTemplates.heading')}</PageHeading>
         <h2>{t('testingTemplates.vpatSection.heading')}</h2>
@@ -43,7 +45,7 @@ const TestingTemplates = () => {
           ))}
           <li>{t('testingTemplates.vpatSection.subSection.item2.text')}</li>
         </ul>
-        <div>
+        <div className="accessibility-testing-templates__downloadBox">
           <h3>
             {t('testingTemplates.vpatSection.subSection.downloadVPAT.heading')}
           </h3>

--- a/src/views/Accessibility/TestingTemplates/index.tsx
+++ b/src/views/Accessibility/TestingTemplates/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from '@trussworks/react-uswds';
 
+import BreadcrumbNav from 'components/BreadcrumbNav';
 import PageHeading from 'components/PageHeading';
 
 import './index.scss';
@@ -28,11 +29,58 @@ const TestingTemplates = () => {
     }
   );
 
+  const tableOfContents = (
+    <div className=".accessibility-testing-templates__tableOfContents">
+      <p>Page contents</p>
+      <ul>
+        <li>
+          <Link
+            href={`#testingTemplates_${t(
+              'testingTemplates.vpatSection.heading'
+            )}`}
+          >
+            {t('testingTemplates.vpatSection.heading')}
+          </Link>
+        </li>
+        <li>
+          <Link
+            href={`#testingTemplates_${t(
+              'testingTemplates.testPlanSection.heading'
+            )}`}
+          >
+            {t('testingTemplates.testPlanSection.heading')}
+          </Link>
+        </li>
+        <li>
+          <Link
+            href={`#testingTemplates_${t(
+              'testingTemplates.remediationPlanSection.heading'
+            )}`}
+          >
+            {t('testingTemplates.remediationPlanSection.heading')}
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+
   return (
     <div className="grid-container accessibility-testing-templates">
+      <BreadcrumbNav className="margin-y-2">
+        <li>
+          <Link href="/">Home</Link>
+          <i className="fa fa-angle-right margin-x-05" aria-hidden />
+        </li>
+        <li>Templates for 508 testing</li>
+      </BreadcrumbNav>
       <div className="tablet:grid-col-10">
         <PageHeading>{t('testingTemplates.heading')}</PageHeading>
-        <h2>{t('testingTemplates.vpatSection.heading')}</h2>
+        {tableOfContents}
+        <h2
+          id={`testingTemplates_${t('testingTemplates.vpatSection.heading')}`}
+        >
+          {t('testingTemplates.vpatSection.heading')}
+        </h2>
         <p>{t('testingTemplates.vpatSection.description')}</p>
         <h3>{t('testingTemplates.vpatSection.subSection.heading')}</h3>
         <ul>
@@ -78,14 +126,13 @@ const TestingTemplates = () => {
           </p>
         </div>
         <div>
-          <h2>{t('testingTemplates.testPlanSection.heading')}</h2>
-          <p>{t('testingTemplates.testPlanSection.description')}</p>
-          <ul>
-            {testPlanList.map(item => (
-              <li>{item}</li>
-            ))}
-          </ul>
-          <h2>{t('testingTemplates.testPlanSection.heading')}</h2>
+          <h2
+            id={`testingTemplates_${t(
+              'testingTemplates.testPlanSection.heading'
+            )}`}
+          >
+            {t('testingTemplates.testPlanSection.heading')}
+          </h2>
           <p>{t('testingTemplates.testPlanSection.description')}</p>
           <ul>
             {testPlanList.map(item => (
@@ -94,7 +141,13 @@ const TestingTemplates = () => {
           </ul>
         </div>
         <div>
-          <h2>{t('testingTemplates.remediationPlanSection.heading')}</h2>
+          <h2
+            id={`testingTemplates_${t(
+              'testingTemplates.remediationPlanSection.heading'
+            )}`}
+          >
+            {t('testingTemplates.remediationPlanSection.heading')}
+          </h2>
           <p>{t('testingTemplates.remediationPlanSection.description')}</p>
           <ul>
             {remediationPlanList.map(item => (

--- a/src/views/Accessibility/TestingTemplates/index.tsx
+++ b/src/views/Accessibility/TestingTemplates/index.tsx
@@ -1,7 +1,37 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import PageHeading from 'components/PageHeading';
 
 const TestingTemplates = () => {
-  return <div>I am the testing templates page</div>;
+  const { t } = useTranslation('accessibility');
+  const vpatConformanceLevels: { name: string; description: string }[] = t(
+    'testingTemplates.vpatSection.subSection.item1.levels',
+    {
+      returnObjects: true
+    }
+  );
+
+  return (
+    <div className="grid-container">
+      <div className="tablet:grid-col-10">
+        <PageHeading>{t('testingTemplates.heading')}</PageHeading>
+        <h2>{t('testingTemplates.vpatSection.heading')}</h2>
+        <p>{t('testingTemplates.vpatSection.description')}</p>
+        <h3>{t('testingTemplates.vpatSection.subSection.heading')}</h3>
+        <ul>
+          <li>{t('testingTemplates.vpatSection.subSection.item1.text')}</li>
+          {vpatConformanceLevels.map(level => (
+            <p>
+              <span className="text-bold">{level.name}</span>{' '}
+              {level.description}
+            </p>
+          ))}
+          <li>{t('testingTemplates.vpatSection.subSection.item2.text')}</li>
+        </ul>
+      </div>
+    </div>
+  );
 };
 
 export default TestingTemplates;

--- a/src/views/Accessibility/TestingTemplates/index.tsx
+++ b/src/views/Accessibility/TestingTemplates/index.tsx
@@ -63,6 +63,101 @@ const TestingTemplates = () => {
       </ul>
     </div>
   );
+  const testPlanSection = (
+    <div>
+      <h2
+        id={`testingTemplates_${t('testingTemplates.testPlanSection.heading')}`}
+      >
+        {t('testingTemplates.testPlanSection.heading')}
+      </h2>
+      <p>{t('testingTemplates.testPlanSection.description')}</p>
+      <ul className="accessibility-testing-templates__test-plan-list">
+        {testPlanList.map(item => (
+          <li>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+  const remediationPlanSection = (
+    <div>
+      <h2
+        id={`testingTemplates_${t(
+          'testingTemplates.remediationPlanSection.heading'
+        )}`}
+      >
+        {t('testingTemplates.remediationPlanSection.heading')}
+      </h2>
+      <p>{t('testingTemplates.remediationPlanSection.description')}</p>
+      <ul className="accessibility-testing-templates__remediation-plan-list">
+        {remediationPlanList.map(item => (
+          <li>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+
+  const downloadVPAT = (
+    <div className="accessibility-testing-templates__downloadBox">
+      <h3 className="margin-top-0">
+        {t('testingTemplates.vpatSection.subSection.downloadVPAT.heading')}
+      </h3>
+      <p>
+        <Link
+          href="https://www.itic.org/policy/accessibility/vpat"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t(
+            'testingTemplates.vpatSection.subSection.downloadVPAT.line1.linkText'
+          )}
+        </Link>
+        {` `}
+        {t(
+          'testingTemplates.vpatSection.subSection.downloadVPAT.line1.otherText'
+        )}
+      </p>
+      <p>
+        <i className="fa fa-exclamation-circle fa-2x" />
+        {` `}
+        {t('testingTemplates.vpatSection.subSection.downloadVPAT.line2.text')}
+      </p>
+      <p>
+        <Link
+          href="https://www.youtube.com/watch?v=kAkSV9xiJ1A"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t(
+            'testingTemplates.vpatSection.subSection.downloadVPAT.line3.linkText'
+          )}
+        </Link>
+        {` `}
+        {t(
+          'testingTemplates.vpatSection.subSection.downloadVPAT.line3.otherText'
+        )}
+      </p>
+    </div>
+  );
+
+  const vpatSection = (
+    <div>
+      <h2 id={`testingTemplates_${t('testingTemplates.vpatSection.heading')}`}>
+        {t('testingTemplates.vpatSection.heading')}
+      </h2>
+      <p>{t('testingTemplates.vpatSection.description')}</p>
+      <h3>{t('testingTemplates.vpatSection.subSection.heading')}</h3>
+      <ul className="accessibility-testing-templates__vpat-list">
+        <li>{t('testingTemplates.vpatSection.subSection.item1.text')}</li>
+        {vpatConformanceLevels.map(level => (
+          <p>
+            <span className="text-bold">{level.name}</span> {level.description}
+          </p>
+        ))}
+        <li>{t('testingTemplates.vpatSection.subSection.item2.text')}</li>
+      </ul>
+      {downloadVPAT}
+    </div>
+  );
 
   return (
     <div className="grid-container accessibility-testing-templates">
@@ -80,102 +175,12 @@ const TestingTemplates = () => {
               {t('testingTemplates.heading')}
             </PageHeading>
             {tableOfContents}
-            <h2
-              id={`testingTemplates_${t(
-                'testingTemplates.vpatSection.heading'
-              )}`}
-            >
-              {t('testingTemplates.vpatSection.heading')}
-            </h2>
-            <p>{t('testingTemplates.vpatSection.description')}</p>
-            <h3>{t('testingTemplates.vpatSection.subSection.heading')}</h3>
-            <ul className="accessibility-testing-templates__vpat-list">
-              <li>{t('testingTemplates.vpatSection.subSection.item1.text')}</li>
-              {vpatConformanceLevels.map(level => (
-                <p>
-                  <span className="text-bold">{level.name}</span>{' '}
-                  {level.description}
-                </p>
-              ))}
-              <li>{t('testingTemplates.vpatSection.subSection.item2.text')}</li>
-            </ul>
-            <div className="accessibility-testing-templates__downloadBox">
-              <h3 className="margin-top-0">
-                {t(
-                  'testingTemplates.vpatSection.subSection.downloadVPAT.heading'
-                )}
-              </h3>
-              <p>
-                <Link
-                  href="https://www.itic.org/policy/accessibility/vpat"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {t(
-                    'testingTemplates.vpatSection.subSection.downloadVPAT.line1.linkText'
-                  )}
-                </Link>
-                {` `}
-                {t(
-                  'testingTemplates.vpatSection.subSection.downloadVPAT.line1.otherText'
-                )}
-              </p>
-              <p>
-                <i className="fa fa-exclamation-circle fa-2x" />
-                {` `}
-                {t(
-                  'testingTemplates.vpatSection.subSection.downloadVPAT.line2.text'
-                )}
-              </p>
-              <p>
-                <Link
-                  href="https://www.youtube.com/watch?v=kAkSV9xiJ1A"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {t(
-                    'testingTemplates.vpatSection.subSection.downloadVPAT.line3.linkText'
-                  )}
-                </Link>
-                {` `}
-                {t(
-                  'testingTemplates.vpatSection.subSection.downloadVPAT.line3.otherText'
-                )}
-              </p>
-            </div>
-            <div>
-              <h2
-                id={`testingTemplates_${t(
-                  'testingTemplates.testPlanSection.heading'
-                )}`}
-              >
-                {t('testingTemplates.testPlanSection.heading')}
-              </h2>
-              <p>{t('testingTemplates.testPlanSection.description')}</p>
-              <ul className="accessibility-testing-templates__test-plan-list">
-                {testPlanList.map(item => (
-                  <li>{item}</li>
-                ))}
-              </ul>
-            </div>
-            <div>
-              <h2
-                id={`testingTemplates_${t(
-                  'testingTemplates.remediationPlanSection.heading'
-                )}`}
-              >
-                {t('testingTemplates.remediationPlanSection.heading')}
-              </h2>
-              <p>{t('testingTemplates.remediationPlanSection.description')}</p>
-              <ul className="accessibility-testing-templates__remediation-plan-list">
-                {remediationPlanList.map(item => (
-                  <li>{item}</li>
-                ))}
-              </ul>
-            </div>
+            {vpatSection}
+            {testPlanSection}
+            {remediationPlanSection}
           </div>
         </div>
-        <div className="grid-col-3 accessibility-testing-templates__side-col">
+        <div className="grid-col-3 accessibility-testing-templates__sidebar">
           <div>
             <h4 className="text-bold">
               Need help? Contact the Section 508 team

--- a/src/views/Accessibility/TestingTemplates/index.tsx
+++ b/src/views/Accessibility/TestingTemplates/index.tsx
@@ -32,7 +32,7 @@ const TestingTemplates = () => {
   const tableOfContents = (
     <div className=".accessibility-testing-templates__tableOfContents">
       <p>Page contents</p>
-      <ul>
+      <ul className="accessibility-testing-templates__table-of-contents">
         <li>
           <Link
             href={`#testingTemplates_${t(
@@ -73,87 +73,113 @@ const TestingTemplates = () => {
         </li>
         <li>Templates for 508 testing</li>
       </BreadcrumbNav>
-      <div className="tablet:grid-col-10">
-        <PageHeading>{t('testingTemplates.heading')}</PageHeading>
-        {tableOfContents}
-        <h2
-          id={`testingTemplates_${t('testingTemplates.vpatSection.heading')}`}
-        >
-          {t('testingTemplates.vpatSection.heading')}
-        </h2>
-        <p>{t('testingTemplates.vpatSection.description')}</p>
-        <h3>{t('testingTemplates.vpatSection.subSection.heading')}</h3>
-        <ul>
-          <li>{t('testingTemplates.vpatSection.subSection.item1.text')}</li>
-          {vpatConformanceLevels.map(level => (
-            <p>
-              <span className="text-bold">{level.name}</span>{' '}
-              {level.description}
-            </p>
-          ))}
-          <li>{t('testingTemplates.vpatSection.subSection.item2.text')}</li>
-        </ul>
-        <div className="accessibility-testing-templates__downloadBox">
-          <h3>
-            {t('testingTemplates.vpatSection.subSection.downloadVPAT.heading')}
-          </h3>
-          <p>
-            <Link href="https://www.itic.org/policy/accessibility/vpat">
-              {t(
-                'testingTemplates.vpatSection.subSection.downloadVPAT.line1.linkText'
-              )}
-            </Link>
-            {` `}
-            {t(
-              'testingTemplates.vpatSection.subSection.downloadVPAT.line1.otherText'
-            )}
-          </p>
-          <p>
-            {t(
-              'testingTemplates.vpatSection.subSection.downloadVPAT.line2.text'
-            )}
-          </p>
-          <p>
-            <Link href="https://www.youtube.com/watch?v=kAkSV9xiJ1A">
-              {t(
-                'testingTemplates.vpatSection.subSection.downloadVPAT.line3.linkText'
-              )}
-            </Link>
-            {` `}
-            {t(
-              'testingTemplates.vpatSection.subSection.downloadVPAT.line3.otherText'
-            )}
-          </p>
+      <div className="grid-row grid-gap-lg">
+        <div className="grid-col-9 line-height-body-4">
+          <div className="tablet:grid-col-10">
+            <PageHeading>{t('testingTemplates.heading')}</PageHeading>
+            {tableOfContents}
+            <h2
+              id={`testingTemplates_${t(
+                'testingTemplates.vpatSection.heading'
+              )}`}
+            >
+              {t('testingTemplates.vpatSection.heading')}
+            </h2>
+            <p>{t('testingTemplates.vpatSection.description')}</p>
+            <h3>{t('testingTemplates.vpatSection.subSection.heading')}</h3>
+            <ul className="accessibility-testing-templates__vpat-list">
+              <li>{t('testingTemplates.vpatSection.subSection.item1.text')}</li>
+              {vpatConformanceLevels.map(level => (
+                <p>
+                  <span className="text-bold">{level.name}</span>{' '}
+                  {level.description}
+                </p>
+              ))}
+              <li>{t('testingTemplates.vpatSection.subSection.item2.text')}</li>
+            </ul>
+            <div className="accessibility-testing-templates__downloadBox">
+              <h3 className="margin-top-0">
+                {t(
+                  'testingTemplates.vpatSection.subSection.downloadVPAT.heading'
+                )}
+              </h3>
+              <p>
+                <Link
+                  href="https://www.itic.org/policy/accessibility/vpat"
+                  target="_blank"
+                >
+                  {t(
+                    'testingTemplates.vpatSection.subSection.downloadVPAT.line1.linkText'
+                  )}
+                </Link>
+                {` `}
+                {t(
+                  'testingTemplates.vpatSection.subSection.downloadVPAT.line1.otherText'
+                )}
+              </p>
+              <p>
+                <i className="fa fa-exclamation-circle fa-2x" />
+                {` `}
+                {t(
+                  'testingTemplates.vpatSection.subSection.downloadVPAT.line2.text'
+                )}
+              </p>
+              <p>
+                <Link
+                  href="https://www.youtube.com/watch?v=kAkSV9xiJ1A"
+                  target="_blank"
+                >
+                  {t(
+                    'testingTemplates.vpatSection.subSection.downloadVPAT.line3.linkText'
+                  )}
+                </Link>
+                {` `}
+                {t(
+                  'testingTemplates.vpatSection.subSection.downloadVPAT.line3.otherText'
+                )}
+              </p>
+            </div>
+            <div>
+              <h2
+                id={`testingTemplates_${t(
+                  'testingTemplates.testPlanSection.heading'
+                )}`}
+              >
+                {t('testingTemplates.testPlanSection.heading')}
+              </h2>
+              <p>{t('testingTemplates.testPlanSection.description')}</p>
+              <ul className="accessibility-testing-templates__test-plan-list">
+                {testPlanList.map(item => (
+                  <li>{item}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h2
+                id={`testingTemplates_${t(
+                  'testingTemplates.remediationPlanSection.heading'
+                )}`}
+              >
+                {t('testingTemplates.remediationPlanSection.heading')}
+              </h2>
+              <p>{t('testingTemplates.remediationPlanSection.description')}</p>
+              <ul className="accessibility-testing-templates__remediation-plan-list">
+                {remediationPlanList.map(item => (
+                  <li>{item}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
         </div>
-        <div>
-          <h2
-            id={`testingTemplates_${t(
-              'testingTemplates.testPlanSection.heading'
-            )}`}
-          >
-            {t('testingTemplates.testPlanSection.heading')}
-          </h2>
-          <p>{t('testingTemplates.testPlanSection.description')}</p>
-          <ul>
-            {testPlanList.map(item => (
-              <li>{item}</li>
-            ))}
-          </ul>
-        </div>
-        <div>
-          <h2
-            id={`testingTemplates_${t(
-              'testingTemplates.remediationPlanSection.heading'
-            )}`}
-          >
-            {t('testingTemplates.remediationPlanSection.heading')}
-          </h2>
-          <p>{t('testingTemplates.remediationPlanSection.description')}</p>
-          <ul>
-            {remediationPlanList.map(item => (
-              <li>{item}</li>
-            ))}
-          </ul>
+        <div className="grid-col-3 accessibility-testing-templates__side-col">
+          <div>
+            <h4 className="text-bold">
+              Need help? Contact the Section 508 team
+            </h4>
+            <Link href="mailto:CMS_Section508@cms.hhs.gov">
+              CMS_Section508@cms.hhs.gov
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/src/views/Accessibility/TestingTemplates/index.tsx
+++ b/src/views/Accessibility/TestingTemplates/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const TestingTemplates = () => {
+  return <div>I am the testing templates page</div>;
+};
+
+export default TestingTemplates;

--- a/src/views/Accessibility/TestingTemplates/index.tsx
+++ b/src/views/Accessibility/TestingTemplates/index.tsx
@@ -73,10 +73,12 @@ const TestingTemplates = () => {
         </li>
         <li>Templates for 508 testing</li>
       </BreadcrumbNav>
-      <div className="grid-row grid-gap-lg">
+      <div className="grid-row grid-gap-lg margin-top-6">
         <div className="grid-col-9 line-height-body-4">
           <div className="tablet:grid-col-10">
-            <PageHeading>{t('testingTemplates.heading')}</PageHeading>
+            <PageHeading className="margin-top-0">
+              {t('testingTemplates.heading')}
+            </PageHeading>
             {tableOfContents}
             <h2
               id={`testingTemplates_${t(
@@ -107,6 +109,7 @@ const TestingTemplates = () => {
                 <Link
                   href="https://www.itic.org/policy/accessibility/vpat"
                   target="_blank"
+                  rel="noopener noreferrer"
                 >
                   {t(
                     'testingTemplates.vpatSection.subSection.downloadVPAT.line1.linkText'
@@ -128,6 +131,7 @@ const TestingTemplates = () => {
                 <Link
                   href="https://www.youtube.com/watch?v=kAkSV9xiJ1A"
                   target="_blank"
+                  rel="noopener noreferrer"
                 >
                   {t(
                     'testingTemplates.vpatSection.subSection.downloadVPAT.line3.linkText'

--- a/src/views/Accessibility/index.tsx
+++ b/src/views/Accessibility/index.tsx
@@ -15,6 +15,7 @@ import AccessibilityTestingStepsOverview from 'views/Accessibility/Accessibility
 import Create from 'views/Accessibility/AccessibiltyRequest/Create';
 import AccessibilityRequestsDocumentsNew from 'views/Accessibility/AccessibiltyRequest/Documents/New';
 import List from 'views/Accessibility/AccessibiltyRequest/List';
+import TestingTemplates from 'views/Accessibility/TestingTemplates';
 import NotFoundPartial from 'views/NotFound/NotFoundPartial';
 import NewTestDateView from 'views/TestDate/NewTestDate';
 import UpdateTestDateView from 'views/TestDate/UpdateTestDate';
@@ -42,6 +43,15 @@ const AccessibilityTestingOverview = (
     path="/508/testing-overview"
     exact
     component={AccessibilityTestingStepsOverview}
+  />
+);
+
+const AccessibilityTestingTemplates = (
+  <SecureRoute
+    key="508-testing-templates"
+    path="/508/templates"
+    exact
+    component={TestingTemplates}
   />
 );
 
@@ -108,6 +118,7 @@ const Accessibility = () => {
             NewRequest,
             AllRequests,
             AccessibilityTestingOverview,
+            AccessibilityTestingTemplates,
             NewDocument,
             UpdateTestDate,
             NewTestDate,
@@ -122,6 +133,7 @@ const Accessibility = () => {
         {[
           NewRequest,
           AccessibilityTestingOverview,
+          AccessibilityTestingTemplates,
           NewDocument,
           RequestDetails,
           Default


### PR DESCRIPTION
# ES-500

## Changes proposed in this pull request

Creates a new static page for Testing Templates at `508/templates`. 

## Reviewer Notes

I pulled out some of the sections into variables for better readability.  Would it make sense to pull any of it out into components?

Please check that I have all the required accessibility code, labels, etc.

## Setup

Go to `508/templates` as a business owner to view the page.  Be sure to check all the links.

## Code Review Verification Steps

### As the original developer, I have

- [ ] Tested user-facing changes with voice-over
- [ ] Checked for landmarks, page heading structure and links using rotor menu
- [ ] Requested a design review for user-facing changes
- [ ] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked accessibility against criteria
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

## How-to rotor menu

1. Turn voice over on `cmd + F5`
1. Open rotor menu `ctrl + option + U` (you’ll see a panel appear)
1. Use :arrow_left: and :arrow_right: to cycle through the rotor menu
1. Use :arrow_up: and :arrow_down: to move down that rotor view
1. When you are done you can dismiss the rotor menu by hitting Esc
1. Turn voice over off `cmd + F5`

## Screenshots

![image](https://user-images.githubusercontent.com/13249580/118564919-18f0b300-b726-11eb-90f5-10b6e088781f.png)

