### PR TITLE
add links to get to the 508 templates page

### DIFF
--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -41,6 +41,7 @@ const accessibility = {
     },
     documentUpload: 'Upload a document',
     other: 'Other request details',
+    testingTemplates: '508 testing templates (opens in a new tab)',
     testingSteps: 'Steps involved in 508 testing (opens in a new tab)',
     remove: 'Remove this request from EASi',
     modal: {
@@ -132,7 +133,7 @@ const accessibility = {
     prepareVPAT: {
       heading: 'Prepare and upload the VPAT and Test plan',
       fillOutVPAT:
-        'Download and fill the VPAT and Test plan from the templates page. These documents will help the 508 team prepare for testing. Uploaded your completed documents to EASi for the 508 team to review.',
+        'Download and fill the VPAT and Test plan from the <1>templates page (opens in a new tab)</1>. These documents will help the 508 team prepare for testing. Uploaded your completed documents to EASi for the 508 team to review.',
       changesVPAT:
         'The 508 team will get back to you via email about any changes needed prior to testing.'
     },

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -227,6 +227,14 @@ const AccessibilityRequestDetailPage = () => {
                 className="display-inline-block margin-top-3"
                 target="_blank"
                 rel="noopener noreferrer"
+                href="/508/templates"
+              >
+                {t('requestDetails.testingTemplates')}
+              </UswdsLink>
+              <UswdsLink
+                className="display-inline-block margin-top-3"
+                target="_blank"
+                rel="noopener noreferrer"
                 href="/508/testing-overview"
               >
                 {t('requestDetails.testingSteps')}

--- a/src/views/Accessibility/AccessibilityTestingStepsOverview/__snapshots__/index.test.tsx.snap
+++ b/src/views/Accessibility/AccessibilityTestingStepsOverview/__snapshots__/index.test.tsx.snap
@@ -62,11 +62,16 @@ exports[`The accessibility testing overview matches the snapshot 1`] = `
           <div
             className="line-height-body-4"
           >
-            <p
-              className="margin-0"
+            Download and fill the VPAT and Test plan from the 
+            <a
+              className="usa-link"
+              href="/508/templates"
+              rel="noopener noreferrer"
+              target="_blank"
             >
-              Download and fill the VPAT and Test plan from the templates page. These documents will help the 508 team prepare for testing. Uploaded your completed documents to EASi for the 508 team to review.
-            </p>
+              templates page (opens in a new tab)
+            </a>
+            . These documents will help the 508 team prepare for testing. Uploaded your completed documents to EASi for the 508 team to review.
             <p
               className="margin-bottom-0"
             >

--- a/src/views/Accessibility/AccessibilityTestingStepsOverview/index.tsx
+++ b/src/views/Accessibility/AccessibilityTestingStepsOverview/index.tsx
@@ -43,9 +43,20 @@ const AccessibilityTestingStepsOverview = () => {
               {t('testingStepsOverview.prepareVPAT.heading')}
             </StepHeading>
             <StepBody>
-              <p className="margin-0">
-                {t('testingStepsOverview.prepareVPAT.fillOutVPAT')}
-              </p>
+              <Trans
+                i18nKey="accessibility:testingStepsOverview.prepareVPAT.fillOutVPAT"
+                className="margin-0"
+              >
+                indexZero
+                <Link
+                  href="/508/templates"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  templatesLink
+                </Link>
+                indexTwo
+              </Trans>
               <p className="margin-bottom-0">
                 {t('testingStepsOverview.prepareVPAT.changesVPAT')}
               </p>


### PR DESCRIPTION
# ES-611

**_#1040 needs to be merged first so that the page exists._**

This PR adds 2 links that help a user get to the 508 Templates page.

1. 508 Request Details page - Sidebar
2. 508 Testing Overview page - link inside paragraph

## Reviewer Notes

- Test that links properly navigate to the page in a new tab

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over
- [ ] Checked for landmarks, page heading structure and links using rotor menu
- [ ] Requested a design review for user-facing changes
- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Made it clear which comments need to be addressed before this work is merged
- [x] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked accessibility against criteria
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

## How-to rotor menu

1. Turn voice over on `cmd + F5`
1. Open rotor menu `ctrl + option + U` (you’ll see a panel appear)
1. Use :arrow_left: and :arrow_right: to cycle through the rotor menu
1. Use :arrow_up: and :arrow_down: to move down that rotor view
1. When you are done you can dismiss the rotor menu by hitting Esc
1. Turn voice over off `cmd + F5`

## Screenshots
508 request details page
![Screen Shot 2021-05-18 at 9 42 36 AM](https://user-images.githubusercontent.com/8367504/118691100-94517380-b7bd-11eb-8b7d-31e0692679b9.png)

508 testing overview page
![Screen Shot 2021-05-18 at 9 43 22 AM](https://user-images.githubusercontent.com/8367504/118691132-9b788180-b7bd-11eb-8522-98279ffb9f1a.png)

