### PR TITLE
change 508 request creation confirmation location

### DIFF
--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -112,7 +112,8 @@ const accessibility = {
     info:
       'A request for 508 testing will be added to the list of 508 requests. An email will be sent to the Business Owner and the 508 team stating that a request has been added to the system.',
     submitBtn: 'Add a new request',
-    confirmation: '{{-requestName}} was added to the 508 requests page'
+    confirmation:
+      '508 testing request created. We have sent you a confirmation email.'
   },
   removeAccessibilityRequest: {
     reason: 'Reason for removal',

--- a/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
@@ -53,10 +53,13 @@ const Create = () => {
           intakeID: values.intakeId
         }
       }
-    }).then(res => {
-      const uuid = res.data.createAccessibilityRequest.accessibilityRequest.id;
-      showMessageOnNextPage(t('newRequestForm.confirmation'));
-      history.push(`/508/requests/${uuid}`);
+    }).then(response => {
+      if (!response.errors) {
+        const uuid =
+          response.data.createAccessibilityRequest.accessibilityRequest.id;
+        showMessageOnNextPage(t('newRequestForm.confirmation'));
+        history.push(`/508/requests/${uuid}`);
+      }
     });
   };
 

--- a/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibiltyRequest/Create/index.tsx
@@ -53,13 +53,10 @@ const Create = () => {
           intakeID: values.intakeId
         }
       }
-    }).then(() => {
-      showMessageOnNextPage(
-        t('newRequestForm.confirmation', {
-          requestName: values.requestName
-        })
-      );
-      history.push('/');
+    }).then(res => {
+      const uuid = res.data.createAccessibilityRequest.accessibilityRequest.id;
+      showMessageOnNextPage(t('newRequestForm.confirmation'));
+      history.push(`/508/requests/${uuid}`);
     });
   };
 


### PR DESCRIPTION
# ES-663

- 508 Request creation now redirects users to the Request Details instead of home
- Update the confirmation message to `508 testing request created. We have sent you a confirmation email.`, as described in Figma

## Code Review Verification Steps

### As the original developer, I have
-  [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Made it clear which comments need to be addressed before this work is merged
- [x] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked accessibility against criteria
- [ ] Tried to break the intended flow
