### PR TITLE
Add empty state and tests for my request table

### DIFF
--- a/src/i18n/en-US/home.ts
+++ b/src/i18n/en-US/home.ts
@@ -21,6 +21,7 @@ const home = {
     }
   },
   requestsTable: {
+    empty: 'Requests will display in a table once you add them',
     breadcrumb: {
       home: 'Home',
       table: 'My governance requests'

--- a/src/views/MyRequests/Table.test.tsx
+++ b/src/views/MyRequests/Table.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { MemoryRouter } from 'react-router-dom';
+import { MockedProvider } from '@apollo/client/testing';
+import { mount, ReactWrapper } from 'enzyme';
+import GetRequestsQuery from 'queries/GetRequestsQuery';
+
+import Table from './Table';
+
+describe('My Requests Table', () => {
+  describe('when there are no requests', () => {
+    it('displays an empty message', async () => {
+      const mocks = [
+        {
+          request: {
+            query: GetRequestsQuery,
+            variables: { first: 20 }
+          },
+          result: {}
+        }
+      ];
+
+      let component: ReactWrapper;
+      await act(async () => {
+        component = mount(
+          <MockedProvider mocks={mocks}>
+            <Table />
+          </MockedProvider>
+        );
+        await new Promise(resolve => setTimeout(resolve, 0));
+        component.update();
+      });
+
+      expect(component.find('p').exists()).toBeTruthy();
+      expect(component.find('table').exists()).toBeFalsy();
+    });
+  });
+
+  describe('when there are requests', () => {
+    const mocks = [
+      {
+        request: {
+          query: GetRequestsQuery,
+          variables: { first: 20 }
+        },
+        result: {
+          data: {
+            requests: {
+              edges: [
+                {
+                  node: {
+                    id: '123',
+                    name: '508 Test 1',
+                    submittedAt: '2021-05-25T19:22:40Z',
+                    type: 'ACCESSIBILITY_REQUEST'
+                  }
+                },
+                {
+                  node: {
+                    id: '456',
+                    name: 'Intake 1',
+                    submittedAt: '2021-05-22T19:22:40Z',
+                    type: 'GOVERNANCE_REQUEST'
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ];
+
+    const renderComponent = async () => {
+      let component: ReactWrapper;
+      await act(async () => {
+        component = mount(
+          <MemoryRouter>
+            <MockedProvider mocks={mocks} addTypename={false}>
+              <Table />
+            </MockedProvider>
+          </MemoryRouter>
+        );
+        await new Promise(resolve => setTimeout(resolve, 0));
+        component.update();
+      });
+      return component;
+    };
+
+    it('displays a table', async () => {
+      const component = await renderComponent();
+      expect(component.find('p').exists()).toBeFalsy();
+      expect(component.find('table').exists()).toBeTruthy();
+    });
+
+    it('displays headers', async () => {
+      const component = await renderComponent();
+      const headers = component.find('thead').find('th');
+      expect(headers.length).toEqual(3);
+      expect(headers.at(0).text()).toEqual('Request name');
+      expect(headers.at(1).text()).toEqual('Governance');
+      expect(headers.at(2).text()).toEqual('Submission date');
+    });
+
+    it('displays rows of data', async () => {
+      const component = await renderComponent();
+      const rows = component.find('tbody').find('tr');
+      expect(rows.length).toEqual(2);
+
+      const rowOne = rows.at(0);
+      expect(rowOne.find('th').find('a').html()).toEqual(
+        '<a class="usa-link" href="/508/requests/123">508 Test 1</a>'
+      );
+      expect(rowOne.find('td').at(0).text()).toEqual('Section 508');
+      expect(rowOne.find('td').at(1).text()).toEqual('May 25 2021');
+
+      const rowTwo = rows.at(1);
+      expect(rowTwo.find('th').find('a').html()).toEqual(
+        '<a class="usa-link" href="/governance-task-list/456">Intake 1</a>'
+      );
+      expect(rowTwo.find('td').at(0).text()).toEqual('IT Governance');
+      expect(rowTwo.find('td').at(1).text()).toEqual('May 22 2021');
+    });
+  });
+});

--- a/src/views/MyRequests/Table.tsx
+++ b/src/views/MyRequests/Table.tsx
@@ -153,6 +153,10 @@ const Table = () => {
     return <div>{JSON.stringify(error)}</div>;
   }
 
+  if (data.length === 0) {
+    return <p>{t('requestsTable.empty')}</p>;
+  }
+
   return (
     <div className="accessibility-requests-table">
       <UswdsTable bordered={false} {...getTableProps()} fullWidth>


### PR DESCRIPTION
# ES-504

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

## Changes proposed in this pull request

- Add code to cover the state of when the table is empty
- Add tests!

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over
- [x] Checked for landmarks, page heading structure and links using rotor menu
- [x] Requested a design review for user-facing changes
- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [x] Checked in the design translated visually
- [x] Checked behavior
- [x] Checked different states (empty, one, some, error)
- [x] Checked accessibility against criteria
- [x] Checked for landmarks, page heading structure, and links
- [x] Tried to break the intended flow

## How-to rotor menu

1. Turn voice over on `cmd + F5`
1. Open rotor menu `ctrl + option + U` (you’ll see a panel appear)
1. Use :arrow_left: and :arrow_right: to cycle through the rotor menu
1. Use :arrow_up: and :arrow_down: to move down that rotor view
1. When you are done you can dismiss the rotor menu by hitting Esc
1. Turn voice over off `cmd + F5`

## Screenshots

<img width="1164" alt="Screen Shot 2021-05-25 at 12 40 40 PM" src="https://user-images.githubusercontent.com/4434681/119558588-6dafb180-bd56-11eb-8008-55fbc8380de2.png">

