### PR TITLE
Add --build flag to docker-compose up

### DIFF
--- a/scripts/dev
+++ b/scripts/dev
@@ -105,12 +105,12 @@ def up(*args)
   environment = {
     "COMPOSE_HTTP_TIMEOUT" => "120"
   }
-  command = "docker-compose up"
-  
+  command = "docker-compose up --build"
+
   if args.any?
     command = "#{command} #{args.join(' ')}"
   end
-  
+
   sh(environment, command, verbose: true)
 
   # Avoid open file limits


### PR DESCRIPTION
# ES-000

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

## Changes proposed in this pull request

- Add the `--build` flag to `docker-compose up` to ensure that images are rebuilt when the underlying dockerfiles
have been modified. I've run into situations where the `scripts/dev down` and `scripts/dev up` sequence uses the cached images and doesn't rebuild the images when I've made modifications to the docker files. Adding the `--build` flag only adds a little bit of extra time to the docker-compose up process. Docker compose will only rebuild an image when necessary; this won't cause all the images to be rebuilt every time.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->


