### PR TITLE
Remove components inside component and use jsx object

### DIFF
--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -127,7 +127,7 @@ const AccessibilityRequestDetailPage = () => {
   const isAccessibilityTeam = user.isAccessibilityTeam(userGroups, flags);
   const hasDocuments = documents.length > 0;
 
-  const UploadDocumentLink = () => (
+  const uploadDocumentLink = (
     <UswdsLink
       className="usa-button"
       variant="unstyled"
@@ -138,10 +138,10 @@ const AccessibilityRequestDetailPage = () => {
     </UswdsLink>
   );
 
-  const BodyWithDocuments = () => (
+  const bodyWithDocuments = (
     <>
       <h2 className="margin-top-0">{t('requestDetails.documents.label')}</h2>
-      <UploadDocumentLink />
+      {uploadDocumentLink}
       <div className="margin-top-6">
         <AccessibilityDocumentsList
           documents={documents}
@@ -153,7 +153,7 @@ const AccessibilityRequestDetailPage = () => {
     </>
   );
 
-  const BodyNoDocuments = () => (
+  const bodyNoDocuments = (
     <>
       <div className="margin-bottom-3">
         <h2 className="margin-y-0 font-heading-lg">
@@ -174,7 +174,7 @@ const AccessibilityRequestDetailPage = () => {
           </Trans>
         </p>
       </div>
-      <UploadDocumentLink />
+      {uploadDocumentLink}
     </>
   );
 
@@ -213,7 +213,7 @@ const AccessibilityRequestDetailPage = () => {
       <PageHeading>{requestName}</PageHeading>
       <div className="grid-row grid-gap-lg">
         <div className="grid-col-8">
-          {hasDocuments ? <BodyWithDocuments /> : <BodyNoDocuments />}
+          {hasDocuments ? bodyWithDocuments : bodyNoDocuments}
         </div>
         <div className="grid-col-1" />
         <div className="grid-col-3">


### PR DESCRIPTION
# ES-665 - remediation

## Changes proposed in this pull request

Based on feedback viewed post-merge of this [PR](https://github.com/CMSgov/easi-app/pull/1066#issuecomment-848190318), I'm removing the jsx objects defined as components inside of the parent component and just setting the object to a variable.

## Reviewer Notes

change based on this reasoning (via Chris):

  "basically, if create a component within a component, every time the parent component re-renders, the child component 
  will get recreated. this means any state will be lost.
  that’s come back to haunt us a handful of times already. it’s not the easiest bug to figure out either"

## Setup

none (but to double check the render, go to a request without documents, and then add one)

## Code Review Verification Steps

### As the original developer, I have

- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Made it clear which comments need to be addressed before this work is merged
- [x] Considered marking this as accepted even if there are small changes needed
