### PR TITLE
add updated confirmation text for 508 request creation

### DIFF
--- a/src/components/shared/Alert/index.test.tsx
+++ b/src/components/shared/Alert/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
-import Alert from './index';
+import Alert, { AlertText } from './index';
 
 describe('The Alert component', () => {
   it('renders without crashing', () => {
@@ -15,10 +15,47 @@ describe('The Alert component', () => {
     expect(component.find('h3').text()).toEqual('Hello');
   });
 
-  it('renders children', () => {
-    const component = shallow(<Alert type="success">Hello</Alert>);
+  describe('children', () => {
+    it('renders string children', () => {
+      const component = mount(<Alert type="success">Hello</Alert>);
 
-    expect(component.find('p').exists()).toEqual(true);
-    expect(component.find('p').text()).toEqual('Hello');
+      expect(component.find('p').exists()).toEqual(true);
+      expect(component.find('p').text()).toEqual('Hello');
+    });
+  });
+
+  it('renders JSX children', () => {
+    const component = shallow(
+      <Alert type="success">
+        <div data-testid="test-child">Hello</div>
+      </Alert>
+    );
+
+    expect(component.find('p').exists()).toEqual(false);
+    expect(component.find('[data-testid="test-child"]').text()).toEqual(
+      'Hello'
+    );
+  });
+});
+
+describe('The AlertText component', () => {
+  it('renders without crashing', () => {
+    shallow(<AlertText>Hello</AlertText>);
+  });
+
+  it('renders custom class name', () => {
+    const component = shallow(
+      <AlertText className="test-class">Hello</AlertText>
+    );
+
+    expect(component.find('.test-class').exists()).toEqual(true);
+  });
+
+  it('renders custom HTML attributes', () => {
+    const component = shallow(
+      <AlertText aria-label="I am aria label">Hello</AlertText>
+    );
+
+    expect(component.props()['aria-label']).toEqual('I am aria label');
   });
 });

--- a/src/components/shared/Alert/index.tsx
+++ b/src/components/shared/Alert/index.tsx
@@ -10,6 +10,22 @@ interface AlertProps {
   inline?: boolean;
 }
 
+type AlertTextProps = {
+  className?: string;
+  children: React.ReactNode;
+} & JSX.IntrinsicElements['p'];
+
+export const AlertText = ({
+  className,
+  children,
+  ...props
+}: AlertTextProps) => {
+  return (
+    <p className={classnames('usa-alert__text', className)} {...props}>
+      {children}
+    </p>
+  );
+};
 export const Alert = ({
   type,
   heading,
@@ -33,11 +49,21 @@ export const Alert = ({
     className
   );
 
+  const renderChildren = () => {
+    if (children) {
+      if (typeof children === 'string') {
+        return <AlertText>{children}</AlertText>;
+      }
+      return children;
+    }
+    return <></>;
+  };
+
   return (
     <div className={classes} data-testid="alert">
       <div className="usa-alert__body">
         {heading && <h3 className="usa-alert__heading">{heading}</h3>}
-        {children && <p className="usa-alert__text">{children}</p>}
+        {renderChildren()}
       </div>
     </div>
   );

--- a/src/components/shared/Alert/index.tsx
+++ b/src/components/shared/Alert/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import classnames from 'classnames';
 
-interface AlertProps {
+type AlertProps = {
   type: 'success' | 'warning' | 'error' | 'info';
   heading?: React.ReactNode;
   children?: React.ReactNode;
   slim?: boolean;
   noIcon?: boolean;
   inline?: boolean;
-}
+} & JSX.IntrinsicElements['div'];
 
 type AlertTextProps = {
   className?: string;
@@ -33,7 +33,8 @@ export const Alert = ({
   slim,
   noIcon,
   className,
-  inline
+  inline,
+  ...props
 }: AlertProps & React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
   const classes = classnames(
     'usa-alert',
@@ -60,7 +61,7 @@ export const Alert = ({
   };
 
   return (
-    <div className={classes} data-testid="alert">
+    <div className={classes} data-testid="alert" {...props}>
       <div className="usa-alert__body">
         {heading && <h3 className="usa-alert__heading">{heading}</h3>}
         {renderChildren()}

--- a/src/hooks/useMessage.tsx
+++ b/src/hooks/useMessage.tsx
@@ -9,9 +9,9 @@ import { useLocation } from 'react-router-dom';
 
 const MessageContext = createContext<
   | {
-      message: string | undefined;
-      showMessage: (message: string) => void;
-      showMessageOnNextPage: (message: string) => void;
+      message: string | React.ReactNode | undefined;
+      showMessage: (message: string | React.ReactNode) => void;
+      showMessageOnNextPage: (message: string | React.ReactNode) => void;
     }
   | undefined
 >(undefined);
@@ -19,8 +19,10 @@ const MessageContext = createContext<
 // MessageProvider manages the state necessary for child components to
 // use the useMessage hook.
 const MessageProvider = ({ children }: { children: ReactNode }) => {
-  const [queuedMessage, setQueuedMessage] = useState<string>();
-  const [message, setMessage] = useState<string>();
+  const [queuedMessage, setQueuedMessage] = useState<
+    string | React.ReactNode
+  >();
+  const [message, setMessage] = useState<string | React.ReactNode>();
   const location = useLocation();
 
   const [lastPathname, setLastPathname] = useState(location.pathname);

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -117,7 +117,8 @@ const accessibility = {
       'A request for 508 testing will be added to the list of 508 requests. An email will be sent to the Business Owner and the 508 team stating that a request has been added to the system.',
     submitBtn: 'Add a new request',
     confirmation:
-      '508 testing request created. We have sent you a confirmation email.'
+      '508 testing request created. We have sent you a confirmation email.',
+    surveyLink: 'Tell us what you think of this service (opens in a new tab)'
   },
   removeAccessibilityRequest: {
     reason: 'Reason for removal',

--- a/src/views/Accessibility/AccessibilityRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Create/index.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
-import { Button, ComboBox } from '@trussworks/react-uswds';
+import { Button, ComboBox, Link } from '@trussworks/react-uswds';
 import {
   Field as FormikField,
   Form as FormikForm,
@@ -19,6 +19,7 @@ import {
 
 import PageHeading from 'components/PageHeading';
 import PlainInfo from 'components/PlainInfo';
+import { AlertText } from 'components/shared/Alert';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
@@ -57,7 +58,19 @@ const Create = () => {
       if (!response.errors) {
         const uuid =
           response.data.createAccessibilityRequest.accessibilityRequest.id;
-        showMessageOnNextPage(t('newRequestForm.confirmation'));
+        showMessageOnNextPage(
+          <>
+            <AlertText>{t('newRequestForm.confirmation')}</AlertText>
+            <br />
+            <Link
+              href="https://www.surveymonkey.com/r/3R6MXSW"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Tell us what you think of this service (opens in a new tab)
+            </Link>
+          </>
+        );
         history.push(`/508/requests/${uuid}`);
       }
     });

--- a/src/views/Accessibility/AccessibilityRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Create/index.tsx
@@ -67,7 +67,7 @@ const Create = () => {
               target="_blank"
               rel="noopener noreferrer"
             >
-              Tell us what you think of this service (opens in a new tab)
+              {t('newRequestForm.surveyLink')}
             </Link>
           </>
         );

--- a/src/views/Accessibility/AccessibilityRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Create/index.tsx
@@ -60,8 +60,9 @@ const Create = () => {
           response.data.createAccessibilityRequest.accessibilityRequest.id;
         showMessageOnNextPage(
           <>
-            <AlertText>{t('newRequestForm.confirmation')}</AlertText>
-            <br />
+            <AlertText className="margin-bottom-2">
+              {t('newRequestForm.confirmation')}
+            </AlertText>
             <Link
               href="https://www.surveymonkey.com/r/3R6MXSW"
               target="_blank"

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
-import { Alert, Button, Link as UswdsLink } from '@trussworks/react-uswds';
+import { Button, Link as UswdsLink } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 import { DateTime } from 'luxon';
@@ -25,6 +25,7 @@ import AccessibilityDocumentsList from 'components/AccessibilityDocumentsList';
 import BreadcrumbNav from 'components/BreadcrumbNav';
 import Modal from 'components/Modal';
 import PageHeading from 'components/PageHeading';
+import Alert from 'components/shared/Alert';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
@@ -206,7 +207,12 @@ const AccessibilityRequestDetailPage = () => {
         <li>{requestName}</li>
       </BreadcrumbNav>
       {message && (
-        <Alert className="margin-top-4" type="success" role="alert">
+        <Alert
+          className="margin-top-4"
+          type="success"
+          role="alert"
+          heading="Success"
+        >
           {message}
         </Alert>
       )}


### PR DESCRIPTION
# ES-680

This PR updates the 508 request creation confirmation message to include a survey link

- update `useMessage` hook to accept `React.ReactNode` in addition to a `string`
- update `Alert` to recognize whether `children` is a `string` or JSX
    - Plan is to make similar changes in the ReactUSWDS Alert component then use the library component
- add proper markup for the confirmation message changes

**Adding the survey link to the email template will come in a separate PR**

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over
- [x] Checked for landmarks, page heading structure and links using rotor menu
- [x] Requested a design review for user-facing changes
- [x] Met the acceptance criteria, or will meet them in a subsequent PR


### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Made it clear which comments need to be addressed before this work is merged
- [x] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked accessibility against criteria
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

![Screen Shot 2021-05-26 at 2 53 42 PM](https://user-images.githubusercontent.com/8367504/119736163-2b5ba280-be32-11eb-8cd8-0860ed945451.png)

