### PR TITLE
fix LD flag types

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,9 +1,13 @@
+import { Flags } from './types/flags';
+
 declare module 'react-axe';
 declare module '@okta/okta-signin-widget';
 declare module '@okta/okta-signin-widget/dist/js/okta-sign-in.min';
 declare module '*.doc';
 declare module '*.docx';
-
+declare module 'launchdarkly-js-sdk-common' {
+  export interface LDFlagSet extends Flags {}
+}
 interface Window {
   Cypress: any;
   store: any;

--- a/src/types/flags.ts
+++ b/src/types/flags.ts
@@ -1,13 +1,13 @@
 export type Flags = {
-  fileUploads: Boolean;
-  sandbox: Boolean;
-  pdfExport: Boolean;
-  prototype508: Boolean;
-  prototypeTRB: Boolean;
-  downgradeGovTeam: Boolean;
-  downgrade508User: Boolean;
-  downgrade508Tester: Boolean;
-  add508Request: Boolean;
+  fileUploads: boolean;
+  sandbox: boolean;
+  pdfExport: boolean;
+  prototype508: boolean;
+  prototypeTRB: boolean;
+  downgradeGovTeam: boolean;
+  downgrade508User: boolean;
+  downgrade508Tester: boolean;
+  add508Request: boolean;
 };
 
 export type FlagsState = {


### PR DESCRIPTION
Ever seen this?
![Screen Shot 2021-05-28 at 11 56 53 AM](https://user-images.githubusercontent.com/8367504/120030111-e196c780-bfab-11eb-884a-6ff3acd37362.png)

LaunchDarkly doesn't support typed flags, so we'll need to do some extra configuration to get that type safety. With the changes in this PR, we're able to get.

![Screen Shot 2021-05-28 at 11 43 11 AM](https://user-images.githubusercontent.com/8367504/120030225-0db24880-bfac-11eb-8793-86bcf7e712d1.png)


## Code Review Verification Steps
- Make sure the app builds
- Make sure your editor is happy (no more red squiggles)


### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
