### PR TITLE
Sort by submitted_at, not created_at

### DIFF
--- a/pkg/storage/requests.go
+++ b/pkg/storage/requests.go
@@ -20,7 +20,6 @@ type Request struct {
 	ID          uuid.UUID
 	Name        null.String
 	SubmittedAt *time.Time        `db:"submitted_at"`
-	CreatedAt   time.Time         `db:"created_at"`
 	Type        model.RequestType `db:"record_type"`
 }
 
@@ -37,8 +36,7 @@ func (s *Store) FetchMyRequests(ctx context.Context) ([]Request, error) {
 			id,
 			name,
 			created_at AS submitted_at,
-			'ACCESSIBILITY_REQUEST' record_type,
-			created_at
+			'ACCESSIBILITY_REQUEST' record_type
 		FROM accessibility_requests
 			WHERE deleted_at IS NULL
 			AND eua_user_id = $1
@@ -47,12 +45,11 @@ func (s *Store) FetchMyRequests(ctx context.Context) ([]Request, error) {
 			id,
 			project_name AS name,
 			submitted_at,
-			'GOVERNANCE_REQUEST' record_type,
-			created_at
+			'GOVERNANCE_REQUEST' record_type
 		FROM system_intakes
 			WHERE archived_at IS NULL
 			AND eua_user_id = $1
-		ORDER BY created_at desc
+		ORDER BY submitted_at desc
 	`
 
 	err := s.db.Select(&requests, requestsSQL, EUAUserID)

--- a/pkg/storage/requests.go
+++ b/pkg/storage/requests.go
@@ -49,7 +49,7 @@ func (s *Store) FetchMyRequests(ctx context.Context) ([]Request, error) {
 		FROM system_intakes
 			WHERE archived_at IS NULL
 			AND eua_user_id = $1
-		ORDER BY submitted_at desc
+		ORDER BY submitted_at desc nulls first
 	`
 
 	err := s.db.Select(&requests, requestsSQL, EUAUserID)


### PR DESCRIPTION
## Changes proposed in this pull request

- Order query by submitted_at date, which is the data point we use in the table
- Not all records have a created_at date, so this query was causing a bug!

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested these changes locally

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
