### PR TITLE
Revert backend code coverage changes

### DIFF
--- a/pkg/graph/schema.resolvers_current_user_test.go
+++ b/pkg/graph/schema.resolvers_current_user_test.go
@@ -7,7 +7,7 @@ import (
 	_ "github.com/lib/pq" // required for postgres driver in sql
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
-	"github.com/cmsgov/easi-app/pkg/authn"
+	"github.com/cmsgov/easi-app/pkg/authentication"
 )
 
 func (s GraphQLTestSuite) TestCurrentUserQuery() {
@@ -30,7 +30,7 @@ func (s GraphQLTestSuite) TestCurrentUserQuery() {
 			}
 		}`, &resp,
 		func(request *client.Request) {
-			principal := authn.EUAPrincipal{EUAID: "ABCD"}
+			principal := authentication.EUAPrincipal{EUAID: "ABCD"}
 			ctx := appcontext.WithPrincipal(context.Background(), &principal)
 			request.HTTP = request.HTTP.WithContext(ctx)
 		},

--- a/scripts/testsuite
+++ b/scripts/testsuite
@@ -7,31 +7,3 @@ builddir="$(git rev-parse --show-toplevel)"
 export EMAIL_TEMPLATE_DIR=$builddir/pkg/email/templates
 
 ( set -x -u ; exec "$builddir"/bin/easi test )
-
-# Convert go-coverage.out to txt and html
-go tool cover -func=go-coverage.out -o "go-coverage.txt"
-go tool cover -html=go-coverage.out -o "go-coverage.html"
-# parse out the total coverage percentage which is on the line with (statements) and strip off the % sign
-# https://unix.stackexchange.com/questions/305190/remove-last-character-from-string-captured-with-awk
-percent=$(grep '(statements)' "go-coverage.txt" | awk '{print substr($NF, 1, length($NF)-1)}')
-# Commenting out threshold percantage and build fail unitl decision
-#goal_percent=50
-# using a oneline python function to test if percent is less than goal and return a proper exit code
-#if python -c "exit(1) if ${percent} < ${goal_percent} else exit()"; then
-    # coverage is good
-    echo "total coverage is ${percent}%"
-#else
-    # coverage is under goal
-    #echo -e "${RED}total coverage has dropped to ${percent}% needs to be at least ${goal_percent}%${NC}"
-    # fail build
-    # commenting out the build failure line since we don't want to fail the build yet until we've had further discussions
-    #exit 1
-#fi
-
-if [ -d "results" ] 
-then
-    mv go-coverage.* results/
-else
-    mkdir -p results
-    mv go-coverage.* results/
-fi


### PR DESCRIPTION
# ES-000

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

## Changes proposed in this pull request

- The recent changes to `scripts/testsuite` meant that unit test errors were being ignored. This PR reverts the recent changes to `scripts/testsuite` and fixes a failing unit test in `pkg/graph/schema.resolvers_current_user_test.go`. 
- We'll open another PR to add the backend code coverage back to `scripts/testsuite` and fix the bug to ensure it fails on any unit test errors.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->