### PR TITLE
Sb refactor tests to use local login

### DIFF
--- a/cmd/devdata/main.go
+++ b/cmd/devdata/main.go
@@ -45,7 +45,7 @@ func main() {
 		panic(storeErr)
 	}
 
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 5; i++ {
 		makeAccessibilityRequest("TACO", store)
 		makeAccessibilityRequest("Big Project", store)
 	}

--- a/cmd/devdata/main.go
+++ b/cmd/devdata/main.go
@@ -82,6 +82,32 @@ func main() {
 		i.Status = models.SystemIntakeStatusNEEDBIZCASE
 	})
 
+	makeSystemIntake("For business case integration test", logger, store, func(i *models.SystemIntake) {
+		i.ID = uuid.MustParse("cd79738d-d453-4e26-a27d-9d2a303e0262")
+		i.EUAUserID = null.StringFrom("TEST")
+		i.Status = models.SystemIntakeStatusNEEDBIZCASE
+		i.RequestType = models.SystemIntakeRequestTypeNEW
+		i.Requester = "John Requester"
+		i.Component = null.StringFrom("Center for Consumer Information and Insurance Oversight")
+		i.BusinessOwner = null.StringFrom("John BusinessOwner")
+		i.BusinessOwnerComponent = null.StringFrom("Center for Consumer Information and Insurance Oversight")
+		i.ProductManager = null.StringFrom("John ProductManager")
+		i.ProductManagerComponent = null.StringFrom("Center for Consumer Information and Insurance Oversight")
+		i.ISSO = null.StringFrom("")
+		i.TRBCollaborator = null.StringFrom("")
+		i.OITSecurityCollaborator = null.StringFrom("")
+		i.EACollaborator = null.StringFrom("")
+		i.ProjectName = null.StringFrom("Easy Access to System Information")
+		i.ExistingFunding = null.BoolFrom(false)
+		i.FundingNumber = null.StringFrom("")
+		i.BusinessNeed = null.StringFrom("Business Need: The quick brown fox jumps over the lazy dog.")
+		i.Solution = null.StringFrom("The quick brown fox jumps over the lazy dog.")
+		i.ProcessStatus = null.StringFrom("The project is already funded")
+		i.EASupportRequest = null.BoolFrom(false)
+		i.ExistingContract = null.StringFrom("No")
+		i.GrtReviewEmailBody = null.StringFrom("")
+	})
+
 	makeBusinessCase("TACO", logger, store, nil)
 
 	intake := makeSystemIntake("Draft Business Case", logger, store, func(i *models.SystemIntake) {

--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -2,7 +2,7 @@ import { formatDate } from '../../src/utils/date';
 
 describe('Accessibility Requests', () => {
   beforeEach(() => {
-    cy.localLogin({name: 'ACES'});
+    cy.localLogin({name: 'A11Y'});
   });
 
   it('can create a request and see its details', () => {

--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -1,18 +1,8 @@
 import { formatDate } from '../../src/utils/date';
 
 describe('Accessibility Requests', () => {
-  before(() => {
-    cy.visit('/login');
-
-    cy.get('[data-testid="LocalAuth-Visit"]').click();
-    cy.get('[data-testid="LocalAuth-EUA"]').type('TEST');
-    cy.get('input[value="EASI_P_USER"]').check();
-    cy.get('[data-testid="LocalAuth-Submit"]').click();
-    cy.saveLocalStorage()
-  });
-
   beforeEach(() => {
-    cy.restoreLocalStorage();
+    cy.localLogin({name: 'ACES', role: 'EASI_P_USER'});
   });
 
   it('can create a request and see its details', () => {

--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -1,9 +1,8 @@
 import { formatDate } from '../../src/utils/date';
-import { BASIC_USER_PROD } from '../../src/constants/jobCodes'
 
 describe('Accessibility Requests', () => {
   beforeEach(() => {
-    cy.localLogin({name: 'ACES', role: BASIC_USER_PROD});
+    cy.localLogin({name: 'ACES'});
   });
 
   it('can create a request and see its details', () => {

--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -1,8 +1,9 @@
 import { formatDate } from '../../src/utils/date';
+import { BASIC_USER_PROD } from '../../src/constants/jobCodes'
 
 describe('Accessibility Requests', () => {
   beforeEach(() => {
-    cy.localLogin({name: 'ACES', role: 'EASI_P_USER'});
+    cy.localLogin({name: 'ACES', role: BASIC_USER_PROD});
   });
 
   it('can create a request and see its details', () => {

--- a/cypress/integration/businessCase.spec.js
+++ b/cypress/integration/businessCase.spec.js
@@ -1,9 +1,11 @@
+import { BASIC_USER_PROD } from '../../src/constants/jobCodes'
+
 describe('The Business Case Form', () => {
   // Data for this intake is set up in cmd/devdata/main.go
   const intakeId = "cd79738d-d453-4e26-a27d-9d2a303e0262"
 
   beforeEach(() => {
-    cy.localLogin({name: 'TEST', role: 'EASI_P_USER'});
+    cy.localLogin({name: 'TEST', role: BASIC_USER_PROD});
     cy.visit(`/governance-task-list/${intakeId}`);
     cy.get('[data-testid="start-biz-case-btn"]').click();
   });

--- a/cypress/integration/businessCase.spec.js
+++ b/cypress/integration/businessCase.spec.js
@@ -1,8 +1,6 @@
-import { BASIC_USER_PROD } from '../../src/constants/jobCodes'
-
 describe('The Business Case Form', () => {
   beforeEach(() => {
-    cy.localLogin({name: 'TEST', role: BASIC_USER_PROD});
+    cy.localLogin({name: 'TEST'});
   });
 
   it('fills out all business case fields', () => {

--- a/cypress/integration/businessCase.spec.js
+++ b/cypress/integration/businessCase.spec.js
@@ -1,52 +1,9 @@
 describe('The Business Case Form', () => {
-  let intakeId;
-  const systemIntake = {
-    status: 'NEED_BIZ_CASE',
-    requestType: 'NEW',
-    requester: 'John Requester',
-    component: 'Center for Consumer Information and Insurance Oversight',
-    businessOwner: 'John BusinessOwner',
-    businessOwnerComponent:
-      'Center for Consumer Information and Insurance Oversight',
-    productManager: 'John ProductManager',
-    productManagerComponent:
-      'Center for Consumer Information and Insurance Oversight',
-    isso: '',
-    trbCollaborator: '',
-    oitSecurityCollaborator: '',
-    eaCollaborator: '',
-    projectName: 'Easy Access to System Information',
-    existingFunding: false,
-    fundingNumber: '',
-    businessNeed: 'Business Need: The quick brown fox jumps over the lazy dog.',
-    solution: 'The quick brown fox jumps over the lazy dog.',
-    processStatus: 'The project is already funded',
-    eaSupportRequest: false,
-    existingContract: 'No',
-    grtReviewEmailBody: ''
-  };
-  before(() => {
-    cy.login();
-    cy.wait(1000);
-    cy.saveLocalStorage().then(() => {
-      cy.getAccessToken().then(accessToken => {
-        cy.request({
-          method: 'POST',
-          url: Cypress.env('systemIntakeApi'),
-          headers: {
-            Authorization: `Bearer ${accessToken}`
-          },
-          body: systemIntake
-        }).then(response => {
-          intakeId = response.body.id;
-        });
-      });
-    });
-  });
+  // Data for this intake is set up in cmd/devdata/main.go
+  const intakeId = "cd79738d-d453-4e26-a27d-9d2a303e0262"
 
   beforeEach(() => {
-    cy.restoreLocalStorage();
-
+    cy.localLogin({name: 'TEST', role: 'EASI_P_USER'});
     cy.visit(`/governance-task-list/${intakeId}`);
     cy.get('[data-testid="start-biz-case-btn"]').click();
   });
@@ -56,17 +13,17 @@ describe('The Business Case Form', () => {
     // Autofilled Fields from System Intake
     cy.get('#BusinessCase-RequestName').should(
       'have.value',
-      systemIntake.projectName
+      'Easy Access to System Information'
     );
 
     cy.get('#BusinessCase-RequesterName').should(
       'have.value',
-      systemIntake.requester
+      'John Requester'
     );
 
     cy.get('#BusinessCase-BusinessOwnerName').should(
       'have.value',
-      systemIntake.businessOwner
+      'John BusinessOwner'
     );
 
     cy.get('#BusinessCase-RequesterPhoneNumber')
@@ -79,7 +36,7 @@ describe('The Business Case Form', () => {
     // Autofilled Field from System Intake
     cy.get('#BusinessCase-BusinessNeed').should(
       'have.value',
-      systemIntake.businessNeed
+      'Business Need: The quick brown fox jumps over the lazy dog.'
     );
 
     cy.get('#BusinessCase-CmsBenefit')

--- a/cypress/integration/businessCase.spec.js
+++ b/cypress/integration/businessCase.spec.js
@@ -1,15 +1,15 @@
 import { BASIC_USER_PROD } from '../../src/constants/jobCodes'
 
 describe('The Business Case Form', () => {
-  // Data for this intake is set up in cmd/devdata/main.go
-  const intakeId = "cd79738d-d453-4e26-a27d-9d2a303e0262"
-
   beforeEach(() => {
     cy.localLogin({name: 'TEST', role: BASIC_USER_PROD});
   });
 
   it('fills out all business case fields', () => {
-    cy.visit(`/governance-task-list/${intakeId}`);
+    cy.visit('/');
+    cy.contains('a', 'Easy Access to System Information').click();
+    cy.contains('h1', 'Get governance approval');
+
     cy.get('[data-testid="start-biz-case-btn"]').click();
 
     // General Request Information

--- a/cypress/integration/businessCase.spec.js
+++ b/cypress/integration/businessCase.spec.js
@@ -6,11 +6,12 @@ describe('The Business Case Form', () => {
 
   beforeEach(() => {
     cy.localLogin({name: 'TEST', role: BASIC_USER_PROD});
-    cy.visit(`/governance-task-list/${intakeId}`);
-    cy.get('[data-testid="start-biz-case-btn"]').click();
   });
 
   it('fills out all business case fields', () => {
+    cy.visit(`/governance-task-list/${intakeId}`);
+    cy.get('[data-testid="start-biz-case-btn"]').click();
+
     // General Request Information
     // Autofilled Fields from System Intake
     cy.get('#BusinessCase-RequestName').should(

--- a/cypress/integration/homepage.js
+++ b/cypress/integration/homepage.js
@@ -1,0 +1,28 @@
+import { ACCESSIBILITY_ADMIN_DEV, ACCESSIBILITY_TESTER_DEV, GOVTEAM_DEV, BASIC_USER_PROD } from '../../src/constants/jobCodes'
+
+describe('Homepage', () => {
+  it('shows the basic homepage for no user roles', () => {
+    cy.localLogin({name: 'USR1'});
+    cy.contains('h2', 'My governance requests');
+  });
+
+  it('shows the basic homepage for basic easi role', () => {
+    cy.localLogin({name: 'USR2', role: BASIC_USER_PROD});
+    cy.contains('h2', 'My governance requests');
+  });
+
+  it('shows the 508 table to 508 admins', () => {
+    cy.localLogin({name: 'USR3', role: ACCESSIBILITY_ADMIN_DEV});
+    cy.contains('h1', '508 Requests');
+  });
+
+  it('shows the 508 table to 508 testers', () => {
+    cy.localLogin({name: 'USR4', role: ACCESSIBILITY_TESTER_DEV});
+    cy.contains('h1', '508 Requests');
+  });
+
+  it('shows the governance table to GRT folks', () => {
+    cy.localLogin({name: 'USR5', role: GOVTEAM_DEV});
+    cy.contains('button', 'Open Requests')
+  });
+});

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -1,3 +1,5 @@
+import { ACCESSIBILITY_ADMIN_DEV } from '../../src/constants/jobCodes'
+
 describe('Logging in', () => {
   it('logs in with okta', () => {
     cy.login();
@@ -5,12 +7,7 @@ describe('Logging in', () => {
   });
 
   it('logs in with local auth', () => {
-    cy.visit('/login');
-
-    cy.get('[data-testid="LocalAuth-Visit"]').click();
-    cy.get('[data-testid="LocalAuth-EUA"]').type('TEST');
-    cy.get('input[value="EASI_D_508_USER"]').check();
-    cy.get('[data-testid="LocalAuth-Submit"]').click();
+    cy.localLogin({name: 'TEST', role: ACCESSIBILITY_ADMIN_DEV});
 
     cy.get('h1', { timeout: 20000 }).should('have.text', '508 Requests');
   });

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -1,5 +1,5 @@
 describe('Logging in', () => {
-  it('logs in', () => {
+  it('logs in with okta', () => {
     cy.login();
     cy.location('pathname', { timeout: 20000 }).should('equal', '/');
   });

--- a/cypress/integration/systemIntake.spec.js
+++ b/cypress/integration/systemIntake.spec.js
@@ -1,18 +1,11 @@
 import cmsGovernanceTeams from '../../src/constants/enums/cmsGovernanceTeams';
 
 describe('The System Intake Form', () => {
-  before(() => {
-    cy.login();
-    // TODO HACK
-    cy.wait(1000);
-    cy.saveLocalStorage();
-  });
-
   beforeEach(() => {
     cy.server();
+    cy.localLogin({name: 'TEST', role: 'EASI_P_USER'});
     cy.route('POST', '/api/v1/system_intake').as('postSystemIntake');
     cy.route('PUT', '/api/v1/system_intake').as('putSystemIntake');
-    cy.restoreLocalStorage();
     cy.visit('/system/new');
   });
 
@@ -69,7 +62,7 @@ describe('The System Intake Form', () => {
       .should('deep.include', {
         requestName: 'Test Request Name',
         requester: {
-          name: 'EASi Testing',
+          name: 'User TEST',
           component: 'Center for Medicare',
           email: ''
         },
@@ -227,7 +220,7 @@ describe('The System Intake Form', () => {
 
     cy.contains('.easi-review-row dt', /^Requester$/)
       .siblings('dd')
-      .contains('EASi Testing');
+      .contains('User TEST');
 
     cy.contains('.easi-review-row dt', 'Requester Component')
       .siblings('dd')

--- a/cypress/integration/systemIntake.spec.js
+++ b/cypress/integration/systemIntake.spec.js
@@ -1,10 +1,9 @@
 import cmsGovernanceTeams from '../../src/constants/enums/cmsGovernanceTeams';
-import { BASIC_USER_PROD } from '../../src/constants/jobCodes'
 
 describe('The System Intake Form', () => {
   beforeEach(() => {
     cy.server();
-    cy.localLogin({name: 'TEST', role: BASIC_USER_PROD});
+    cy.localLogin({name: 'TEST'});
     cy.route('POST', '/api/v1/system_intake').as('postSystemIntake');
     cy.route('PUT', '/api/v1/system_intake').as('putSystemIntake');
     cy.visit('/system/new');

--- a/cypress/integration/systemIntake.spec.js
+++ b/cypress/integration/systemIntake.spec.js
@@ -1,9 +1,10 @@
 import cmsGovernanceTeams from '../../src/constants/enums/cmsGovernanceTeams';
+import { BASIC_USER_PROD } from '../../src/constants/jobCodes'
 
 describe('The System Intake Form', () => {
   beforeEach(() => {
     cy.server();
-    cy.localLogin({name: 'TEST', role: 'EASI_P_USER'});
+    cy.localLogin({name: 'TEST', role: BASIC_USER_PROD});
     cy.route('POST', '/api/v1/system_intake').as('postSystemIntake');
     cy.route('PUT', '/api/v1/system_intake').as('putSystemIntake');
     cy.visit('/system/new');

--- a/cypress/integration/taskList.spec.js
+++ b/cypress/integration/taskList.spec.js
@@ -1,7 +1,9 @@
+import { BASIC_USER_PROD } from '../../src/constants/jobCodes'
+
 describe('The Task List', () => {
   beforeEach(() => {
     cy.server();
-    cy.localLogin({name: 'TEST', role: 'EASI_P_USER'});
+    cy.localLogin({name: 'TEST', role: BASIC_USER_PROD});
     cy.route('POST', '/api/v1/system_intake').as('postSystemIntake');
     cy.route('PUT', '/api/v1/system_intake').as('putSystemIntake');
     cy.visit('/governance-task-list/new');

--- a/cypress/integration/taskList.spec.js
+++ b/cypress/integration/taskList.spec.js
@@ -1,16 +1,9 @@
 describe('The Task List', () => {
-  before(() => {
-    cy.login();
-    // TODO HACK
-    cy.wait(1000);
-    cy.saveLocalStorage();
-  });
-
   beforeEach(() => {
     cy.server();
+    cy.localLogin({name: 'TEST', role: 'EASI_P_USER'});
     cy.route('POST', '/api/v1/system_intake').as('postSystemIntake');
     cy.route('PUT', '/api/v1/system_intake').as('putSystemIntake');
-    cy.restoreLocalStorage();
     cy.visit('/governance-task-list/new');
   });
 

--- a/cypress/integration/taskList.spec.js
+++ b/cypress/integration/taskList.spec.js
@@ -1,9 +1,7 @@
-import { BASIC_USER_PROD } from '../../src/constants/jobCodes'
-
 describe('The Task List', () => {
   beforeEach(() => {
     cy.server();
-    cy.localLogin({name: 'TEST', role: BASIC_USER_PROD});
+    cy.localLogin({name: 'TEST'});
     cy.route('POST', '/api/v1/system_intake').as('postSystemIntake');
     cy.route('PUT', '/api/v1/system_intake').as('putSystemIntake');
     cy.visit('/governance-task-list/new');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,26 +23,3 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
-
-const LOCAL_STORAGE_MEMORY = {};
-
-Cypress.Commands.add('saveLocalStorage', () => {
-  Object.keys(localStorage).forEach(key => {
-    LOCAL_STORAGE_MEMORY[key] = localStorage[key];
-  });
-});
-
-Cypress.Commands.add('restoreLocalStorage', () => {
-  Object.keys(LOCAL_STORAGE_MEMORY).forEach(key => {
-    localStorage.setItem(key, LOCAL_STORAGE_MEMORY[key]);
-  });
-});
-
-Cypress.Commands.add('getAccessToken', () => {
-  if (LOCAL_STORAGE_MEMORY['okta-token-storage']) {
-    const tokenObj = JSON.parse(LOCAL_STORAGE_MEMORY['okta-token-storage']);
-    return cy.wrap(tokenObj.accessToken.value, { log: false });
-  }
-  cy.log('Access Token not found');
-  return cy.wrap('');
-});

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -34,7 +34,9 @@ Cypress.Commands.add('localLogin', ({name, role}) => {
 
   cy.get('[data-testid="LocalAuth-Visit"]').click();
   cy.get('[data-testid="LocalAuth-EUA"]').type(name);
-  cy.get(`input[value="${role}"]`).check();
+  if (role) {
+    cy.get(`input[value="${role}"]`).check();
+  }
   cy.get('[data-testid="LocalAuth-Submit"]').click();
 
   cy.url().should('eq', 'http://localhost:3000/');

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -26,3 +26,16 @@ Cypress.Commands.add('login', () => {
   });
   cy.url().should('eq', 'http://localhost:3000/');
 });
+
+Cypress.Commands.add('localLogin', ({name, role}) => {
+  cy.server();
+
+  cy.visit('/login');
+
+  cy.get('[data-testid="LocalAuth-Visit"]').click();
+  cy.get('[data-testid="LocalAuth-EUA"]').type(name);
+  cy.get(`input[value="${role}"]`).check();
+  cy.get('[data-testid="LocalAuth-Submit"]').click();
+
+  cy.url().should('eq', 'http://localhost:3000/');
+});

--- a/scripts/run-cypress-test-docker
+++ b/scripts/run-cypress-test-docker
@@ -19,7 +19,7 @@ if [[ -n "${CIRCLECI+x}" ]]; then
 
     docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.circleci.yml pull db_migrate easi
 
-    docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.circleci.yml build --parallel easi_client cypress
+    docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.circleci.yml build --parallel easi_client cypress db_seed
 
     docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.circleci.yml up -d db
     docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.circleci.yml up --exit-code-from db_migrate db_migrate


### PR DESCRIPTION
## Changes proposed in this pull request

- Removed the POST request in our business case spec and added the data setup to our seeds file
- Created a helper for local login
- Refactored existing tests to use the new local login helper (we still use Okta for one login test)
- Removed unused support code
- Added homepage tests for each of our personas