### PR TITLE
Build db_seed image for e2e tests

### DIFF
--- a/scripts/run-cypress-test-docker
+++ b/scripts/run-cypress-test-docker
@@ -19,7 +19,7 @@ if [[ -n "${CIRCLECI+x}" ]]; then
 
     docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.circleci.yml pull db_migrate easi
 
-    docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.circleci.yml build --parallel easi_client cypress
+    docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.circleci.yml build --parallel easi_client cypress db_seed
 
     docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.circleci.yml up -d db
     docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.circleci.yml up --exit-code-from db_migrate db_migrate


### PR DESCRIPTION
# ES-000

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

## Changes proposed in this pull request

- Rebuild the db_seed image for e2e tests to ensure we're using an up-to-date version of db_seed rather than a cached version.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->