### PR TITLE
update USWDS sorted table heading color token

### DIFF
--- a/src/stylesheets/_settings.scss
+++ b/src/stylesheets/_settings.scss
@@ -8,5 +8,8 @@ $theme-header-max-width: 'desktop-lg';
 $theme-grid-container-max-width: 'desktop-lg';
 $theme-footer-max-width: 'desktop-lg';
 
-//Override default USWDS body font
+// Override default USWDS body font
 $theme-font-type-sans: 'public-sans';
+
+// Override default sorted header background color
+$theme-table-sorted-header-background-color: 'white';


### PR DESCRIPTION
Updating USWDS introduced some new styles that made table headings a different color.

This PR updates the SCSS token to make it white (like it was before).

**This will remove it for all tables.**

## Code Review Verification Steps

### As the original developer, I have

- [ ] Requested a design review for user-facing changes
- [ ] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Made it clear which comments need to be addressed before this work is merged
- [x] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked accessibility against criteria
