### PR TITLE
Add view to allow 508 team update request status

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -242,6 +242,7 @@ type ComplexityRoot struct {
 		IssueLifecycleID                                 func(childComplexity int, input model.IssueLifecycleIDInput) int
 		MarkSystemIntakeReadyForGrb                      func(childComplexity int, input model.AddGRTFeedbackInput) int
 		RejectIntake                                     func(childComplexity int, input model.RejectIntakeInput) int
+		UpdateAccessibilityRequestStatus                 func(childComplexity int, input *model.UpdateAccessibilityRequestStatus) int
 		UpdateSystemIntakeAdminLead                      func(childComplexity int, input model.UpdateSystemIntakeAdminLeadInput) int
 		UpdateSystemIntakeReviewDates                    func(childComplexity int, input model.UpdateSystemIntakeReviewDatesInput) int
 		UpdateTestDate                                   func(childComplexity int, input model.UpdateTestDateInput) int
@@ -419,6 +420,13 @@ type ComplexityRoot struct {
 		TestType func(childComplexity int) int
 	}
 
+	UpdateAccessibilityRequestStatusPayload struct {
+		ID         func(childComplexity int) int
+		RequestID  func(childComplexity int) int
+		Status     func(childComplexity int) int
+		UserErrors func(childComplexity int) int
+	}
+
 	UpdateSystemIntakePayload struct {
 		SystemIntake func(childComplexity int) int
 		UserErrors   func(childComplexity int) int
@@ -478,6 +486,7 @@ type MutationResolver interface {
 	DeleteAccessibilityRequest(ctx context.Context, input model.DeleteAccessibilityRequestInput) (*model.DeleteAccessibilityRequestPayload, error)
 	CreateAccessibilityRequestDocument(ctx context.Context, input model.CreateAccessibilityRequestDocumentInput) (*model.CreateAccessibilityRequestDocumentPayload, error)
 	DeleteAccessibilityRequestDocument(ctx context.Context, input model.DeleteAccessibilityRequestDocumentInput) (*model.DeleteAccessibilityRequestDocumentPayload, error)
+	UpdateAccessibilityRequestStatus(ctx context.Context, input *model.UpdateAccessibilityRequestStatus) (*model.UpdateAccessibilityRequestStatusPayload, error)
 	CreateSystemIntakeActionBusinessCaseNeeded(ctx context.Context, input model.BasicActionInput) (*model.UpdateSystemIntakePayload, error)
 	CreateSystemIntakeActionBusinessCaseNeedsChanges(ctx context.Context, input model.BasicActionInput) (*model.UpdateSystemIntakePayload, error)
 	CreateSystemIntakeActionGuideReceievedClose(ctx context.Context, input model.BasicActionInput) (*model.UpdateSystemIntakePayload, error)
@@ -1510,6 +1519,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.RejectIntake(childComplexity, args["input"].(model.RejectIntakeInput)), true
 
+	case "Mutation.updateAccessibilityRequestStatus":
+		if e.complexity.Mutation.UpdateAccessibilityRequestStatus == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateAccessibilityRequestStatus_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateAccessibilityRequestStatus(childComplexity, args["input"].(*model.UpdateAccessibilityRequestStatus)), true
+
 	case "Mutation.updateSystemIntakeAdminLead":
 		if e.complexity.Mutation.UpdateSystemIntakeAdminLead == nil {
 			break
@@ -2313,6 +2334,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TestDate.TestType(childComplexity), true
 
+	case "UpdateAccessibilityRequestStatusPayload.id":
+		if e.complexity.UpdateAccessibilityRequestStatusPayload.ID == nil {
+			break
+		}
+
+		return e.complexity.UpdateAccessibilityRequestStatusPayload.ID(childComplexity), true
+
+	case "UpdateAccessibilityRequestStatusPayload.requestID":
+		if e.complexity.UpdateAccessibilityRequestStatusPayload.RequestID == nil {
+			break
+		}
+
+		return e.complexity.UpdateAccessibilityRequestStatusPayload.RequestID(childComplexity), true
+
+	case "UpdateAccessibilityRequestStatusPayload.status":
+		if e.complexity.UpdateAccessibilityRequestStatusPayload.Status == nil {
+			break
+		}
+
+		return e.complexity.UpdateAccessibilityRequestStatusPayload.Status(childComplexity), true
+
+	case "UpdateAccessibilityRequestStatusPayload.userErrors":
+		if e.complexity.UpdateAccessibilityRequestStatusPayload.UserErrors == nil {
+			break
+		}
+
+		return e.complexity.UpdateAccessibilityRequestStatusPayload.UserErrors(childComplexity), true
+
 	case "UpdateSystemIntakePayload.systemIntake":
 		if e.complexity.UpdateSystemIntakePayload.SystemIntake == nil {
 			break
@@ -2479,6 +2528,24 @@ type AccessibilityRequestStatusRecord {
   id: UUID!
   requestID: UUID!
   status: AccessibilityRequestStatus!
+}
+
+"""
+Parameters for updating a 508/accessibility request's status
+"""
+input UpdateAccessibilityRequestStatus {
+  requestID: UUID!
+  status: AccessibilityRequestStatus!
+}
+
+"""
+ Result of updating an accessibiiity request's status
+ """
+type UpdateAccessibilityRequestStatusPayload {
+  id: UUID!
+  requestID: UUID!
+  status: AccessibilityRequestStatus!
+  userErrors: [UserError!]
 }
 
 """
@@ -3040,6 +3107,7 @@ type Mutation {
     input: CreateAccessibilityRequestDocumentInput!
   ): CreateAccessibilityRequestDocumentPayload
   deleteAccessibilityRequestDocument(input: DeleteAccessibilityRequestDocumentInput!): DeleteAccessibilityRequestDocumentPayload
+  updateAccessibilityRequestStatus(input: UpdateAccessibilityRequestStatus) : UpdateAccessibilityRequestStatusPayload @hasRole(role: EASI_508_TESTER_OR_USER)
   createSystemIntakeActionBusinessCaseNeeded(input: BasicActionInput!): UpdateSystemIntakePayload @hasRole(role: EASI_GOVTEAM)
   createSystemIntakeActionBusinessCaseNeedsChanges(input: BasicActionInput!): UpdateSystemIntakePayload @hasRole(role: EASI_GOVTEAM)
   createSystemIntakeActionGuideReceievedClose(input: BasicActionInput!): UpdateSystemIntakePayload @hasRole(role: EASI_GOVTEAM)
@@ -3472,6 +3540,21 @@ func (ec *executionContext) field_Mutation_rejectIntake_args(ctx context.Context
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNRejectIntakeInput2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐRejectIntakeInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_updateAccessibilityRequestStatus_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *model.UpdateAccessibilityRequestStatus
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalOUpdateAccessibilityRequestStatus2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUpdateAccessibilityRequestStatus(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -7273,6 +7356,69 @@ func (ec *executionContext) _Mutation_deleteAccessibilityRequestDocument(ctx con
 	res := resTmp.(*model.DeleteAccessibilityRequestDocumentPayload)
 	fc.Result = res
 	return ec.marshalODeleteAccessibilityRequestDocumentPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐDeleteAccessibilityRequestDocumentPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_updateAccessibilityRequestStatus(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_updateAccessibilityRequestStatus_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().UpdateAccessibilityRequestStatus(rctx, args["input"].(*model.UpdateAccessibilityRequestStatus))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "EASI_508_TESTER_OR_USER")
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.HasRole == nil {
+				return nil, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, role)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*model.UpdateAccessibilityRequestStatusPayload); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/cmsgov/easi-app/pkg/graph/model.UpdateAccessibilityRequestStatusPayload`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.UpdateAccessibilityRequestStatusPayload)
+	fc.Result = res
+	return ec.marshalOUpdateAccessibilityRequestStatusPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUpdateAccessibilityRequestStatusPayload(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_createSystemIntakeActionBusinessCaseNeeded(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -12006,6 +12152,143 @@ func (ec *executionContext) _TestDate_testType(ctx context.Context, field graphq
 	return ec.marshalNTestDateTestType2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTestDateTestType(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _UpdateAccessibilityRequestStatusPayload_id(ctx context.Context, field graphql.CollectedField, obj *model.UpdateAccessibilityRequestStatusPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "UpdateAccessibilityRequestStatusPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uuid.UUID)
+	fc.Result = res
+	return ec.marshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _UpdateAccessibilityRequestStatusPayload_requestID(ctx context.Context, field graphql.CollectedField, obj *model.UpdateAccessibilityRequestStatusPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "UpdateAccessibilityRequestStatusPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RequestID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uuid.UUID)
+	fc.Result = res
+	return ec.marshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _UpdateAccessibilityRequestStatusPayload_status(ctx context.Context, field graphql.CollectedField, obj *model.UpdateAccessibilityRequestStatusPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "UpdateAccessibilityRequestStatusPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(models.AccessibilityRequestStatus)
+	fc.Result = res
+	return ec.marshalNAccessibilityRequestStatus2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐAccessibilityRequestStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _UpdateAccessibilityRequestStatusPayload_userErrors(ctx context.Context, field graphql.CollectedField, obj *model.UpdateAccessibilityRequestStatusPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "UpdateAccessibilityRequestStatusPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UserErrors, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.UserError)
+	fc.Result = res
+	return ec.marshalOUserError2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUserErrorᚄ(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _UpdateSystemIntakePayload_systemIntake(ctx context.Context, field graphql.CollectedField, obj *model.UpdateSystemIntakePayload) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -13739,6 +14022,34 @@ func (ec *executionContext) unmarshalInputRejectIntakeInput(ctx context.Context,
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateAccessibilityRequestStatus(ctx context.Context, obj interface{}) (model.UpdateAccessibilityRequestStatus, error) {
+	var it model.UpdateAccessibilityRequestStatus
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "requestID":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requestID"))
+			it.RequestID, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "status":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
+			it.Status, err = ec.unmarshalNAccessibilityRequestStatus2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐAccessibilityRequestStatus(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateSystemIntakeAdminLeadInput(ctx context.Context, obj interface{}) (model.UpdateSystemIntakeAdminLeadInput, error) {
 	var it model.UpdateSystemIntakeAdminLeadInput
 	var asMap = obj.(map[string]interface{})
@@ -14898,6 +15209,8 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec._Mutation_createAccessibilityRequestDocument(ctx, field)
 		case "deleteAccessibilityRequestDocument":
 			out.Values[i] = ec._Mutation_deleteAccessibilityRequestDocument(ctx, field)
+		case "updateAccessibilityRequestStatus":
+			out.Values[i] = ec._Mutation_updateAccessibilityRequestStatus(ctx, field)
 		case "createSystemIntakeActionBusinessCaseNeeded":
 			out.Values[i] = ec._Mutation_createSystemIntakeActionBusinessCaseNeeded(ctx, field)
 		case "createSystemIntakeActionBusinessCaseNeedsChanges":
@@ -16085,6 +16398,45 @@ func (ec *executionContext) _TestDate(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var updateAccessibilityRequestStatusPayloadImplementors = []string{"UpdateAccessibilityRequestStatusPayload"}
+
+func (ec *executionContext) _UpdateAccessibilityRequestStatusPayload(ctx context.Context, sel ast.SelectionSet, obj *model.UpdateAccessibilityRequestStatusPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateAccessibilityRequestStatusPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateAccessibilityRequestStatusPayload")
+		case "id":
+			out.Values[i] = ec._UpdateAccessibilityRequestStatusPayload_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "requestID":
+			out.Values[i] = ec._UpdateAccessibilityRequestStatusPayload_requestID(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "status":
+			out.Values[i] = ec._UpdateAccessibilityRequestStatusPayload_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "userErrors":
+			out.Values[i] = ec._UpdateAccessibilityRequestStatusPayload_userErrors(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -17959,6 +18311,21 @@ func (ec *executionContext) marshalOUUID2ᚖgithubᚗcomᚋgoogleᚋuuidᚐUUID(
 		return graphql.Null
 	}
 	return models.MarshalUUID(*v)
+}
+
+func (ec *executionContext) unmarshalOUpdateAccessibilityRequestStatus2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUpdateAccessibilityRequestStatus(ctx context.Context, v interface{}) (*model.UpdateAccessibilityRequestStatus, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputUpdateAccessibilityRequestStatus(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOUpdateAccessibilityRequestStatusPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUpdateAccessibilityRequestStatusPayload(ctx context.Context, sel ast.SelectionSet, v *model.UpdateAccessibilityRequestStatusPayload) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._UpdateAccessibilityRequestStatusPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOUpdateSystemIntakePayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUpdateSystemIntakePayload(ctx context.Context, sel ast.SelectionSet, v *model.UpdateSystemIntakePayload) graphql.Marshaler {

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -285,6 +285,20 @@ type SystemIntakeRequester struct {
 	Name      string  `json:"name"`
 }
 
+// Parameters for updating a 508/accessibility request's status
+type UpdateAccessibilityRequestStatus struct {
+	RequestID uuid.UUID                         `json:"requestID"`
+	Status    models.AccessibilityRequestStatus `json:"status"`
+}
+
+// Result of updating an accessibiiity request's status
+type UpdateAccessibilityRequestStatusPayload struct {
+	ID         uuid.UUID                         `json:"id"`
+	RequestID  uuid.UUID                         `json:"requestID"`
+	Status     models.AccessibilityRequestStatus `json:"status"`
+	UserErrors []*UserError                      `json:"userErrors"`
+}
+
 type UpdateSystemIntakeAdminLeadInput struct {
 	AdminLead string    `json:"adminLead"`
 	ID        uuid.UUID `json:"id"`

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -61,6 +61,24 @@ type AccessibilityRequestStatusRecord {
 }
 
 """
+Parameters for updating a 508/accessibility request's status
+"""
+input UpdateAccessibilityRequestStatus {
+  requestID: UUID!
+  status: AccessibilityRequestStatus!
+}
+
+"""
+ Result of updating an accessibiiity request's status
+ """
+type UpdateAccessibilityRequestStatusPayload {
+  id: UUID!
+  requestID: UUID!
+  status: AccessibilityRequestStatus!
+  userErrors: [UserError!]
+}
+
+"""
 A business owner is the person at CMS responsible for a system
 """
 type BusinessOwner {
@@ -619,6 +637,7 @@ type Mutation {
     input: CreateAccessibilityRequestDocumentInput!
   ): CreateAccessibilityRequestDocumentPayload
   deleteAccessibilityRequestDocument(input: DeleteAccessibilityRequestDocumentInput!): DeleteAccessibilityRequestDocumentPayload
+  updateAccessibilityRequestStatus(input: UpdateAccessibilityRequestStatus) : UpdateAccessibilityRequestStatusPayload @hasRole(role: EASI_508_TESTER_OR_USER)
   createSystemIntakeActionBusinessCaseNeeded(input: BasicActionInput!): UpdateSystemIntakePayload @hasRole(role: EASI_GOVTEAM)
   createSystemIntakeActionBusinessCaseNeedsChanges(input: BasicActionInput!): UpdateSystemIntakePayload @hasRole(role: EASI_GOVTEAM)
   createSystemIntakeActionGuideReceievedClose(input: BasicActionInput!): UpdateSystemIntakePayload @hasRole(role: EASI_GOVTEAM)

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -487,6 +487,22 @@ func (r *mutationResolver) DeleteAccessibilityRequestDocument(ctx context.Contex
 	return &model.DeleteAccessibilityRequestDocumentPayload{ID: &input.ID}, nil
 }
 
+func (r *mutationResolver) UpdateAccessibilityRequestStatus(ctx context.Context, input *model.UpdateAccessibilityRequestStatus) (*model.UpdateAccessibilityRequestStatusPayload, error) {
+	statusRecord, err := r.store.CreateAccessibilityRequestStatusRecord(ctx, &models.AccessibilityRequestStatusRecord{
+		RequestID: input.RequestID,
+		Status:    input.Status,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.UpdateAccessibilityRequestStatusPayload{
+		RequestID:  statusRecord.ID,
+		Status:     statusRecord.Status,
+		UserErrors: nil,
+	}, nil
+}
+
 func (r *mutationResolver) CreateSystemIntakeActionBusinessCaseNeeded(ctx context.Context, input model.BasicActionInput) (*model.UpdateSystemIntakePayload, error) {
 	intake, err := r.service.CreateActionUpdateStatus(
 		ctx,

--- a/src/components/PlainInfo/index.scss
+++ b/src/components/PlainInfo/index.scss
@@ -12,5 +12,11 @@
     font-size: 35px;
     text-align: center;
     color: #fff;
+
+    &--small {
+      height: 24px;
+      width: 24px;
+      font-size: 22px;
+    }
   }
 }

--- a/src/components/PlainInfo/index.tsx
+++ b/src/components/PlainInfo/index.tsx
@@ -1,19 +1,28 @@
 import React from 'react';
+import classnames from 'classnames';
 
 import './index.scss';
 
 type PlainInfoProps = {
+  className?: string;
   children: React.ReactNode;
+  small?: boolean;
 };
 
 /**
  * This is a custom "info" component inspired by USWDS's Alert component.
  * The main difference is that this is plain with no background.
  */
-const PlainInfo = ({ children }: PlainInfoProps) => {
+const PlainInfo = ({ className, children, small }: PlainInfoProps) => {
+  const classes = classnames('easi-plain-info', className);
+
+  const iconClasses = classnames('easi-plain-info__icon', {
+    'easi-plain-info__icon--small': small
+  });
+
   return (
-    <div className="easi-plain-info">
-      <div className="easi-plain-info__icon">
+    <div className={classes}>
+      <div className={iconClasses}>
         <i className="fa fa-info" />
       </div>
       <p className="line-height-body-5">{children}</p>

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -2,6 +2,11 @@
 
 const accessibility = {
   reportProblem: 'Report a problem (opens in a new tab)',
+  requestStatus: {
+    open: 'Open',
+    remediation: 'In Remediation',
+    closed: 'Closed'
+  },
   documentTable: {
     caption: 'Documents uploaded for',
     header: {
@@ -298,6 +303,14 @@ const accessibility = {
           'Download the Remediation Plan template as a PDF (opens in a new tab)'
       }
     }
+  },
+  updateRequestStatus: {
+    heading: 'Choose a status for {{-requestName}}',
+    statusFieldLegend: 'Choose a status for {{-requestName}}',
+    changeStatusDisclaimer:
+      'Changing the request status will send an email to all members of the 508 team letting them know about the new status.',
+    submit: 'Change status',
+    cancel: "Don't change status and return to request page"
   }
 };
 

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -310,6 +310,7 @@ const accessibility = {
     changeStatusDisclaimer:
       'Changing the request status will send an email to all members of the 508 team letting them know about the new status.',
     submit: 'Change status',
+    confirmation: 'Status has changed to {{-status}} for {{-requestName}}',
     cancel: "Don't change status and return to request page"
   }
 };

--- a/src/queries/GetAccessibilityRequestForStatusChange.ts
+++ b/src/queries/GetAccessibilityRequestForStatusChange.ts
@@ -1,0 +1,15 @@
+import { gql } from '@apollo/client';
+
+const GetAccessibilityRequestForStatusChange = gql`
+  query accessibilityRequest($id: UUID!) {
+    accessibilityRequest(id: $id) {
+      id
+      name
+      statusRecord {
+        status
+      }
+    }
+  }
+`;
+
+export default GetAccessibilityRequestForStatusChange;

--- a/src/queries/UpdateAccessibilityRequestStatusQuery.ts
+++ b/src/queries/UpdateAccessibilityRequestStatusQuery.ts
@@ -1,0 +1,17 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  mutation UpdateAccessibilityRequestStatus(
+    $input: UpdateAccessibilityRequestStatus!
+  ) {
+    updateAccessibilityRequestStatus(input: $input) {
+      id
+      requestID
+      status
+      userErrors {
+        message
+        path
+      }
+    }
+  }
+`;

--- a/src/queries/types/UpdateAccessibilityRequestStatus.ts
+++ b/src/queries/types/UpdateAccessibilityRequestStatus.ts
@@ -1,0 +1,32 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { UpdateAccessibilityRequestStatus, AccessibilityRequestStatus } from "./../../types/graphql-global-types";
+
+// ====================================================
+// GraphQL mutation operation: UpdateAccessibilityRequestStatus
+// ====================================================
+
+export interface UpdateAccessibilityRequestStatus_updateAccessibilityRequestStatus_userErrors {
+  __typename: "UserError";
+  message: string;
+  path: string[];
+}
+
+export interface UpdateAccessibilityRequestStatus_updateAccessibilityRequestStatus {
+  __typename: "UpdateAccessibilityRequestStatusPayload";
+  id: UUID;
+  requestID: UUID;
+  status: AccessibilityRequestStatus;
+  userErrors: UpdateAccessibilityRequestStatus_updateAccessibilityRequestStatus_userErrors[] | null;
+}
+
+export interface UpdateAccessibilityRequestStatus {
+  updateAccessibilityRequestStatus: UpdateAccessibilityRequestStatus_updateAccessibilityRequestStatus | null;
+}
+
+export interface UpdateAccessibilityRequestStatusVariables {
+  input: UpdateAccessibilityRequestStatus;
+}

--- a/src/queries/types/accessibilityRequest.ts
+++ b/src/queries/types/accessibilityRequest.ts
@@ -1,0 +1,30 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { AccessibilityRequestStatus } from "./../../types/graphql-global-types";
+
+// ====================================================
+// GraphQL query operation: accessibilityRequest
+// ====================================================
+
+export interface accessibilityRequest_accessibilityRequest_statusRecord {
+  __typename: "AccessibilityRequestStatusRecord";
+  status: AccessibilityRequestStatus;
+}
+
+export interface accessibilityRequest_accessibilityRequest {
+  __typename: "AccessibilityRequest";
+  id: UUID;
+  name: string;
+  statusRecord: accessibilityRequest_accessibilityRequest_statusRecord;
+}
+
+export interface accessibilityRequest {
+  accessibilityRequest: accessibilityRequest_accessibilityRequest | null;
+}
+
+export interface accessibilityRequestVariables {
+  id: UUID;
+}

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -171,6 +171,14 @@ export interface RejectIntakeInput {
   reason: string;
 }
 
+/**
+ * Parameters for updating a 508/accessibility request's status
+ */
+export interface UpdateAccessibilityRequestStatus {
+  requestID: UUID;
+  status: AccessibilityRequestStatus;
+}
+
 export interface UpdateSystemIntakeAdminLeadInput {
   adminLead: string;
   id: UUID;

--- a/src/utils/accessibilityRequest.test.ts
+++ b/src/utils/accessibilityRequest.test.ts
@@ -1,0 +1,23 @@
+import { accessibilityRequestStatusMap } from './accessibilityRequest';
+
+describe('Accessibility Utils', () => {
+  describe('accessibilityRequestStatusMap', () => {
+    it('returns Open', () => {
+      expect(accessibilityRequestStatusMap.OPEN).toEqual('Open');
+    });
+
+    it('returns In Remediation', () => {
+      expect(accessibilityRequestStatusMap.IN_REMEDIATION).toEqual(
+        'In Remediation'
+      );
+    });
+
+    it('returns Closed', () => {
+      expect(accessibilityRequestStatusMap.CLOSED).toEqual('Closed');
+    });
+
+    it('returns undefined (no such status)', () => {
+      expect(accessibilityRequestStatusMap.TEST).toEqual(undefined);
+    });
+  });
+});

--- a/src/utils/accessibilityRequest.ts
+++ b/src/utils/accessibilityRequest.ts
@@ -42,3 +42,12 @@ export const translateTestType = (testType: TestDateTestType) => {
       return '';
   }
 };
+
+/**
+ * Map 508 Request type API enum to a human readable string
+ */
+export const accessibilityRequestStatusMap: { [key: string]: string } = {
+  OPEN: i18next.t('accessibility:requestStatus.open'),
+  IN_REMEDIATION: i18next.t('accessibility:requestStatus.remediation'),
+  CLOSED: i18next.t('accessibility:requestStatus.closed')
+};

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -240,6 +240,14 @@ const AccessibilityRequestDetailPage = () => {
               </span>
             </div>
           </h2>
+          {isAccessibilityTeam && (
+            <UswdsLink
+              asCustom={Link}
+              to={`/508/requests/${accessibilityRequestId}/change-status`}
+            >
+              Change
+            </UswdsLink>
+          )}
         </div>
       </div>
       <div className="grid-container margin-top-2 padding-top-6 padding-top">

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -134,9 +134,9 @@ const AccessibilityRequestDetailPage = () => {
   const hasDocuments = documents.length > 0;
   const statusEnum = data?.accessibilityRequest?.statusRecord.status;
   const statusMap: { [key: string]: string } = {
-    OPEN: 'Open',
-    IN_REMEDIATION: 'In remediation',
-    CLOSED: 'Closed'
+    OPEN: t('requestStatus.open'),
+    IN_REMEDIATION: t('requestStatus.remediation'),
+    CLOSED: t('requestStatus.closed')
   };
   const requestStatus = statusMap[`${statusEnum}`];
 
@@ -244,6 +244,7 @@ const AccessibilityRequestDetailPage = () => {
             <UswdsLink
               asCustom={Link}
               to={`/508/requests/${accessibilityRequestId}/change-status`}
+              aria-label="Change status"
             >
               Change
             </UswdsLink>

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -40,6 +40,7 @@ import useMessage from 'hooks/useMessage';
 import { AppState } from 'reducers/rootReducer';
 import { DeleteAccessibilityRequestForm } from 'types/accessibility';
 import { AccessibilityRequestDeletionReason } from 'types/graphql-global-types';
+import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
 import { formatDate } from 'utils/date';
 import flattenErrors from 'utils/flattenErrors';
 import user from 'utils/user';
@@ -133,12 +134,7 @@ const AccessibilityRequestDetailPage = () => {
   const isAccessibilityTeam = user.isAccessibilityTeam(userGroups, flags);
   const hasDocuments = documents.length > 0;
   const statusEnum = data?.accessibilityRequest?.statusRecord.status;
-  const statusMap: { [key: string]: string } = {
-    OPEN: t('requestStatus.open'),
-    IN_REMEDIATION: t('requestStatus.remediation'),
-    CLOSED: t('requestStatus.closed')
-  };
-  const requestStatus = statusMap[`${statusEnum}`];
+  const requestStatus = accessibilityRequestStatusMap[`${statusEnum}`];
 
   const uploadDocumentLink = (
     <UswdsLink

--- a/src/views/Accessibility/ChangeRequestStatus/index.test.tsx
+++ b/src/views/Accessibility/ChangeRequestStatus/index.test.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { render, waitFor } from '@testing-library/react';
+import GetAccessibilityRequestForStatusChange from 'queries/GetAccessibilityRequestForStatusChange';
 
-import ChangeRequestStatus, { GET_REQUEST } from './index';
+import ChangeRequestStatus from './index';
 
 describe('Update 508 request status page', () => {
   const mockQuery = [
     {
       request: {
-        query: GET_REQUEST,
+        query: GetAccessibilityRequestForStatusChange,
         variables: {
           id: '26908e00-927c-4924-8133-119be7eb21a9'
         }
@@ -27,7 +28,7 @@ describe('Update 508 request status page', () => {
       }
     }
   ];
-  it('renders without errors', async () => {
+  xit('renders without errors', async () => {
     const { getByTestId } = render(
       <MemoryRouter>
         <MockedProvider mocks={mockQuery} addTypename={false}>

--- a/src/views/Accessibility/ChangeRequestStatus/index.test.tsx
+++ b/src/views/Accessibility/ChangeRequestStatus/index.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { render, waitFor } from '@testing-library/react';
 import GetAccessibilityRequestForStatusChange from 'queries/GetAccessibilityRequestForStatusChange';
+
+import { MessageProvider } from 'hooks/useMessage';
 
 import ChangeRequestStatus from './index';
 
@@ -28,11 +30,21 @@ describe('Update 508 request status page', () => {
       }
     }
   ];
-  xit('renders without errors', async () => {
+
+  it('renders without errors', async () => {
     const { getByTestId } = render(
-      <MemoryRouter>
+      <MemoryRouter
+        initialEntries={[
+          '/508/requests/26908e00-927c-4924-8133-119be7eb21a9/change-status'
+        ]}
+      >
         <MockedProvider mocks={mockQuery} addTypename={false}>
-          <ChangeRequestStatus />
+          <MessageProvider>
+            <Route
+              path="/508/requests/:accessibilityRequestId"
+              component={ChangeRequestStatus}
+            />
+          </MessageProvider>
         </MockedProvider>
       </MemoryRouter>
     );

--- a/src/views/Accessibility/ChangeRequestStatus/index.test.tsx
+++ b/src/views/Accessibility/ChangeRequestStatus/index.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { MockedProvider } from '@apollo/client/testing';
+import { render, waitFor } from '@testing-library/react';
+
+import ChangeRequestStatus, { GET_REQUEST } from './index';
+
+describe('Update 508 request status page', () => {
+  const mockQuery = [
+    {
+      request: {
+        query: GET_REQUEST,
+        variables: {
+          id: '26908e00-927c-4924-8133-119be7eb21a9'
+        }
+      },
+      result: {
+        data: {
+          accessibilityRequest: {
+            id: '26908e00-927c-4924-8133-119be7eb21a9',
+            name: 'Mock 508 Request',
+            statusRecord: {
+              status: 'OPEN'
+            }
+          }
+        }
+      }
+    }
+  ];
+  it('renders without errors', async () => {
+    const { getByTestId } = render(
+      <MemoryRouter>
+        <MockedProvider mocks={mockQuery} addTypename={false}>
+          <ChangeRequestStatus />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => new Promise(res => setTimeout(res, 0)));
+
+    expect(getByTestId('change-request-status-view')).toBeInTheDocument();
+  });
+});

--- a/src/views/Accessibility/ChangeRequestStatus/index.tsx
+++ b/src/views/Accessibility/ChangeRequestStatus/index.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { Link, useHistory, useParams } from 'react-router-dom';
+import { useMutation, useQuery } from '@apollo/client';
+import {
+  Button,
+  Fieldset,
+  Link as UswdsLink,
+  Radio
+} from '@trussworks/react-uswds';
+import { Field, Form, Formik, FormikProps } from 'formik';
+import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
+import {
+  GetAccessibilityRequest,
+  GetAccessibilityRequestVariables
+} from 'queries/types/GetAccessibilityRequest';
+import UpdateAccessibilityRequestStatus from 'queries/UpdateAccessibilityRequestStatusQuery';
+
+import PageHeading from 'components/PageHeading';
+import PlainInfo from 'components/PlainInfo';
+import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
+import FieldGroup from 'components/shared/FieldGroup';
+import { AccessibilityRequestStatus } from 'types/graphql-global-types';
+import { NotFoundPartial } from 'views/NotFound';
+
+type ChangeRequestStatusForm = {
+  status: AccessibilityRequestStatus;
+};
+
+const ChangeRequestStatus = () => {
+  const history = useHistory();
+  const { accessibilityRequestId } = useParams<{
+    accessibilityRequestId: string;
+  }>();
+  const { loading, data } = useQuery<
+    GetAccessibilityRequest,
+    GetAccessibilityRequestVariables
+  >(GetAccessibilityRequestQuery, {
+    variables: {
+      id: accessibilityRequestId
+    }
+  });
+  const [mutate, mutationResult] = useMutation(
+    UpdateAccessibilityRequestStatus
+  );
+  const initialValues = {
+    status:
+      data?.accessibilityRequest?.statusRecord.status ||
+      AccessibilityRequestStatus.OPEN
+  };
+
+  const handleSubmit = (values: ChangeRequestStatusForm) => {
+    console.log('submitting');
+    mutate({
+      variables: {
+        input: {
+          requestID: accessibilityRequestId,
+          status: values.status
+        }
+      }
+    }).then(response => {
+      if (!response.errors) {
+        history.push(`/508/requests/${accessibilityRequestId}`);
+      }
+    });
+  };
+
+  if (loading) {
+    return <div>Loading</div>;
+  }
+
+  if (!data) {
+    return (
+      <div className="grid-container">
+        <NotFoundPartial />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid-container margin-y-5">
+      <Formik initialValues={initialValues} onSubmit={handleSubmit}>
+        {(formikProps: FormikProps<ChangeRequestStatusForm>) => {
+          const { values } = formikProps;
+
+          return (
+            <>
+              {mutationResult.error && (
+                <ErrorAlert heading="System error">
+                  <ErrorAlertMessage
+                    message={mutationResult.error.message}
+                    errorKey="system"
+                  />
+                </ErrorAlert>
+              )}
+              <PageHeading>
+                Choose a status for Medicare Office of Change Initiative
+              </PageHeading>
+              <div className="tablet:grid-col-10">
+                <Form>
+                  <FieldGroup>
+                    <Fieldset
+                      className="display-inline-block"
+                      legend="Choose a status for Medicare Office of Change Initiative"
+                      legendStyle="srOnly"
+                    >
+                      <Field
+                        as={Radio}
+                        id="RequestStatus-Open"
+                        name="status"
+                        label="Open"
+                        value="OPEN"
+                        checked={values.status === 'OPEN'}
+                      />
+                      <Field
+                        as={Radio}
+                        id="RequestStatus-Remediation"
+                        name="status"
+                        label="In Remediation"
+                        value="IN_REMEDIATION"
+                        checked={values.status === 'IN_REMEDIATION'}
+                      />
+                      <Field
+                        as={Radio}
+                        id="RequestStatus-Closed"
+                        name="status"
+                        label="Closed"
+                        value="CLOSED"
+                        checked={values.status === 'CLOSED'}
+                      />
+                    </Fieldset>
+                  </FieldGroup>
+                  <PlainInfo className="margin-top-2" small>
+                    Changing the request status will send an email to all
+                    members of the 508 team letting them know about the new
+                    status.
+                  </PlainInfo>
+                  <Button type="submit" className="margin-top-4">
+                    Change status
+                  </Button>
+                  <UswdsLink
+                    className="display-block margin-top-3"
+                    asCustom={Link}
+                    to={`/508/request/${accessibilityRequestId}`}
+                  >
+                    Don&apos;t change status and return to request page
+                  </UswdsLink>
+                </Form>
+              </div>
+            </>
+          );
+        }}
+      </Formik>
+    </div>
+  );
+};
+
+export default ChangeRequestStatus;

--- a/src/views/Accessibility/ChangeRequestStatus/index.tsx
+++ b/src/views/Accessibility/ChangeRequestStatus/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
@@ -8,11 +9,7 @@ import {
   Radio
 } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
-import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
-import {
-  GetAccessibilityRequest,
-  GetAccessibilityRequestVariables
-} from 'queries/types/GetAccessibilityRequest';
+import GetAccessibilityRequestForStatusChange from 'queries/GetAccessibilityRequestForStatusChange';
 import UpdateAccessibilityRequestStatus from 'queries/UpdateAccessibilityRequestStatusQuery';
 
 import PageHeading from 'components/PageHeading';
@@ -28,13 +25,11 @@ type ChangeRequestStatusForm = {
 
 const ChangeRequestStatus = () => {
   const history = useHistory();
+  const { t } = useTranslation('accessibility');
   const { accessibilityRequestId } = useParams<{
     accessibilityRequestId: string;
   }>();
-  const { loading, data } = useQuery<
-    GetAccessibilityRequest,
-    GetAccessibilityRequestVariables
-  >(GetAccessibilityRequestQuery, {
+  const { loading, data } = useQuery(GetAccessibilityRequestForStatusChange, {
     variables: {
       id: accessibilityRequestId
     }
@@ -49,7 +44,6 @@ const ChangeRequestStatus = () => {
   };
 
   const handleSubmit = (values: ChangeRequestStatusForm) => {
-    console.log('submitting');
     mutate({
       variables: {
         input: {
@@ -77,7 +71,10 @@ const ChangeRequestStatus = () => {
   }
 
   return (
-    <div className="grid-container margin-y-5">
+    <div
+      className="grid-container margin-y-5"
+      data-testid="change-request-status-view"
+    >
       <Formik initialValues={initialValues} onSubmit={handleSubmit}>
         {(formikProps: FormikProps<ChangeRequestStatusForm>) => {
           const { values } = formikProps;
@@ -93,21 +90,25 @@ const ChangeRequestStatus = () => {
                 </ErrorAlert>
               )}
               <PageHeading>
-                Choose a status for Medicare Office of Change Initiative
+                {t('updateRequestStatus.heading', {
+                  requestName: data.accessibilityRequest?.name
+                })}
               </PageHeading>
               <div className="tablet:grid-col-10">
                 <Form>
                   <FieldGroup>
                     <Fieldset
                       className="display-inline-block"
-                      legend="Choose a status for Medicare Office of Change Initiative"
+                      legend={t('updateRequestStatus.statusFieldLegend', {
+                        requestName: data.accessibilityRequest?.name
+                      })}
                       legendStyle="srOnly"
                     >
                       <Field
                         as={Radio}
                         id="RequestStatus-Open"
                         name="status"
-                        label="Open"
+                        label={t('requestStatus.open')}
                         value="OPEN"
                         checked={values.status === 'OPEN'}
                       />
@@ -115,7 +116,7 @@ const ChangeRequestStatus = () => {
                         as={Radio}
                         id="RequestStatus-Remediation"
                         name="status"
-                        label="In Remediation"
+                        label={t('requestStatus.remediation')}
                         value="IN_REMEDIATION"
                         checked={values.status === 'IN_REMEDIATION'}
                       />
@@ -123,26 +124,24 @@ const ChangeRequestStatus = () => {
                         as={Radio}
                         id="RequestStatus-Closed"
                         name="status"
-                        label="Closed"
+                        label={t('requestStatus.closed')}
                         value="CLOSED"
                         checked={values.status === 'CLOSED'}
                       />
                     </Fieldset>
                   </FieldGroup>
                   <PlainInfo className="margin-top-2" small>
-                    Changing the request status will send an email to all
-                    members of the 508 team letting them know about the new
-                    status.
+                    {t('updateRequestStatus.changeStatusDisclaimer')}
                   </PlainInfo>
                   <Button type="submit" className="margin-top-4">
-                    Change status
+                    {t('updateRequestStatus.submit')}
                   </Button>
                   <UswdsLink
                     className="display-block margin-top-3"
                     asCustom={Link}
-                    to={`/508/request/${accessibilityRequestId}`}
+                    to={`/508/requests/${accessibilityRequestId}`}
                   >
-                    Don&apos;t change status and return to request page
+                    {t('updateRequestStatus.cancel')}
                   </UswdsLink>
                 </Form>
               </div>

--- a/src/views/Accessibility/ChangeRequestStatus/index.tsx
+++ b/src/views/Accessibility/ChangeRequestStatus/index.tsx
@@ -16,7 +16,9 @@ import PageHeading from 'components/PageHeading';
 import PlainInfo from 'components/PlainInfo';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldGroup from 'components/shared/FieldGroup';
+import useMessage from 'hooks/useMessage';
 import { AccessibilityRequestStatus } from 'types/graphql-global-types';
+import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
 import { NotFoundPartial } from 'views/NotFound';
 
 type ChangeRequestStatusForm = {
@@ -26,6 +28,7 @@ type ChangeRequestStatusForm = {
 const ChangeRequestStatus = () => {
   const history = useHistory();
   const { t } = useTranslation('accessibility');
+  const { showMessageOnNextPage } = useMessage();
   const { accessibilityRequestId } = useParams<{
     accessibilityRequestId: string;
   }>();
@@ -34,6 +37,7 @@ const ChangeRequestStatus = () => {
       id: accessibilityRequestId
     }
   });
+
   const [mutate, mutationResult] = useMutation(
     UpdateAccessibilityRequestStatus
   );
@@ -53,6 +57,15 @@ const ChangeRequestStatus = () => {
       }
     }).then(response => {
       if (!response.errors) {
+        showMessageOnNextPage(
+          t('updateRequestStatus.confirmation', {
+            status:
+              accessibilityRequestStatusMap[
+                response.data.updateAccessibilityRequestStatus.status
+              ],
+            requestName: data.accessibilityRequest?.name
+          })
+        );
         history.push(`/508/requests/${accessibilityRequestId}`);
       }
     });

--- a/src/views/Accessibility/ChangeRequestStatus/types/accessibilityRequest.ts
+++ b/src/views/Accessibility/ChangeRequestStatus/types/accessibilityRequest.ts
@@ -1,0 +1,30 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { AccessibilityRequestStatus } from "./../../../../types/graphql-global-types";
+
+// ====================================================
+// GraphQL query operation: accessibilityRequest
+// ====================================================
+
+export interface accessibilityRequest_accessibilityRequest_statusRecord {
+  __typename: "AccessibilityRequestStatusRecord";
+  status: AccessibilityRequestStatus;
+}
+
+export interface accessibilityRequest_accessibilityRequest {
+  __typename: "AccessibilityRequest";
+  id: UUID;
+  name: string;
+  statusRecord: accessibilityRequest_accessibilityRequest_statusRecord;
+}
+
+export interface accessibilityRequest {
+  accessibilityRequest: accessibilityRequest_accessibilityRequest | null;
+}
+
+export interface accessibilityRequestVariables {
+  id: UUID;
+}

--- a/src/views/Accessibility/index.tsx
+++ b/src/views/Accessibility/index.tsx
@@ -16,16 +16,18 @@ import {
 } from 'constants/externalUrls';
 import { AppState } from 'reducers/rootReducer';
 import user from 'utils/user';
-import Create from 'views/Accessibility/AccessibilityRequest/Create';
-import AccessibilityRequestsDocumentsNew from 'views/Accessibility/AccessibilityRequest/Documents/New';
-import List from 'views/Accessibility/AccessibilityRequest/List';
-import AccessibilityRequestDetailPage from 'views/Accessibility/AccessibilityRequestDetailPage';
-import AccessibilityTestingStepsOverview from 'views/Accessibility/AccessibilityTestingStepsOverview';
-import MakingARequest from 'views/Accessibility/MakingARequest';
-import TestingTemplates from 'views/Accessibility/TestingTemplates';
 import NotFoundPartial from 'views/NotFound/NotFoundPartial';
 import NewTestDateView from 'views/TestDate/NewTestDate';
 import UpdateTestDateView from 'views/TestDate/UpdateTestDate';
+
+import Create from './AccessibilityRequest/Create';
+import AccessibilityRequestsDocumentsNew from './AccessibilityRequest/Documents/New';
+import List from './AccessibilityRequest/List';
+import AccessibilityRequestDetailPage from './AccessibilityRequestDetailPage';
+import AccessibilityTestingStepsOverview from './AccessibilityTestingStepsOverview';
+import ChangeRequestStatus from './ChangeRequestStatus';
+import MakingARequest from './MakingARequest';
+import TestingTemplates from './TestingTemplates';
 
 const NewRequest = (
   <SecureRoute
@@ -93,11 +95,20 @@ const NewTestDate = (
   />
 );
 
+const RequestStatusChange = (
+  <SecureRoute
+    key="change-508-request-status"
+    path="/508/requests/:accessibilityRequestId/change-status"
+    component={ChangeRequestStatus}
+  />
+);
+
 const RequestDetails = (
   <SecureRoute
     key="508-request-detail"
     path="/508/requests/:accessibilityRequestId"
     component={AccessibilityRequestDetailPage}
+    exact
   />
 );
 
@@ -153,6 +164,7 @@ const Accessibility = () => {
             AllRequests,
             AccessibilityTestingOverview,
             MakingANewRequest,
+            RequestStatusChange,
             AccessibilityTestingTemplates,
             NewDocument,
             UpdateTestDate,


### PR DESCRIPTION
# ES-701

Add view at `/508/requests/:requestId/change-status` to allow 508 team update the request status

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over
- [x] Checked for landmarks, page heading structure and links using [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu)
- [x] Requested a design review for user-facing changes
- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked accessibility against criteria
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
