### PR TITLE
K1m 704 tester table status

### DIFF
--- a/src/components/AccessibilityRequestsTable/index.test.tsx
+++ b/src/components/AccessibilityRequestsTable/index.test.tsx
@@ -42,7 +42,7 @@ describe('AccessibilityRequestsTable', () => {
       {
         id: '124',
         name: 'Burrito v2',
-        relevantTestDate: '2021-06-30T19:22:40Z',
+        relevantTestDate: { date: '2021-06-30T19:22:40Z' },
         submittedAt: '2021-06-10T19:22:40Z',
         system: {
           lcid: '0000',

--- a/src/components/AccessibilityRequestsTable/index.test.tsx
+++ b/src/components/AccessibilityRequestsTable/index.test.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { mount, shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
 
 import AccessibilityRequestsTable from './index';
 
@@ -15,5 +18,61 @@ describe('AccessibilityRequestsTable', () => {
     expect(wrapper.find('th').at(2).contains('Business Owner')).toBe(true);
     expect(wrapper.find('th').at(3).contains('Test Date')).toBe(true);
     expect(wrapper.find('th').at(4).contains('Status')).toBe(true);
+  });
+
+  it('contains the expected values in the rows', () => {
+    const mockStore = configureMockStore();
+    const store = mockStore({
+      auth: {
+        euaId: 'AAAA'
+      }
+    });
+
+    const requests = [
+      {
+        id: '123',
+        name: 'Burrito v1',
+        submittedAt: '2021-06-10T19:22:40Z',
+        system: {
+          lcid: '0000',
+          businessOwner: { name: 'Shade', component: 'OIT' }
+        },
+        statusRecord: { status: 'OPEN' }
+      },
+      {
+        id: '124',
+        name: 'Burrito v2',
+        relevantTestDate: '2021-06-30T19:22:40Z',
+        submittedAt: '2021-06-10T19:22:40Z',
+        system: {
+          lcid: '0000',
+          businessOwner: { name: 'Shade', component: 'OIT' }
+        },
+        statusRecord: { status: 'IN_REMEDIATION' }
+      }
+    ];
+    const wrapperWithRequests = mount(
+      <MemoryRouter initialEntries={['/508/requests/all']}>
+        <Provider store={store}>
+          <Route path="/508/requests/:accessibilityRequestId">
+            <AccessibilityRequestsTable requests={requests} />
+          </Route>
+        </Provider>
+      </MemoryRouter>
+    );
+
+    const row1 = wrapperWithRequests.find('tbody').find('tr').at(0);
+    expect(row1.find('th').find('a').text()).toEqual('Burrito v1');
+    expect(row1.find('td').at(0).text()).toEqual('June 10 2021');
+    expect(row1.find('td').at(1).text()).toEqual('Shade, OIT');
+    expect(row1.find('td').at(2).text()).toEqual('Not Added');
+    expect(row1.find('td').at(3).text()).toEqual('Open');
+
+    const row2 = wrapperWithRequests.find('tbody').find('tr').at(1);
+    expect(row2.find('th').find('a').text()).toEqual('Burrito v2');
+    expect(row2.find('td').at(0).text()).toEqual('June 10 2021');
+    expect(row2.find('td').at(1).text()).toEqual('Shade, OIT');
+    expect(row2.find('td').at(2).text()).toEqual('June 30 2021');
+    expect(row2.find('td').at(3).text()).toEqual('In remediation');
   });
 });

--- a/src/components/AccessibilityRequestsTable/index.test.tsx
+++ b/src/components/AccessibilityRequestsTable/index.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import AccessibilityRequestsTable from './index';
+
+describe('AccessibilityRequestsTable', () => {
+  const wrapper = shallow(<AccessibilityRequestsTable requests={[]} />);
+  it('renders without crashing', () => {
+    expect(wrapper.length).toEqual(1);
+  });
+
+  it('contains all the expected columns', () => {
+    expect(wrapper.find('th').at(0).contains('Request Name')).toBe(true);
+    expect(wrapper.find('th').at(1).contains('Submission Date')).toBe(true);
+    expect(wrapper.find('th').at(2).contains('Business Owner')).toBe(true);
+    expect(wrapper.find('th').at(3).contains('Test Date')).toBe(true);
+    expect(wrapper.find('th').at(4).contains('Status')).toBe(true);
+  });
+});

--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -154,6 +154,8 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
     return 'none';
   };
 
+  const tableColWidths = [350, 150, 260, 150, 260]; // [request name, submission date, business owner, test date, status]
+
   return (
     <div className="accessibility-requests-table">
       <Table bordered={false} {...getTableProps()} fullWidth>
@@ -199,14 +201,20 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
                       <th
                         {...cell.getCellProps()}
                         scope="row"
-                        style={{ maxWidth: '16rem' }}
+                        style={{ width: '350px', maxWidth: '16em' }}
                       >
                         {cell.render('Cell')}
                       </th>
                     );
                   }
                   return (
-                    <td {...cell.getCellProps()} style={{ maxWidth: '16rem' }}>
+                    <td
+                      {...cell.getCellProps()}
+                      style={{
+                        width: `${tableColWidths[i]}px`,
+                        maxWidth: '16em'
+                      }}
+                    >
                       {cell.render('Cell')}
                     </td>
                   );

--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -35,7 +35,8 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
             </UswdsLink>
           );
         },
-        maxWidth: 350
+        maxWidth: 350,
+        width: 350
       },
       {
         Header: t('requestTable.header.submissionDate'),
@@ -154,8 +155,6 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
     return 'none';
   };
 
-  const tableColWidths = [350, 150, 260, 150, 260]; // [request name, submission date, business owner, test date, status]
-
   return (
     <div className="accessibility-requests-table">
       <Table bordered={false} {...getTableProps()} fullWidth>
@@ -165,9 +164,10 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
             <tr {...headerGroup.getHeaderGroupProps()}>
               {headerGroup.headers.map(column => (
                 <th
-                  {...column.getHeaderProps()}
+                  {...column.getHeaderProps({
+                    style: { width: column.width, whiteSpace: 'nowrap' }
+                  })}
                   aria-sort={getColumnSortStatus(column)}
-                  style={{ whiteSpace: 'nowrap' }}
                   scope="col"
                 >
                   <button
@@ -199,12 +199,10 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
                   if (i === 0) {
                     return (
                       <th
-                        {...cell.getCellProps()}
+                        {...cell.getCellProps({
+                          style: { width: cell.column.width, maxWidth: '16em' }
+                        })}
                         scope="row"
-                        style={{
-                          width: `${tableColWidths[0]}px`,
-                          maxWidth: '16em'
-                        }}
                       >
                         {cell.render('Cell')}
                       </th>
@@ -212,11 +210,9 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
                   }
                   return (
                     <td
-                      {...cell.getCellProps()}
-                      style={{
-                        width: `${tableColWidths[i]}px`,
-                        maxWidth: '16em'
-                      }}
+                      {...cell.getCellProps({
+                        style: { width: cell.column.width, maxWidth: '16em' }
+                      })}
                     >
                       {cell.render('Cell')}
                     </td>

--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -59,23 +59,14 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
           }
           return t('requestTable.emptyTestDate');
         }
+      },
+      {
+        Header: t('requestTable.header.status'),
+        accessor: 'status',
+        Cell: ({ row, value }: any) => {
+          return <strong>{value}</strong>;
+        }
       }
-      // {
-      //   Header: t('requestTable.header.status'),
-      //   accessor: 'status',
-      //   Cell: ({ row, value }: any) => {
-      //     const date = DateTime.fromISO(row.original.updatedAt).toLocaleString(
-      //       DateTime.DATE_FULL
-      //     );
-      //     return (
-      //       <>
-      //         <strong>{value}</strong>
-      //         <br />
-      //         <span>{`${t('requestTable.lastUpdated')} ${date}`}</span>
-      //       </>
-      //     );
-      //   }
-      // }
     ];
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { DateTime } from 'luxon';
 import { GetAccessibilityRequests_accessibilityRequests_edges_node as AccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
 
+import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
 import { formatDate } from 'utils/date';
 
 import './index.scss';
@@ -63,8 +64,8 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
       {
         Header: t('requestTable.header.status'),
         accessor: 'status',
-        Cell: ({ row, value }: any) => {
-          return <strong>{value}</strong>;
+        Cell: ({ value }: any) => {
+          return value;
         }
       }
     ];
@@ -80,13 +81,16 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
       const testDate = request.relevantTestDate?.date
         ? DateTime.fromISO(request.relevantTestDate?.date)
         : null;
+      const status =
+        accessibilityRequestStatusMap[`${request.statusRecord.status}`];
 
       return {
         id: request.id,
         requestName: request.name,
         submittedAt,
         businessOwner,
-        relevantTestDate: testDate
+        relevantTestDate: testDate,
+        status
       };
     });
 

--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -201,7 +201,10 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
                       <th
                         {...cell.getCellProps()}
                         scope="row"
-                        style={{ width: '350px', maxWidth: '16em' }}
+                        style={{
+                          width: `${tableColWidths[0]}px`,
+                          maxWidth: '16em'
+                        }}
                       >
                         {cell.render('Cell')}
                       </th>

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -1,11 +1,6 @@
 // This is for the CMS 508 project flow
 
 const accessibility = {
-  statusMap: {
-    OPEN: 'Open',
-    IN_REMEDIATION: 'In remediation',
-    CLOSED: 'Closed'
-  },
   reportProblem: 'Report a problem (opens in a new tab)',
   requestStatus: {
     open: 'Open',

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -9,7 +9,7 @@ const accessibility = {
   reportProblem: 'Report a problem (opens in a new tab)',
   requestStatus: {
     open: 'Open',
-    remediation: 'In Remediation',
+    remediation: 'In remediation',
     closed: 'Closed'
   },
   documentTable: {

--- a/src/utils/accessibilityRequest.test.ts
+++ b/src/utils/accessibilityRequest.test.ts
@@ -6,9 +6,9 @@ describe('Accessibility Utils', () => {
       expect(accessibilityRequestStatusMap.OPEN).toEqual('Open');
     });
 
-    it('returns In Remediation', () => {
+    it('returns In remediation', () => {
       expect(accessibilityRequestStatusMap.IN_REMEDIATION).toEqual(
-        'In Remediation'
+        'In remediation'
       );
     });
 

--- a/src/views/MyRequests/Table.tsx
+++ b/src/views/MyRequests/Table.tsx
@@ -13,6 +13,7 @@ import GetRequestsQuery from 'queries/GetRequestsQuery';
 import { GetRequests, GetRequestsVariables } from 'queries/types/GetRequests';
 
 import { RequestType } from 'types/graphql-global-types';
+import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
 import { formatDate } from 'utils/date';
 
 const Table = () => {
@@ -74,7 +75,7 @@ const Table = () => {
           let statusString;
           switch (row.original.type) {
             case RequestType.ACCESSIBILITY_REQUEST:
-              statusString = t(`accessibility:statusMap.${value}`);
+              statusString = accessibilityRequestStatusMap[`${value}`];
               break;
             case RequestType.GOVERNANCE_REQUEST:
               statusString = t(`intake:statusMap.${value}`);


### PR DESCRIPTION
# ES-704

## Changes proposed in this pull request

- Adds a Status column to the table showing accessibility requests to the 508 tester/user

## Reviewer Notes

I noticed there are two ways we were accessing the human-readable accessibility request status.  SInce we are trying not to do enum to human-readable in i18n, I replaced it with the util mapping, `accessibilityRequestStatusMap`.

## Setup

Log in as a 508 user or 508 tester.
You should see the all requests page and a new column "Status".  Check that all three statuses show properly.

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over
- [x] Checked for landmarks, page heading structure and links using [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu)
- [x] Requested a design review for user-facing changes
- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Made it clear which comments need to be addressed before this work is merged
- [x] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [x] Checked in the design translated visually
- [x] Checked behavior
- [x] Checked different states (empty, one, some, error)
- [x] Checked accessibility against criteria
- [x] Checked for landmarks, page heading structure, and links
- [x] Tried to break the intended flow

## Screenshots

![image](https://user-images.githubusercontent.com/13249580/121757558-d5922600-cad2-11eb-85cd-d229efa141b9.png)
