### PR TITLE
Show Documents heading with no documents list for 508 user/tester

### DIFF
--- a/src/components/AccessibilityDocumentsList/index.tsx
+++ b/src/components/AccessibilityDocumentsList/index.tsx
@@ -119,6 +119,9 @@ const AccessibilityDocumentsList = ({
     }
   });
 
+  if (documents.length === 0) {
+    return <div>{t('documentTable.noDocuments')}</div>;
+  }
   return (
     <>
       <Table bordered={false} {...getTableProps()} fullWidth>

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -27,7 +27,8 @@ const accessibility = {
         'You will not be able to access this document after it is removed.',
       proceedButton: 'Remove document',
       declineButton: 'Keep document'
-    }
+    },
+    noDocuments: 'No documents added to request yet.'
   },
   requestTable: {
     caption: 'List of 508 requests',

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
@@ -62,7 +62,7 @@ describe('AccessibilityRequestDetailPage', () => {
     expect(wrapper.find('AccessibilityRequestDetailPage').length).toEqual(1);
   });
 
-  describe('for a basic user', () => {
+  describe('for a business owner', () => {
     it('renders Next step if no documents', async () => {
       let wrapper: any;
       await act(async () => {

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -191,7 +191,7 @@ const AccessibilityRequestDetailPage = () => {
     </>
   );
 
-  const bodyNoDocumentsBasicUser = (
+  const bodyNoDocumentsBusinessOwner = (
     <>
       <div className="margin-bottom-3">
         <h2 className="margin-y-0 font-heading-lg">
@@ -281,7 +281,7 @@ const AccessibilityRequestDetailPage = () => {
           <div className="grid-col-8">
             {hasDocuments || isAccessibilityTeam
               ? bodyWithDocumentsTable
-              : bodyNoDocumentsBasicUser}
+              : bodyNoDocumentsBusinessOwner}
           </div>
           <div className="grid-col-1" />
           <div className="grid-col-3">

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -177,7 +177,7 @@ const AccessibilityRequestDetailPage = () => {
     </UswdsLink>
   );
 
-  const bodyWithDocuments = (
+  const bodyWithDocumentsTable = (
     <>
       <h2 className="margin-top-0">{t('requestDetails.documents.label')}</h2>
       {uploadDocumentLink}
@@ -191,7 +191,7 @@ const AccessibilityRequestDetailPage = () => {
     </>
   );
 
-  const bodyNoDocuments = (
+  const bodyNoDocumentsBasicUser = (
     <>
       <div className="margin-bottom-3">
         <h2 className="margin-y-0 font-heading-lg">
@@ -279,7 +279,9 @@ const AccessibilityRequestDetailPage = () => {
       <div className="grid-container margin-top-2 padding-top-6 padding-top">
         <div className="grid-row grid-gap-lg">
           <div className="grid-col-8">
-            {hasDocuments ? bodyWithDocuments : bodyNoDocuments}
+            {hasDocuments || isAccessibilityTeam
+              ? bodyWithDocumentsTable
+              : bodyNoDocumentsBasicUser}
           </div>
           <div className="grid-col-1" />
           <div className="grid-col-3">


### PR DESCRIPTION
# ES-672

## Changes proposed in this pull request

- Shows the heading "Documents" with a  no documents message for a 508 user or tester (instead of the "Next Steps" message shown to a business owner)

## Reviewer Notes

None

## Setup

Log in as a 508 user or 508 tester.
Go to an accessibility request with no documents.  See the no documents message and not the Next steps message.

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over
- [x] Checked for landmarks, page heading structure and links using [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu)
- [x] Requested a design review for user-facing changes
- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [x] Checked in the design translated visually
- [x] Checked behavior
- [x] Checked different states (empty, one, some, error)
- [x] Checked accessibility against criteria
- [x] Checked for landmarks, page heading structure, and links
- [x] Tried to break the intended flow

## Screenshots

![image](https://user-images.githubusercontent.com/13249580/121759411-65879e00-cada-11eb-9bce-6f61359a3f29.png)

