### PR TITLE
Update Accessibility/508 radio/checkbox spacing

### DIFF
--- a/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
@@ -230,7 +230,7 @@ const New = () => {
                         error={!!flatErrors['documentType.commonType']}
                       >
                         <fieldset className="usa-fieldset margin-top-4">
-                          <legend className="usa-label margin-bottom-1">
+                          <legend className="usa-label">
                             What type of document are you uploading?
                           </legend>
                           <FieldErrorMsg>

--- a/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
@@ -288,7 +288,6 @@ const New = () => {
                                 <Label
                                   htmlFor="FileUpload-OtherType"
                                   className="margin-bottom-1"
-                                  style={{ marginTop: '0.5em' }}
                                 >
                                   Document name
                                 </Label>

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -419,7 +419,7 @@ const AccessibilityRequestDetailPage = () => {
                             error={!!flatErrors.deletionReason}
                           >
                             <fieldset className="usa-fieldset margin-top-4">
-                              <legend className="usa-label margin-bottom-1">
+                              <legend className="usa-label">
                                 {t('removeAccessibilityRequest.reason')}
                               </legend>
                               <FieldErrorMsg>

--- a/src/views/TestDate/Form.tsx
+++ b/src/views/TestDate/Form.tsx
@@ -91,7 +91,7 @@ const TestDateForm = ({
                 >
                   <FieldGroup error={!!flatErrors.testType}>
                     <fieldset className="usa-fieldset">
-                      <legend className="usa-label margin-bottom-1">
+                      <legend className="usa-label">
                         {t('testDateForm.testTypeHeader')}
                       </legend>
                       <FieldErrorMsg>{flatErrors.testType}</FieldErrorMsg>
@@ -188,7 +188,7 @@ const TestDateForm = ({
                     error={!!flatErrors['score.isPresent']}
                   >
                     <fieldset className="usa-fieldset margin-top-4">
-                      <legend className="usa-label margin-bottom-1">
+                      <legend className="usa-label">
                         {t('testDateForm.scoreHeader')}
                       </legend>
 

--- a/src/views/TestDate/Form.tsx
+++ b/src/views/TestDate/Form.tsx
@@ -227,7 +227,6 @@ const TestDateForm = ({
                             <Label
                               htmlFor="TestDate-ScoreValue"
                               className="margin-bottom-1"
-                              style={{ marginTop: '0.5em' }}
                               aria-label={t(
                                 'testDateForm.scoreValueSRHelpText'
                               )}


### PR DESCRIPTION
# ES-369

One of the quietly major changes was introduced  in `v2.9.0`. Here is the [changeset](https://github.com/uswds/uswds/pull/3638/files). The offending file is `src/stylesheets/elements/form-controls/_checkbox-and-radio.scss`.

They changed `margin-bottom` to `margin-top`. This means there's too much margin on top and too little margin on the bottom.

This PR is mainly adding/subtracting margins.

## Code Review Verification Steps

### As the original developer, I have
- [ ] Requested a design review for user-facing changes

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
