### PR TITLE
Update file input label when a file has been selected.

### DIFF
--- a/src/components/FileUpload/index.tsx
+++ b/src/components/FileUpload/index.tsx
@@ -12,7 +12,6 @@ type FileUploadProps = {
   disabled?: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur: () => void;
-  ariaDescribedBy: string;
 } & JSX.IntrinsicElements['input'];
 
 const FileUpload = (props: FileUploadProps) => {
@@ -23,8 +22,7 @@ const FileUpload = (props: FileUploadProps) => {
     // multiple = false,
     disabled = false,
     onChange,
-    onBlur,
-    ariaDescribedBy
+    onBlur
   } = props;
   const [file, setFile] = useState<File>(null);
   const [error, setError] = useState(false);
@@ -82,6 +80,11 @@ const FileUpload = (props: FileUploadProps) => {
             <span className="usa-file-input__choose">Change file</span>
           </div>
         )}
+        {file && (
+          <div role="alert" aria-live="assertive" className="sr-only">
+            File {file.name} selected.
+          </div>
+        )}
         <div className={instructionsClasses} aria-hidden>
           <span className="usa-file-input__drag-text">
             Drag document here or{' '}
@@ -111,11 +114,14 @@ const FileUpload = (props: FileUploadProps) => {
           accept={accept}
           // multiple={multiple}
           disabled={disabled}
-          aria-describedby={ariaDescribedBy}
+          aria-describedby="FileUpload-Description"
           onChange={handleChange}
           onBlur={onBlur}
           data-testid="file-upload-input"
         />
+      </div>
+      <div id="FileUpload-Description" className="sr-only" tabIndex={-1}>
+        {file ? `File ${file.name} selected` : 'Select a file'}
       </div>
     </div>
   );

--- a/src/components/FileUpload/index.tsx
+++ b/src/components/FileUpload/index.tsx
@@ -120,7 +120,7 @@ const FileUpload = (props: FileUploadProps) => {
           data-testid="file-upload-input"
         />
       </div>
-      <div id="FileUpload-Description" className="sr-only" tabIndex={-1}>
+      <div id="FileUpload-Description" className="sr-only">
         {file ? `File ${file.name} selected` : 'Select a file'}
       </div>
     </div>

--- a/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
@@ -210,19 +210,11 @@ const New = () => {
                         as={FileUpload}
                         id="FileUpload-File"
                         name="file"
-                        ariaDescribedBy="FileUpload-Description"
                         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                           onChange(e);
                           setFieldValue('file', e.currentTarget?.files?.[0]);
                         }}
                       />
-                      <div
-                        id="FileUpload-Description"
-                        className="sr-only"
-                        tabIndex={-1}
-                      >
-                        Select a file.
-                      </div>
                     </FieldGroup>
                     {values.file && (
                       <FieldGroup


### PR DESCRIPTION
# ES-735

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

## Changes proposed in this pull request

- Add an aria alert that is read (by some browsers) when a file is selected. This works in JAWS/Chrome, but not in VO/Safari.
- Move the aria-described-by tag inside the `fileInput` and update its value when a file is selected. This works in all both browser/screen reader combinations I tested.

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over
- [x] Requested a design review for user-facing changes
- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked accessibility against criteria
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

## Videos

JAWS/Chrome:

https://user-images.githubusercontent.com/3331/122287763-eff34780-ceb6-11eb-98a8-88372a398b57.mov

VO/Safari:

https://user-images.githubusercontent.com/3331/122287789-f5e92880-ceb6-11eb-9ad7-7ee0ad990338.mov


