### PR TITLE
fix 508 document name field label

### DIFF
--- a/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
@@ -299,7 +299,7 @@ const New = () => {
                                   as={TextField}
                                   error={!!flatErrors['documentType.otherType']}
                                   className="margin-top-0"
-                                  id="DocumentType-OtherType"
+                                  id="FileUpload-OtherType"
                                   name="documentType.otherType"
                                 />
                               </FieldGroup>


### PR DESCRIPTION
# ES-725
Fixes the id mapping between the label and document name field

<img width="600" alt="Screen Shot 2021-06-17 at 9 35 10 AM" src="https://user-images.githubusercontent.com/8367504/122438200-50ce5e80-cf4f-11eb-8573-89134ee8ca15.png">

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked accessibility against criteria
