### PR TITLE
fix 508 detail page headings

### DIFF
--- a/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
@@ -83,7 +83,7 @@ describe('AccessibilityRequestDetailPage', () => {
         wrapper.update();
       });
       expect(
-        wrapper.find('h2').at(1).contains('Next step: Provide your documents')
+        wrapper.find('h2').at(0).contains('Next step: Provide your documents')
       ).toBe(true);
     });
 
@@ -149,7 +149,7 @@ describe('AccessibilityRequestDetailPage', () => {
         await new Promise(resolve => setTimeout(resolve, 1000));
         wrapper.update();
       });
-      expect(wrapper.find('h2').at(1).contains('Documents')).toBe(true);
+      expect(wrapper.find('h2').at(0).contains('Documents')).toBe(true);
       expect(wrapper.find('AccessibilityDocumentsList').exists()).toBe(true);
     });
   });
@@ -177,7 +177,7 @@ describe('AccessibilityRequestDetailPage', () => {
         await new Promise(resolve => setTimeout(resolve, 1000));
         wrapper.update();
       });
-      expect(wrapper.find('h2').at(1).contains('Documents')).toBe(true);
+      expect(wrapper.find('h2').at(0).contains('Documents')).toBe(true);
       expect(wrapper.find('AccessibilityDocumentsList').exists()).toBe(true);
       expect(wrapper.find('AccessibilityDocumentsList').text()).toEqual(
         'No documents added to request yet.'
@@ -204,7 +204,13 @@ describe('AccessibilityRequestDetailPage', () => {
       await new Promise(resolve => setTimeout(resolve, 1000));
       wrapper.update();
     });
-    expect(wrapper.find('h2').at(0).contains('Current status')).toBe(true);
-    expect(wrapper.find('h2').at(0).find('span').contains('Open')).toBe(true);
+    expect(
+      wrapper
+        .find('[data-testid="current-status-dt"]')
+        .contains('Current status')
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="current-status-dd"]').contains('Open')
+    ).toBe(true);
   });
 });

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -257,15 +257,20 @@ const AccessibilityRequestDetailPage = () => {
               {message}
             </Alert>
           )}
-          <PageHeading>{requestName}</PageHeading>
-          <h2 className="font-heading-sm text-normal">
-            Current status
-            <div className="display-block">
-              <span className="bg-warning-lighter text-ink padding-05 display-inline-block margin-top-1">
-                {requestStatus}
-              </span>
-            </div>
-          </h2>
+          <PageHeading
+            aria-label={`${requestName} current status ${requestStatus}`}
+          >
+            {requestName}
+          </PageHeading>
+          <dl>
+            <dt data-testid="current-status-dt">Current status</dt>
+            <dd
+              data-testid="current-status-dd"
+              className="bg-warning-lighter padding-05 display-inline-block margin-top-1 margin-left-0"
+            >
+              {requestStatus}
+            </dd>
+          </dl>
           {isAccessibilityTeam && (
             <UswdsLink
               asCustom={Link}


### PR DESCRIPTION
- Update `h1` to read out current status of the request
- Update current status info to live in dl, dt, dd tags instead of h2

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
