### PR TITLE
update okta sign in widget color contrast

### DIFF
--- a/src/components/shared/OktaSignInWidget/index.scss
+++ b/src/components/shared/OktaSignInWidget/index.scss
@@ -1,0 +1,15 @@
+#easi-okta-sign-in {
+  #okta-sign-in.auth-container {
+    .okta-form-label,
+    .okta-form-input-field input,
+    .link,
+    h2,
+    h3 {
+      color: #595959;
+    }
+  }
+
+  #okta-sign-in.auth-container.main-container {
+    color: #595959;
+  }
+}

--- a/src/components/shared/OktaSignInWidget/index.tsx
+++ b/src/components/shared/OktaSignInWidget/index.tsx
@@ -3,6 +3,8 @@
 import React, { useEffect, useRef } from 'react';
 import OktaSignIn from '@okta/okta-signin-widget';
 
+import './index.scss';
+
 type OktaSignInWidgetProps = {
   onSuccess: (auth: any) => any;
   onError: () => void;
@@ -41,7 +43,7 @@ const OktaSignInWidget = ({ onSuccess, onError }: OktaSignInWidgetProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return <div ref={widgetRef} />;
+  return <div id="easi-okta-sign-in" ref={widgetRef} />;
 };
 
 export default OktaSignInWidget;


### PR DESCRIPTION
# ES-737

In our accessibility testing, we learned that the Okta sign in widget has insufficient color contrast. This PR changes the text inside of the widget to be `#595959`. This color is WCAG AA/AAA compliant against `#ffffff` background.

---
Backstory

Originally we were going to make the text very clear (text: `#fff`, background: `#000`). We learned that the "Remember me" checkbox renders from a sprite sheet. This means we can't actually update the color of the border. The widget looked strange with black text and light grey borders so I looked for a color that was AA/AAA compliant, but also didn't look too different from the background colors. That's how I settled on `#595959`.

## Code Review Verification Steps

### As the original developer, I have

- [ ] Requested a design review for user-facing changes

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked accessibility against criteria


<img width="448" alt="Screen Shot 2021-06-21 at 5 48 14 AM" src="https://user-images.githubusercontent.com/8367504/122768148-2b479a80-d258-11eb-8cd6-3270e8187f76.png">

With updated colors

<img width="437" alt="Screen Shot 2021-06-21 at 6 16 27 AM" src="https://user-images.githubusercontent.com/8367504/122768195-38648980-d258-11eb-985e-709239dac996.png">