### PR TITLE
fix download requests xls link for gov team

### DIFF
--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -345,23 +345,18 @@ const RequestRepository = () => {
           </Breadcrumb>
           <Breadcrumb current>Requests</Breadcrumb>
         </BreadcrumbBar>
-        <div>
-          <CSVLink
-            data={convertIntakesToCSV(data)}
-            filename="request-repository.csv"
-            headers={csvHeaders}
-          >
-            <i className="fa fa-download" />
-          </CSVLink>
-          &nbsp;
-          <CSVLink
-            data={convertIntakesToCSV(data)}
-            filename="request-repository.csv"
-            headers={csvHeaders}
-          >
+        <CSVLink
+          className="flex-align-self-center text-no-underline"
+          data={convertIntakesToCSV(data)}
+          filename="request-repository.csv"
+          headers={csvHeaders}
+        >
+          <i className="fa fa-download" />
+          &nbsp;{' '}
+          <span className="text-underline">
             Download all requests as excel file
-          </CSVLink>
-        </div>
+          </span>
+        </CSVLink>
       </div>
       <nav aria-label="Request Repository Table Navigation">
         <ul className="easi-request-repo__tab-list">


### PR DESCRIPTION
# ES-726

Update gov team XLS requests download link
    - it should one link instead of two.
    - fix styling (underline and vertical spacing)


## Code Review Verification Steps

### As the original developer, I have

- [ ] Tested user-facing changes with voice-over
- [ ] Checked for landmarks, page heading structure and links using [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu)
- [ ] Requested a design review for user-facing changes
- [ ] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked accessibility against criteria
- [ ] Checked for landmarks, page heading structure, and links
