### PR TITLE
Send email (optionally) when creating 508 note

### DIFF
--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -40,6 +40,7 @@ type templates struct {
 	removedAccessibilityRequestTemplate        templateCaller
 	newDocumentTemplate                        templateCaller
 	changeAccessibilityRequestStatus           templateCaller
+	newAccessibilityRequestNote                templateCaller
 }
 
 // sender is an interface for swapping out email provider implementations
@@ -150,6 +151,13 @@ func NewClient(config Config, sender sender) (Client, error) {
 		return Client{}, templateError(changeAccessibilityRequestStatusTemplateName)
 	}
 	appTemplates.changeAccessibilityRequestStatus = changeAccessibilityRequestStatusTemplate
+
+	newAccessibilityRequestNoteTemplateName := "change_508_status.gohtml"
+	newAccessibilityRequestNoteTemplate := rawTemplates.Lookup(newAccessibilityRequestNoteTemplateName)
+	if newAccessibilityRequestNoteTemplate == nil {
+		return Client{}, templateError(newAccessibilityRequestNoteTemplateName)
+	}
+	appTemplates.newAccessibilityRequestNote = newAccessibilityRequestNoteTemplate
 
 	client := Client{
 		config:    config,

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -152,7 +152,7 @@ func NewClient(config Config, sender sender) (Client, error) {
 	}
 	appTemplates.changeAccessibilityRequestStatus = changeAccessibilityRequestStatusTemplate
 
-	newAccessibilityRequestNoteTemplateName := "change_508_status.gohtml"
+	newAccessibilityRequestNoteTemplateName := "new_508_note.gohtml"
 	newAccessibilityRequestNoteTemplate := rawTemplates.Lookup(newAccessibilityRequestNoteTemplateName)
 	if newAccessibilityRequestNoteTemplate == nil {
 		return Client{}, templateError(newAccessibilityRequestNoteTemplateName)

--- a/pkg/email/new_accessibility_request_note.go
+++ b/pkg/email/new_accessibility_request_note.go
@@ -1,0 +1,61 @@
+package email
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	"github.com/google/uuid"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+)
+
+type newAccessibilityRequestNote struct {
+	RequestName string
+	CreatorName string
+	RequestLink string
+}
+
+func (c Client) newAccessibilityRequestNoteBody(requestID uuid.UUID, requestName, creatorName string) (string, error) {
+	requestPath := path.Join("508", "requests", requestID.String())
+	data := newAccessibilityRequestNote{
+		CreatorName: creatorName,
+		RequestName: requestName,
+		RequestLink: c.urlFromPath(requestPath),
+	}
+	var b bytes.Buffer
+	if c.templates.newAccessibilityRequestNote == nil {
+		return "", errors.New("email template is nil")
+	}
+	err := c.templates.newAccessibilityRequestNote.Execute(&b, data)
+	if err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// SendNewAccessibilityRequestNoteEmail sends an email for a new 508 note
+func (c Client) SendNewAccessibilityRequestNoteEmail(
+	ctx context.Context,
+	requestID uuid.UUID,
+	requestName,
+	creatorName string,
+) error {
+	subject := fmt.Sprintf("%s: New note added", requestName)
+	body, err := c.newAccessibilityRequestNoteBody(requestID, requestName, creatorName)
+	if err != nil {
+		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}
+	}
+	err = c.sender.Send(
+		ctx,
+		c.config.AccessibilityTeamEmail,
+		subject,
+		body,
+	)
+	if err != nil {
+		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}
+	}
+	return nil
+}

--- a/pkg/email/templates/new_508_note.gohtml
+++ b/pkg/email/templates/new_508_note.gohtml
@@ -1,0 +1,2 @@
+<p>{{.CreatorName}} added a new note to {{.RequestName}} request.</p>
+<a href="{{.RequestLink}}">Go to request in EASi</a>

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -2661,6 +2661,7 @@ type UpdateAccessibilityRequestStatusPayload {
 input CreateAccessibilityRequestNoteInput {
   requestID: UUID!
   note: String!
+  shouldSendEmail: Boolean!
 }
 
 type AccessibilityRequestNote {
@@ -14360,6 +14361,14 @@ func (ec *executionContext) unmarshalInputCreateAccessibilityRequestNoteInput(ct
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("note"))
 			it.Note, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "shouldSendEmail":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("shouldSendEmail"))
+			it.ShouldSendEmail, err = ec.unmarshalNBoolean2bool(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -93,8 +93,9 @@ type CreateAccessibilityRequestInput struct {
 }
 
 type CreateAccessibilityRequestNoteInput struct {
-	RequestID uuid.UUID `json:"requestID"`
-	Note      string    `json:"note"`
+	RequestID       uuid.UUID `json:"requestID"`
+	Note            string    `json:"note"`
+	ShouldSendEmail bool      `json:"shouldSendEmail"`
 }
 
 type CreateAccessibilityRequestNotePayload struct {

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -85,6 +85,7 @@ type UpdateAccessibilityRequestStatusPayload {
 input CreateAccessibilityRequestNoteInput {
   requestID: UUID!
   note: String!
+  shouldSendEmail: Boolean!
 }
 
 type AccessibilityRequestNote {

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -473,6 +473,23 @@ func (r *mutationResolver) CreateAccessibilityRequestNote(ctx context.Context, i
 		return nil, err
 	}
 
+	if input.ShouldSendEmail {
+		request, err := r.store.FetchAccessibilityRequestByID(ctx, input.RequestID)
+		if err != nil {
+			return nil, err
+		}
+
+		userInfo, err := r.service.FetchUserInfo(ctx, appcontext.Principal(ctx).ID())
+		if err != nil {
+			return nil, err
+		}
+
+		err = r.emailClient.SendNewAccessibilityRequestNoteEmail(ctx, input.RequestID, request.Name, userInfo.CommonName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &model.CreateAccessibilityRequestNotePayload{AccessibilityRequestNote: created}, nil
 }
 

--- a/src/types/accessibility.ts
+++ b/src/types/accessibility.ts
@@ -14,6 +14,7 @@ export type DeleteAccessibilityRequestForm = {
 
 export type CreateNoteForm = {
   noteText: string;
+  shouldSendEmail: boolean;
 };
 
 // Form for reviewer to add dates

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -126,6 +126,7 @@ export interface CreateAccessibilityRequestInput {
 export interface CreateAccessibilityRequestNoteInput {
   requestID: UUID;
   note: string;
+  shouldSendEmail: boolean;
 }
 
 export interface CreateSystemIntakeInput {

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -125,7 +125,7 @@ const AccessibilityRequestDetailPage = () => {
           shouldSendEmail: values.shouldSendEmail
         }
       }
-    }).then(response => {
+    }).then(() => {
       showMessage(t('requestDetails.notes.confirmation', { requestName }));
       resetForm({});
     });

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -41,10 +41,10 @@ import AccessibilityDocumentsList from 'components/AccessibilityDocumentsList';
 import Modal from 'components/Modal';
 import PageHeading from 'components/PageHeading';
 import Alert from 'components/shared/Alert';
+import CheckboxField from 'components/shared/CheckboxField';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
-import Label from 'components/shared/Label';
 import { RadioField } from 'components/shared/RadioField';
 import TextAreaField from 'components/shared/TextAreaField';
 import { TabPanel, Tabs } from 'components/Tabs';
@@ -121,7 +121,8 @@ const AccessibilityRequestDetailPage = () => {
       variables: {
         input: {
           requestID: accessibilityRequestId,
-          note: values.noteText
+          note: values.noteText,
+          shouldSendEmail: values.shouldSendEmail
         }
       }
     }).then(response => {
@@ -267,7 +268,8 @@ const AccessibilityRequestDetailPage = () => {
       >
         <Formik
           initialValues={{
-            noteText: ''
+            noteText: '',
+            shouldSendEmail: false
           }}
           onSubmit={createNote}
           validationSchema={accessibilitySchema.noteForm}
@@ -276,7 +278,7 @@ const AccessibilityRequestDetailPage = () => {
           validateOnMount={false}
         >
           {(formikProps: FormikProps<CreateNoteForm>) => {
-            const { errors } = formikProps;
+            const { values, errors, setFieldValue } = formikProps;
             const flatErrors = flattenErrors(errors);
             return (
               <>
@@ -298,10 +300,8 @@ const AccessibilityRequestDetailPage = () => {
                   </ErrorAlert>
                 )}
                 <Form className="usa-form maxw-full ">
-                  <FieldGroup>
-                    <Label htmlFor="CreateAccessibilityRequestNote-NoteText">
-                      {t('requestDetails.notes.addNote')}
-                    </Label>
+                  <h3>{t('requestDetails.notes.addNote')}</h3>
+                  <FieldGroup className="margin-bottom-2">
                     <FieldErrorMsg>{flatErrors.noteText}</FieldErrorMsg>
                     <Field
                       as={TextAreaField}
@@ -310,6 +310,19 @@ const AccessibilityRequestDetailPage = () => {
                       error={!!flatErrors.noteText}
                       className="accessibility-request__note-field"
                       name="noteText"
+                    />
+                  </FieldGroup>
+                  <FieldGroup>
+                    <Field
+                      as={CheckboxField}
+                      checked={values.shouldSendEmail}
+                      id="CreateAccessibilityRequestNote-ShouldSendEmail"
+                      name="shouldSendEmail"
+                      label="Email the 508 team about this note"
+                      value="ShouldSendEmail"
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        setFieldValue(`shouldSendEmail`, e.target.checked);
+                      }}
                     />
                   </FieldGroup>
                   <Button className="margin-top-2" type="submit">


### PR DESCRIPTION
# ES-579

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

## Changes proposed in this pull request

- There is a checkbox on the 'Add 508 note' tab, which, if selected, will email the 508 team about a new note. 
- If the checkbox is not checked, no email is sent. 

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer Notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## Code Review Verification Steps

### As the original developer, I have

- [ ] Tested user-facing changes with voice-over
- [ ] Requested a design review for user-facing changes

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked accessibility against criteria
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
