### PR TITLE
fix calculation of adding two days in integration test

### DIFF
--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -235,10 +235,10 @@ describe('Accessibility Requests', () => {
       // This seeded 508 request comes with a test date that's scheduled one day
       // after the 508 request was created. This is why we're adding a test date
       // two days into the future.
-      const now = DateTime.local();
-      const currentMonth = String(now.month);
-      const tomorrow = String(now.day + 2);
-      const currentYear = String(now.year);
+      const futureDatetime = DateTime.local().plus({ day: 2 });
+      const currentMonth = String(futureDatetime.month);
+      const tomorrow = String(futureDatetime.day);
+      const currentYear = String(futureDatetime.year);
       const tomorrowDate = formatDate(
         DateTime.fromObject({
           month: currentMonth,


### PR DESCRIPTION
Add dates to DateTime instead of directly to the string. :doh:

## Code Review Verification Steps


### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Made it clear which comments need to be addressed before this work is merged
- [x] Considered marking this as accepted even if there are small changes needed

