### PR TITLE
fix heading target for test date cypress test

### DIFF
--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -229,6 +229,8 @@ describe('Accessibility Requests', () => {
     beforeEach(() => {
       cy.localLogin({ name: 'ADMI', role: 'EASI_D_508_USER' });
       cy.visit('/508/requests/6e224030-09d5-46f7-ad04-4bb851b36eab');
+      cy.get('[data-testid="page-loading"]').should('exist');
+      cy.get('[data-testid="page-loading"]').should('not.exist');
     });
 
     it('adds a 508 test date', () => {


### PR DESCRIPTION
Recently, we got this error from Cypress. This was confusing because it's pretty clear that the `h1` has the appropriate text Cypress is trying to match.

<img width="2015" alt="Screen Shot 2021-06-29 at 4 10 01 PM" src="https://user-images.githubusercontent.com/8367504/123878729-83d00500-d8f4-11eb-9db7-2af9401aef3d.png">


After some clicking around, I realized that Cypress was watching the `h1` from the "loading" page and was still watching it after the the page was fully loaded. So when the actual page loaded, it didn't pick up the new `h1`.

<img width="2014" alt="Screen Shot 2021-06-29 at 4 11 28 PM" src="https://user-images.githubusercontent.com/8367504/123878826-aa8e3b80-d8f4-11eb-8f08-904abbfc859d.png">

To resolve that, I told Cypress to make sure the loading indicator is no longer on the screen.

