### PR TITLE
add sufficient help text for fields

### DIFF
--- a/src/components/shared/DateInput/index.tsx
+++ b/src/components/shared/DateInput/index.tsx
@@ -29,7 +29,7 @@ const DateInputMonth = ({
   return (
     <>
       <span id="DateMonthHelp" className="usa-sr-only">
-        Month, this field requies two digits. For example, zero three
+        Month, this field requires two digits. For example, zero three
       </span>
       <input
         className={classes}
@@ -67,7 +67,7 @@ const DateInputDay = ({
   return (
     <>
       <span id="DateDayHelp" className="usa-sr-only">
-        Day, this field requies two digits. For example, two three
+        Day, this field requires two digits. For example, two three
       </span>
       <input
         className={classes}
@@ -105,7 +105,7 @@ const DateInputYear = ({
   return (
     <>
       <span id="DateYearHelp" className="usa-sr-only">
-        Year, this field requies four digits. For example, two zero two one
+        Year, this field requires four digits. For example, two zero two one
       </span>
       <input
         className={classes}

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -92,10 +92,12 @@ const accessibility = {
     testTypeHeader: 'What type of test?',
     dateHeader: 'Test date',
     dateHelpText: 'For example: 4 28 2020',
-    scoreHelpText: 'The test score must be a number between 0 and 100',
-    scoreHeader: 'Does this test have a score?',
-    scoreValueHeader: 'Test Score',
-    scoreValueSRHelpText: 'Enter the test score without the percentage symbol',
+    score: {
+      heading: 'Does this test have a score?',
+      label: 'Test Score',
+      help: 'Must be between 0 and 100',
+      srHelp: 'Enter the test score without the percentage symbol'
+    },
     submitButton: {
       create: 'Add date',
       update: 'Update date'

--- a/src/validations/systemIntakeSchema.ts
+++ b/src/validations/systemIntakeSchema.ts
@@ -103,7 +103,7 @@ const SystemIntakeValidationSchema: any = {
         then: Yup.string()
           .trim()
           .length(6, 'Funding number must be exactly 6 digits')
-          .matches(/^\d+$/, 'Fuding number can only contain digits')
+          .matches(/^\d+$/, 'Funding number can only contain digits')
           .required(
             'Tell us your funding number. This is a six digit number and starts with 00'
           )

--- a/src/views/BusinessCase/GeneralRequestInfo/index.tsx
+++ b/src/views/BusinessCase/GeneralRequestInfo/index.tsx
@@ -10,6 +10,7 @@ import AutoSave from 'components/shared/AutoSave';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
+import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import TextField from 'components/shared/TextField';
 import { alternativeSolutionHasFilledFields } from 'data/businessCase';
@@ -147,6 +148,9 @@ const GeneralRequestInfo = ({
                   <Label htmlFor="BusinessCase-RequesterPhoneNumber">
                     Requester Phone Number
                   </Label>
+                  <HelpText id="BusinessCase-PhoneNumber">
+                    For example 123456789 or 123-456-789
+                  </HelpText>
                   <FieldErrorMsg>
                     {flatErrors['requester.phoneNumber']}
                   </FieldErrorMsg>
@@ -158,6 +162,7 @@ const GeneralRequestInfo = ({
                       maxLength={20}
                       name="requester.phoneNumber"
                       match={allowedPhoneNumberCharacters}
+                      aria-describedby="BusinessCase-PhoneNumber"
                     />
                   </div>
                 </FieldGroup>

--- a/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
@@ -170,7 +170,7 @@ const IssueLifecycleId = () => {
                       value={false}
                     />
                     {values.newLifecycleId === false && (
-                      <div className="width-card-lg margin-top-neg-2 margin-left-3 margin-bottom-1">
+                      <div className="margin-top-neg-2 margin-left-3 margin-bottom-1">
                         <FieldGroup
                           scrollElement="lifecycleId"
                           error={!!flatErrors.lifecycleId}
@@ -178,13 +178,18 @@ const IssueLifecycleId = () => {
                           <Label htmlFor="IssueLifecycleIdForm-LifecycleId">
                             {t('issueLCID.lcid.label')}
                           </Label>
+                          <HelpText id="IssueLifecycleIdForm-LifecycleIdHelp">
+                            For example A123456 or 123456
+                          </HelpText>
                           <FieldErrorMsg>
                             {flatErrors.lifecycleId}
                           </FieldErrorMsg>
                           <Field
                             as={TextField}
+                            className="width-card-lg"
                             error={!!flatErrors.lifecycleId}
                             id="IssueLifecycleIdForm-LifecycleId"
+                            aria-describedby="IssueLifecycleIdForm-LifecycleIdHelp"
                             maxLength={7}
                             name="lifecycleId"
                           />

--- a/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
@@ -170,12 +170,15 @@ const IssueLifecycleId = () => {
                       value={false}
                     />
                     {values.newLifecycleId === false && (
-                      <div className="margin-top-neg-2 margin-left-3 margin-bottom-1">
+                      <div className="margin-bottom-1">
                         <FieldGroup
                           scrollElement="lifecycleId"
                           error={!!flatErrors.lifecycleId}
                         >
-                          <Label htmlFor="IssueLifecycleIdForm-LifecycleId">
+                          <Label
+                            htmlFor="IssueLifecycleIdForm-LifecycleId"
+                            className="margin-bottom-1"
+                          >
                             {t('issueLCID.lcid.label')}
                           </Label>
                           <HelpText id="IssueLifecycleIdForm-LifecycleIdHelp">

--- a/src/views/GovernanceReviewTeam/Dates/index.tsx
+++ b/src/views/GovernanceReviewTeam/Dates/index.tsx
@@ -153,7 +153,7 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntake }) => {
                       {t('governanceReviewTeam:dates.grtDate.label')}
                     </legend>
                     <HelpText id="TestDate-DateHelp">
-                      For example 4 28 2020
+                      For example 04 28 2020
                     </HelpText>
                     <FieldErrorMsg>{flatErrors.grtDateMonth}</FieldErrorMsg>
                     <FieldErrorMsg>{flatErrors.grtDateDay}</FieldErrorMsg>

--- a/src/views/GovernanceReviewTeam/Dates/index.tsx
+++ b/src/views/GovernanceReviewTeam/Dates/index.tsx
@@ -21,6 +21,7 @@ import {
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
+import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import TextField from 'components/shared/TextField';
 import { AnythingWrongSurvey } from 'components/Survey';
@@ -151,6 +152,9 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntake }) => {
                     <legend className="usa-label margin-bottom-1">
                       {t('governanceReviewTeam:dates.grtDate.label')}
                     </legend>
+                    <HelpText id="TestDate-DateHelp">
+                      For example 4 28 2020
+                    </HelpText>
                     <FieldErrorMsg>{flatErrors.grtDateMonth}</FieldErrorMsg>
                     <FieldErrorMsg>{flatErrors.grtDateDay}</FieldErrorMsg>
                     <FieldErrorMsg>{flatErrors.grtDateYear}</FieldErrorMsg>

--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -219,6 +219,9 @@ const ContractDetails = ({
                           <Label htmlFor="IntakeForm-FundingNumber">
                             Funding Number
                           </Label>
+                          <HelpText id="IntakeForm-FundingNumberRestrictions">
+                            Funding number must be 6 digits long
+                          </HelpText>
                           <FieldErrorMsg>
                             {flatErrors['fundingSource.fundingNumber']}
                           </FieldErrorMsg>
@@ -229,7 +232,7 @@ const ContractDetails = ({
                             id="IntakeForm-FundingNumber"
                             maxLength={6}
                             name="fundingSource.fundingNumber"
-                            aria-describedby="IntakeForm-FundingNumberHelp"
+                            aria-describedby="IntakeForm-FundingNumberRestrictions IntakeForm-FundingNumberHelp"
                             // If funding source is 'Unknown' disable funding number input and set
                             // placeholder to 'N/A' (funding number value is set to '')
                             disabled={values.fundingSource.source === 'Unknown'}
@@ -441,7 +444,7 @@ const ContractDetails = ({
                             Period of performance
                           </legend>
                           <HelpText className="margin-bottom-1">
-                            For example: 4/10/2020
+                            For example: 04 10 2020
                           </HelpText>
                           <FieldErrorMsg>
                             {flatErrors['contract.startDate.month']}

--- a/src/views/TestDate/Form.tsx
+++ b/src/views/TestDate/Form.tsx
@@ -189,7 +189,7 @@ const TestDateForm = ({
                   >
                     <fieldset className="usa-fieldset margin-top-4">
                       <legend className="usa-label">
-                        {t('testDateForm.scoreHeader')}
+                        {t('testDateForm.score.heading')}
                       </legend>
 
                       <FieldErrorMsg>
@@ -227,12 +227,16 @@ const TestDateForm = ({
                             <Label
                               htmlFor="TestDate-ScoreValue"
                               className="margin-bottom-1"
-                              aria-label={t(
-                                'testDateForm.scoreValueSRHelpText'
-                              )}
+                              aria-label={t('testDateForm.score.srHelp')}
                             >
-                              {t('testDateForm.scoreValueHeader')}
+                              {t('testDateForm.score.label')}
                             </Label>
+                            <HelpText
+                              id="TestDate-ScoreValueHelpText"
+                              className="margin-bottom-1"
+                            >
+                              {t('testDateForm.score.help')}
+                            </HelpText>
                             <FieldErrorMsg>
                               {flatErrors['score.value']}
                             </FieldErrorMsg>
@@ -252,9 +256,6 @@ const TestDateForm = ({
                                 <span className="text-bold">%</span>
                               </div>
                             </div>
-                            <HelpText id="TestDate-ScoreValueHelpText">
-                              {t('testDateForm.scoreHelpText')}
-                            </HelpText>
                           </FieldGroup>
                         </div>
                       )}


### PR DESCRIPTION
# ES-728

This PR adds sufficient help text for fields.
- Did not add much for any Dates field
    - It should be common sense to enter in a valid date. It doesn't make sense to tell a user a month should be from 1-12. That's common knowledge
    - The date input fields have help text that reads when the input field is focused
- Phone number, LCID,  and test score all have added help text.

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over
- [x] Requested a design review for user-facing changes


### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked accessibility against criteria
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
