### PR TITLE
indicate which tab is selected on get home page

### DIFF
--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -371,6 +371,9 @@ const RequestRepository = () => {
               type="button"
               className="easi-request-repo__tab-btn"
               onClick={() => setActiveTable('open')}
+              aria-label={
+                activeTable === 'open' ? 'Open requests selected' : ''
+              }
             >
               Open Requests
             </button>
@@ -385,6 +388,9 @@ const RequestRepository = () => {
               className="easi-request-repo__tab-btn"
               onClick={() => setActiveTable('closed')}
               data-testid="view-closed-intakes-btn"
+              aria-label={
+                activeTable === 'closed' ? 'Closed requests selected' : ''
+              }
             >
               Closed Requests
             </button>


### PR DESCRIPTION
# ES-748

- add `aria-label` for the open/closed requests button to indicate which is selected

Note: there's actually already an `h1`, so I didn't need to add one.
## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over
- [x] Checked for landmarks, page heading structure and links using [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu)
- [x] Requested a design review for user-facing changes

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked accessibility against criteria
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

