### PR TITLE
add test to check page flow for 508 request

### DIFF
--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -33,6 +33,28 @@ describe('Accessibility Requests', () => {
     });
   });
 
+  it('has the correct page order when clicking through 508 team home page', () => {
+    cy.localLogin({ name: 'A11Y', role: 'EASI_D_508_USER' });
+
+    cy.contains('a', 'Add a new request').click();
+    cy.location().should(loc => {
+      expect(loc.pathname).to.eq('/508/making-a-request');
+    });
+    cy.contains('h1', 'Making a 508 testing request');
+    cy.contains('a', 'steps involved').click();
+
+    cy.location().should(loc => {
+      expect(loc.pathname).to.eq('/508/testing-overview');
+    });
+    cy.contains('h1', 'Steps involved');
+    cy.contains('a', 'Get started').click();
+
+    cy.location().should(loc => {
+      expect(loc.pathname).to.eq('/508/requests/new');
+    });
+    cy.contains('h1', 'Request 508 testing');
+  });
+
   it('adds and removes a document from a 508 request as the owner', () => {
     cy.localLogin({ name: 'CMSU' });
     cy.accessibility.create508Request();


### PR DESCRIPTION
# ES-769

We already have a test for creating 508 requests.
For this test, I am checking the page flow when a 508 team user tries to add a 508 request from the home page. I am checking URLs and `h1`'s

Note: I am only partially checking key terms in the `h1` to make these tests more resilient to content/copy changes.

## Code Review Verification Steps

### As the original developer, I have
- [ ] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

