### PR TITLE
Separate the paths for documents and notes

### DIFF
--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -203,7 +203,7 @@ describe('Accessibility Requests', () => {
 
       cy.location().should(loc => {
         expect(loc.pathname).to.eq(
-          '/508/requests/6e224030-09d5-46f7-ad04-4bb851b36eab'
+          '/508/requests/6e224030-09d5-46f7-ad04-4bb851b36eab/documents'
         );
       });
       cy.get('[data-testid="alert"]');
@@ -234,7 +234,7 @@ describe('Accessibility Requests', () => {
 
       cy.location().should(loc => {
         expect(loc.pathname).to.eq(
-          '/508/requests/6e224030-09d5-46f7-ad04-4bb851b36eab'
+          '/508/requests/6e224030-09d5-46f7-ad04-4bb851b36eab/documents'
         );
       });
       cy.get('b').contains('Test 1: Initial');

--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -139,7 +139,7 @@ describe('Accessibility Requests', () => {
       cy.localLogin({ name: 'A11Y', role: 'EASI_D_508_USER' });
       cy.visit('/508/requests/6e224030-09d5-46f7-ad04-4bb851b36eab');
 
-      cy.contains('button', 'Notes').click();
+      cy.contains('a', 'Notes').click();
       cy.get('#CreateAccessibilityRequestNote-NoteText').type(
         'This is a really great note'
       );

--- a/src/components/shared/Label/index.tsx
+++ b/src/components/shared/Label/index.tsx
@@ -8,7 +8,7 @@ type LabelProps = {
 } & JSX.IntrinsicElements['label'];
 
 const Label = ({ children, htmlFor, className, ...props }: LabelProps) => {
-  const classes = classnames('usa-label', className);
+  const classes = classnames(className, 'usa-label');
 
   return (
     <label className={classes} htmlFor={htmlFor} {...props}>

--- a/src/components/shared/Label/index.tsx
+++ b/src/components/shared/Label/index.tsx
@@ -8,7 +8,7 @@ type LabelProps = {
 } & JSX.IntrinsicElements['label'];
 
 const Label = ({ children, htmlFor, className, ...props }: LabelProps) => {
-  const classes = classnames(className, 'usa-label');
+  const classes = classnames('usa-label', className);
 
   return (
     <label className={classes} htmlFor={htmlFor} {...props}>

--- a/src/views/Accessibility/AccessibilityRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Create/index.tsx
@@ -66,7 +66,7 @@ const Create = () => {
             </Link>
           </>
         );
-        history.push(`/508/requests/${uuid}`);
+        history.push(`/508/requests/${uuid}/documents`);
       }
     });
   };

--- a/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
@@ -147,7 +147,7 @@ const New = () => {
               showMessageOnNextPage(
                 `${file.name} uploaded to ${data?.accessibilityRequest?.name}`
               );
-              history.push(`/508/requests/${accessibilityRequestId}`);
+              history.push(`/508/requests/${accessibilityRequestId}/documents`);
             }
           })
           .catch(() => {

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
@@ -57,7 +57,13 @@ describe('AccessibilityRequestDetailPage', () => {
   };
 
   const buildProviders = (mocks: any, store: any, useNotesPath: boolean) => (
-    <MemoryRouter initialEntries={['/508/requests/a11yRequest123']}>
+    <MemoryRouter
+      initialEntries={[
+        useNotesPath
+          ? '/508/requests/a11yRequest123/notes'
+          : '/508/requests/a11yRequest123'
+      ]}
+    >
       <MockedProvider mocks={mocks} addTypename={false}>
         <Provider store={store}>
           <Route

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
@@ -56,11 +56,17 @@ describe('AccessibilityRequestDetailPage', () => {
     }
   };
 
-  const buildProviders = (mocks: any, store: any) => (
+  const buildProviders = (mocks: any, store: any, useNotesPath: boolean) => (
     <MemoryRouter initialEntries={['/508/requests/a11yRequest123']}>
       <MockedProvider mocks={mocks} addTypename={false}>
         <Provider store={store}>
-          <Route path="/508/requests/:accessibilityRequestId">
+          <Route
+            path={
+              useNotesPath
+                ? '/508/requests/:accessibilityRequestId/notes'
+                : '/508/requests/:accessibilityRequestId'
+            }
+          >
             <MessageProvider>
               <AccessibilityRequestDetailPage />
             </MessageProvider>
@@ -71,7 +77,7 @@ describe('AccessibilityRequestDetailPage', () => {
   );
 
   it('renders without crashing', async () => {
-    render(buildProviders([default508RequestQuery], defaultStore));
+    render(buildProviders([default508RequestQuery], defaultStore, false));
 
     await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
 
@@ -110,7 +116,7 @@ describe('AccessibilityRequestDetailPage', () => {
       }
     };
 
-    render(buildProviders([deleted508RequestQuery], defaultStore));
+    render(buildProviders([deleted508RequestQuery], defaultStore, false));
 
     await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
 
@@ -202,7 +208,7 @@ describe('AccessibilityRequestDetailPage', () => {
     };
 
     it('renders Next step if no documents', async () => {
-      render(buildProviders([withoutDocsQuery], defaultStore));
+      render(buildProviders([withoutDocsQuery], defaultStore, false));
 
       await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
 
@@ -365,7 +371,7 @@ describe('AccessibilityRequestDetailPage', () => {
     });
 
     const defaultRender = () =>
-      render(buildProviders([defaultQuery], testerStore));
+      render(buildProviders([defaultQuery], testerStore, false));
 
     it("doesn't render table if there are no documents", async () => {
       defaultRender();
@@ -378,7 +384,7 @@ describe('AccessibilityRequestDetailPage', () => {
     });
 
     it('renders table if there are documents', async () => {
-      render(buildProviders([withDocsQuery], testerStore));
+      render(buildProviders([withDocsQuery], testerStore, false));
 
       await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
 
@@ -389,7 +395,7 @@ describe('AccessibilityRequestDetailPage', () => {
 
     describe('notes tab', () => {
       it('can view existing notes', async () => {
-        render(buildProviders([withNotesQuery], testerStore));
+        render(buildProviders([withNotesQuery], testerStore, true));
 
         await waitForElementToBeRemoved(() =>
           screen.getByTestId('page-loading')
@@ -481,7 +487,7 @@ describe('AccessibilityRequestDetailPage', () => {
           withNotesQueryWithNewNote
         ];
 
-        const providers = buildProviders(createNoteMocks, testerStore);
+        const providers = buildProviders(createNoteMocks, testerStore, true);
         render(providers);
 
         await waitForElementToBeRemoved(() =>
@@ -506,7 +512,7 @@ describe('AccessibilityRequestDetailPage', () => {
 
       it('shows an error alert when there is a form validation error', async () => {
         const mocks = [defaultQuery];
-        const providers = buildProviders(mocks, testerStore);
+        const providers = buildProviders(mocks, testerStore, true);
 
         render(providers);
 
@@ -549,7 +555,7 @@ describe('AccessibilityRequestDetailPage', () => {
           }
         ];
 
-        const providers = buildProviders(errorMocks, testerStore);
+        const providers = buildProviders(errorMocks, testerStore, true);
         render(providers);
 
         await waitForElementToBeRemoved(() =>
@@ -599,7 +605,7 @@ describe('AccessibilityRequestDetailPage', () => {
           }
         ];
 
-        const providers = buildProviders(userErrorMocks, testerStore);
+        const providers = buildProviders(userErrorMocks, testerStore, true);
         render(providers);
 
         await waitForElementToBeRemoved(() =>

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
@@ -61,18 +61,12 @@ describe('AccessibilityRequestDetailPage', () => {
       initialEntries={[
         useNotesPath
           ? '/508/requests/a11yRequest123/notes'
-          : '/508/requests/a11yRequest123'
+          : '/508/requests/a11yRequest123/documents'
       ]}
     >
       <MockedProvider mocks={mocks} addTypename={false}>
         <Provider store={store}>
-          <Route
-            path={
-              useNotesPath
-                ? '/508/requests/:accessibilityRequestId/notes'
-                : '/508/requests/:accessibilityRequestId'
-            }
-          >
+          <Route path="/508/requests/:accessibilityRequestId/:secondaryNavTab">
             <MessageProvider>
               <AccessibilityRequestDetailPage />
             </MessageProvider>

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -61,6 +61,7 @@ import CheckboxField from 'components/shared/CheckboxField';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
+import Label from 'components/shared/Label';
 import { RadioField } from 'components/shared/RadioField';
 import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import TextAreaField from 'components/shared/TextAreaField';
@@ -349,13 +350,10 @@ const AccessibilityRequestDetailPage = () => {
             return (
               <>
                 <Form className="usa-form maxw-full">
-                  <FieldGroup>
-                    <label
-                      htmlFor="CreateAccessibilityRequestNote-NoteText"
-                      className="margin-top-0 text-bold"
-                    >
+                  <FieldGroup className="margin-top-0">
+                    <Label htmlFor="CreateAccessibilityRequestNote-NoteText">
                       {t('requestDetails.notes.form.note')}
-                    </label>
+                    </Label>
                     <FieldErrorMsg>{flatErrors.noteText}</FieldErrorMsg>
                     <Field
                       as={TextAreaField}

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { Link, useHistory, useParams } from 'react-router-dom';
+import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
   Breadcrumb,
@@ -61,10 +61,9 @@ import CheckboxField from 'components/shared/CheckboxField';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
-import Label from 'components/shared/Label';
 import { RadioField } from 'components/shared/RadioField';
+import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import TextAreaField from 'components/shared/TextAreaField';
-import { TabPanel, Tabs } from 'components/Tabs';
 import TestDateCard from 'components/TestDateCard';
 import useMessage from 'hooks/useMessage';
 import { AppState } from 'reducers/rootReducer';
@@ -94,6 +93,7 @@ const AccessibilityRequestDetailPage = () => {
   const { accessibilityRequestId } = useParams<{
     accessibilityRequestId: string;
   }>();
+  const { pathname } = useLocation();
 
   const userGroups = useSelector((state: AppState) => state.auth.groups);
   const isAccessibilityTeam = user.isAccessibilityTeam(userGroups, flags);
@@ -180,7 +180,7 @@ const AccessibilityRequestDetailPage = () => {
           resetForm({});
         }
       })
-      .catch(response => {});
+      .catch(() => {});
   };
 
   const [deleteTestDateMutation] = useMutation<DeleteTestDate>(
@@ -325,12 +325,7 @@ const AccessibilityRequestDetailPage = () => {
       >
         {t('requestDetails.notes.skipToExistingNotes')}
       </Button>
-      <div
-        role="region"
-        aria-label="add new note"
-        className="margin-y-2"
-        id="notes-form"
-      >
+      <div role="region" aria-label="add new note" id="notes-form">
         <Formik
           initialValues={{
             noteText: '',
@@ -355,9 +350,12 @@ const AccessibilityRequestDetailPage = () => {
               <>
                 <Form className="usa-form maxw-full">
                   <FieldGroup>
-                    <Label htmlFor="CreateAccessibilityRequestNote-NoteText">
+                    <label
+                      htmlFor="CreateAccessibilityRequestNote-NoteText"
+                      className="margin-top-0 text-bold"
+                    >
                       {t('requestDetails.notes.form.note')}
-                    </Label>
+                    </label>
                     <FieldErrorMsg>{flatErrors.noteText}</FieldErrorMsg>
                     <Field
                       as={TextAreaField}
@@ -531,21 +529,25 @@ const AccessibilityRequestDetailPage = () => {
           )}
         </div>
       </div>
-      <div className="grid-container margin-top-2 padding-top-6 padding-top">
+      {isAccessibilityTeam && (
+        <SecondaryNav>
+          <NavLink to={`/508/requests/${accessibilityRequestId}`}>
+            Documents
+          </NavLink>
+          <NavLink to={`/508/requests/${accessibilityRequestId}/notes`}>
+            Notes
+          </NavLink>
+        </SecondaryNav>
+      )}
+      <div className="grid-container padding-top-6 padding-top">
         <div className="grid-row grid-gap-lg">
           <div className="grid-col-8">
-            {isAccessibilityTeam ? (
-              <Tabs>
-                <TabPanel id="Documents" tabName="Documents">
-                  <div className="margin-top-2">{bodyWithDocumentsTable}</div>
-                </TabPanel>
-                <TabPanel id="Notes" tabName="Notes">
-                  {notesTab}
-                </TabPanel>
-              </Tabs>
-            ) : (
-              documentsTab
-            )}
+            {/* eslint-disable-next-line no-nested-ternary */}
+            {isAccessibilityTeam
+              ? pathname.endsWith('notes')
+                ? notesTab
+                : bodyWithDocumentsTable
+              : documentsTab}
           </div>
           <div className="grid-col-1" />
           <div className="grid-col-3">

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -538,7 +538,7 @@ const AccessibilityRequestDetailPage = () => {
       </div>
       {isAccessibilityTeam && (
         <SecondaryNav>
-          <NavLink to={`/508/requests/${accessibilityRequestId}`}>
+          <NavLink to={`/508/requests/${accessibilityRequestId}/documents`}>
             Documents
           </NavLink>
           <NavLink to={`/508/requests/${accessibilityRequestId}/notes`}>

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -437,6 +437,10 @@ const AccessibilityRequestDetailPage = () => {
     );
   }
 
+  const selectedTabContent = pathname.endsWith('notes')
+    ? notesTab
+    : bodyWithDocumentsTable;
+
   // What type of errors can we get/return?
   // How can we actually use the errors?
   if (error) {
@@ -540,12 +544,7 @@ const AccessibilityRequestDetailPage = () => {
       <div className="grid-container padding-top-6 padding-top">
         <div className="grid-row grid-gap-lg">
           <div className="grid-col-8">
-            {/* eslint-disable-next-line no-nested-ternary */}
-            {isAccessibilityTeam
-              ? pathname.endsWith('notes')
-                ? notesTab
-                : bodyWithDocumentsTable
-              : documentsTab}
+            {isAccessibilityTeam ? selectedTabContent : documentsTab}
           </div>
           <div className="grid-col-1" />
           <div className="grid-col-3">

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
+import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
   Breadcrumb,
@@ -93,10 +93,10 @@ const AccessibilityRequestDetailPage = () => {
   const flags = useFlags();
   const history = useHistory();
   const existingNotesHeading = useRef<HTMLHeadingElement>(null);
-  const { accessibilityRequestId } = useParams<{
+  const { accessibilityRequestId, secondaryNavTab } = useParams<{
     accessibilityRequestId: string;
+    secondaryNavTab: string;
   }>();
-  const { pathname } = useLocation();
 
   const userGroups = useSelector((state: AppState) => state.auth.groups);
   const isAccessibilityTeam = user.isAccessibilityTeam(userGroups, flags);
@@ -439,9 +439,8 @@ const AccessibilityRequestDetailPage = () => {
     );
   }
 
-  const selectedTabContent = pathname.endsWith('notes')
-    ? notesTab
-    : bodyWithDocumentsTable;
+  const selectedTabContent =
+    secondaryNavTab === 'notes' ? notesTab : bodyWithDocumentsTable;
 
   if (data?.accessibilityRequest?.statusRecord?.status === 'DELETED') {
     return <RequestDeleted />;

--- a/src/views/Accessibility/index.tsx
+++ b/src/views/Accessibility/index.tsx
@@ -112,6 +112,15 @@ const RequestDetails = (
   />
 );
 
+const RequestDetailsNotes = (
+  <SecureRoute
+    key="508-request-detail-notes"
+    path="/508/requests/:accessibilityRequestId/notes"
+    component={AccessibilityRequestDetailPage}
+    exact
+  />
+);
+
 const NotFound = () => (
   <div className="grid-container">
     <NotFoundPartial />
@@ -169,6 +178,7 @@ const Accessibility = () => {
             NewDocument,
             UpdateTestDate,
             NewTestDate,
+            RequestDetailsNotes,
             RequestDetails,
             Default
           ]}

--- a/src/views/Accessibility/index.tsx
+++ b/src/views/Accessibility/index.tsx
@@ -116,7 +116,7 @@ const RequestDetails = (
   <SecureRoute
     exact
     key="508-request-detail"
-    path="/508/requests/:accessibilityRequestId/:tab"
+    path="/508/requests/:accessibilityRequestId/:secondaryNavTab"
     component={AccessibilityRequestDetailPage}
   />
 );

--- a/src/views/Accessibility/index.tsx
+++ b/src/views/Accessibility/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { SecureRoute } from '@okta/okta-react';
 import { Link } from '@trussworks/react-uswds';
 import { useFlags } from 'launchdarkly-react-client-sdk';
@@ -103,10 +103,20 @@ const RequestStatusChange = (
   />
 );
 
+const DocumentsRedirect = (
+  <Redirect
+    key="508-request-documents-redirect"
+    exact
+    from="/508/requests/:accessibilityRequestId"
+    to="/508/requests/:accessibilityRequestId/documents"
+  />
+);
+
 const RequestDetails = (
   <SecureRoute
+    exact
     key="508-request-detail"
-    path="/508/requests/:accessibilityRequestId"
+    path="/508/requests/:accessibilityRequestId/:tab"
     component={AccessibilityRequestDetailPage}
   />
 );
@@ -168,6 +178,7 @@ const Accessibility = () => {
             NewDocument,
             UpdateTestDate,
             NewTestDate,
+            DocumentsRedirect,
             RequestDetails,
             Default
           ]}
@@ -182,6 +193,7 @@ const Accessibility = () => {
           MakingANewRequest,
           AccessibilityTestingTemplates,
           NewDocument,
+          DocumentsRedirect,
           RequestDetails,
           Default
         ]}

--- a/src/views/Accessibility/index.tsx
+++ b/src/views/Accessibility/index.tsx
@@ -108,16 +108,6 @@ const RequestDetails = (
     key="508-request-detail"
     path="/508/requests/:accessibilityRequestId"
     component={AccessibilityRequestDetailPage}
-    exact
-  />
-);
-
-const RequestDetailsNotes = (
-  <SecureRoute
-    key="508-request-detail-notes"
-    path="/508/requests/:accessibilityRequestId/notes"
-    component={AccessibilityRequestDetailPage}
-    exact
   />
 );
 
@@ -178,7 +168,6 @@ const Accessibility = () => {
             NewDocument,
             UpdateTestDate,
             NewTestDate,
-            RequestDetailsNotes,
             RequestDetails,
             Default
           ]}

--- a/src/views/TestDate/NewTestDate.tsx
+++ b/src/views/TestDate/NewTestDate.tsx
@@ -82,7 +82,7 @@ const NewTestDate = () => {
     }).then(result => {
       if (!result.errors) {
         showMessageOnNextPage(submitConfirmation);
-        history.push(`/508/requests/${accessibilityRequestId}`);
+        history.push(`/508/requests/${accessibilityRequestId}/documents`);
       }
     });
   };


### PR DESCRIPTION
# ES-759

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

## Changes proposed in this pull request

- Puts 508 notes at its own path, /508/requests/{id}/notes

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer Notes

Should the documents view and the notes view be split into separate components?

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## Code Review Verification Steps

### As the original developer, I have

- [ ] Tested user-facing changes with voice-over
- [ ] Checked for landmarks, page heading structure and links using [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu)
- [ ] Requested a design review for user-facing changes

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked accessibility against criteria
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
