### PR TITLE
Add test for changing admin lead (breaking)

### DIFF
--- a/cypress/integration/systemIntake.spec.js
+++ b/cypress/integration/systemIntake.spec.js
@@ -359,7 +359,7 @@ describe('users who got lost', () => {
 });
 
 describe('office user', () => {
-  it.only('can assign Admin Lead', () => {
+  it('can assign Admin Lead', () => {
     cy.localLogin({ name: 'OFFI', role: 'EASI_D_GOVTEAM' });
     cy.visit(
       'governance-review-team/af7a3924-3ff7-48ec-8a54-b8b4bc95610b/intake-request'

--- a/cypress/integration/systemIntake.spec.js
+++ b/cypress/integration/systemIntake.spec.js
@@ -3,27 +3,25 @@ import cmsGovernanceTeams from '../../src/constants/enums/cmsGovernanceTeams';
 describe('The System Intake Form', () => {
   beforeEach(() => {
     cy.server();
-    cy.localLogin({name: 'TEST'});
+    cy.localLogin({ name: 'TEST' });
     cy.route('PUT', '/api/v1/system_intake').as('putSystemIntake');
     cy.visit('/system/request-type');
     cy.get('#RequestType-NewSystem').check({ force: true });
     cy.contains('button', 'Continue').click();
     cy.contains('a', 'Get started').click();
-    cy.wait(1000)
+    cy.wait(1000);
     cy.contains('a', 'Start').click();
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/\/system\/.{36}\/contact-details/)
-    })
-    cy.contains('h1', 'Contact details')
+      expect(loc.pathname).to.match(/\/system\/.{36}\/contact-details/);
+    });
+    cy.contains('h1', 'Contact details');
   });
 
   it('fills out minimum required fields (smoke test)', () => {
     // Contact Details
     cy.systemIntake.contactDetails.fillNonBranchingFields();
 
-    cy.get('#IntakeForm-HasIssoNo')
-      .check({ force: true })
-      .should('be.checked');
+    cy.get('#IntakeForm-HasIssoNo').check({ force: true }).should('be.checked');
 
     cy.get('#IntakeForm-NoGovernanceTeam')
       .check({ force: true })
@@ -197,9 +195,7 @@ describe('The System Intake Form', () => {
       .type('1')
       .should('have.value', '1');
 
-    cy.get('#IntakeForm-ContractStartDay')
-      .type('2')
-      .should('have.value', '2');
+    cy.get('#IntakeForm-ContractStartDay').type('2').should('have.value', '2');
 
     cy.get('#IntakeForm-ContractStartYear')
       .type('2020')
@@ -209,9 +205,7 @@ describe('The System Intake Form', () => {
       .type('12')
       .should('have.value', '12');
 
-    cy.get('#IntakeForm-ContractEndDay')
-      .type('29')
-      .should('have.value', '29');
+    cy.get('#IntakeForm-ContractEndDay').type('29').should('have.value', '29');
 
     cy.get('#IntakeForm-ContractEndYear')
       .type('2021')
@@ -316,9 +310,7 @@ describe('The System Intake Form', () => {
   it('displays request details error messages', () => {
     cy.systemIntake.contactDetails.fillNonBranchingFields();
 
-    cy.get('#IntakeForm-HasIssoNo')
-      .check({ force: true })
-      .should('be.checked');
+    cy.get('#IntakeForm-HasIssoNo').check({ force: true }).should('be.checked');
 
     cy.get('#IntakeForm-NoGovernanceTeam')
       .check({ force: true })
@@ -335,9 +327,7 @@ describe('The System Intake Form', () => {
 
   it('saves on back click', () => {
     cy.systemIntake.contactDetails.fillNonBranchingFields();
-    cy.get('#IntakeForm-HasIssoNo')
-      .check({ force: true })
-      .should('be.checked');
+    cy.get('#IntakeForm-HasIssoNo').check({ force: true }).should('be.checked');
 
     cy.get('#IntakeForm-NoGovernanceTeam')
       .check({ force: true })
@@ -360,10 +350,24 @@ describe('The System Intake Form', () => {
 describe('users who got lost', () => {
   it('redirects to the system type page if somebody managed to skip it', () => {
     cy.server();
-    cy.localLogin({name: 'TEST'});
-    cy.visit('/system/new')
+    cy.localLogin({ name: 'TEST' });
+    cy.visit('/system/new');
     cy.location().should(loc => {
-      expect(loc.pathname).to.equal('/system/request-type')
-    })
-  })
-})
+      expect(loc.pathname).to.equal('/system/request-type');
+    });
+  });
+});
+
+describe('office user', () => {
+  it.only('can assign Admin Lead', () => {
+    cy.localLogin({ name: 'OFFI', role: 'EASI_D_GOVTEAM' });
+    cy.visit(
+      'governance-review-team/af7a3924-3ff7-48ec-8a54-b8b4bc95610b/intake-request'
+    );
+    cy.get('[data-testid="adminLead"]').contains('Not assigned');
+    cy.contains('button', 'Change').click();
+    cy.get('input[value="Ann Rudolph"]').check({ force: true });
+    cy.get('[data-testid="button"]').contains('Save').click();
+    cy.get('dd[data-testid="adminLead"]').contains('Ann Rudolph');
+  });
+});

--- a/cypress/integration/systemIntake.spec.js
+++ b/cypress/integration/systemIntake.spec.js
@@ -364,10 +364,10 @@ describe('office user', () => {
     cy.visit(
       'governance-review-team/af7a3924-3ff7-48ec-8a54-b8b4bc95610b/intake-request'
     );
-    cy.get('[data-testid="adminLead"]').contains('Not assigned');
+    cy.get('[data-testid="admin-lead"]').contains('Not Assigned');
     cy.contains('button', 'Change').click();
     cy.get('input[value="Ann Rudolph"]').check({ force: true });
     cy.get('[data-testid="button"]').contains('Save').click();
-    cy.get('dd[data-testid="adminLead"]').contains('Ann Rudolph');
+    cy.get('dd[data-testid="admin-lead"]').contains('Ann Rudolph');
   });
 });

--- a/src/views/GovernanceReviewTeam/Summary/index.tsx
+++ b/src/views/GovernanceReviewTeam/Summary/index.tsx
@@ -151,13 +151,12 @@ const RequestSummary = ({ intake }: { intake: SystemIntake }) => {
             </div>
             <div className="text-gray-90">
               <dt className="text-bold">{t('intake:fields.adminLead')}</dt>
-              <dd className="margin-left-0 padding-1" data-testid="adminLead">
+              <dd className="margin-left-0 padding-1" data-testid="admin-lead">
                 {getAdminLead()}
               </dd>
               <Button
                 type="button"
                 unstyled
-                data-testid="changeAdminLeadButton"
                 onClick={() => {
                   // Reset newAdminLead to value in intake
                   resetNewAdminLead();

--- a/src/views/GovernanceReviewTeam/Summary/index.tsx
+++ b/src/views/GovernanceReviewTeam/Summary/index.tsx
@@ -151,10 +151,13 @@ const RequestSummary = ({ intake }: { intake: SystemIntake }) => {
             </div>
             <div className="text-gray-90">
               <dt className="text-bold">{t('intake:fields.adminLead')}</dt>
-              <dd className="margin-left-0 padding-1">{getAdminLead()}</dd>
+              <dd className="margin-left-0 padding-1" data-testid="adminLead">
+                {getAdminLead()}
+              </dd>
               <Button
                 type="button"
                 unstyled
+                data-testid="changeAdminLeadButton"
                 onClick={() => {
                   // Reset newAdminLead to value in intake
                   resetNewAdminLead();


### PR DESCRIPTION
# ES-768

## Changes proposed in this pull request

- Adds a test for an intake request on the office side to change the admin lead

## Setup

`npx cypress open`

## Code Review Verification Steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated client tests for new components, parent components,
      functions, or e2e tests as necessary

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
