### PR TITLE
clean up 508 request page routing and tests

### DIFF
--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { Link, useHistory, useParams } from 'react-router-dom';
+import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
   Breadcrumb,
@@ -93,10 +93,10 @@ const AccessibilityRequestDetailPage = () => {
   const flags = useFlags();
   const history = useHistory();
   const existingNotesHeading = useRef<HTMLHeadingElement>(null);
-  const { accessibilityRequestId, secondaryNavTab } = useParams<{
+  const { accessibilityRequestId } = useParams<{
     accessibilityRequestId: string;
-    secondaryNavTab: string;
   }>();
+  const { pathname } = useLocation();
 
   const userGroups = useSelector((state: AppState) => state.auth.groups);
   const isAccessibilityTeam = user.isAccessibilityTeam(userGroups, flags);
@@ -439,8 +439,9 @@ const AccessibilityRequestDetailPage = () => {
     );
   }
 
-  const selectedTabContent =
-    secondaryNavTab === 'notes' ? notesTab : bodyWithDocumentsTable;
+  const selectedTabContent = pathname.endsWith('/notes')
+    ? notesTab
+    : bodyWithDocumentsTable;
 
   if (data?.accessibilityRequest?.statusRecord?.status === 'DELETED') {
     return <RequestDeleted />;

--- a/src/views/Accessibility/index.tsx
+++ b/src/views/Accessibility/index.tsx
@@ -116,7 +116,10 @@ const RequestDetails = (
   <SecureRoute
     exact
     key="508-request-detail"
-    path="/508/requests/:accessibilityRequestId/:secondaryNavTab"
+    path={[
+      '/508/requests/:accessibilityRequestId/documents',
+      '/508/requests/:accessibilityRequestId/notes'
+    ]}
     component={AccessibilityRequestDetailPage}
   />
 );

--- a/src/views/TestDate/UpdateTestDate.tsx
+++ b/src/views/TestDate/UpdateTestDate.tsx
@@ -92,7 +92,7 @@ const TestDate = () => {
       }
     }).then(() => {
       showMessageOnNextPage(confirmationText);
-      history.push(`/508/requests/${accessibilityRequestId}`);
+      history.push(`/508/requests/${accessibilityRequestId}/documents`);
     });
   };
 


### PR DESCRIPTION
- Updates routing in `src/views/Accessibility/index.tsx`
    - Only known routes `/documents` and `/notes` can be used
    - Anything else wil show not found
- Updates tests to be more clear
    - `buildProviders` is now `render508DocumentsPage` and `render508NotesPage` depending on which view is being tested

## Code Review Verification Steps

### As the original developer, I have

 - [x] Tests pass

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
