### PR TITLE
add sr feedback for documents and notes tab

### DIFF
--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -89,6 +89,8 @@ const accessibility = {
       confirm: 'Remove request',
       cancel: 'Keep request'
     },
+    activeDocumentTab: 'Displaying documents',
+    activeNoteTab: 'Displaying notes',
     removeConfirmationText: '{{-requestName}} successfully removed'
   },
   testDateForm: {

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -266,6 +266,9 @@ const AccessibilityRequestDetailPage = () => {
 
   const bodyWithDocumentsTable = (
     <div data-testid="body-with-doc-table">
+      <p className="usa-sr-only" aria-live="polite">
+        {t('requestDetails.activeDocumentTab')}
+      </p>
       <h2 className="margin-top-0">{t('requestDetails.documents.label')}</h2>
       {uploadDocumentLink}
       <div className="margin-top-6">
@@ -281,6 +284,9 @@ const AccessibilityRequestDetailPage = () => {
   const bodyNoDocumentsBusinessOwner = (
     <>
       <div className="margin-bottom-3">
+        <p className="usa-sr-only" aria-live="polite">
+          {t('requestDetails.activeDocumentTab')}
+        </p>
         <h2 className="margin-y-0 font-heading-lg">
           {t('requestDetails.documents.noDocs.heading')}
         </h2>
@@ -319,6 +325,9 @@ const AccessibilityRequestDetailPage = () => {
             createdAt: formatDate(notes[0]?.createdAt)
           })}
       </h3>
+      <p className="usa-sr-only" aria-live="polite">
+        {t('requestDetails.activeNoteTab')}
+      </p>
       <Button
         className="accessibility-request__add-note-btn"
         type="button"


### PR DESCRIPTION
This PR adds screen reader feedback when a user changes tabs (documents and notes) on the 508 request detail page.
1. Navigate to a 508 request
2. Turn on screen reader
3. Switch to the inactive tab
4. Listen for the screen reader to let you know what tab is active

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over
- [x] Requested a design review for user-facing changes
- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Checked that all code is adequately covered by tests
- [x] Made it clear which comments need to be addressed before this work is merged
- [x] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked behavior
- [ ] Checked accessibility against criteria
