### PR TITLE
add tests for making a request pages

### DIFF
--- a/src/components/PageWrapper/index.tsx
+++ b/src/components/PageWrapper/index.tsx
@@ -6,11 +6,15 @@ import './index.scss';
 type PageWrapperProps = {
   className?: string;
   children: React.ReactNode;
-};
+} & JSX.IntrinsicElements['div'];
 
-const PageWrapper = ({ className, children }: PageWrapperProps) => {
+const PageWrapper = ({ className, children, ...props }: PageWrapperProps) => {
   const classes = classnames('easi-page-wrapper', className);
-  return <div className={classes}>{children}</div>;
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
 };
 
 export default PageWrapper;

--- a/src/views/Accessibility/MakingARequest/index.test.tsx
+++ b/src/views/Accessibility/MakingARequest/index.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
+
+import { MessageProvider } from 'hooks/useMessage';
+
+import MakingARequest from './index';
+
+jest.mock('@okta/okta-react', () => ({
+  useOktaAuth: () => {
+    return {
+      authState: {
+        isAuthenticated: true
+      },
+      oktaAuth: {
+        getUser: async () => {},
+        logout: async () => {}
+      }
+    };
+  }
+}));
+
+describe('The 508 making a request page', () => {
+  it('renders without errors', () => {
+    const mockStore = configureMockStore();
+    const defaultStore = mockStore({
+      auth: {
+        euaId: 'AAAA'
+      }
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/508/making-a-request']}>
+        <Provider store={defaultStore}>
+          <MessageProvider>
+            <Route path="/508/making-a-request">
+              <MakingARequest />
+            </Route>
+          </MessageProvider>
+        </Provider>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('making-a-508-request')).toBeInTheDocument();
+  });
+});

--- a/src/views/Accessibility/MakingARequest/index.tsx
+++ b/src/views/Accessibility/MakingARequest/index.tsx
@@ -16,7 +16,10 @@ const MakingARequest = () => {
   const { t } = useTranslation('accessibility');
 
   return (
-    <div className="grid-container margin-bottom-2">
+    <div
+      className="grid-container margin-bottom-2"
+      data-testid="making-a-508-request"
+    >
       <BreadcrumbBar variant="wrap">
         <Breadcrumb>
           <BreadcrumbLink asCustom={Link} to="/">

--- a/src/views/MakingARequest/__snapshots__/index.test.tsx.snap
+++ b/src/views/MakingARequest/__snapshots__/index.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`The making a request page matches the snapshot 1`] = `
 <div
   className="easi-page-wrapper"
+  data-testid="making-a-system-request"
 >
   <header
     className="usa-header easi-header"

--- a/src/views/MakingARequest/index.test.tsx
+++ b/src/views/MakingARequest/index.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route } from 'react-router-dom';
 import renderer from 'react-test-renderer';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
+
+import { MessageProvider } from 'hooks/useMessage';
 
 import MakingARequest from './index';
 
@@ -20,12 +24,27 @@ jest.mock('@okta/okta-react', () => ({
 }));
 
 describe('The making a request page', () => {
-  it('renders without crashing', () => {
-    shallow(
-      <MemoryRouter>
-        <MakingARequest />
+  it('renders without errors', () => {
+    const mockStore = configureMockStore();
+    const defaultStore = mockStore({
+      auth: {
+        euaId: 'AAAA'
+      }
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/system/making-a-request']}>
+        <Provider store={defaultStore}>
+          <MessageProvider>
+            <Route path="/system/making-a-request">
+              <MakingARequest />
+            </Route>
+          </MessageProvider>
+        </Provider>
       </MemoryRouter>
     );
+
+    expect(screen.getByTestId('making-a-system-request')).toBeInTheDocument();
   });
 
   it('matches the snapshot', () => {

--- a/src/views/MakingARequest/index.tsx
+++ b/src/views/MakingARequest/index.tsx
@@ -19,7 +19,7 @@ const MakingARequest = () => {
   const reasons = t('reasonList.options', { returnObjects: true }) as string[];
 
   return (
-    <PageWrapper>
+    <PageWrapper data-testid="making-a-system-request">
       <Header />
       <MainContent className="grid-container line-height-body-5 margin-bottom-5">
         <BreadcrumbBar variant="wrap">


### PR DESCRIPTION
This PR adds tests for system and 508 making a request pages. This is low hanging fruit.

```
/system/making-a-request
/508/making-a-request
```

The file name space is a little confusing. I'm not sure how to address that yet.

## Code Review Verification Steps

### As the original developer, I have

- [x] Tests pass

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
