### PR TITLE
update eslint sorting for queries directory

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -58,7 +58,7 @@
           ["^react", "^@?\\w"],
           // Internal packages.
           [
-            "^(assets|components|constants|contexts|data|hooks|i18n|images|reducers|sagas|types|utils|validations|views)(/.*|$)"
+            "^(assets|components|constants|contexts|data|hooks|i18n|images|queries|reducers|sagas|types|utils|validations|views)(/.*|$)"
           ],
           // Side effect imports.
           ["^\\u0000"],

--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -7,8 +7,8 @@ import { useSortBy, useTable } from 'react-table';
 import { Link as UswdsLink, Table } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 import { DateTime } from 'luxon';
-import { GetAccessibilityRequests_accessibilityRequests_edges_node as AccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
 
+import { GetAccessibilityRequests_accessibilityRequests_edges_node as AccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
 import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
 import { formatDate } from 'utils/date';
 

--- a/src/components/BusinessCaseReview/index.tsx
+++ b/src/components/BusinessCaseReview/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { DateTime } from 'luxon';
-import { GetSystemIntake_systemIntake_grtFeedbacks as GRTFeedback } from 'queries/types/GetSystemIntake';
 
 import GRTFeedbackView from 'components/GRTFeedbackView';
 import PDFExport from 'components/PDFExport';
+import { GetSystemIntake_systemIntake_grtFeedbacks as GRTFeedback } from 'queries/types/GetSystemIntake';
 import { BusinessCaseModel } from 'types/businessCase';
 import { getFiscalYear } from 'utils/date';
 

--- a/src/components/GRTFeedbackView/index.tsx
+++ b/src/components/GRTFeedbackView/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { DateTime } from 'luxon';
-import { GetGRTFeedback_systemIntake_grtFeedbacks as GRTFeedback } from 'queries/types/GetGRTFeedback';
 
 import HelpText from 'components/shared/HelpText';
+import { GetGRTFeedback_systemIntake_grtFeedbacks as GRTFeedback } from 'queries/types/GetGRTFeedback';
 
 type GRTFeedbackViewProps = {
   grtFeedbacks: GRTFeedback[];

--- a/src/components/TestDateCard/index.test.tsx
+++ b/src/components/TestDateCard/index.test.tsx
@@ -3,9 +3,9 @@ import { MemoryRouter } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { mount, shallow } from 'enzyme';
 import { DateTime } from 'luxon';
-import { GetAccessibilityRequest_accessibilityRequest_testDates as TestDateType } from 'queries/types/GetAccessibilityRequest';
 
 import TestDateCard from 'components/TestDateCard';
+import { GetAccessibilityRequest_accessibilityRequest_testDates as TestDateType } from 'queries/types/GetAccessibilityRequest';
 import { TestDateTestType } from 'types/graphql-global-types';
 
 const renderComponent = (customProps?: any) => {

--- a/src/components/TestDateCard/index.tsx
+++ b/src/components/TestDateCard/index.tsx
@@ -2,10 +2,10 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { Button, Link as UswdsLink } from '@trussworks/react-uswds';
-import { GetAccessibilityRequest_accessibilityRequest_testDates as TestDateType } from 'queries/types/GetAccessibilityRequest';
 
 import Modal from 'components/Modal';
 import PageHeading from 'components/PageHeading';
+import { GetAccessibilityRequest_accessibilityRequest_testDates as TestDateType } from 'queries/types/GetAccessibilityRequest';
 import { translateTestType } from 'utils/accessibilityRequest';
 import { formatDate } from 'utils/date';
 

--- a/src/views/Accessibility/AccessibilityRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Create/index.tsx
@@ -5,12 +5,6 @@ import { useHistory } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import { Button, ComboBox, Link } from '@trussworks/react-uswds';
 import { Form as FormikForm, Formik, FormikProps } from 'formik';
-import CreateAccessibilityRequestQuery from 'queries/CreateAccessibilityRequestQuery';
-import GetSystemsQuery from 'queries/GetSystems';
-import {
-  GetSystems,
-  GetSystems_systems_edges_node as SystemNode
-} from 'queries/types/GetSystems';
 
 import PageHeading from 'components/PageHeading';
 import PlainInfo from 'components/PlainInfo';
@@ -23,6 +17,12 @@ import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import { initialAccessibilityRequestFormData } from 'data/accessibility';
 import useMessage from 'hooks/useMessage';
+import CreateAccessibilityRequestQuery from 'queries/CreateAccessibilityRequestQuery';
+import GetSystemsQuery from 'queries/GetSystems';
+import {
+  GetSystems,
+  GetSystems_systems_edges_node as SystemNode
+} from 'queries/types/GetSystems';
 import { AccessibilityRequestForm } from 'types/accessibility';
 import flattenErrors from 'utils/flattenErrors';
 import accessibilitySchema from 'validations/accessibilitySchema';

--- a/src/views/Accessibility/AccessibilityRequest/Documents/New/index.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Documents/New/index.test.tsx
@@ -7,10 +7,10 @@ import {
   screen,
   waitForElementToBeRemoved
 } from '@testing-library/react';
-import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
 import configureMockStore from 'redux-mock-store';
 
 import { MessageProvider } from 'hooks/useMessage';
+import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
 
 import New from './index';
 

--- a/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
@@ -6,15 +6,6 @@ import { Button, Label } from '@trussworks/react-uswds';
 import axios from 'axios';
 import { Field, Form, Formik, FormikProps } from 'formik';
 import { isUndefined } from 'lodash';
-import { CreateAccessibilityRequestDocumentQuery } from 'queries/AccessibilityRequestDocumentQueries';
-import GeneratePresignedUploadURLQuery from 'queries/GeneratePresignedUploadURLQuery';
-import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
-import {
-  CreateAccessibilityRequestDocument,
-  CreateAccessibilityRequestDocumentVariables
-} from 'queries/types/CreateAccessibilityRequestDocument';
-import { GeneratePresignedUploadURL } from 'queries/types/GeneratePresignedUploadURL';
-import { GetAccessibilityRequest } from 'queries/types/GetAccessibilityRequest';
 
 import FileUpload from 'components/FileUpload';
 import PageHeading from 'components/PageHeading';
@@ -27,6 +18,15 @@ import { RadioField } from 'components/shared/RadioField';
 import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import TextField from 'components/shared/TextField';
 import { useMessage } from 'hooks/useMessage';
+import { CreateAccessibilityRequestDocumentQuery } from 'queries/AccessibilityRequestDocumentQueries';
+import GeneratePresignedUploadURLQuery from 'queries/GeneratePresignedUploadURLQuery';
+import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
+import {
+  CreateAccessibilityRequestDocument,
+  CreateAccessibilityRequestDocumentVariables
+} from 'queries/types/CreateAccessibilityRequestDocument';
+import { GeneratePresignedUploadURL } from 'queries/types/GeneratePresignedUploadURL';
+import { GetAccessibilityRequest } from 'queries/types/GetAccessibilityRequest';
 import { FileUploadForm } from 'types/files';
 import { AccessibilityRequestDocumentCommonType } from 'types/graphql-global-types';
 import { translateDocumentCommonType } from 'utils/accessibilityRequest';

--- a/src/views/Accessibility/AccessibilityRequest/List/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/List/index.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import { Alert, Link as UswdsLink } from '@trussworks/react-uswds';
-import GetAccessibilityRequestsQuery from 'queries/GetAccessibilityRequestsQuery';
-import { GetAccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
 
 import AccessibilityRequestsTable from 'components/AccessibilityRequestsTable';
 import PageHeading from 'components/PageHeading';
 import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import useMessage from 'hooks/useMessage';
+import GetAccessibilityRequestsQuery from 'queries/GetAccessibilityRequestsQuery';
+import { GetAccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
 
 const List = () => {
   const { t } = useTranslation('home');

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
@@ -9,13 +9,13 @@ import {
   within
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import CreateAccessibilityRequestNote from 'queries/CreateAccessibilityRequestNoteQuery';
-import GetAccessibilityRequestAccessibilityTeamOnlyQuery from 'queries/GetAccessibilityRequestAccessibilityTeamOnlyQuery';
-import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
 import configureMockStore from 'redux-mock-store';
 
 import { ACCESSIBILITY_TESTER_DEV } from 'constants/jobCodes';
 import { MessageProvider } from 'hooks/useMessage';
+import CreateAccessibilityRequestNote from 'queries/CreateAccessibilityRequestNoteQuery';
+import GetAccessibilityRequestAccessibilityTeamOnlyQuery from 'queries/GetAccessibilityRequestAccessibilityTeamOnlyQuery';
+import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
 
 import AccessibilityRequestDetailPage from './AccessibilityRequestDetailPage';
 

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -20,6 +20,28 @@ import {
 } from 'formik';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 import { DateTime } from 'luxon';
+
+import AccessibilityDocumentsList from 'components/AccessibilityDocumentsList';
+import Modal from 'components/Modal';
+import {
+  NoteByline,
+  NoteContent,
+  NoteListItem,
+  NotesList
+} from 'components/NotesList';
+import PageHeading from 'components/PageHeading';
+import PageLoading from 'components/PageLoading/index';
+import Alert from 'components/shared/Alert';
+import CheckboxField from 'components/shared/CheckboxField';
+import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
+import FieldErrorMsg from 'components/shared/FieldErrorMsg';
+import FieldGroup from 'components/shared/FieldGroup';
+import Label from 'components/shared/Label';
+import { RadioField } from 'components/shared/RadioField';
+import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
+import TextAreaField from 'components/shared/TextAreaField';
+import TestDateCard from 'components/TestDateCard';
+import useMessage from 'hooks/useMessage';
 import { DeleteAccessibilityRequestDocumentQuery } from 'queries/AccessibilityRequestDocumentQueries';
 import CreateAccessibilityRequestNoteQuery from 'queries/CreateAccessibilityRequestNoteQuery';
 import DeleteAccessibilityRequestQuery from 'queries/DeleteAccessibilityRequestQuery';
@@ -45,28 +67,6 @@ import {
   GetAccessibilityRequestAccessibilityTeamOnly as GetAccessibilityRequest,
   GetAccessibilityRequestAccessibilityTeamOnlyVariables as GetAccessibilityRequestPayload
 } from 'queries/types/GetAccessibilityRequestAccessibilityTeamOnly';
-
-import AccessibilityDocumentsList from 'components/AccessibilityDocumentsList';
-import Modal from 'components/Modal';
-import {
-  NoteByline,
-  NoteContent,
-  NoteListItem,
-  NotesList
-} from 'components/NotesList';
-import PageHeading from 'components/PageHeading';
-import PageLoading from 'components/PageLoading/index';
-import Alert from 'components/shared/Alert';
-import CheckboxField from 'components/shared/CheckboxField';
-import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
-import FieldErrorMsg from 'components/shared/FieldErrorMsg';
-import FieldGroup from 'components/shared/FieldGroup';
-import Label from 'components/shared/Label';
-import { RadioField } from 'components/shared/RadioField';
-import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
-import TextAreaField from 'components/shared/TextAreaField';
-import TestDateCard from 'components/TestDateCard';
-import useMessage from 'hooks/useMessage';
 import { AppState } from 'reducers/rootReducer';
 import {
   CreateNoteForm,

--- a/src/views/Accessibility/ChangeRequestStatus/index.test.tsx
+++ b/src/views/Accessibility/ChangeRequestStatus/index.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { render, waitFor } from '@testing-library/react';
-import GetAccessibilityRequestForStatusChange from 'queries/GetAccessibilityRequestForStatusChange';
 
 import { MessageProvider } from 'hooks/useMessage';
+import GetAccessibilityRequestForStatusChange from 'queries/GetAccessibilityRequestForStatusChange';
 
 import ChangeRequestStatus from './index';
 

--- a/src/views/Accessibility/ChangeRequestStatus/index.tsx
+++ b/src/views/Accessibility/ChangeRequestStatus/index.tsx
@@ -9,14 +9,14 @@ import {
   Radio
 } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
-import GetAccessibilityRequestForStatusChange from 'queries/GetAccessibilityRequestForStatusChange';
-import UpdateAccessibilityRequestStatus from 'queries/UpdateAccessibilityRequestStatusQuery';
 
 import PageHeading from 'components/PageHeading';
 import PlainInfo from 'components/PlainInfo';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldGroup from 'components/shared/FieldGroup';
 import useMessage from 'hooks/useMessage';
+import GetAccessibilityRequestForStatusChange from 'queries/GetAccessibilityRequestForStatusChange';
+import UpdateAccessibilityRequestStatus from 'queries/UpdateAccessibilityRequestStatusQuery';
 import { AccessibilityRequestStatus } from 'types/graphql-global-types';
 import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
 import { NotFoundPartial } from 'views/NotFound';

--- a/src/views/BusinessCase/ViewOnly/index.tsx
+++ b/src/views/BusinessCase/ViewOnly/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { GetSystemIntake_systemIntake_grtFeedbacks as GRTFeedback } from 'queries/types/GetSystemIntake';
 
 import BusinessCaseReview from 'components/BusinessCaseReview';
 import PageHeading from 'components/PageHeading';
+import { GetSystemIntake_systemIntake_grtFeedbacks as GRTFeedback } from 'queries/types/GetSystemIntake';
 import { BusinessCaseModel } from 'types/businessCase';
 
 type BusinessCaseViewOnlyProps = {

--- a/src/views/BusinessCase/index.tsx
+++ b/src/views/BusinessCase/index.tsx
@@ -15,17 +15,17 @@ import {
   BreadcrumbLink
 } from '@trussworks/react-uswds';
 import { FormikProps } from 'formik';
-import GetGRTFeedbackQuery from 'queries/GetGRTFeedbackQuery';
-import {
-  GetGRTFeedback,
-  GetGRTFeedbackVariables
-} from 'queries/types/GetGRTFeedback';
 
 import Footer from 'components/Footer';
 import Header from 'components/Header';
 import MainContent from 'components/MainContent';
 import PageWrapper from 'components/PageWrapper';
 import usePrevious from 'hooks/usePrevious';
+import GetGRTFeedbackQuery from 'queries/GetGRTFeedbackQuery';
+import {
+  GetGRTFeedback,
+  GetGRTFeedbackVariables
+} from 'queries/types/GetGRTFeedback';
 import { AppState } from 'reducers/rootReducer';
 import { BusinessCaseModel } from 'types/businessCase';
 import {

--- a/src/views/FlagsWrapper/index.tsx
+++ b/src/views/FlagsWrapper/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useQuery } from '@apollo/client';
 import { useOktaAuth } from '@okta/okta-react';
 import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
+
 import GetCurrentUserQuery from 'queries/GetCurrentUserQuery';
 import { GetCurrentUser } from 'queries/types/GetCurrentUser';
 

--- a/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
@@ -5,8 +5,6 @@ import { useMutation } from '@apollo/client';
 import { Button, Link as UswdsLink } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 import { DateTime } from 'luxon';
-import IssueLifecycleIdQuery from 'queries/IssueLifecycleIdQuery';
-import { IssueLifecycleId as IssueLifecycleIdType } from 'queries/types/IssueLifecycleId';
 
 import MandatoryFieldsAlert from 'components/MandatoryFieldsAlert';
 import PageHeading from 'components/PageHeading';
@@ -23,6 +21,8 @@ import Label from 'components/shared/Label';
 import { RadioField } from 'components/shared/RadioField';
 import TextAreaField from 'components/shared/TextAreaField';
 import TextField from 'components/shared/TextField';
+import IssueLifecycleIdQuery from 'queries/IssueLifecycleIdQuery';
+import { IssueLifecycleId as IssueLifecycleIdType } from 'queries/types/IssueLifecycleId';
 import { SubmitLifecycleIdForm } from 'types/action';
 import flattenErrors from 'utils/flattenErrors';
 import { lifecycleIdSchema } from 'validations/actionSchema';

--- a/src/views/GovernanceReviewTeam/Actions/ProvideGRTFeedbackToBusinessOwner.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ProvideGRTFeedbackToBusinessOwner.tsx
@@ -4,10 +4,6 @@ import { Link, useHistory, useParams } from 'react-router-dom';
 import { DocumentNode, useMutation } from '@apollo/client';
 import { Button } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
-import {
-  AddGRTFeedback,
-  AddGRTFeedbackVariables
-} from 'queries/types/AddGRTFeedback';
 
 import MandatoryFieldsAlert from 'components/MandatoryFieldsAlert';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
@@ -16,6 +12,10 @@ import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import TextAreaField from 'components/shared/TextAreaField';
+import {
+  AddGRTFeedback,
+  AddGRTFeedbackVariables
+} from 'queries/types/AddGRTFeedback';
 import { ProvideGRTFeedbackForm } from 'types/action';
 import flattenErrors from 'utils/flattenErrors';
 import { provideGRTFeedbackSchema } from 'validations/actionSchema';

--- a/src/views/GovernanceReviewTeam/Actions/ProvideGRTRecommendationsToGRB.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ProvideGRTRecommendationsToGRB.tsx
@@ -4,11 +4,6 @@ import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
 import { Button } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
-import MarkReadyForGRBQuery from 'queries/MarkReadyForGRBQuery';
-import {
-  AddGRTFeedback,
-  AddGRTFeedbackVariables
-} from 'queries/types/AddGRTFeedback';
 
 import MandatoryFieldsAlert from 'components/MandatoryFieldsAlert';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
@@ -17,6 +12,11 @@ import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import TextAreaField from 'components/shared/TextAreaField';
+import MarkReadyForGRBQuery from 'queries/MarkReadyForGRBQuery';
+import {
+  AddGRTFeedback,
+  AddGRTFeedbackVariables
+} from 'queries/types/AddGRTFeedback';
 import { ProvideGRTFeedbackForm } from 'types/action';
 import flattenErrors from 'utils/flattenErrors';
 import { provideGRTFeedbackSchema } from 'validations/actionSchema';

--- a/src/views/GovernanceReviewTeam/Actions/RejectIntake.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/RejectIntake.tsx
@@ -4,11 +4,6 @@ import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
 import { Button, Link as UswdsLink } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
-import RejectIntakeQuery from 'queries/RejectIntakeQuery';
-import {
-  RejectIntake as RejectIntakeType,
-  RejectIntakeVariables
-} from 'queries/types/RejectIntake';
 
 import PageHeading from 'components/PageHeading';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
@@ -17,6 +12,11 @@ import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import TextAreaField from 'components/shared/TextAreaField';
+import RejectIntakeQuery from 'queries/RejectIntakeQuery';
+import {
+  RejectIntake as RejectIntakeType,
+  RejectIntakeVariables
+} from 'queries/types/RejectIntake';
 import { RejectIntakeForm } from 'types/action';
 import flattenErrors from 'utils/flattenErrors';
 import { rejectIntakeSchema } from 'validations/actionSchema';

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/index.tsx
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/index.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { Link as UswdsLink } from '@trussworks/react-uswds';
 import { DateTime } from 'luxon';
-import { GetSystemIntake_systemIntake_grtFeedbacks as GRTFeedback } from 'queries/types/GetSystemIntake';
 
 import AlternativeAnalysisReview from 'components/BusinessCaseReview/AlternativeAnalysisReview';
 import GeneralRequestInfoReview from 'components/BusinessCaseReview/GeneralRequestInfoReview';
@@ -12,6 +11,7 @@ import GRTFeedbackView from 'components/GRTFeedbackView';
 import PageHeading from 'components/PageHeading';
 import PDFExport from 'components/PDFExport';
 import { AnythingWrongSurvey } from 'components/Survey';
+import { GetSystemIntake_systemIntake_grtFeedbacks as GRTFeedback } from 'queries/types/GetSystemIntake';
 import { BusinessCaseModel } from 'types/businessCase';
 import { getFiscalYear } from 'utils/date';
 

--- a/src/views/GovernanceReviewTeam/Dates/index.tsx
+++ b/src/views/GovernanceReviewTeam/Dates/index.tsx
@@ -5,12 +5,6 @@ import { useMutation } from '@apollo/client';
 import { Button } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 import { DateTime } from 'luxon';
-import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetSystemIntake';
-import {
-  UpdateSystemIntakeReviewDates,
-  UpdateSystemIntakeReviewDatesVariables
-} from 'queries/types/UpdateSystemIntakeReviewDates';
-import UpdateSystemIntakeReviewDatesQuery from 'queries/UpdateSystemIntakeReviewDatesQuery';
 
 import MandatoryFieldsAlert from 'components/MandatoryFieldsAlert';
 import PageHeading from 'components/PageHeading';
@@ -26,6 +20,12 @@ import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import TextField from 'components/shared/TextField';
 import { AnythingWrongSurvey } from 'components/Survey';
+import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetSystemIntake';
+import {
+  UpdateSystemIntakeReviewDates,
+  UpdateSystemIntakeReviewDatesVariables
+} from 'queries/types/UpdateSystemIntakeReviewDates';
+import UpdateSystemIntakeReviewDatesQuery from 'queries/UpdateSystemIntakeReviewDatesQuery';
 import { SubmitDatesForm } from 'types/systemIntake';
 import { parseAsDate } from 'utils/date';
 import flattenErrors from 'utils/flattenErrors';

--- a/src/views/GovernanceReviewTeam/Decision/index.tsx
+++ b/src/views/GovernanceReviewTeam/Decision/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { DateTime } from 'luxon';
-import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetSystemIntake';
 
 import PageHeading from 'components/PageHeading';
 import ReviewRow from 'components/ReviewRow';
@@ -10,6 +9,7 @@ import {
   DescriptionList,
   DescriptionTerm
 } from 'components/shared/DescriptionGroup';
+import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetSystemIntake';
 
 type DecisionProps = {
   systemIntake?: SystemIntake | null;

--- a/src/views/GovernanceReviewTeam/Notes/index.tsx
+++ b/src/views/GovernanceReviewTeam/Notes/index.tsx
@@ -6,16 +6,6 @@ import { useMutation, useQuery } from '@apollo/client';
 import { Button } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikHelpers, FormikProps } from 'formik';
 import { DateTime } from 'luxon';
-import CreateSystemIntakeNoteQuery from 'queries/CreateSystemIntakeNoteQuery';
-import GetAdminNotesAndActionsQuery from 'queries/GetAdminNotesAndActionsQuery';
-import {
-  CreateSystemIntakeNote,
-  CreateSystemIntakeNoteVariables
-} from 'queries/types/CreateSystemIntakeNote';
-import {
-  GetAdminNotesAndActions,
-  GetAdminNotesAndActionsVariables
-} from 'queries/types/GetAdminNotesAndActions';
 
 import {
   NoteByline,
@@ -31,6 +21,16 @@ import FieldGroup from 'components/shared/FieldGroup';
 import Label from 'components/shared/Label';
 import TextAreaField from 'components/shared/TextAreaField';
 import { AnythingWrongSurvey } from 'components/Survey';
+import CreateSystemIntakeNoteQuery from 'queries/CreateSystemIntakeNoteQuery';
+import GetAdminNotesAndActionsQuery from 'queries/GetAdminNotesAndActionsQuery';
+import {
+  CreateSystemIntakeNote,
+  CreateSystemIntakeNoteVariables
+} from 'queries/types/CreateSystemIntakeNote';
+import {
+  GetAdminNotesAndActions,
+  GetAdminNotesAndActionsVariables
+} from 'queries/types/GetAdminNotesAndActions';
 import { AppState } from 'reducers/rootReducer';
 import { formatDate } from 'utils/date';
 

--- a/src/views/GovernanceReviewTeam/RequestOverview.tsx
+++ b/src/views/GovernanceReviewTeam/RequestOverview.tsx
@@ -5,6 +5,11 @@ import { Link, Route, useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import classnames from 'classnames';
 import { DateTime } from 'luxon';
+
+import Footer from 'components/Footer';
+import Header from 'components/Header';
+import MainContent from 'components/MainContent';
+import PageWrapper from 'components/PageWrapper';
 import AddGRTFeedbackKeepDraftBizCase from 'queries/AddGRTFeedbackKeepDraftBizCase';
 import AddGRTFeedbackProgressToFinal from 'queries/AddGRTFeedbackProgressToFinal';
 import AddGRTFeedbackRequestBizCaseQuery from 'queries/AddGRTFeedbackRequestBizCaseQuery';
@@ -21,11 +26,6 @@ import {
   GetSystemIntake,
   GetSystemIntakeVariables
 } from 'queries/types/GetSystemIntake';
-
-import Footer from 'components/Footer';
-import Header from 'components/Header';
-import MainContent from 'components/MainContent';
-import PageWrapper from 'components/PageWrapper';
 import { AppState } from 'reducers/rootReducer';
 import { fetchBusinessCase, fetchSystemIntake } from 'types/routines';
 import ProvideGRTFeedbackToBusinessOwner from 'views/GovernanceReviewTeam/Actions/ProvideGRTFeedbackToBusinessOwner';

--- a/src/views/GovernanceReviewTeam/Summary/index.tsx
+++ b/src/views/GovernanceReviewTeam/Summary/index.tsx
@@ -9,15 +9,15 @@ import {
   Button
 } from '@trussworks/react-uswds';
 import classnames from 'classnames';
-import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetSystemIntake';
-import { UpdateSystemIntakeAdminLead } from 'queries/types/UpdateSystemIntakeAdminLead';
-import UpdateSystemIntakeAdminLeadQuery from 'queries/UpdateSystemIntakeAdminLeadQuery';
 
 import Modal from 'components/Modal';
 import PageHeading from 'components/PageHeading';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import { RadioField, RadioGroup } from 'components/shared/RadioField';
 import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
+import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetSystemIntake';
+import { UpdateSystemIntakeAdminLead } from 'queries/types/UpdateSystemIntakeAdminLead';
+import UpdateSystemIntakeAdminLeadQuery from 'queries/UpdateSystemIntakeAdminLeadQuery';
 import { formatDate } from 'utils/date';
 import {
   isIntakeClosed,

--- a/src/views/Home/index.test.tsx
+++ b/src/views/Home/index.test.tsx
@@ -5,11 +5,11 @@ import { MemoryRouter } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { mount, ReactWrapper, shallow } from 'enzyme';
 import { mockFlags, resetLDMocks } from 'jest-launchdarkly-mock';
-import GetRequestsQuery from 'queries/GetRequestsQuery';
 import configureMockStore from 'redux-mock-store';
 
 import { initialSystemIntakeForm } from 'data/systemIntake';
 import { MessageProvider } from 'hooks/useMessage';
+import GetRequestsQuery from 'queries/GetRequestsQuery';
 import Table from 'views/MyRequests/Table';
 
 import Home from './index';

--- a/src/views/MyRequests/Table.tsx
+++ b/src/views/MyRequests/Table.tsx
@@ -9,9 +9,9 @@ import {
 } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 import { DateTime } from 'luxon';
+
 import GetRequestsQuery from 'queries/GetRequestsQuery';
 import { GetRequests, GetRequestsVariables } from 'queries/types/GetRequests';
-
 import { RequestType } from 'types/graphql-global-types';
 import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
 import { formatDate } from 'utils/date';

--- a/src/views/RequestTypeForm/index.tsx
+++ b/src/views/RequestTypeForm/index.tsx
@@ -11,7 +11,6 @@ import {
   Link as UswdsLink
 } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
-import { CreateSystemIntake } from 'queries/SystemIntakeQueries';
 
 import Footer from 'components/Footer';
 import Header from 'components/Header';
@@ -23,6 +22,7 @@ import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
 import { RadioField } from 'components/shared/RadioField';
+import { CreateSystemIntake } from 'queries/SystemIntakeQueries';
 import flattenErrors from 'utils/flattenErrors';
 import SystemIntakeValidationSchema from 'validations/systemIntakeSchema';
 

--- a/src/views/TestDate/NewTestDate.test.tsx
+++ b/src/views/TestDate/NewTestDate.test.tsx
@@ -7,10 +7,10 @@ import {
   screen,
   waitForElementToBeRemoved
 } from '@testing-library/react';
-import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
 import configureMockStore from 'redux-mock-store';
 
 import { MessageProvider } from 'hooks/useMessage';
+import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
 
 import NewTestDate from './NewTestDate';
 

--- a/src/views/TestDate/NewTestDate.tsx
+++ b/src/views/TestDate/NewTestDate.tsx
@@ -4,13 +4,13 @@ import { useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import { Alert } from '@trussworks/react-uswds';
 import { DateTime } from 'luxon';
+
+import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
+import { useMessage } from 'hooks/useMessage';
 import CreateTestDateQuery from 'queries/CreateTestDateQuery';
 import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
 import { CreateTestDate } from 'queries/types/CreateTestDate';
 import { GetAccessibilityRequest } from 'queries/types/GetAccessibilityRequest';
-
-import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
-import { useMessage } from 'hooks/useMessage';
 import { TestDateFormType } from 'types/accessibility';
 import { formatDate } from 'utils/date';
 

--- a/src/views/TestDate/UpdateTestDate.test.tsx
+++ b/src/views/TestDate/UpdateTestDate.test.tsx
@@ -7,10 +7,10 @@ import {
   screen,
   waitForElementToBeRemoved
 } from '@testing-library/react';
-import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
 import configureMockStore from 'redux-mock-store';
 
 import { MessageProvider } from 'hooks/useMessage';
+import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
 
 import UpdateTestDate from './UpdateTestDate';
 

--- a/src/views/TestDate/UpdateTestDate.tsx
+++ b/src/views/TestDate/UpdateTestDate.tsx
@@ -3,6 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import { DateTime } from 'luxon';
+
+import PageLoading from 'components/PageLoading';
+import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
+import { useMessage } from 'hooks/useMessage';
 import GetAccessibilityRequestQuery from 'queries/GetAccessibilityRequestQuery';
 import {
   GetAccessibilityRequest,
@@ -10,10 +14,6 @@ import {
 } from 'queries/types/GetAccessibilityRequest';
 import { UpdateTestDate } from 'queries/types/UpdateTestDate';
 import UpdateTestDateQuery from 'queries/UpdateTestDateQuery';
-
-import PageLoading from 'components/PageLoading';
-import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
-import { useMessage } from 'hooks/useMessage';
 import { TestDateFormType } from 'types/accessibility';
 import { formatDate } from 'utils/date';
 


### PR DESCRIPTION
This PR updates the ESLint import sorting. Currently the `src/queries` directory is getting sorted as an NPM import. It should be sorted as an internal project directory alphabetically.

This PR only fixes the ESLint rule and **does not** fix each affected file. I'd prefer to fix this lint errors incrementally rather than in one shot. This means each developer will see import sorting lint errors as they do work. It's up to them to fix as they come up. They should get caught in `pre-commit`.