### PR TITLE
Add tests for RequestOverview.tsx (GovTeam request view)

### DIFF
--- a/src/components/PageWrapper/index.tsx
+++ b/src/components/PageWrapper/index.tsx
@@ -6,11 +6,15 @@ import './index.scss';
 type PageWrapperProps = {
   className?: string;
   children: React.ReactNode;
-};
+} & JSX.IntrinsicElements['div'];
 
-const PageWrapper = ({ className, children }: PageWrapperProps) => {
+const PageWrapper = ({ className, children, ...props }: PageWrapperProps) => {
   const classes = classnames('easi-page-wrapper', className);
-  return <div className={classes}>{children}</div>;
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
 };
 
 export default PageWrapper;

--- a/src/views/GovernanceReviewTeam/Actions/ChooseAction.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ChooseAction.tsx
@@ -228,7 +228,9 @@ const ChooseAction = ({
 
   return (
     <>
-      <PageHeading>{t('submitAction.heading')}</PageHeading>
+      <PageHeading data-testid="grt-actions-view">
+        {t('submitAction.heading')}
+      </PageHeading>
       <h2 className="margin-y-3">{t('submitAction.subheading')}</h2>
       <form onSubmit={onSubmit}>
         <ActionContext.Provider

--- a/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
@@ -124,7 +124,9 @@ const IssueLifecycleId = () => {
                 />
               </ErrorAlert>
             )}
-            <PageHeading>{t('issueLCID.heading')}</PageHeading>
+            <PageHeading data-testid="issue-lcid">
+              {t('issueLCID.heading')}
+            </PageHeading>
             <h2>{t('issueLCID.subheading')}</h2>
             <p>
               Approve request and issue Lifecycle ID{' '}

--- a/src/views/GovernanceReviewTeam/Actions/ProvideGRTFeedbackToBusinessOwner.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ProvideGRTFeedbackToBusinessOwner.tsx
@@ -87,7 +87,9 @@ const ProvideGRTFeedbackToBusinessOwner = ({
                 })}
               </ErrorAlert>
             )}
-            <h1>{t('submitAction.heading')}</h1>
+            <h1 data-testid="provide-feedback-biz-case">
+              {t('submitAction.heading')}
+            </h1>
             <h2>{t('submitAction.subheading')}</h2>
             <p>
               {actionName} &nbsp;

--- a/src/views/GovernanceReviewTeam/Actions/ProvideGRTRecommendationsToGRB.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ProvideGRTRecommendationsToGRB.tsx
@@ -82,7 +82,7 @@ const ProvideGRTRecommendationsToGRB = () => {
                 })}
               </ErrorAlert>
             )}
-            <h1>{t('submitAction.heading')}</h1>
+            <h1 data-testid="ready-for-grb">{t('submitAction.heading')}</h1>
             <h2>{t('submitAction.subheading')}</h2>
             <p>
               {t('actions.readyForGrb')} &nbsp;

--- a/src/views/GovernanceReviewTeam/Actions/RejectIntake.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/RejectIntake.tsx
@@ -99,7 +99,9 @@ const RejectIntake = () => {
                 />
               </ErrorAlert>
             )}
-            <PageHeading>{t('rejectIntake.heading')}</PageHeading>
+            <PageHeading data-testid="not-approved">
+              {t('rejectIntake.heading')}
+            </PageHeading>
             <h2>{t('rejectIntake.subheading')}</h2>
             <p>
               {t('rejectIntake.actionDescription')}{' '}

--- a/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
@@ -93,7 +93,9 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
                 />
               </ErrorAlert>
             )}
-            <PageHeading>{t('submitAction.heading')}</PageHeading>
+            <PageHeading data-testid="grt-submit-action-view">
+              {t('submitAction.heading')}
+            </PageHeading>
             <h2>{t('submitAction.subheading')}</h2>
             <p>
               {actionName} &nbsp;

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The GRT business case review matches the snapshot 1`] = `
-<div>
+<div
+  data-testid="business-case-review"
+>
   <div
     className="easi-pdf-export"
   >

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/index.tsx
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/index.tsx
@@ -28,7 +28,7 @@ const BusinessCaseReview = ({
 
   if (!businessCase.id) {
     return (
-      <div>
+      <div data-testid="business-case-review-not-found">
         <PageHeading className="margin-top-0">
           {t('general:businessCase')}
         </PageHeading>
@@ -38,7 +38,7 @@ const BusinessCaseReview = ({
   }
 
   return (
-    <div>
+    <div data-testid="business-case-review">
       <PDFExport
         title="System Intake"
         filename={filename}

--- a/src/views/GovernanceReviewTeam/Dates/index.tsx
+++ b/src/views/GovernanceReviewTeam/Dates/index.tsx
@@ -132,7 +132,9 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntake }) => {
                 />
               </ErrorAlert>
             )}
-            <PageHeading>{t('governanceReviewTeam:dates.heading')}</PageHeading>
+            <PageHeading data-testid="grt-dates-view">
+              {t('governanceReviewTeam:dates.heading')}
+            </PageHeading>
             <h2>{t('governanceReviewTeam:dates.subheading')}</h2>
             <div className="tablet:grid-col-6">
               <MandatoryFieldsAlert />

--- a/src/views/GovernanceReviewTeam/Decision/index.tsx
+++ b/src/views/GovernanceReviewTeam/Decision/index.tsx
@@ -152,7 +152,9 @@ const Decision = ({ systemIntake }: DecisionProps) => {
 
   return (
     <>
-      <PageHeading>{t('governanceReviewTeam:decision.title')}</PageHeading>
+      <PageHeading data-testid="grt-decision-view">
+        {t('governanceReviewTeam:decision.title')}
+      </PageHeading>
       <p>{t('governanceReviewTeam:decision.noDecision')}</p>
     </>
   );

--- a/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`The GRT intake review view matches the snapshot 1`] = `
 Array [
-  <div>
+  <div
+    data-testid="intake-review"
+  >
     <h1
       aria-live="polite"
       className="easi-h1 margin-top-0"

--- a/src/views/GovernanceReviewTeam/IntakeReview/index.tsx
+++ b/src/views/GovernanceReviewTeam/IntakeReview/index.tsx
@@ -20,7 +20,7 @@ const IntakeReview = ({ systemIntake, now }: IntakeReviewProps) => {
   const filename = `System intake for ${systemIntake.requestName}.pdf`;
 
   return (
-    <div>
+    <div data-testid="intake-review">
       <PageHeading className="margin-top-0">{t('general:intake')}</PageHeading>
       <PDFExport
         title="System Intake"

--- a/src/views/GovernanceReviewTeam/Notes/index.tsx
+++ b/src/views/GovernanceReviewTeam/Notes/index.tsx
@@ -140,7 +140,9 @@ const Notes = () => {
 
   return (
     <>
-      <PageHeading>{t('notes.heading')}</PageHeading>
+      <PageHeading data-testid="grt-notes-view">
+        {t('notes.heading')}
+      </PageHeading>
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         {(formikProps: FormikProps<NoteForm>) => {
           const { values, handleSubmit } = formikProps;

--- a/src/views/GovernanceReviewTeam/RequestOverview.test.tsx
+++ b/src/views/GovernanceReviewTeam/RequestOverview.test.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { MockedProvider } from '@apollo/client/testing';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved
+} from '@testing-library/react';
+import GetAdminNotesAndActionsQuery from 'queries/GetAdminNotesAndActionsQuery';
+import GetSystemIntakeQuery from 'queries/GetSystemIntakeQuery';
 import configureMockStore from 'redux-mock-store';
 
+import { businessCaseInitialData } from 'data/businessCase';
 import { initialSystemIntakeForm } from 'data/systemIntake';
 
 import RequestOverview from './RequestOverview';
@@ -26,35 +33,436 @@ jest.mock('@okta/okta-react', () => ({
   }
 }));
 
-describe('The GRT Review page', () => {
-  it('renders the Summary component', async () => {
-    const mockStore = configureMockStore();
-    const store = mockStore({
-      auth: {
-        groups: ['EASI_D_GOVTEAM'],
-        isUserSet: true
-      },
-      systemIntake: {
-        systemIntake: {
-          ...initialSystemIntakeForm,
-          status: 'INTAKE_SUBMITTED'
-        }
-      },
-      businessCase: {
-        form: {}
-      }
-    });
+window.matchMedia = (): any => ({
+  addListener: () => {},
+  removeListener: () => {}
+});
 
-    let component: ShallowWrapper;
-    await act(async () => {
-      component = shallow(
-        <MemoryRouter>
-          <Provider store={store}>
-            <RequestOverview />
+const waitForPageLoad = async () => {
+  await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
+};
+
+describe('Governance Review Team', () => {
+  const intakeQuery = {
+    request: {
+      query: GetSystemIntakeQuery,
+      variables: {
+        id: 'a4158ad8-1236-4a55-9ad5-7e15a5d49de2'
+      }
+    },
+    result: {
+      data: {
+        systemIntake: {
+          id: 'a4158ad8-1236-4a55-9ad5-7e15a5d49de2',
+          adminLead: null,
+          businessNeed: 'Test business need',
+          businessSolution: 'Test business solution',
+          businessOwner: {
+            component: 'Center for Medicaid and CHIP Services',
+            name: 'ABCD'
+          },
+          contract: {
+            contractor: 'Contractor Name',
+            endDate: {
+              day: '31',
+              month: '12',
+              year: '2023'
+            },
+            hasContract: 'HAVE_CONTRACT',
+            startDate: {
+              day: '1',
+              month: '1',
+              year: '2021'
+            },
+            vehicle: 'Sole source'
+          },
+          costs: {
+            isExpectingIncrease: 'YES',
+            expectedIncreaseAmount: '10 million dollars'
+          },
+          currentStage: 'I have done some initial research',
+          decisionNextSteps: null,
+          grbDate: null,
+          grtDate: null,
+          grtFeedbacks: [],
+          governanceTeams: {
+            isPresent: true,
+            teams: [
+              {
+                acronym: 'EA',
+                collaborator: 'EA Collaborator Name',
+                key: 'enterpriseArchitecture',
+                label: 'Enterprise Architecture (EA)',
+                name: 'Enterprise Architecture'
+              },
+              {
+                acronym: 'ISPG',
+                collaborator: 'OIT Collaborator Name',
+                key: 'securityPrivacy',
+                label: "OIT's Security and Privacy Group (ISPG)",
+                name: "OIT's Security and Privacy Group"
+              },
+              {
+                acronym: 'TRB',
+                collaborator: 'TRB Collaborator Name',
+                key: 'technicalReviewBoard',
+                label: 'Technical Review Board (TRB)',
+                name: 'Technical Review Board'
+              }
+            ]
+          },
+          isso: {
+            isPresent: true,
+            name: 'ISSO Name'
+          },
+          fundingSource: {
+            fundingNumber: '123456',
+            isFunded: true,
+            source: 'Research'
+          },
+          lcid: null,
+          lcidExpiresAt: null,
+          lcidScope: null,
+          needsEaSupport: true,
+          productManager: {
+            component: 'Center for Program Integrity',
+            name: 'Project Manager'
+          },
+          rejectionReason: null,
+          requester: {
+            component: 'Center for Medicaid and CHIP Services',
+            email: null,
+            name: 'User ABCD'
+          },
+          requestName: 'TACO',
+          requestType: 'NEW',
+          status: 'INTAKE_SUBMITTED',
+          submittedAt: null
+        }
+      }
+    }
+  };
+
+  const adminNotesAndActionsQuery = {
+    request: {
+      query: GetAdminNotesAndActionsQuery,
+      variables: {
+        id: 'a4158ad8-1236-4a55-9ad5-7e15a5d49de2'
+      }
+    },
+    result: {
+      data: {
+        systemIntake: {
+          notes: [
+            {
+              id: '074632f8-44fd-4c57-851c-4577ec1af230',
+              createdAt: '2021-07-07T20:27:04Z',
+              content: 'a clever remark',
+              author: {
+                name: 'Author Name',
+                eua: 'QQQQ'
+              }
+            }
+          ],
+          actions: [
+            {
+              id: '9c3e767b-f1af-46ff-93cf-0ace61f30e89',
+              createdAt: '2021-07-07T20:32:04Z',
+              feedback: 'This business case needs feedback',
+              type: 'PROVIDE_FEEDBACK_NEED_BIZ_CASE',
+              actor: {
+                name: 'Actor Name',
+                email: 'actor@example.com'
+              }
+            },
+            {
+              id: '7e94bf26-70ac-44f2-af8c-179e34b960cf',
+              createdAt: '2021-07-07T20:22:04Z',
+              feedback: null,
+              type: 'SUBMIT_INTAKE',
+              actor: {
+                name: 'Actor Name',
+                email: 'actor@example.com'
+              }
+            }
+          ]
+        }
+      }
+    }
+  };
+
+  const mockStore = configureMockStore();
+  const defaultStore = mockStore({
+    auth: {
+      euaId: 'AAAA',
+      isUserSet: true,
+      groups: ['EASI_D_GOVTEAM']
+    },
+    systemIntake: {
+      systemIntake: {
+        ...initialSystemIntakeForm,
+        businessCaseId: '51aaa76e-57a6-4bff-ae51-f693b8038ba2'
+      }
+    },
+    businessCase: {
+      form: {
+        ...businessCaseInitialData,
+        id: '51aaa76e-57a6-4bff-ae51-f693b8038ba2'
+      }
+    }
+  });
+
+  it('renders without errors (intake request)', async () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/governance-review-team/a4158ad8-1236-4a55-9ad5-7e15a5d49de2/intake-request'
+        ]}
+      >
+        <MockedProvider mocks={[intakeQuery]} addTypename={false}>
+          <Provider store={defaultStore}>
+            <Route path="/governance-review-team/:systemId/intake-request">
+              <RequestOverview />
+            </Route>
           </Provider>
+        </MockedProvider>
+      </MemoryRouter>
+    );
+    await waitForPageLoad();
+
+    expect(screen.getByTestId('grt-request-overview')).toBeInTheDocument();
+    expect(screen.getByTestId('intake-review')).toBeInTheDocument();
+  });
+
+  it('renders GRT business case view', async () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/governance-review-team/a4158ad8-1236-4a55-9ad5-7e15a5d49de2/business-case'
+        ]}
+      >
+        <MockedProvider mocks={[intakeQuery]} addTypename={false}>
+          <Provider store={defaultStore}>
+            <Route path="/governance-review-team/:systemId/business-case">
+              <RequestOverview />
+            </Route>
+          </Provider>
+        </MockedProvider>
+      </MemoryRouter>
+    );
+    await waitForPageLoad();
+
+    expect(screen.getByTestId('business-case-review')).toBeInTheDocument();
+  });
+
+  it('renders GRT notes view', async () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/governance-review-team/a4158ad8-1236-4a55-9ad5-7e15a5d49de2/notes'
+        ]}
+      >
+        {/* TODO: There shouldn't need to be three mocked queries; only 2 */}
+        <MockedProvider
+          mocks={[intakeQuery, adminNotesAndActionsQuery, intakeQuery]}
+          addTypename={false}
+        >
+          <Provider store={defaultStore}>
+            <Route path="/governance-review-team/:systemId/notes">
+              <RequestOverview />
+            </Route>
+          </Provider>
+        </MockedProvider>
+      </MemoryRouter>
+    );
+    await waitForPageLoad();
+
+    expect(screen.getByTestId('grt-notes-view')).toBeInTheDocument();
+  });
+
+  it('renders GRT dates view', async () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/governance-review-team/a4158ad8-1236-4a55-9ad5-7e15a5d49de2/dates'
+        ]}
+      >
+        <MockedProvider mocks={[intakeQuery]} addTypename={false}>
+          <Provider store={defaultStore}>
+            <Route path="/governance-review-team/:systemId/dates">
+              <RequestOverview />
+            </Route>
+          </Provider>
+        </MockedProvider>
+      </MemoryRouter>
+    );
+    await waitForPageLoad();
+
+    expect(screen.getByTestId('grt-dates-view')).toBeInTheDocument();
+  });
+
+  it('renders GRT dates view', async () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/governance-review-team/a4158ad8-1236-4a55-9ad5-7e15a5d49de2/decision'
+        ]}
+      >
+        <MockedProvider mocks={[intakeQuery]} addTypename={false}>
+          <Provider store={defaultStore}>
+            <Route path="/governance-review-team/:systemId/decision">
+              <RequestOverview />
+            </Route>
+          </Provider>
+        </MockedProvider>
+      </MemoryRouter>
+    );
+    await waitForPageLoad();
+
+    expect(screen.getByTestId('grt-decision-view')).toBeInTheDocument();
+  });
+
+  it('renders GRT actions view', async () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          '/governance-review-team/a4158ad8-1236-4a55-9ad5-7e15a5d49de2/actions'
+        ]}
+      >
+        <MockedProvider mocks={[intakeQuery]} addTypename={false}>
+          <Provider store={defaultStore}>
+            <Route path="/governance-review-team/:systemId/actions">
+              <RequestOverview />
+            </Route>
+          </Provider>
+        </MockedProvider>
+      </MemoryRouter>
+    );
+    await waitForPageLoad();
+
+    expect(screen.getByTestId('grt-actions-view')).toBeInTheDocument();
+  });
+
+  describe('actions', () => {
+    const renderPage = (slug: string) => {
+      render(
+        <MemoryRouter
+          initialEntries={[
+            `/governance-review-team/a4158ad8-1236-4a55-9ad5-7e15a5d49de2/actions/${slug}`
+          ]}
+        >
+          <MockedProvider mocks={[intakeQuery]} addTypename={false}>
+            <Provider store={defaultStore}>
+              <Route path="/governance-review-team/:systemId/actions/:activePage">
+                <RequestOverview />
+              </Route>
+            </Provider>
+          </MockedProvider>
         </MemoryRouter>
       );
+    };
+    it('renders not IT request action', async () => {
+      renderPage('not-it-request');
+      await waitForPageLoad();
+
+      expect(screen.getByTestId('grt-submit-action-view')).toBeInTheDocument();
     });
-    expect(component!.find('Summary').exists()).toBeFalsy();
+
+    it('renders GRT need business case action', async () => {
+      renderPage('need-biz-case');
+      await waitForPageLoad();
+
+      expect(screen.getByTestId('grt-submit-action-view')).toBeInTheDocument();
+    });
+
+    it('renders GRT feedback and need business case action', async () => {
+      renderPage('provide-feedback-need-biz-case');
+      await waitForPageLoad();
+
+      expect(
+        screen.getByTestId('provide-feedback-biz-case')
+      ).toBeInTheDocument();
+    });
+
+    it('renders GRT draft business case feedback action', async () => {
+      renderPage('provide-feedback-keep-draft');
+      await waitForPageLoad();
+
+      expect(
+        screen.getByTestId('provide-feedback-biz-case')
+      ).toBeInTheDocument();
+    });
+
+    it('renders GRT final business case feedback action', async () => {
+      renderPage('provide-feedback-need-final');
+      await waitForPageLoad();
+
+      expect(
+        screen.getByTestId('provide-feedback-biz-case')
+      ).toBeInTheDocument();
+    });
+
+    it('renders ready for GRT action', async () => {
+      renderPage('ready-for-grt');
+      await waitForPageLoad();
+
+      expect(screen.getByTestId('grt-submit-action-view')).toBeInTheDocument();
+    });
+
+    it('renders ready for GRB action', async () => {
+      renderPage('ready-for-grb');
+      await waitForPageLoad();
+
+      expect(screen.getByTestId('ready-for-grb')).toBeInTheDocument();
+    });
+
+    it('renders business case not ready for GRT action', async () => {
+      renderPage('biz-case-needs-changes');
+      await waitForPageLoad();
+
+      expect(screen.getByTestId('grt-submit-action-view')).toBeInTheDocument();
+    });
+
+    it('renders no governance action', async () => {
+      renderPage('no-governance');
+      await waitForPageLoad();
+
+      expect(screen.getByTestId('grt-submit-action-view')).toBeInTheDocument();
+    });
+
+    it('renders send email action', async () => {
+      renderPage('send-email');
+      await waitForPageLoad();
+
+      expect(screen.getByTestId('grt-submit-action-view')).toBeInTheDocument();
+    });
+
+    it('renders guide received close action', async () => {
+      renderPage('guide-received-close');
+      await waitForPageLoad();
+
+      expect(screen.getByTestId('grt-submit-action-view')).toBeInTheDocument();
+    });
+
+    it('renders not responding close action', async () => {
+      renderPage('not-responding-close');
+      await waitForPageLoad();
+
+      expect(screen.getByTestId('grt-submit-action-view')).toBeInTheDocument();
+    });
+
+    it('renders not issue lcid action', async () => {
+      renderPage('issue-lcid');
+      await waitForPageLoad();
+
+      expect(screen.getByTestId('issue-lcid')).toBeInTheDocument();
+    });
+
+    it('renders not approved action', async () => {
+      renderPage('not-approved');
+      await waitForPageLoad();
+
+      expect(screen.getByTestId('not-approved')).toBeInTheDocument();
+    });
   });
 });

--- a/src/views/GovernanceReviewTeam/RequestOverview.tsx
+++ b/src/views/GovernanceReviewTeam/RequestOverview.tsx
@@ -25,6 +25,7 @@ import {
 import Footer from 'components/Footer';
 import Header from 'components/Header';
 import MainContent from 'components/MainContent';
+import PageLoading from 'components/PageLoading';
 import PageWrapper from 'components/PageWrapper';
 import { AppState } from 'reducers/rootReducer';
 import { fetchBusinessCase, fetchSystemIntake } from 'types/routines';
@@ -82,11 +83,15 @@ const RequestOverview = () => {
       'easi-grt__nav-link--active': page === activePage
     });
 
+  if (loading) {
+    return <PageLoading />;
+  }
+
   return (
-    <PageWrapper className="easi-grt">
+    <PageWrapper className="easi-grt" data-testid="grt-request-overview">
       <Header />
       <MainContent>
-        {intake && <Summary intake={intake} />}
+        <Summary intake={intake} />
         <section className="grid-container grid-row margin-y-5 ">
           <nav className="tablet:grid-col-2 margin-right-2">
             <ul className="easi-grt__nav-list">
@@ -154,9 +159,6 @@ const RequestOverview = () => {
             <Route
               path="/governance-review-team/:systemId/intake-request"
               render={() => {
-                if (loading) {
-                  return <p>Loading...</p>;
-                }
                 return (
                   <IntakeReview systemIntake={intake} now={DateTime.local()} />
                 );
@@ -178,9 +180,6 @@ const RequestOverview = () => {
             <Route
               path="/governance-review-team/:systemId/dates"
               render={() => {
-                if (loading) {
-                  return <p>Loading...</p>;
-                }
                 return <Dates systemIntake={intake} />;
               }}
             />

--- a/src/views/GovernanceReviewTeam/index.tsx
+++ b/src/views/GovernanceReviewTeam/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
-import { SecureRoute } from '@okta/okta-react';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import RequestRepository from 'components/RequestRepository';
@@ -15,30 +14,29 @@ const GovernanceReviewTeam = () => {
   const isUserSet = useSelector((state: AppState) => state.auth.isUserSet);
   const flags = useFlags();
 
-  const RenderPage = () => (
-    <Switch>
-      <SecureRoute
-        path="/governance-review-team/all"
-        render={() => (
-          // Changed GRT table from grid-container to just slight margins. This is take up
-          // entire screen to better fit the more expansive data in the table.
-          // NOTE: not sure this is ever used (deprecated for Home/index.tsx ?)
-          <div className="padding-x-4">
-            <RequestRepository />
-          </div>
-        )}
-      />
-      <SecureRoute
-        path="/governance-review-team/:systemId/:activePage"
-        component={RequestOverview}
-      />
-      <Route path="*" component={NotFound} />
-    </Switch>
-  );
-
   if (isUserSet) {
     if (user.isGrtReviewer(userGroups, flags)) {
-      return <RenderPage />;
+      return (
+        <Switch>
+          <Route
+            key="grt-request-list"
+            path="/governance-review-team/all"
+            render={() => (
+              // Changed GRT table from grid-container to just slight margins. This is take up
+              // entire screen to better fit the more expansive data in the table.
+              <div className="padding-x-4">
+                <RequestRepository />
+              </div>
+            )}
+          />
+          <Route
+            key="grt-overview"
+            path="/governance-review-team/:systemId/:activePage"
+            component={RequestOverview}
+          />
+          <Route key="not-found" path="*" component={NotFound} />
+        </Switch>
+      );
     }
     return <NotFound />;
   }

--- a/src/views/GovernanceReviewTeam/index.tsx
+++ b/src/views/GovernanceReviewTeam/index.tsx
@@ -14,29 +14,31 @@ const GovernanceReviewTeam = () => {
   const isUserSet = useSelector((state: AppState) => state.auth.isUserSet);
   const flags = useFlags();
 
+  // TODO: this is causing the Routes to unexpectedly unmount
+  const RenderPage = () => (
+    <Switch>
+      <Route
+        path="/governance-review-team/all"
+        render={() => (
+          // Changed GRT table from grid-container to just slight margins. This is take up
+          // entire screen to better fit the more expansive data in the table.
+          // NOTE: not sure this is ever used (deprecated for Home/index.tsx ?)
+          <div className="padding-x-4">
+            <RequestRepository />
+          </div>
+        )}
+      />
+      <Route
+        path="/governance-review-team/:systemId/:activePage"
+        component={RequestOverview}
+      />
+      <Route path="*" component={NotFound} />
+    </Switch>
+  );
+
   if (isUserSet) {
     if (user.isGrtReviewer(userGroups, flags)) {
-      return (
-        <Switch>
-          <Route
-            key="grt-request-list"
-            path="/governance-review-team/all"
-            render={() => (
-              // Changed GRT table from grid-container to just slight margins. This is take up
-              // entire screen to better fit the more expansive data in the table.
-              <div className="padding-x-4">
-                <RequestRepository />
-              </div>
-            )}
-          />
-          <Route
-            key="grt-overview"
-            path="/governance-review-team/:systemId/:activePage"
-            component={RequestOverview}
-          />
-          <Route key="not-found" path="*" component={NotFound} />
-        </Switch>
-      );
+      return <RenderPage />;
     }
     return <NotFound />;
   }


### PR DESCRIPTION
This PR adds tests for `RequestOverview.tsx`. These are mainly smoke tests to make sure that the correct route/view paints when a user selects an action.

**After this is merged, I will work on follow up PRs to test the form for each action.**

## Code Review Verification Steps

### As the original developer, I have

- [x] Tests pass

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
