### PR TITLE
update flaky 508 test

### DIFF
--- a/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
@@ -400,7 +400,12 @@ describe('AccessibilityRequestDetailPage', () => {
     });
 
     describe('add note', () => {
-      it('can add a note', async () => {
+      // TODO: Flaky test; need to investigate why
+      // expect(received).toHaveLength(expected)
+
+      // Expected length: 3
+      // Received length: 2
+      xit('can add a note', async () => {
         const withNotesQueryWithNewNote = {
           request: {
             query: GetAccessibilityRequestAccessibilityTeamOnlyQuery,

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
@@ -400,12 +400,7 @@ describe('AccessibilityRequestDetailPage', () => {
     });
 
     describe('add note', () => {
-      // TODO: Flaky test; need to investigate why
-      // expect(received).toHaveLength(expected)
-
-      // Expected length: 3
-      // Received length: 2
-      xit('can add a note', async () => {
+      it('can add a note', async () => {
         const withNotesQueryWithNewNote = {
           request: {
             query: GetAccessibilityRequestAccessibilityTeamOnlyQuery,
@@ -501,7 +496,9 @@ describe('AccessibilityRequestDetailPage', () => {
         const notesList = screen.getByRole('list', {
           name: /existing notes/i
         });
-        expect(within(notesList).getAllByRole('listitem')).toHaveLength(3);
+        expect(await within(notesList).findAllByRole('listitem')).toHaveLength(
+          3
+        );
       });
 
       it('shows an error alert when there is a note form validation error', async () => {


### PR DESCRIPTION
~This PR disables a flaky test on the 508 view.~

~I ran it with no issues locally 10/10, but ran into a few hiccups when code coverage reports are generated. I don't know why that happens, but it also happens intermittently in CI too.~

~There might be something we can do better in the unit test itself, but I'm not fully sure what that is yet.~

~In the mean time, I want to disable the test to minimize setbacks during development.~

Okay, lets talk about these changes I think will make this test more solid.

**Sequence of events**
1. User types in note
2. User clicks button to add note
3. Note is added and success alert appears
4. Refetch occurs to get the new note list (with new note)
5. New note list renders

**What I suspect is happening**
After the success alert appears, there's a race condition between the mocked fetch query (w/ new note) and the test assertion matching the number of notes. Sometimes the mocked query happens first (test passes), sometimes it doesn't (test fails).

**What fixes that?**
By using `await` and `findAllBy*`.

By definition `findAllBy*`: [source](https://testing-library.com/docs/queries/about/#types-of-queries)
>  Returns a promise which resolves to an array of elements when any elements are found which match the given query. The promise is rejected if no elements are found after a default timeout of 1000ms.

Generally `find*` queries are used to query element(s) that aren't immediately on the page. This usually refers to dynamic elements that are displayed as a result of an action.

Since the new comment isn't on the screen yet, I'm hoping `findAllBy*` will do a better job of picking up the new note from the `refetch()`.

**Will it work?**
I guess we'll find out