### PR TITLE
Await success of notes check in flaky react test

### DIFF
--- a/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.test.tsx
@@ -5,6 +5,7 @@ import { MockedProvider } from '@apollo/client/testing';
 import {
   render,
   screen,
+  waitFor,
   waitForElementToBeRemoved,
   within
 } from '@testing-library/react';
@@ -496,8 +497,8 @@ describe('AccessibilityRequestDetailPage', () => {
         const notesList = screen.getByRole('list', {
           name: /existing notes/i
         });
-        expect(await within(notesList).findAllByRole('listitem')).toHaveLength(
-          3
+        await waitFor(() =>
+          expect(within(notesList).getAllByRole('listitem')).toHaveLength(3)
         );
       });
 


### PR DESCRIPTION
## Changes proposed in this pull request

I think we can change the test to wait for the notes to be populated with the new note. It'll check every 50 ms for 1 second, and fail if the new note is not present by then.  

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->
