### PR TITLE
update selector so that the test navigates to the actions page 

### DIFF
--- a/cypress/integration/governanceReviewTeam.spec.js
+++ b/cypress/integration/governanceReviewTeam.spec.js
@@ -113,9 +113,7 @@ describe('Governance Review Team', () => {
     cy.get('a').contains('A Completed Intake Form').click();
     cy.get(
       'a[href="/governance-review-team/af7a3924-3ff7-48ec-8a54-b8b4bc95610b/actions"]'
-    )
-      .contains('Take an action')
-      .click();
+    ).click();
 
     cy.get('button[data-testid="collapsable-link"]').click();
     cy.get('#issue-lcid').check({ force: true }).should('be.checked');
@@ -174,9 +172,7 @@ describe('Governance Review Team', () => {
     cy.get('a').contains('Closable Request').click();
     cy.get(
       'a[href="/governance-review-team/20cbcfbf-6459-4c96-943b-e76b83122dbf/actions"]'
-    )
-      .contains('Take an action')
-      .click();
+    ).click();
 
     cy.get('button[data-testid="collapsable-link"]').click();
     cy.get('#no-governance').check({ force: true }).should('be.checked');


### PR DESCRIPTION
This is the error from CircleCI.
<img width="487" alt="Screen Shot 2021-07-19 at 1 03 01 PM" src="https://user-images.githubusercontent.com/8367504/126220243-5f96d335-a45a-4809-8c63-ecf4046768e8.png">

There are two links to navigate to the "Action" page from the GovTeam request view.

<img width="1895" alt="Screen Shot 2021-07-19 at 1 06 47 PM" src="https://user-images.githubusercontent.com/8367504/126220661-389b7113-6a56-4fe5-9389-fba74ad2d04f.png">

Currently, the test is trying to find the link that has the text `Take an action`, but that's not always rendered in time. By updating the test to click the first "Actions" link it finds, we'll get more consistent results for this test.

## Code Review Verification Steps

### As the original developer, I have

- [x] Tests pass

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
