### PR TITLE
add test id to specifically target a link on get actions cypress tests

### DIFF
--- a/cypress/integration/governanceReviewTeam.spec.js
+++ b/cypress/integration/governanceReviewTeam.spec.js
@@ -111,9 +111,7 @@ describe('Governance Review Team', () => {
     // Selecting name based on pre-seeded data
     // A Completed Intake Form - af7a3924-3ff7-48ec-8a54-b8b4bc95610b
     cy.get('a').contains('A Completed Intake Form').click();
-    cy.get(
-      'a[href="/governance-review-team/af7a3924-3ff7-48ec-8a54-b8b4bc95610b/actions"]'
-    ).click();
+    cy.get('[data-testid="grt-nav-actions-link"]').click();
 
     cy.get('button[data-testid="collapsable-link"]').click();
     cy.get('#issue-lcid').check({ force: true }).should('be.checked');
@@ -170,9 +168,7 @@ describe('Governance Review Team', () => {
     // Selecting name based on pre-seeded data
     // Closable Request - 20cbcfbf-6459-4c96-943b-e76b83122dbf
     cy.get('a').contains('Closable Request').click();
-    cy.get(
-      'a[href="/governance-review-team/20cbcfbf-6459-4c96-943b-e76b83122dbf/actions"]'
-    ).click();
+    cy.get('[data-testid="grt-nav-actions-link"]').click();
 
     cy.get('button[data-testid="collapsable-link"]').click();
     cy.get('#no-governance').check({ force: true }).should('be.checked');

--- a/src/views/GovernanceReviewTeam/RequestOverview.tsx
+++ b/src/views/GovernanceReviewTeam/RequestOverview.tsx
@@ -133,6 +133,7 @@ const RequestOverview = () => {
                 <Link
                   to={`/governance-review-team/${systemId}/actions`}
                   className={getNavLinkClasses('actions')}
+                  data-testid="grt-nav-actions-link"
                 >
                   {t('actions')}
                 </Link>


### PR DESCRIPTION
#1216 did not work.

It just exposed us to the other side of the coin. By loosening the selector, Cypress didn't know which link to click if both were rendered.

I think that adding a specific test id for the HTML element will ensure that it's rendered and clicked.

## Code Review Verification Steps

### As the original developer, I have

- [ ] Tests pass

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
