### PR TITLE
remove react-axe

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "jest-launchdarkly-mock": "^0.1.1",
     "markdown-spellcheck": "^1.3.1",
     "prettier": "^2.0.0",
-    "react-axe": "^3.3.0",
     "react-test-renderer": "^16.12.0",
     "redux-mock-store": "^1.5.3",
     "sass-resources-loader": "^2.1.1",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,6 +1,5 @@
 import { Flags } from './types/flags';
 
-declare module 'react-axe';
 declare module '@okta/okta-signin-widget';
 declare module '@okta/okta-signin-widget/dist/js/okta-sign-in.min';
 declare module '*.doc';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,15 +23,6 @@ import store from './store';
 
 import './index.scss';
 
-/**
- * Enables react axe accessibility tooling in development environments
- */
-if (process.env.NODE_ENV === 'development') {
-  import('react-axe').then(axe => {
-    axe.default(React, ReactDOM, 1000);
-  });
-}
-
 const apiHost = new URL(process.env.REACT_APP_API_ADDRESS || '').host;
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5699,11 +5699,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axe-core@^3.5.0:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
-  integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
-
 axe-core@^4.0.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.3.tgz#2a3afc332f0031b42f602f4a3de03c211ca98f72"
@@ -15922,14 +15917,6 @@ react-autowhatever@^10.1.2:
     react-themeable "^1.1.0"
     section-iterator "^2.0.0"
 
-react-axe@^3.3.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/react-axe/-/react-axe-3.5.3.tgz#38dac84e20cdf3e09e5752eb405b30c5ac845fa8"
-  integrity sha512-WDKAoLVsC6rsmYboXThY7OnVDaQOOOecySHJJjggn1cFOJyWtzNh2uiV3oSxoAolONGTi22G9zKDxw53g/8Vqg==
-  dependencies:
-    axe-core "^3.5.0"
-    requestidlecallback "^0.3.0"
-
 react-colorful@^5.1.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.2.2.tgz#0a69d0648db47e51359d343854d83d250a742243"
@@ -16721,11 +16708,6 @@ request@^2.88.0, request@^2.88.2:
     tough-cookie "~2.5.0"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
-
-requestidlecallback@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/requestidlecallback/-/requestidlecallback-0.3.0.tgz#6fb74e0733f90df3faa4838f9f6a2a5f9b742ac5"
-  integrity sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU=
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
[react-axe](https://github.com/dequelabs/react-axe) has been deprecated.

It's been giving us false positives. I noticed it's deprecated, so it's time to let go.

## Code Review Verification Steps

### As the original developer, I have

- [x] Removed the deprecated package

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
