### PR TITLE
K1m 811 add 508 metrics values csv

### DIFF
--- a/pkg/models/accessibility_request.go
+++ b/pkg/models/accessibility_request.go
@@ -41,9 +41,9 @@ type AccessibilityRequestMetrics struct {
 
 // AccessibilityMetricsLine models a row of the 508 metrics csv
 type AccessibilityMetricsLine struct {
-	Name   string
-	LCID   string
-	Status AccessibilityRequestStatus
-	//CreatedAt time.Time
-	//StatusCreatedAt time.Time
+	Name            string
+	LCID            string
+	Status          AccessibilityRequestStatus
+	CreatedAt       time.Time `db:"created_at"`
+	StatusCreatedAt time.Time `db:"status_created_at"`
 }

--- a/pkg/models/accessibility_request.go
+++ b/pkg/models/accessibility_request.go
@@ -41,5 +41,9 @@ type AccessibilityRequestMetrics struct {
 
 // AccessibilityMetricsLine models a row of the 508 metrics csv
 type AccessibilityMetricsLine struct {
-	Name string
+	Name   string
+	LCID   string
+	Status AccessibilityRequestStatus
+	//CreatedAt time.Time
+	//StatusCreatedAt time.Time
 }

--- a/pkg/services/metrics.go
+++ b/pkg/services/metrics.go
@@ -59,9 +59,14 @@ func NewFetchAccessibilityMetrics(
 		if err != nil {
 			return nil, err
 		}
-		data := [][]string{{"Request Name"}}
+		data := [][]string{{"Request Name", "Lifecycle ID", "Request Status", "Date Opened", "Date Closed"}}
 		for _, line := range lines {
-			data = append(data, []string{line.Name})
+			//dateClosedString := ""
+			//if line.Status == models.AccessibilityRequestStatusClosed {
+			//	dateClosedString = line.StatusCreatedAt.Format("01/02/2006")
+			//}
+			data = append(data, []string{line.Name, line.LCID, string(line.Status)})
+			//data = append(data, []string{line.Name, line.LCID, string(line.Status), line.CreatedAt.Format("01/02/2006"), dateClosedString})
 		}
 		return data, nil
 	}

--- a/pkg/services/metrics.go
+++ b/pkg/services/metrics.go
@@ -61,12 +61,11 @@ func NewFetchAccessibilityMetrics(
 		}
 		data := [][]string{{"Request Name", "Lifecycle ID", "Request Status", "Date Opened", "Date Closed"}}
 		for _, line := range lines {
-			//dateClosedString := ""
-			//if line.Status == models.AccessibilityRequestStatusClosed {
-			//	dateClosedString = line.StatusCreatedAt.Format("01/02/2006")
-			//}
-			data = append(data, []string{line.Name, line.LCID, string(line.Status)})
-			//data = append(data, []string{line.Name, line.LCID, string(line.Status), line.CreatedAt.Format("01/02/2006"), dateClosedString})
+			dateClosedString := ""
+			if line.Status == models.AccessibilityRequestStatusClosed {
+				dateClosedString = line.StatusCreatedAt.Format("01/02/2006")
+			}
+			data = append(data, []string{line.Name, line.LCID, string(line.Status), line.CreatedAt.Format("01/02/2006"), dateClosedString})
 		}
 		return data, nil
 	}

--- a/pkg/services/metrics_test.go
+++ b/pkg/services/metrics_test.go
@@ -73,8 +73,8 @@ func (s ServicesTestSuite) TestNewFetchMetrics() {
 func (s ServicesTestSuite) TestNewFetchAccessibilityMetrics() {
 	fetchMetrics := func() ([]models.AccessibilityMetricsLine, error) {
 		return []models.AccessibilityMetricsLine{
-			{Name: "Name 1"},
-			{Name: "Name 2"},
+			{Name: "Name 1", LCID: "C3PO", Status: "OPEN", CreatedAt: time.Date(2020, 01, 01, 0, 0, 0, 0, time.UTC)},
+			{Name: "Name 2", LCID: "OBI1", Status: "CLOSED", CreatedAt: time.Date(2020, 01, 15, 0, 0, 0, 0, time.UTC), StatusCreatedAt: time.Date(2020, 04, 15, 0, 0, 0, 0, time.UTC)},
 		}, nil
 	}
 
@@ -83,9 +83,9 @@ func (s ServicesTestSuite) TestNewFetchAccessibilityMetrics() {
 		s.NoError(err)
 
 		s.Equal([][]string{
-			{"Request Name"},
-			{"Name 1"},
-			{"Name 2"},
+			{"Request Name", "Lifecycle ID", "Request Status", "Date Opened", "Date Closed"},
+			{"Name 1", "C3PO", "OPEN", "01/01/2020", ""},
+			{"Name 2", "OBI1", "CLOSED", "01/15/2020", "04/15/2020"},
 		}, data)
 	})
 

--- a/pkg/storage/accessibility_request.go
+++ b/pkg/storage/accessibility_request.go
@@ -187,9 +187,10 @@ func (s *Store) FetchAccessibilityRequestMetrics(_ context.Context, startTime ti
 // FetchAccessibilityMetrics fetches data about accessibility requests
 func (s *Store) FetchAccessibilityMetrics() ([]models.AccessibilityMetricsLine, error) {
 	const accessibilityMetricsSQL = `
-		SELECT name
-		FROM accessibility_requests_and_statuses
-	`
+		SELECT aras.name, si.lcid, aras.status
+		FROM accessibility_requests_and_statuses aras
+		JOIN system_intakes si on aras.intake_id=si.id`
+
 	var metrics []models.AccessibilityMetricsLine
 	err := s.db.Select(&metrics, accessibilityMetricsSQL)
 

--- a/pkg/storage/accessibility_request.go
+++ b/pkg/storage/accessibility_request.go
@@ -187,7 +187,7 @@ func (s *Store) FetchAccessibilityRequestMetrics(_ context.Context, startTime ti
 // FetchAccessibilityMetrics fetches data about accessibility requests
 func (s *Store) FetchAccessibilityMetrics() ([]models.AccessibilityMetricsLine, error) {
 	const accessibilityMetricsSQL = `
-		SELECT aras.name, si.lcid, aras.status
+		SELECT aras.name, si.lcid, aras.status, aras.created_at, aras.status_created_at
 		FROM accessibility_requests_and_statuses aras
 		JOIN system_intakes si on aras.intake_id=si.id`
 

--- a/src/views/Accessibility/AccessibilityRequest/List/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/List/index.tsx
@@ -76,7 +76,7 @@ const List = () => {
           <PageHeading>{t('accessibility.heading')}</PageHeading>
           <div className="flex-align-self-center">
             <button
-              className="usa-button usa-button--unstyled easi-no-print display-block margin-bottom-3"
+              className="usa-button usa-button--unstyled easi-no-print display-block margin-bottom-4 text-no-underline"
               type="button"
               onClick={fetchCSV}
             >


### PR DESCRIPTION
# ES-811

## Changes proposed in this pull request

- Adds fields to accessibility request metrics CSV:
    - LCID
    - Status
    - Date opened
    - Date closed (only show if last status is closed)

## Reviewer Notes

I made the value of `Date closed` to be an empty string if the status is not CLOSED.  Lmk if that's not the right approach.

It's wasn't part of this PR, but I'm wondering if the text of the download link should be in i18n Translation instead of hard-coded

## Setup

Log in as a 508 tester or 508 user.
Close one of the requests.
From the list of requests, see the button to `download requests as excel file`.
It should download a file.  Check to see that all the values are there, and there is no value for 'Date closed` unless the status is closed.

## Code Review Verification Steps

### As the original developer, I have

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
- [x] Added or updated tests for BE resolvers or other functions as needed

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [x] Checked in the design translated visually (for download button that missed design review when merged)
- [x] Checked behavior
- [x] Checked different states (empty, one, some, error)
- [x] Checked accessibility against criteria
- [x] Checked for landmarks, page heading structure, and links
- [x] Tried to break the intended flow

## Screenshots

From previous PR to create button (adjusted styling):

![image](https://user-images.githubusercontent.com/13249580/127528302-3a25a88f-45ba-4087-a035-7237e99d09ea.png)
