### PR TITLE
K1m 610 hide add request admin

### DIFF
--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -53,9 +53,10 @@ describe('Accessibility Requests', () => {
   });
 
   it('has the correct page order when clicking through 508 team home page', () => {
-    cy.localLogin({ name: 'A11Y', role: 'EASI_D_508_TESTER' });
+    cy.localLogin({ name: 'A11Y', role: 'EASI_D_508_USER' });
 
-    cy.contains('a', 'Add a new request').click();
+    cy.contains('button', 'User A11Y').click();
+    cy.contains('button', 'Make 508 request').click();
     cy.location().should(loc => {
       expect(loc.pathname).to.eq('/508/making-a-request');
     });

--- a/cypress/integration/accessibility.spec.js
+++ b/cypress/integration/accessibility.spec.js
@@ -53,7 +53,7 @@ describe('Accessibility Requests', () => {
   });
 
   it('has the correct page order when clicking through 508 team home page', () => {
-    cy.localLogin({ name: 'A11Y', role: 'EASI_D_508_USER' });
+    cy.localLogin({ name: 'A11Y', role: 'EASI_D_508_TESTER' });
 
     cy.contains('a', 'Add a new request').click();
     cy.location().should(loc => {

--- a/src/views/Accessibility/AccessibilityRequest/List/index.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/List/index.test.tsx
@@ -11,7 +11,7 @@ import configureMockStore from 'redux-mock-store';
 
 // import userEvent from '@testing-library/user-event';
 import {
-  // ACCESSIBILITY_ADMIN_DEV,
+  ACCESSIBILITY_ADMIN_DEV,
   ACCESSIBILITY_TESTER_DEV
 } from 'constants/jobCodes';
 import { MessageProvider } from 'hooks/useMessage';
@@ -24,13 +24,16 @@ describe('Accessibility Request List page', () => {
   const testerStore = mockStore({
     auth: { groups: [ACCESSIBILITY_TESTER_DEV], isUserSet: true }
   });
-  // const adminStore = mockStore({
-  //   auth: { groups: [ACCESSIBILITY_ADMIN_DEV], isUserSet: true }
-  // });
+  const adminStore = mockStore({
+    auth: { groups: [ACCESSIBILITY_ADMIN_DEV], isUserSet: true }
+  });
 
   const default508RequestsQuery = {
     request: {
-      query: GetAccessibilityRequestsQuery
+      query: GetAccessibilityRequestsQuery,
+      variables: {
+        first: 20
+      }
     },
     result: {
       data: {
@@ -90,15 +93,28 @@ describe('Accessibility Request List page', () => {
     );
 
   it('renders without errors', async () => {
-    const wrapper = render508RequestListPage(
-      [default508RequestsQuery],
-      testerStore
-    );
+    render508RequestListPage([default508RequestsQuery], testerStore);
     await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
-    console.log(wrapper.debug());
 
     expect(
       screen.getByTestId('accessibility-request-list-page')
     ).toBeInTheDocument();
+  });
+
+  it('shows the Add a new request button to a 508 tester', async () => {
+    render508RequestListPage([default508RequestsQuery], testerStore);
+    await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
+    // console.log(wrapper.debug());
+    expect(
+      screen.getByRole('link', { name: /Add a new request/i })
+    ).toBeInTheDocument();
+  });
+
+  it('does not show the Add a new request button to a 508 admin', async () => {
+    render508RequestListPage([default508RequestsQuery], adminStore);
+    await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
+    expect(
+      screen.queryByRole('link', { name: /A a new request/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/views/Accessibility/AccessibilityRequest/List/index.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/List/index.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { MockedProvider } from '@apollo/client/testing';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved
+} from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
+
+// import userEvent from '@testing-library/user-event';
+import {
+  // ACCESSIBILITY_ADMIN_DEV,
+  ACCESSIBILITY_TESTER_DEV
+} from 'constants/jobCodes';
+import { MessageProvider } from 'hooks/useMessage';
+import GetAccessibilityRequestsQuery from 'queries/GetAccessibilityRequestsQuery';
+
+import AccessibilityRequestListPage from './index';
+
+describe('Accessibility Request List page', () => {
+  const mockStore = configureMockStore();
+  const testerStore = mockStore({
+    auth: { groups: [ACCESSIBILITY_TESTER_DEV], isUserSet: true }
+  });
+  // const adminStore = mockStore({
+  //   auth: { groups: [ACCESSIBILITY_ADMIN_DEV], isUserSet: true }
+  // });
+
+  const default508RequestsQuery = {
+    request: {
+      query: GetAccessibilityRequestsQuery
+    },
+    result: {
+      data: {
+        accessibilityRequests: {
+          edges: [
+            {
+              node: {
+                id: 'a11yRequest123',
+                name: 'My Special Request',
+                relevantTestDate: { date: new Date().toISOString() },
+                submittedAt: new Date().toISOString(),
+                system: {
+                  lcid: '123456',
+                  businessOwner: { name: 'Clark Kent', component: 'OIT' }
+                },
+                statusRecord: {
+                  status: 'OPEN',
+                  createdAt: new Date().toISOString()
+                }
+              }
+            },
+            {
+              node: {
+                id: 'a11yRequest543',
+                relevantTestDate: { date: new Date().toISOString() },
+                submittedAt: new Date().toISOString(),
+                name: 'My Other Special Request',
+                system: {
+                  lcid: '654321',
+                  businessOwner: { name: 'Jayla Doe', component: 'OIT' }
+                },
+                statusRecord: {
+                  status: 'OPEN',
+                  createdAt: new Date().toISOString()
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  };
+
+  const render508RequestListPage = (mocks: any[], store: any) =>
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <Provider store={store}>
+            <Route path="/">
+              <MessageProvider>
+                <AccessibilityRequestListPage />
+              </MessageProvider>
+            </Route>
+          </Provider>
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+  it('renders without errors', async () => {
+    const wrapper = render508RequestListPage(
+      [default508RequestsQuery],
+      testerStore
+    );
+    await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
+    console.log(wrapper.debug());
+
+    expect(
+      screen.getByTestId('accessibility-request-list-page')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/views/Accessibility/AccessibilityRequest/List/index.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/List/index.test.tsx
@@ -9,11 +9,7 @@ import {
 } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 
-// import userEvent from '@testing-library/user-event';
-import {
-  ACCESSIBILITY_ADMIN_DEV,
-  ACCESSIBILITY_TESTER_DEV
-} from 'constants/jobCodes';
+import { ACCESSIBILITY_TESTER_DEV } from 'constants/jobCodes';
 import { MessageProvider } from 'hooks/useMessage';
 import GetAccessibilityRequestsQuery from 'queries/GetAccessibilityRequestsQuery';
 
@@ -23,9 +19,6 @@ describe('Accessibility Request List page', () => {
   const mockStore = configureMockStore();
   const testerStore = mockStore({
     auth: { groups: [ACCESSIBILITY_TESTER_DEV], isUserSet: true }
-  });
-  const adminStore = mockStore({
-    auth: { groups: [ACCESSIBILITY_ADMIN_DEV], isUserSet: true }
   });
 
   const default508RequestsQuery = {
@@ -99,22 +92,5 @@ describe('Accessibility Request List page', () => {
     expect(
       screen.getByTestId('accessibility-request-list-page')
     ).toBeInTheDocument();
-  });
-
-  it('shows the Add a new request button to a 508 tester', async () => {
-    render508RequestListPage([default508RequestsQuery], testerStore);
-    await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
-    // console.log(wrapper.debug());
-    expect(
-      screen.getByRole('link', { name: /Add a new request/i })
-    ).toBeInTheDocument();
-  });
-
-  it('does not show the Add a new request button to a 508 admin', async () => {
-    render508RequestListPage([default508RequestsQuery], adminStore);
-    await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
-    expect(
-      screen.queryByRole('link', { name: /A a new request/i })
-    ).not.toBeInTheDocument();
   });
 });

--- a/src/views/Accessibility/AccessibilityRequest/List/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/List/index.tsx
@@ -9,6 +9,7 @@ import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import AccessibilityRequestsTable from 'components/AccessibilityRequestsTable';
 import PageHeading from 'components/PageHeading';
+import PageLoading from 'components/PageLoading';
 import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import useMessage from 'hooks/useMessage';
 import GetAccessibilityRequestsQuery from 'queries/GetAccessibilityRequestsQuery';
@@ -35,7 +36,7 @@ const List = () => {
   );
 
   if (loading) {
-    return <div>Loading</div>;
+    return <PageLoading />;
   }
 
   if (error) {
@@ -73,7 +74,10 @@ const List = () => {
           {t('accessibility:tabs.accessibilityRequests')}
         </NavLink>
       </SecondaryNav>
-      <div className="grid-container">
+      <div
+        className="grid-container"
+        data-testid="accessibility-request-list-page"
+      >
         {message && (
           <Alert className="margin-top-4" type="success" role="alert">
             {message}

--- a/src/views/Accessibility/AccessibilityRequest/List/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/List/index.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
-import { Alert, Link as UswdsLink } from '@trussworks/react-uswds';
+import { Alert } from '@trussworks/react-uswds';
 import axios from 'axios';
-import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import AccessibilityRequestsTable from 'components/AccessibilityRequestsTable';
 import PageHeading from 'components/PageHeading';
@@ -14,16 +11,11 @@ import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import useMessage from 'hooks/useMessage';
 import GetAccessibilityRequestsQuery from 'queries/GetAccessibilityRequestsQuery';
 import { GetAccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
-import { AppState } from 'reducers/rootReducer';
 import { downloadBlob } from 'utils/downloadFile';
-import user from 'utils/user';
 
 const List = () => {
   const { t } = useTranslation('home');
   const { message } = useMessage();
-  const userGroups = useSelector((state: AppState) => state.auth.groups);
-  const flags = useFlags();
-  const isAccessibilityAdmin = user.isAccessibilityAdmin(userGroups, flags);
 
   const { loading, error, data } = useQuery<GetAccessibilityRequests>(
     GetAccessibilityRequestsQuery,
@@ -97,16 +89,6 @@ const List = () => {
                 Download all requests as excel file
               </span>
             </button>
-            {!isAccessibilityAdmin && (
-              <UswdsLink
-                asCustom={Link}
-                className="usa-button display-block float-right"
-                variant="unstyled"
-                to="/508/making-a-request"
-              >
-                {t('accessibility.newRequest')}
-              </UswdsLink>
-            )}
           </div>
         </div>
         <AccessibilityRequestsTable requests={requests || []} />

--- a/src/views/Accessibility/AccessibilityRequest/List/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/List/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import { Alert, Link as UswdsLink } from '@trussworks/react-uswds';
 import axios from 'axios';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import AccessibilityRequestsTable from 'components/AccessibilityRequestsTable';
 import PageHeading from 'components/PageHeading';
@@ -11,11 +13,16 @@ import { NavLink, SecondaryNav } from 'components/shared/SecondaryNav';
 import useMessage from 'hooks/useMessage';
 import GetAccessibilityRequestsQuery from 'queries/GetAccessibilityRequestsQuery';
 import { GetAccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
+import { AppState } from 'reducers/rootReducer';
 import { downloadBlob } from 'utils/downloadFile';
+import user from 'utils/user';
 
 const List = () => {
   const { t } = useTranslation('home');
   const { message } = useMessage();
+  const userGroups = useSelector((state: AppState) => state.auth.groups);
+  const flags = useFlags();
+  const isAccessibilityAdmin = user.isAccessibilityAdmin(userGroups, flags);
 
   const { loading, error, data } = useQuery<GetAccessibilityRequests>(
     GetAccessibilityRequestsQuery,
@@ -86,14 +93,16 @@ const List = () => {
                 Download all requests as excel file
               </span>
             </button>
-            <UswdsLink
-              asCustom={Link}
-              className="usa-button display-block float-right"
-              variant="unstyled"
-              to="/508/making-a-request"
-            >
-              {t('accessibility.newRequest')}
-            </UswdsLink>
+            {!isAccessibilityAdmin && (
+              <UswdsLink
+                asCustom={Link}
+                className="usa-button display-block float-right"
+                variant="unstyled"
+                to="/508/making-a-request"
+              >
+                {t('accessibility.newRequest')}
+              </UswdsLink>
+            )}
           </div>
         </div>
         <AccessibilityRequestsTable requests={requests || []} />


### PR DESCRIPTION
# ES-610

## Changes proposed in this pull request

- Removes the "Add a new request" button on the request list page for the 508 admin (job code 508_user)
- Adds tests for that page

## Setup

- Go to a 508_user home page.  There should be no button with the text "Add a new request"
- Go to a 508_tester home page.  The button should be visible.

## Code Review Verification Steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated client tests for new components, parent components,
      functions, or e2e tests as necessary

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

## Screenshots

508_tester view:
![image](https://user-images.githubusercontent.com/13249580/127577596-41e3c191-faf2-428e-875d-f9087f280ebd.png)

508_user view:
![image](https://user-images.githubusercontent.com/13249580/127577673-a8135290-ced7-40f4-b814-b5945b7c3435.png)

