### PR TITLE
Align text for opening in a new tab

### DIFF
--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -290,8 +290,7 @@ const accessibility = {
         downloadVPAT: {
           heading: 'Download VPAT template',
           line1: {
-            linkText:
-              'Download the current VPAT template (opens link in new tab)',
+            linkText: 'Download the current VPAT template (opens in a new tab)',
             otherText:
               'from the Information Technology Industry Council (ITI) website.'
           },
@@ -301,7 +300,7 @@ const accessibility = {
           },
           line3: {
             linkText:
-              'Watch tutorial on how to fill out a VPAT (opens link a new tab).'
+              'Watch tutorial on how to fill out a VPAT (opens in a new tab).'
           }
         }
       }

--- a/src/views/Accessibility/TestingTemplates/__snapshots__/index.test.tsx.snap
+++ b/src/views/Accessibility/TestingTemplates/__snapshots__/index.test.tsx.snap
@@ -202,7 +202,7 @@ exports[`TestingTemplates matches the snapshot 1`] = `
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Download the current VPAT template (opens link in new tab)
+                    Download the current VPAT template (opens in a new tab)
                   </a>
                    
                   from the Information Technology Industry Council (ITI) website.
@@ -223,7 +223,7 @@ exports[`TestingTemplates matches the snapshot 1`] = `
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Watch tutorial on how to fill out a VPAT (opens link a new tab).
+                    Watch tutorial on how to fill out a VPAT (opens in a new tab).
                   </a>
                 </p>
               </div>


### PR DESCRIPTION
# ES-691

## Changes proposed in this pull request

- Makes all text about opening in the same tab the same ("opens in a new tab")

## Setup

Can be viewed throughout application, including templates page, "report a problem" link at bottom of request page, under documents when there are no documents, in the right hand column of the request page, in the new request form (survey link), and the testing steps overview page

## Code Review Verification Steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated client tests for new components, parent components,
      functions, or e2e tests as necessary

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
