### PR TITLE
K1m 830 increase code coverage thresholds

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -138,3 +138,4 @@ v2
 JS
 AirBnb
 Enzyme.js
+Github

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -128,6 +128,31 @@ Currently, Cypress tests are written in JavaScript. The benefit in writing these
 tests in TypeScript isn't immediately apparent. If the project gravitates toward
 writing these tests in TypeScript, there is documentation in supporting that [here](https://www.cypress.io/blog/2019/05/13/code-create-react-app-v3-and-its-cypress-tests-using-typescript/).
 
+### Frontend integration/unit tests
+
+The project is now using [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/).
+ It originally started with Enzyme, and the decision was made to switch to RTL,
+ so there may still be tests that have not been converted.
+ (See [ADR](https://github.com/CMSgov/easi-app/blob/master/docs/adr/0028-use-react-testing-library.md)
+ for reasoning)
+
+### Code coverage
+
+  To view  client test thresholds:
+`yarn test:coverage`
+
+To view current Go test coverage, go to Github Actions `server_test`
+on the latest master build, and search for "total coverage is."
+
+There are thresholds set such that the build in Github Actions
+will fail if minimum code coverage thresholds are not met.
+The intention is that as code coverage improves, the thresholds are moved upwards.
+
+To adjust these thresholds for client tests, see the `package.json` file under `"coverageThreshold"`
+
+To adjust the threshold for Go tests, go to `scripts/testsuite`,
+and find the variable `goal_percent`.
+
 ## React Storybook
 
 This application comes equipped with [React Storybook](https://storybook.js.org).

--- a/package.json
+++ b/package.json
@@ -170,10 +170,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 30,
-        "functions": 20,
-        "lines": 30,
-        "statements": 30
+        "branches": 50,
+        "functions": 50,
+        "lines": 60,
+        "statements": 60
       }
     }
   }

--- a/scripts/testsuite
+++ b/scripts/testsuite
@@ -16,7 +16,7 @@ go tool cover -html=go-coverage.out -o "go-coverage.html"
 # parse out the total coverage percentage which is on the line with (statements) and strip off the % sign
 # https://unix.stackexchange.com/questions/305190/remove-last-character-from-string-captured-with-awk
 percent=$(grep '(statements)' "go-coverage.txt" | awk '{print substr($NF, 1, length($NF)-1)}')
-goal_percent=40
+goal_percent=55
 # using a oneline python function to test if percent is less than goal and return a proper exit code
 if python -c "exit(1) if ${percent} < ${goal_percent} else exit()"; then
     # coverage is good


### PR DESCRIPTION
# ES-830

## Changes proposed in this pull request

- Increases client-side jest test thresholds 30 points.  Increases Go tests coverage threshold to 55.
- Add documentation about code coverage and how to change thresholds

## Reviewer Notes

I made a guess at appropriate thresholds based on where we are at currently.  Lmk if they are too close to our actual coverage.

We do not yet have Cypress coverage thresholds set up.  There is a ticket on Infrasec's backlog for this https://jiraent.cms.gov/browse/ES-711

## Setup

See doc for how to run coverage if you want to see where we are currently at.

## Code Review Verification Steps

### As the original developer, I have

- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked accessibility against criteria
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
