### PR TITLE
Always upload the cypress artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -393,12 +393,14 @@ jobs:
         run: |
           ./scripts/run-cypress-test-docker-github-actions
       - name: Upload cypress videos
+        if: ${{ always() }}
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074 # v2.2.4
         with:
           name: cypress-videos
           path: cypress/videos
           retention-days: 14
       - name: Upload cypress screenshots
+        if: ${{ always() }}
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074 # v2.2.4
         with:
           name: cypress-screenshots


### PR DESCRIPTION
# ES-000

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

## Changes proposed in this pull request

- Always upload the cypress artifacts, even if a step within the e2e_tests job fails.
- With the current configuration, if the cypress tests fail, the steps for uploading the artifacts are skipped, but it's precisely in those situations when the cypress tests fail, that we most want to view the cypress videos/screenshots.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer Notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## Code Review Verification Steps

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
