### PR TITLE
Add GRT email as CC for all actions

### DIFF
--- a/pkg/appses/ses.go
+++ b/pkg/appses/ses.go
@@ -40,14 +40,20 @@ func NewSender(config Config) Sender {
 func (s Sender) Send(
 	ctx context.Context,
 	toAddress models.EmailAddress,
+	ccAddress *models.EmailAddress,
 	subject string,
 	body string,
 ) error {
+	ccAddresses := []*string{}
+	if ccAddress != nil {
+		ccAddresses = append(ccAddresses, aws.String(ccAddress.String()))
+	}
 	input := &ses.SendEmailInput{
 		Destination: &ses.Destination{
 			ToAddresses: []*string{
 				aws.String(toAddress.String()),
 			},
+			CcAddresses: ccAddresses,
 		},
 		Message: &ses.Message{
 			Subject: &ses.Content{

--- a/pkg/appses/ses_test.go
+++ b/pkg/appses/ses_test.go
@@ -67,6 +67,7 @@ func (s SESTestSuite) TestSend() {
 		err := s.sender.Send(
 			context.Background(),
 			models.NewEmailAddress("success@simulator.amazonses.com"),
+			nil,
 			"Test Subject",
 			"Test Body",
 		)

--- a/pkg/email/business_case.go
+++ b/pkg/email/business_case.go
@@ -46,6 +46,7 @@ func (c Client) SendBusinessCaseSubmissionEmail(ctx context.Context, requestName
 	err = c.sender.Send(
 		ctx,
 		c.config.GRTEmail,
+		nil,
 		subject,
 		body,
 	)

--- a/pkg/email/change_508_status.go
+++ b/pkg/email/change_508_status.go
@@ -71,6 +71,7 @@ func (c Client) SendChangeAccessibilityRequestStatusEmail(
 	err = c.sender.Send(
 		ctx,
 		c.config.AccessibilityTeamEmail,
+		nil,
 		subject,
 		body,
 	)

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -45,7 +45,7 @@ type templates struct {
 
 // sender is an interface for swapping out email provider implementations
 type sender interface {
-	Send(ctx context.Context, toAddress models.EmailAddress, subject string, body string) error
+	Send(ctx context.Context, toAddress models.EmailAddress, ccAddress *models.EmailAddress, subject string, body string) error
 }
 
 // Client is an EASi SES client wrapper
@@ -180,5 +180,5 @@ func (c Client) urlFromPath(path string) string {
 // SendTestEmail sends an email to a no-reply address
 func (c Client) SendTestEmail(ctx context.Context) error {
 	testToAddress := models.NewEmailAddress("success@simulator.amazonses.com")
-	return c.sender.Send(ctx, testToAddress, "test", "test")
+	return c.sender.Send(ctx, testToAddress, nil, "test", "test")
 }

--- a/pkg/email/email_test.go
+++ b/pkg/email/email_test.go
@@ -26,7 +26,7 @@ type mockSender struct {
 	body      string
 }
 
-func (s *mockSender) Send(ctx context.Context, toAddress models.EmailAddress, subject string, body string) error {
+func (s *mockSender) Send(ctx context.Context, toAddress models.EmailAddress, ccAddress *models.EmailAddress, subject string, body string) error {
 	s.toAddress = toAddress
 	s.subject = subject
 	s.body = body
@@ -35,7 +35,7 @@ func (s *mockSender) Send(ctx context.Context, toAddress models.EmailAddress, su
 
 type mockFailedSender struct{}
 
-func (s *mockFailedSender) Send(ctx context.Context, toAddress models.EmailAddress, subject string, body string) error {
+func (s *mockFailedSender) Send(ctx context.Context, toAddress models.EmailAddress, ccAddress *models.EmailAddress, subject string, body string) error {
 	return errors.New("sender had an error")
 }
 

--- a/pkg/email/intake_review.go
+++ b/pkg/email/intake_review.go
@@ -44,6 +44,7 @@ func (c Client) SendSystemIntakeReviewEmail(ctx context.Context, emailText strin
 	err = c.sender.Send(
 		ctx,
 		recipientAddress,
+		&c.config.GRTEmail,
 		subject,
 		body,
 	)

--- a/pkg/email/issue_lcid.go
+++ b/pkg/email/issue_lcid.go
@@ -47,6 +47,7 @@ func (c Client) SendIssueLCIDEmail(ctx context.Context, recipient models.EmailAd
 	err = c.sender.Send(
 		ctx,
 		recipient,
+		&c.config.GRTEmail,
 		subject,
 		body,
 	)

--- a/pkg/email/new_accessibility_request.go
+++ b/pkg/email/new_accessibility_request.go
@@ -76,6 +76,7 @@ func (c Client) SendNewAccessibilityRequestEmail(ctx context.Context, requesterN
 	err = c.sender.Send(
 		ctx,
 		c.config.AccessibilityTeamEmail,
+		nil,
 		subject,
 		body,
 	)
@@ -95,6 +96,7 @@ func (c Client) SendNewAccessibilityRequestEmailToRequester(ctx context.Context,
 	err = c.sender.Send(
 		ctx,
 		requesterEmail,
+		nil,
 		subject,
 		body,
 	)

--- a/pkg/email/new_accessibility_request_note.go
+++ b/pkg/email/new_accessibility_request_note.go
@@ -51,6 +51,7 @@ func (c Client) SendNewAccessibilityRequestNoteEmail(
 	err = c.sender.Send(
 		ctx,
 		c.config.AccessibilityTeamEmail,
+		nil,
 		subject,
 		body,
 	)

--- a/pkg/email/new_document.go
+++ b/pkg/email/new_document.go
@@ -78,6 +78,7 @@ func (c Client) sendNewDocumentEmail(
 	err = c.sender.Send(
 		ctx,
 		recipient,
+		nil,
 		subject,
 		body,
 	)

--- a/pkg/email/reject_request.go
+++ b/pkg/email/reject_request.go
@@ -42,6 +42,7 @@ func (c Client) SendRejectRequestEmail(ctx context.Context, recipient models.Ema
 	err = c.sender.Send(
 		ctx,
 		recipient,
+		&c.config.GRTEmail,
 		subject,
 		body,
 	)

--- a/pkg/email/removed_accessibility_request.go
+++ b/pkg/email/removed_accessibility_request.go
@@ -64,6 +64,7 @@ func (c Client) SendRemovedAccessibilityRequestEmail(
 	err = c.sender.Send(
 		ctx,
 		c.config.AccessibilityTeamEmail,
+		nil,
 		subject,
 		body,
 	)

--- a/pkg/email/request_withdraw.go
+++ b/pkg/email/request_withdraw.go
@@ -61,6 +61,7 @@ func (c Client) SendWithdrawRequestEmail(ctx context.Context, requestName string
 	err = c.sender.Send(
 		ctx,
 		c.config.GRTEmail,
+		nil,
 		subject,
 		body,
 	)

--- a/pkg/email/system_intake.go
+++ b/pkg/email/system_intake.go
@@ -44,6 +44,7 @@ func (c Client) SendSystemIntakeSubmissionEmail(ctx context.Context, requestName
 	err = c.sender.Send(
 		ctx,
 		c.config.GRTEmail,
+		nil,
 		subject,
 		body,
 	)

--- a/pkg/local/email.go
+++ b/pkg/local/email.go
@@ -20,9 +20,14 @@ type Sender struct {
 
 // Send logs an email
 func (s Sender) Send(ctx context.Context, toAddress models.EmailAddress, ccAddress *models.EmailAddress, subject string, body string) error {
+	ccAddresses := ""
+	if ccAddress != nil {
+		ccAddresses = ccAddress.String()
+	}
+
 	appcontext.ZLogger(ctx).Info("Mock sending email",
 		zap.String("To", toAddress.String()),
-		zap.String("CC", ccAddress.String()),
+		zap.String("CC", ccAddresses),
 		zap.String("Subject", subject),
 		zap.String("Body", body),
 	)

--- a/pkg/local/email.go
+++ b/pkg/local/email.go
@@ -19,9 +19,10 @@ type Sender struct {
 }
 
 // Send logs an email
-func (s Sender) Send(ctx context.Context, toAddress models.EmailAddress, subject string, body string) error {
+func (s Sender) Send(ctx context.Context, toAddress models.EmailAddress, ccAddress *models.EmailAddress, subject string, body string) error {
 	appcontext.ZLogger(ctx).Info("Mock sending email",
 		zap.String("To", toAddress.String()),
+		zap.String("CC", ccAddress.String()),
 		zap.String("Subject", subject),
 		zap.String("Body", body),
 	)


### PR DESCRIPTION
# ES-843

This adds the GRT team as a CC to all emails on the governance side.

## Code Review Verification Steps

### As the original developer, I have

- [ ] Tested on Dev

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
