### PR TITLE
Add governance feedback page

### DIFF
--- a/src/i18n/en-US/taskList.ts
+++ b/src/i18n/en-US/taskList.ts
@@ -21,7 +21,24 @@ const taskList = {
       'Finish these next steps to complete the governance review process.'
   },
   navigation: {
+    home: 'Home',
+    governanceApproval: 'Get governance approval',
+    feedback: 'Feedback',
     returnToTaskList: 'Return to task list'
+  },
+  feedback: {
+    heading: 'Recommendations',
+    grb: {
+      heading: 'GRT recommendations to the GRB',
+      help:
+        'These are the Governance Reiew Team recommendations for the Governance Review Board'
+    },
+    businessOwner: {
+      heading: 'GRT recommendations to the Business Owner',
+      help:
+        'These are the Governance Review Team recommendations for the Business Owner'
+    },
+    descriptiveDate: 'Feedback given on {{date}}'
   }
 };
 

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -19,6 +19,7 @@ import FlagsWrapper from 'views/FlagsWrapper';
 import GovernanceOverview from 'views/GovernanceOverview';
 import GovernanceReviewTeam from 'views/GovernanceReviewTeam';
 import GovernanceTaskList from 'views/GovernanceTaskList';
+import GovernanceFeedback from 'views/GovernanceTaskList/Feedback';
 import RequestDecision from 'views/GovernanceTaskList/RequestDecision';
 import Home from 'views/Home';
 import Login from 'views/Login';
@@ -80,6 +81,11 @@ const AppRoutes = () => {
         path="/governance-task-list/:systemId"
         exact
         component={GovernanceTaskList}
+      />
+      <SecureRoute
+        path="/governance-task-list/:systemId/feedback"
+        exact
+        component={GovernanceFeedback}
       />
       <SecureRoute
         exact

--- a/src/views/GovernanceTaskList/Feedback/index.tsx
+++ b/src/views/GovernanceTaskList/Feedback/index.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+import {
+  Breadcrumb,
+  BreadcrumbBar,
+  BreadcrumbLink,
+  Link as USWDSLink
+} from '@trussworks/react-uswds';
+import { DateTime } from 'luxon';
+
+import Footer from 'components/Footer';
+import Header from 'components/Header';
+import MainContent from 'components/MainContent';
+import PageHeading from 'components/PageHeading';
+import PageWrapper from 'components/PageWrapper';
+import HelpText from 'components/shared/HelpText';
+import GetGRTFeedbackQuery from 'queries/GetGRTFeedbackQuery';
+import {
+  GetGRTFeedback,
+  GetGRTFeedback_systemIntake_grtFeedbacks as GRTFeedback,
+  GetGRTFeedbackVariables
+} from 'queries/types/GetGRTFeedback';
+
+const GovernanceFeedback = () => {
+  const { systemId } = useParams<{ systemId: string }>();
+  const { t } = useTranslation('taskList');
+  const { data: grtFeedbackData } = useQuery<
+    GetGRTFeedback,
+    GetGRTFeedbackVariables
+  >(GetGRTFeedbackQuery, {
+    variables: {
+      intakeID: systemId
+    }
+  });
+
+  const feedback = grtFeedbackData?.systemIntake?.grtFeedbacks || [];
+  const feedbackforGRB = feedback.filter(
+    grtFeedback => grtFeedback.feedbackType === 'GRB'
+  );
+  const feedbackforBusinessOwner = feedback.filter(
+    grtFeedback => grtFeedback.feedbackType === 'BUSINESS_OWNER'
+  );
+
+  const formatGRTFeedback = (item: GRTFeedback) => {
+    const formattedDate = DateTime.fromISO(item.createdAt).toLocaleString(
+      DateTime.DATE_MED
+    );
+    return (
+      <div className="margin-bottom-3" key={item.id}>
+        <h4
+          className="margin-y-0"
+          aria-label={t('feedback.descriptiveDate', { date: formattedDate })}
+        >
+          {formattedDate}
+        </h4>
+        <p className="margin-top-1 line-height-body-6">{item.feedback}</p>
+      </div>
+    );
+  };
+
+  return (
+    <PageWrapper>
+      <Header />
+      <MainContent>
+        <div className="grid-container">
+          <BreadcrumbBar variant="wrap">
+            <Breadcrumb>
+              <BreadcrumbLink asCustom={Link} to="/">
+                <span>{t('navigation.home')}</span>
+              </BreadcrumbLink>
+            </Breadcrumb>
+            <Breadcrumb>
+              <BreadcrumbLink
+                asCustom={Link}
+                to={`/governance-task-list/${systemId}`}
+              >
+                <span>{t('navigation.governanceApproval')}</span>
+              </BreadcrumbLink>
+            </Breadcrumb>
+            <Breadcrumb current>{t('navigation.feedback')}</Breadcrumb>
+          </BreadcrumbBar>
+          <div className="grid-col-10">
+            <PageHeading>{t('feedback.heading')}</PageHeading>
+            {feedbackforGRB.length > 0 && (
+              <>
+                <h2>{t('feedback.grb.heading')}</h2>
+                <HelpText>{t('feedback.grb.help')}</HelpText>
+                <div className="margin-top-3">
+                  {feedbackforGRB.map(item => formatGRTFeedback(item))}
+                </div>
+              </>
+            )}
+
+            <h2>{t('feedback.businessOwner.heading')}</h2>
+            <HelpText>{t('feedback.businessOwner.help')}</HelpText>
+            <div className="margin-top-3">
+              {feedbackforBusinessOwner.map(item => formatGRTFeedback(item))}
+            </div>
+          </div>
+          <USWDSLink asCustom={Link} to={`/governance-task-list/${systemId}`}>
+            {t('navigation.returnToTaskList')}
+          </USWDSLink>
+        </div>
+      </MainContent>
+      <Footer />
+    </PageWrapper>
+  );
+};
+
+export default GovernanceFeedback;

--- a/src/views/GovernanceTaskList/index.test.tsx
+++ b/src/views/GovernanceTaskList/index.test.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
+import { MockedProvider } from '@apollo/client/testing';
 import { render, screen, within } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 
 import { initialSystemIntakeForm } from 'data/systemIntake';
 import { MessageProvider } from 'hooks/useMessage';
+import GetGRTFeedbackQuery from 'queries/GetGRTFeedbackQuery';
 
 import GovernanceTaskList from './index';
 
@@ -28,20 +30,39 @@ jest.mock('@okta/okta-react', () => ({
 }));
 
 describe('The Goveranance Task List', () => {
+  const grtFeedback = {
+    request: {
+      query: GetGRTFeedbackQuery,
+      variables: {
+        intakeID: '1be65d1a-af87-4e6c-89b2-d2e86f1ee784'
+      }
+    },
+    result: {
+      data: {
+        systemIntake: {
+          grtFeedbacks: []
+        }
+      }
+    }
+  };
+
   it('renders without crashing', async () => {
     const mockStore = configureMockStore();
     const store = mockStore({
       systemIntake: { systemIntake: {} },
       businessCase: { form: {} }
     });
+
     await act(async () => {
       render(
         <MemoryRouter initialEntries={['/']} initialIndex={0}>
-          <Provider store={store}>
-            <MessageProvider>
-              <GovernanceTaskList />
-            </MessageProvider>
-          </Provider>
+          <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+            <Provider store={store}>
+              <MessageProvider>
+                <GovernanceTaskList />
+              </MessageProvider>
+            </Provider>
+          </MockedProvider>
         </MemoryRouter>
       );
     });
@@ -57,14 +78,17 @@ describe('The Goveranance Task List', () => {
     await act(async () => {
       render(
         <MemoryRouter initialEntries={['/']} initialIndex={0}>
-          <Provider store={store}>
-            <MessageProvider>
-              <GovernanceTaskList />
-            </MessageProvider>
-          </Provider>
+          <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+            <Provider store={store}>
+              <MessageProvider>
+                <GovernanceTaskList />
+              </MessageProvider>
+            </Provider>
+          </MockedProvider>
         </MemoryRouter>
       );
     });
+
     const taskList = screen.getByTestId('task-list');
     expect(taskList).toBeInTheDocument();
     expect(
@@ -104,11 +128,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -138,11 +164,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -178,11 +206,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -223,11 +253,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -250,11 +282,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -276,11 +310,13 @@ describe('The Goveranance Task List', () => {
     await act(async () => {
       render(
         <MemoryRouter initialEntries={['/']} initialIndex={0}>
-          <Provider store={store}>
-            <MessageProvider>
-              <GovernanceTaskList />
-            </MessageProvider>
-          </Provider>
+          <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+            <Provider store={store}>
+              <MessageProvider>
+                <GovernanceTaskList />
+              </MessageProvider>
+            </Provider>
+          </MockedProvider>
         </MemoryRouter>
       );
     });
@@ -304,11 +340,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -338,11 +376,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -377,11 +417,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -420,11 +462,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -465,11 +509,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -510,11 +556,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -556,11 +604,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -619,11 +669,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -677,11 +729,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -736,11 +790,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -792,11 +848,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -854,11 +912,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });
@@ -902,11 +962,13 @@ describe('The Goveranance Task List', () => {
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/']} initialIndex={0}>
-            <Provider store={store}>
-              <MessageProvider>
-                <GovernanceTaskList />
-              </MessageProvider>
-            </Provider>
+            <MockedProvider mocks={[grtFeedback]} addTypename={false}>
+              <Provider store={store}>
+                <MessageProvider>
+                  <GovernanceTaskList />
+                </MessageProvider>
+              </Provider>
+            </MockedProvider>
           </MemoryRouter>
         );
       });


### PR DESCRIPTION
# ES-845

This PR adds a feedback page for business owners to be able to see the feedback that was left by the gov team. The links are located on the governance task list. It displays a "Read feedback" link/button dependent on what the status of the request is.

## Code Review Verification Steps

### As the original developer, I have

- [x] Tested user-facing changes with voice-over
- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Checked that all code is adequately covered by tests
- [x] Made it clear which comments need to be addressed before this work is merged
- [x] Considered marking this as accepted even if there are small changes needed
