### PR TITLE
Modify contract and POP language in intake form

### DIFF
--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -391,7 +391,7 @@ const ContractDetails = ({
                       checked={values.contract.hasContract === 'HAVE_CONTRACT'}
                       id="IntakeForm-ContractHaveContract"
                       name="contract.hasContract"
-                      label="I already have a contract/InterAgency Agreement (IAA) in place"
+                      label="I am planning project changes during my existing contract/InterAgency Agreement (IAA) period of performance"
                       value="HAVE_CONTRACT"
                       aria-describedby="IntakeForm-HasContractHelp"
                       aria-expanded={
@@ -458,10 +458,11 @@ const ContractDetails = ({
                           )}
                         >
                           <legend className="usa-label">
-                            Period of performance
+                            Period of Performance dates (include all option
+                            years)
                           </legend>
                           <HelpText className="margin-bottom-1">
-                            For example: 04 10 2020
+                            For example: 4/10/2020 - 4/9/2025
                           </HelpText>
                           <FieldErrorMsg>
                             {flatErrors['contract.startDate.month']}
@@ -669,10 +670,11 @@ const ContractDetails = ({
                           )}
                         >
                           <legend className="usa-label">
-                            Estimated period of performance
+                            New Period of Performance dates (include all option
+                            years)
                           </legend>
                           <HelpText className="margin-bottom-1">
-                            For example: 4/10/2020
+                            For example: 4/10/2020 - 4/9/2025
                           </HelpText>
                           <FieldErrorMsg>
                             {flatErrors['contract.startDate.month']}


### PR DESCRIPTION
# ES-840

## Changes proposed in this pull request

- Changed language for contract question in the intake form
- Change is based on governance team / business owner feedback

## Reviewer Notes

## Setup

## Code Review Verification Steps

### As the original developer, I have

- [ ] Tested user-facing changes with voice-over
- [ ] Checked for landmarks, page heading structure and links using [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu)
- [ ] Requested a design review for user-facing changes
- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for BE resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
      functions, or e2e tests as necessary
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

### As a designer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked accessibility against criteria
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow

## Screenshots

If this PR makes visible UI changes, an image of the finished UI can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
