### PR TITLE
update timeout wrapper so local auth is not affected

### DIFF
--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -6,7 +6,9 @@ import { Button } from '@trussworks/react-uswds';
 import { DateTime, Duration } from 'luxon';
 
 import Modal from 'components/Modal';
+import { localAuthStorageKey } from 'constants/localAuth';
 import useInterval from 'hooks/useInterval';
+import { isLocalAuthEnabled } from 'utils/auth';
 
 type TimeOutWrapperProps = {
   children: React.ReactNode;
@@ -18,6 +20,10 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
     Duration.fromObject({ minutes: 5 }).as('seconds')
   );
   const LAST_ACTIVE_AT_KEY = 'easiLastActiveAt';
+  const isLocalAuth =
+    isLocalAuthEnabled() &&
+    window.localStorage[localAuthStorageKey] &&
+    JSON.parse(window.localStorage[localAuthStorageKey]).favorLocalAuth;
 
   useIdleTimer({
     onAction: () => {
@@ -97,7 +103,7 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
         setIsModalOpen(true);
       }
     },
-    authState?.isAuthenticated && !isModalOpen ? 1000 : null
+    authState?.isAuthenticated && !isModalOpen && !isLocalAuth ? 1000 : null
   );
 
   // Set lastActiveAt between tabs


### PR DESCRIPTION
Currently, the timeout modal displays regardless if a user is logged in via Okta auth or our dev/local auth. This PR updates the timeout wrapper so the timeout modal **does not** display when a developer is logged in locally with local auth.
## Code Review Verification Steps

### As the original developer, I have

- [x] Tested that auth still works when logged in via Okta
- [x] Tested that timeout modal does not display when using local auth

### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Checked that all code is adequately covered by tests
- [x] Made it clear which comments need to be addressed before this work is merged
- [x] Considered marking this as accepted even if there are small changes needed
