### PR TITLE
Add back missing system intake action definition

### DIFF
--- a/cypress/integration/systemIntake.spec.js
+++ b/cypress/integration/systemIntake.spec.js
@@ -55,68 +55,12 @@ describe('The System Intake Form', () => {
 
     cy.contains('button', 'Next').click();
 
-    cy.wait('@putSystemIntake');
-    cy.wait(1000);
     // Review
     cy.contains('h1', 'Check your answers before sending');
 
-    cy.window()
-      .its('store')
-      .invoke('getState')
-      .its('systemIntake')
-      .its('systemIntake')
-      .should('deep.include', {
-        requestName: 'Test Request Name',
-        requester: {
-          name: 'User TEST',
-          component: 'Center for Medicare',
-          email: ''
-        },
-        businessOwner: {
-          name: 'Casey Doe',
-          component: 'Center for Medicare'
-        },
-        productManager: {
-          name: 'Casey Doe',
-          component: 'Center for Medicare'
-        },
-        isso: {
-          isPresent: false,
-          name: ''
-        },
-        governanceTeams: {
-          isPresent: false,
-          teams: []
-        },
-        fundingSource: {
-          isFunded: false,
-          fundingNumber: '',
-          source: ''
-        },
-        costs: {
-          isExpectingIncrease: 'NO',
-          expectedIncreaseAmount: ''
-        },
-        contract: {
-          hasContract: 'NOT_NEEDED',
-          contractor: '',
-          vehicle: '',
-          startDate: {
-            month: '',
-            day: '',
-            year: ''
-          },
-          endDate: {
-            month: '',
-            day: '',
-            year: ''
-          }
-        },
-        businessNeed: 'This is my business need.',
-        businessSolution: 'This is my business solution.',
-        currentStage: 'Just an idea',
-        needsEaSupport: false
-      });
+    // Submit
+    cy.contains('button', 'Send my intake request').click();
+    cy.contains('h1', 'Your Intake Request has been submitted');
   });
 
   it('displays and fills conditional fields', () => {

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -357,6 +357,18 @@ func (s *Server) routes(
 					store.UpdateBusinessCase,
 					emailClient.SendBusinessCaseSubmissionEmail,
 					models.SystemIntakeStatusBIZCASEFINALSUBMITTED,
+				), models.ActionTypeSUBMITINTAKE: services.NewSubmitSystemIntake(
+					serviceConfig,
+					services.AuthorizeUserIsIntakeRequester,
+					store.UpdateSystemIntake,
+					func(c context.Context, si *models.SystemIntake) (string, error) {
+						// quick adapter to retrofit the new interface to take the place
+						// of the old interface
+						err := publisher.PublishSnapshot(c, si, nil, nil, nil, nil)
+						return "", err
+					},
+					saveAction,
+					emailClient.SendSystemIntakeSubmissionEmail,
 				),
 			},
 		),


### PR DESCRIPTION
This PR fixes [a regression that occurred when we merged in the GraphQL intake work](https://github.com/CMSgov/easi-app/commit/6a2e6e5351a2f1854f4c3c6c70b97dd620833bef#diff-096ca5d6226d764718a0e392b1b2f66eadd7098349b2d9cdf1395979f7d7cad2L326-L338). A system intake action definition was removed, preventing new system intakes from being submitted.

## Changes proposed in this pull request

* Restore the `models.ActionTypeSUBMITINTAKE` action
* Extend existing cypress test to verify that the intake is actually submitted

## Code Review Verification Steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for BE resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
      functions, or e2e tests as necessary

### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed