### PR TITLE
force renew token and use time to track timeout instead of counter

### DIFF
--- a/src/views/AuthenticationWrapper/index.tsx
+++ b/src/views/AuthenticationWrapper/index.tsx
@@ -20,7 +20,7 @@ const AuthenticationWrapper = ({ children }: ParentComponentProps) => {
     clientId: process.env.REACT_APP_OKTA_CLIENT_ID,
     redirectUri: process.env.REACT_APP_OKTA_REDIRECT_URI,
     tokenManager: {
-      autoRenew: true
+      autoRenew: false
     }
   });
 


### PR DESCRIPTION
- `autoRenew` isn't working (again). Instead of running around it, this PR forces the token to renew manually
- We discovered an issue with the timeout when a tab is "inactive". This [blog post](https://developer.chrome.com/blog/timer-throttling-in-chrome-88/) describes some of the throttling that happens in Chrome that made our code fail.
- Instead of manually counting down the timer, I updated the session time remaining to be calculated against the real world time. This way, the countdown timer will be consistent with the real world time, even when intervals are throttled down. 

I can talk through this PR in more detail if needed.

## Code Review Verification Steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

