### PR TITLE
Remove circleci from precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,6 @@ repos:
             vendor/|
             docs/adr/index.md
           )$
-      - id: circleci-validate
 
   - repo: git://github.com/golangci/golangci-lint
     rev: v1.41.1

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ There are multiple ways to run the Cypress tests:
   the Cypress tests. The `APP_ENV` environment variable should be set to `test`.
 - `APP_ENV=test ./scripts/run-cypress-test-docker` : Run the Cypress tests,
   database, migrations, backend, and frontend locally in Docker, similar to how
-  they run in CircleCI. Running the tests in this way takes time, but is useful
+  they run in CI. Running the tests in this way takes time, but is useful
   for troubleshooting integration test failures in CI.
 
 ## Optional Setup
@@ -297,13 +297,6 @@ export FLAG_SOURCE=LAUNCH_DARKLY
 
 These values can be obtained from the LaunchDarkly settings page or from
 1Password.
-
-### CircleCI
-
-If you want to make changes to the CircleCI configuration, you will need to
-install the `circleci` cli tool so that the changes can be validated by
-pre-commit: `brew install circleci`. This should be done automatically by
-`scripts/dev prereqs`.
 
 ### 1Password
 

--- a/scripts/dev
+++ b/scripts/dev
@@ -46,7 +46,6 @@ needs "psql", install_with: "brew install postgresql"
 needs "air", install_with: "go get -u github.com/cosmtrek/air"
 needs "gotest", install_with: "go get -u github.com/rakyll/gotest"
 needs "goimports", install_with: "go get -u golang.org/x/tools/cmd/goimports"
-needs "circleci", install_with: "brew install circleci"
 needs "pgcli", install_with: "brew install pgcli"
 
 # Gracefully handle folks trying to explore using common help flags


### PR DESCRIPTION
I noticed while working on another PR that we are still running a task as part of our pre-commit config to verify CircleCI configs. Now that we aren't using that service, there's no need to do that.

## Changes proposed in this pull request

- Remove CircleCI check from pre-commit and list of project prerequisites.