### PR TITLE
make intake updatedAt nullable

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -3267,7 +3267,7 @@ type SystemIntake {
   submittedAt: Time
   trbCollaborator: String
   trbCollaboratorName: String
-  updatedAt: Time!
+  updatedAt: Time
   grtReviewEmailBody: String
   decidedAt: Time
   businessCaseId: UUID
@@ -12068,14 +12068,11 @@ func (ec *executionContext) _SystemIntake_updatedAt(ctx context.Context, field g
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*time.Time)
 	fc.Result = res
-	return ec.marshalNTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _SystemIntake_grtReviewEmailBody(ctx context.Context, field graphql.CollectedField, obj *models.SystemIntake) (ret graphql.Marshaler) {
@@ -18390,9 +18387,6 @@ func (ec *executionContext) _SystemIntake(ctx context.Context, sel ast.Selection
 			})
 		case "updatedAt":
 			out.Values[i] = ec._SystemIntake_updatedAt(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "grtReviewEmailBody":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -527,7 +527,7 @@ type SystemIntake {
   submittedAt: Time
   trbCollaborator: String
   trbCollaboratorName: String
-  updatedAt: Time!
+  updatedAt: Time
   grtReviewEmailBody: String
   decidedAt: Time
   businessCaseId: UUID

--- a/src/queries/types/GetSystemIntake.ts
+++ b/src/queries/types/GetSystemIntake.ts
@@ -129,7 +129,7 @@ export interface GetSystemIntake_systemIntake {
   decidedAt: Time | null;
   businessCaseId: UUID | null;
   submittedAt: Time | null;
-  updatedAt: Time;
+  updatedAt: Time | null;
   createdAt: Time;
   archivedAt: Time | null;
   euaUserId: string;


### PR DESCRIPTION
Make intake `updatedAt` nullable because legacy imported data doesn't have `updatedAt` defined.

## Code Review Verification Steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
