### PR TITLE
fix grb grt meeting date rendering

### DIFF
--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -89,7 +89,6 @@ const GovernanceTaskList = () => {
     grtDate,
     grbDate
   } = systemIntake || {};
-
   useEffect(() => {
     if (businessCaseId) {
       dispatch(fetchBusinessCase(businessCaseId));
@@ -125,11 +124,12 @@ const GovernanceTaskList = () => {
 
   // The meeting date is "scheduled" until the next day since there is no time
   // associated with meeting dates.
-  const getMeetingDate = (date: DateTime | null): string => {
-    if (date) {
-      return date.plus({ day: 1 }).toMillis() > DateTime.local().toMillis()
-        ? `Scheduled for ${date.toLocaleString(DateTime.DATE_FULL)}`
-        : `Attended on ${date.toLocaleString(DateTime.DATE_FULL)}`;
+  const getMeetingDate = (date: string): string => {
+    const dateTime = DateTime.fromISO(date);
+    if (dateTime.isValid) {
+      return dateTime.plus({ day: 1 }).toMillis() > DateTime.local().toMillis()
+        ? `Scheduled for ${dateTime.toLocaleString(DateTime.DATE_FULL)}`
+        : `Attended on ${dateTime.toLocaleString(DateTime.DATE_FULL)}`;
     }
     return '';
   };
@@ -156,7 +156,7 @@ const GovernanceTaskList = () => {
           </BreadcrumbBar>
         </div>
         {loading && <PageLoading />}
-        {systemIntake && (
+        {!loading && !!systemIntake && (
           <div className="grid-row">
             <div className="tablet:grid-col-9">
               <PageHeading>

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -45,7 +45,7 @@ export const SystemIntake = () => {
   );
 
   const systemIntake = data?.systemIntake;
-  console.log(systemIntake, loading);
+
   if (!loading && !systemIntake) {
     return <NotFound />;
   }

--- a/src/views/SystemIntake/index.tsx
+++ b/src/views/SystemIntake/index.tsx
@@ -45,7 +45,7 @@ export const SystemIntake = () => {
   );
 
   const systemIntake = data?.systemIntake;
-
+  console.log(systemIntake, loading);
   if (!loading && !systemIntake) {
     return <NotFound />;
   }
@@ -71,7 +71,7 @@ export const SystemIntake = () => {
           <Breadcrumb current>Intake Request</Breadcrumb>
         </BreadcrumbBar>
         {loading && <PageLoading />}
-        {!!systemIntake && (
+        {!loading && !!systemIntake && (
           <Switch>
             <Route
               path="/system/:systemId/contact-details"


### PR DESCRIPTION
Prior to implementing GraphQL, the REST API response would go through a "transform" to convert the meeting dates to a Luxon `DateTime` object. Now that the date is begin returned from a GraphQL query, it's returning the date in the form of an ISO string. That's why the date time math was failing.

This PR fixes the issue by converting the ISO string to a `DateTime` object so the date math can be calculated.

## Code Review Verification Steps

### As the original developer, I have

- [x] Met the acceptance criteria, or will meet them in a subsequent PR
### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
