### PR TITLE
ES-880 Add extendLifecycleId mutation

### DIFF
--- a/migrations/V93__Add_ExtendLCID_Action_Type.sql
+++ b/migrations/V93__Add_ExtendLCID_Action_Type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE action_type ADD VALUE 'EXTEND_LCID';

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -256,6 +256,7 @@ type ComplexityRoot struct {
 		CreateSystemIntake                               func(childComplexity int, input model.CreateSystemIntakeInput) int
 		CreateSystemIntakeActionBusinessCaseNeeded       func(childComplexity int, input model.BasicActionInput) int
 		CreateSystemIntakeActionBusinessCaseNeedsChanges func(childComplexity int, input model.BasicActionInput) int
+		CreateSystemIntakeActionExtendLifecycleID        func(childComplexity int, input model.ExtendLifecycleIDInput) int
 		CreateSystemIntakeActionGuideReceievedClose      func(childComplexity int, input model.BasicActionInput) int
 		CreateSystemIntakeActionNoGovernanceNeeded       func(childComplexity int, input model.BasicActionInput) int
 		CreateSystemIntakeActionNotItRequest             func(childComplexity int, input model.BasicActionInput) int
@@ -267,7 +268,6 @@ type ComplexityRoot struct {
 		DeleteAccessibilityRequest                       func(childComplexity int, input model.DeleteAccessibilityRequestInput) int
 		DeleteAccessibilityRequestDocument               func(childComplexity int, input model.DeleteAccessibilityRequestDocumentInput) int
 		DeleteTestDate                                   func(childComplexity int, input model.DeleteTestDateInput) int
-		ExtendLifecycleID                                func(childComplexity int, input model.ExtendLifecycleIDInput) int
 		GeneratePresignedUploadURL                       func(childComplexity int, input model.GeneratePresignedUploadURLInput) int
 		IssueLifecycleID                                 func(childComplexity int, input model.IssueLifecycleIDInput) int
 		MarkSystemIntakeReadyForGrb                      func(childComplexity int, input model.AddGRTFeedbackInput) int
@@ -543,6 +543,7 @@ type MutationResolver interface {
 	CreateSystemIntakeActionNotRespondingClose(ctx context.Context, input model.BasicActionInput) (*model.UpdateSystemIntakePayload, error)
 	CreateSystemIntakeActionReadyForGrt(ctx context.Context, input model.BasicActionInput) (*model.UpdateSystemIntakePayload, error)
 	CreateSystemIntakeActionSendEmail(ctx context.Context, input model.BasicActionInput) (*model.UpdateSystemIntakePayload, error)
+	CreateSystemIntakeActionExtendLifecycleID(ctx context.Context, input model.ExtendLifecycleIDInput) (*model.ExtendLifecycleIDPayload, error)
 	CreateSystemIntakeNote(ctx context.Context, input model.CreateSystemIntakeNoteInput) (*model.SystemIntakeNote, error)
 	CreateSystemIntake(ctx context.Context, input model.CreateSystemIntakeInput) (*models.SystemIntake, error)
 	CreateTestDate(ctx context.Context, input model.CreateTestDateInput) (*model.CreateTestDatePayload, error)
@@ -558,7 +559,6 @@ type MutationResolver interface {
 	UpdateSystemIntakeContactDetails(ctx context.Context, input model.UpdateSystemIntakeContactDetailsInput) (*model.UpdateSystemIntakePayload, error)
 	UpdateSystemIntakeRequestDetails(ctx context.Context, input model.UpdateSystemIntakeRequestDetailsInput) (*model.UpdateSystemIntakePayload, error)
 	UpdateSystemIntakeContractDetails(ctx context.Context, input model.UpdateSystemIntakeContractDetailsInput) (*model.UpdateSystemIntakePayload, error)
-	ExtendLifecycleID(ctx context.Context, input model.ExtendLifecycleIDInput) (*model.ExtendLifecycleIDPayload, error)
 }
 type QueryResolver interface {
 	AccessibilityRequest(ctx context.Context, id uuid.UUID) (*models.AccessibilityRequest, error)
@@ -1519,6 +1519,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.CreateSystemIntakeActionBusinessCaseNeedsChanges(childComplexity, args["input"].(model.BasicActionInput)), true
 
+	case "Mutation.createSystemIntakeActionExtendLifecycleId":
+		if e.complexity.Mutation.CreateSystemIntakeActionExtendLifecycleID == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createSystemIntakeActionExtendLifecycleId_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateSystemIntakeActionExtendLifecycleID(childComplexity, args["input"].(model.ExtendLifecycleIDInput)), true
+
 	case "Mutation.createSystemIntakeActionGuideReceievedClose":
 		if e.complexity.Mutation.CreateSystemIntakeActionGuideReceievedClose == nil {
 			break
@@ -1650,18 +1662,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DeleteTestDate(childComplexity, args["input"].(model.DeleteTestDateInput)), true
-
-	case "Mutation.extendLifecycleId":
-		if e.complexity.Mutation.ExtendLifecycleID == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_extendLifecycleId_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.ExtendLifecycleID(childComplexity, args["input"].(model.ExtendLifecycleIDInput)), true
 
 	case "Mutation.generatePresignedUploadURL":
 		if e.complexity.Mutation.GeneratePresignedUploadURL == nil {
@@ -3579,6 +3579,9 @@ type Mutation {
   createSystemIntakeActionSendEmail(
     input: BasicActionInput!
   ): UpdateSystemIntakePayload @hasRole(role: EASI_GOVTEAM)
+  createSystemIntakeActionExtendLifecycleId(
+    input: ExtendLifecycleIdInput!
+  ): ExtendLifecycleIdPayload @hasRole(role: EASI_GOVTEAM)
   createSystemIntakeNote(input: CreateSystemIntakeNoteInput!): SystemIntakeNote
     @hasRole(role: EASI_GOVTEAM)
   createSystemIntake(input: CreateSystemIntakeInput!): SystemIntake
@@ -3609,7 +3612,6 @@ type Mutation {
   updateSystemIntakeContactDetails(input: UpdateSystemIntakeContactDetailsInput!): UpdateSystemIntakePayload
   updateSystemIntakeRequestDetails(input: UpdateSystemIntakeRequestDetailsInput!): UpdateSystemIntakePayload
   updateSystemIntakeContractDetails(input: UpdateSystemIntakeContractDetailsInput!): UpdateSystemIntakePayload
-  extendLifecycleId(input: ExtendLifecycleIdInput!): ExtendLifecycleIdPayload @hasRole(role: EASI_GOVTEAM)
 }
 
 type Query {
@@ -3808,6 +3810,21 @@ func (ec *executionContext) field_Mutation_createSystemIntakeActionBusinessCaseN
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_createSystemIntakeActionExtendLifecycleId_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.ExtendLifecycleIDInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNExtendLifecycleIdInput2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐExtendLifecycleIDInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_createSystemIntakeActionGuideReceievedClose_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -3980,21 +3997,6 @@ func (ec *executionContext) field_Mutation_deleteTestDate_args(ctx context.Conte
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNDeleteTestDateInput2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐDeleteTestDateInput(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["input"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_extendLifecycleId_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 model.ExtendLifecycleIDInput
-	if tmp, ok := rawArgs["input"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-		arg0, err = ec.unmarshalNExtendLifecycleIdInput2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐExtendLifecycleIDInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -9062,6 +9064,69 @@ func (ec *executionContext) _Mutation_createSystemIntakeActionSendEmail(ctx cont
 	return ec.marshalOUpdateSystemIntakePayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUpdateSystemIntakePayload(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Mutation_createSystemIntakeActionExtendLifecycleId(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_createSystemIntakeActionExtendLifecycleId_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().CreateSystemIntakeActionExtendLifecycleID(rctx, args["input"].(model.ExtendLifecycleIDInput))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "EASI_GOVTEAM")
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.HasRole == nil {
+				return nil, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, role)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*model.ExtendLifecycleIDPayload); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/cmsgov/easi-app/pkg/graph/model.ExtendLifecycleIDPayload`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.ExtendLifecycleIDPayload)
+	fc.Result = res
+	return ec.marshalOExtendLifecycleIdPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐExtendLifecycleIDPayload(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Mutation_createSystemIntakeNote(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -9885,69 +9950,6 @@ func (ec *executionContext) _Mutation_updateSystemIntakeContractDetails(ctx cont
 	res := resTmp.(*model.UpdateSystemIntakePayload)
 	fc.Result = res
 	return ec.marshalOUpdateSystemIntakePayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUpdateSystemIntakePayload(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_extendLifecycleId(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   true,
-		IsResolver: true,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_extendLifecycleId_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	fc.Args = args
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		directive0 := func(rctx context.Context) (interface{}, error) {
-			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().ExtendLifecycleID(rctx, args["input"].(model.ExtendLifecycleIDInput))
-		}
-		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "EASI_GOVTEAM")
-			if err != nil {
-				return nil, err
-			}
-			if ec.directives.HasRole == nil {
-				return nil, errors.New("directive hasRole is not implemented")
-			}
-			return ec.directives.HasRole(ctx, nil, directive0, role)
-		}
-
-		tmp, err := directive1(rctx)
-		if err != nil {
-			return nil, graphql.ErrorOnPath(ctx, err)
-		}
-		if tmp == nil {
-			return nil, nil
-		}
-		if data, ok := tmp.(*model.ExtendLifecycleIDPayload); ok {
-			return data, nil
-		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/cmsgov/easi-app/pkg/graph/model.ExtendLifecycleIDPayload`, tmp)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.ExtendLifecycleIDPayload)
-	fc.Result = res
-	return ec.marshalOExtendLifecycleIdPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐExtendLifecycleIDPayload(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_accessibilityRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -17867,6 +17869,8 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec._Mutation_createSystemIntakeActionReadyForGRT(ctx, field)
 		case "createSystemIntakeActionSendEmail":
 			out.Values[i] = ec._Mutation_createSystemIntakeActionSendEmail(ctx, field)
+		case "createSystemIntakeActionExtendLifecycleId":
+			out.Values[i] = ec._Mutation_createSystemIntakeActionExtendLifecycleId(ctx, field)
 		case "createSystemIntakeNote":
 			out.Values[i] = ec._Mutation_createSystemIntakeNote(ctx, field)
 		case "createSystemIntake":
@@ -17897,8 +17901,6 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec._Mutation_updateSystemIntakeRequestDetails(ctx, field)
 		case "updateSystemIntakeContractDetails":
 			out.Values[i] = ec._Mutation_updateSystemIntakeContractDetails(ctx, field)
-		case "extendLifecycleId":
-			out.Values[i] = ec._Mutation_extendLifecycleId(ctx, field)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -187,6 +187,11 @@ type ComplexityRoot struct {
 		UserErrors           func(childComplexity int) int
 	}
 
+	CreateSystemIntakeActionExtendLifecycleIDPayload struct {
+		SystemIntake func(childComplexity int) int
+		UserErrors   func(childComplexity int) int
+	}
+
 	CreateTestDatePayload struct {
 		TestDate   func(childComplexity int) int
 		UserErrors func(childComplexity int) int
@@ -217,11 +222,6 @@ type ComplexityRoot struct {
 		Phase          func(childComplexity int) int
 		Solution       func(childComplexity int) int
 		Year           func(childComplexity int) int
-	}
-
-	ExtendLifecycleIDPayload struct {
-		SystemIntake func(childComplexity int) int
-		UserErrors   func(childComplexity int) int
 	}
 
 	GRTFeedback struct {
@@ -256,7 +256,7 @@ type ComplexityRoot struct {
 		CreateSystemIntake                               func(childComplexity int, input model.CreateSystemIntakeInput) int
 		CreateSystemIntakeActionBusinessCaseNeeded       func(childComplexity int, input model.BasicActionInput) int
 		CreateSystemIntakeActionBusinessCaseNeedsChanges func(childComplexity int, input model.BasicActionInput) int
-		CreateSystemIntakeActionExtendLifecycleID        func(childComplexity int, input model.ExtendLifecycleIDInput) int
+		CreateSystemIntakeActionExtendLifecycleID        func(childComplexity int, input model.CreateSystemIntakeActionExtendLifecycleIDInput) int
 		CreateSystemIntakeActionGuideReceievedClose      func(childComplexity int, input model.BasicActionInput) int
 		CreateSystemIntakeActionNoGovernanceNeeded       func(childComplexity int, input model.BasicActionInput) int
 		CreateSystemIntakeActionNotItRequest             func(childComplexity int, input model.BasicActionInput) int
@@ -543,7 +543,7 @@ type MutationResolver interface {
 	CreateSystemIntakeActionNotRespondingClose(ctx context.Context, input model.BasicActionInput) (*model.UpdateSystemIntakePayload, error)
 	CreateSystemIntakeActionReadyForGrt(ctx context.Context, input model.BasicActionInput) (*model.UpdateSystemIntakePayload, error)
 	CreateSystemIntakeActionSendEmail(ctx context.Context, input model.BasicActionInput) (*model.UpdateSystemIntakePayload, error)
-	CreateSystemIntakeActionExtendLifecycleID(ctx context.Context, input model.ExtendLifecycleIDInput) (*model.ExtendLifecycleIDPayload, error)
+	CreateSystemIntakeActionExtendLifecycleID(ctx context.Context, input model.CreateSystemIntakeActionExtendLifecycleIDInput) (*model.CreateSystemIntakeActionExtendLifecycleIDPayload, error)
 	CreateSystemIntakeNote(ctx context.Context, input model.CreateSystemIntakeNoteInput) (*model.SystemIntakeNote, error)
 	CreateSystemIntake(ctx context.Context, input model.CreateSystemIntakeInput) (*models.SystemIntake, error)
 	CreateTestDate(ctx context.Context, input model.CreateTestDateInput) (*model.CreateTestDatePayload, error)
@@ -1229,6 +1229,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CreateAccessibilityRequestPayload.UserErrors(childComplexity), true
 
+	case "CreateSystemIntakeActionExtendLifecycleIdPayload.systemIntake":
+		if e.complexity.CreateSystemIntakeActionExtendLifecycleIDPayload.SystemIntake == nil {
+			break
+		}
+
+		return e.complexity.CreateSystemIntakeActionExtendLifecycleIDPayload.SystemIntake(childComplexity), true
+
+	case "CreateSystemIntakeActionExtendLifecycleIdPayload.userErrors":
+		if e.complexity.CreateSystemIntakeActionExtendLifecycleIDPayload.UserErrors == nil {
+			break
+		}
+
+		return e.complexity.CreateSystemIntakeActionExtendLifecycleIDPayload.UserErrors(childComplexity), true
+
 	case "CreateTestDatePayload.testDate":
 		if e.complexity.CreateTestDatePayload.TestDate == nil {
 			break
@@ -1326,20 +1340,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.EstimatedLifecycleCost.Year(childComplexity), true
-
-	case "ExtendLifecycleIdPayload.systemIntake":
-		if e.complexity.ExtendLifecycleIDPayload.SystemIntake == nil {
-			break
-		}
-
-		return e.complexity.ExtendLifecycleIDPayload.SystemIntake(childComplexity), true
-
-	case "ExtendLifecycleIdPayload.userErrors":
-		if e.complexity.ExtendLifecycleIDPayload.UserErrors == nil {
-			break
-		}
-
-		return e.complexity.ExtendLifecycleIDPayload.UserErrors(childComplexity), true
 
 	case "GRTFeedback.createdAt":
 		if e.complexity.GRTFeedback.CreatedAt == nil {
@@ -1529,7 +1529,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateSystemIntakeActionExtendLifecycleID(childComplexity, args["input"].(model.ExtendLifecycleIDInput)), true
+		return e.complexity.Mutation.CreateSystemIntakeActionExtendLifecycleID(childComplexity, args["input"].(model.CreateSystemIntakeActionExtendLifecycleIDInput)), true
 
 	case "Mutation.createSystemIntakeActionGuideReceievedClose":
 		if e.complexity.Mutation.CreateSystemIntakeActionGuideReceievedClose == nil {
@@ -3391,12 +3391,12 @@ input UpdateSystemIntakeContractDetailsInput {
   contract: SystemIntakeContractInput
 }
 
-input ExtendLifecycleIdInput {
+input CreateSystemIntakeActionExtendLifecycleIdInput {
   id: UUID!
   expirationDate: Time
 }
 
-type ExtendLifecycleIdPayload {
+type CreateSystemIntakeActionExtendLifecycleIdPayload {
   systemIntake: SystemIntake
   userErrors: [UserError!]
 }
@@ -3580,8 +3580,8 @@ type Mutation {
     input: BasicActionInput!
   ): UpdateSystemIntakePayload @hasRole(role: EASI_GOVTEAM)
   createSystemIntakeActionExtendLifecycleId(
-    input: ExtendLifecycleIdInput!
-  ): ExtendLifecycleIdPayload @hasRole(role: EASI_GOVTEAM)
+    input: CreateSystemIntakeActionExtendLifecycleIdInput!
+  ): CreateSystemIntakeActionExtendLifecycleIdPayload @hasRole(role: EASI_GOVTEAM)
   createSystemIntakeNote(input: CreateSystemIntakeNoteInput!): SystemIntakeNote
     @hasRole(role: EASI_GOVTEAM)
   createSystemIntake(input: CreateSystemIntakeInput!): SystemIntake
@@ -3813,10 +3813,10 @@ func (ec *executionContext) field_Mutation_createSystemIntakeActionBusinessCaseN
 func (ec *executionContext) field_Mutation_createSystemIntakeActionExtendLifecycleId_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 model.ExtendLifecycleIDInput
+	var arg0 model.CreateSystemIntakeActionExtendLifecycleIDInput
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-		arg0, err = ec.unmarshalNExtendLifecycleIdInput2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐExtendLifecycleIDInput(ctx, tmp)
+		arg0, err = ec.unmarshalNCreateSystemIntakeActionExtendLifecycleIdInput2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐCreateSystemIntakeActionExtendLifecycleIDInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -7242,6 +7242,70 @@ func (ec *executionContext) _CreateAccessibilityRequestPayload_userErrors(ctx co
 	return ec.marshalOUserError2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUserErrorᚄ(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _CreateSystemIntakeActionExtendLifecycleIdPayload_systemIntake(ctx context.Context, field graphql.CollectedField, obj *model.CreateSystemIntakeActionExtendLifecycleIDPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CreateSystemIntakeActionExtendLifecycleIdPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SystemIntake, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.SystemIntake)
+	fc.Result = res
+	return ec.marshalOSystemIntake2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐSystemIntake(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CreateSystemIntakeActionExtendLifecycleIdPayload_userErrors(ctx context.Context, field graphql.CollectedField, obj *model.CreateSystemIntakeActionExtendLifecycleIDPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CreateSystemIntakeActionExtendLifecycleIdPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UserErrors, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.UserError)
+	fc.Result = res
+	return ec.marshalOUserError2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUserErrorᚄ(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _CreateTestDatePayload_testDate(ctx context.Context, field graphql.CollectedField, obj *model.CreateTestDatePayload) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -7697,70 +7761,6 @@ func (ec *executionContext) _EstimatedLifecycleCost_year(ctx context.Context, fi
 	res := resTmp.(models.LifecycleCostYear)
 	fc.Result = res
 	return ec.marshalOLifecycleCostYear2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐLifecycleCostYear(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _ExtendLifecycleIdPayload_systemIntake(ctx context.Context, field graphql.CollectedField, obj *model.ExtendLifecycleIDPayload) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "ExtendLifecycleIdPayload",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.SystemIntake, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*models.SystemIntake)
-	fc.Result = res
-	return ec.marshalOSystemIntake2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐSystemIntake(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _ExtendLifecycleIdPayload_userErrors(ctx context.Context, field graphql.CollectedField, obj *model.ExtendLifecycleIDPayload) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "ExtendLifecycleIdPayload",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.UserErrors, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]*model.UserError)
-	fc.Result = res
-	return ec.marshalOUserError2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUserErrorᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _GRTFeedback_id(ctx context.Context, field graphql.CollectedField, obj *models.GRTFeedback) (ret graphql.Marshaler) {
@@ -9090,7 +9090,7 @@ func (ec *executionContext) _Mutation_createSystemIntakeActionExtendLifecycleId(
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().CreateSystemIntakeActionExtendLifecycleID(rctx, args["input"].(model.ExtendLifecycleIDInput))
+			return ec.resolvers.Mutation().CreateSystemIntakeActionExtendLifecycleID(rctx, args["input"].(model.CreateSystemIntakeActionExtendLifecycleIDInput))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "EASI_GOVTEAM")
@@ -9110,10 +9110,10 @@ func (ec *executionContext) _Mutation_createSystemIntakeActionExtendLifecycleId(
 		if tmp == nil {
 			return nil, nil
 		}
-		if data, ok := tmp.(*model.ExtendLifecycleIDPayload); ok {
+		if data, ok := tmp.(*model.CreateSystemIntakeActionExtendLifecycleIDPayload); ok {
 			return data, nil
 		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/cmsgov/easi-app/pkg/graph/model.ExtendLifecycleIDPayload`, tmp)
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/cmsgov/easi-app/pkg/graph/model.CreateSystemIntakeActionExtendLifecycleIDPayload`, tmp)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -9122,9 +9122,9 @@ func (ec *executionContext) _Mutation_createSystemIntakeActionExtendLifecycleId(
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.ExtendLifecycleIDPayload)
+	res := resTmp.(*model.CreateSystemIntakeActionExtendLifecycleIDPayload)
 	fc.Result = res
-	return ec.marshalOExtendLifecycleIdPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐExtendLifecycleIDPayload(ctx, field.Selections, res)
+	return ec.marshalOCreateSystemIntakeActionExtendLifecycleIdPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐCreateSystemIntakeActionExtendLifecycleIDPayload(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_createSystemIntakeNote(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -15577,6 +15577,37 @@ func (ec *executionContext) unmarshalInputCreateAccessibilityRequestNoteInput(ct
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateSystemIntakeActionExtendLifecycleIdInput(ctx context.Context, obj interface{}) (model.CreateSystemIntakeActionExtendLifecycleIDInput, error) {
+	var it model.CreateSystemIntakeActionExtendLifecycleIDInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	for k, v := range asMap {
+		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "expirationDate":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("expirationDate"))
+			it.ExpirationDate, err = ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateSystemIntakeInput(ctx context.Context, obj interface{}) (model.CreateSystemIntakeInput, error) {
 	var it model.CreateSystemIntakeInput
 	asMap := map[string]interface{}{}
@@ -15762,37 +15793,6 @@ func (ec *executionContext) unmarshalInputDeleteTestDateInput(ctx context.Contex
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
 			it.ID, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		}
-	}
-
-	return it, nil
-}
-
-func (ec *executionContext) unmarshalInputExtendLifecycleIdInput(ctx context.Context, obj interface{}) (model.ExtendLifecycleIDInput, error) {
-	var it model.ExtendLifecycleIDInput
-	asMap := map[string]interface{}{}
-	for k, v := range obj.(map[string]interface{}) {
-		asMap[k] = v
-	}
-
-	for k, v := range asMap {
-		switch k {
-		case "id":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
-			it.ID, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "expirationDate":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("expirationDate"))
-			it.ExpirationDate, err = ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -17511,6 +17511,32 @@ func (ec *executionContext) _CreateAccessibilityRequestPayload(ctx context.Conte
 	return out
 }
 
+var createSystemIntakeActionExtendLifecycleIdPayloadImplementors = []string{"CreateSystemIntakeActionExtendLifecycleIdPayload"}
+
+func (ec *executionContext) _CreateSystemIntakeActionExtendLifecycleIdPayload(ctx context.Context, sel ast.SelectionSet, obj *model.CreateSystemIntakeActionExtendLifecycleIDPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createSystemIntakeActionExtendLifecycleIdPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateSystemIntakeActionExtendLifecycleIdPayload")
+		case "systemIntake":
+			out.Values[i] = ec._CreateSystemIntakeActionExtendLifecycleIdPayload_systemIntake(ctx, field, obj)
+		case "userErrors":
+			out.Values[i] = ec._CreateSystemIntakeActionExtendLifecycleIdPayload_userErrors(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var createTestDatePayloadImplementors = []string{"CreateTestDatePayload"}
 
 func (ec *executionContext) _CreateTestDatePayload(ctx context.Context, sel ast.SelectionSet, obj *model.CreateTestDatePayload) graphql.Marshaler {
@@ -17669,32 +17695,6 @@ func (ec *executionContext) _EstimatedLifecycleCost(ctx context.Context, sel ast
 			out.Values[i] = ec._EstimatedLifecycleCost_solution(ctx, field, obj)
 		case "year":
 			out.Values[i] = ec._EstimatedLifecycleCost_year(ctx, field, obj)
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var extendLifecycleIdPayloadImplementors = []string{"ExtendLifecycleIdPayload"}
-
-func (ec *executionContext) _ExtendLifecycleIdPayload(ctx context.Context, sel ast.SelectionSet, obj *model.ExtendLifecycleIDPayload) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, extendLifecycleIdPayloadImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("ExtendLifecycleIdPayload")
-		case "systemIntake":
-			out.Values[i] = ec._ExtendLifecycleIdPayload_systemIntake(ctx, field, obj)
-		case "userErrors":
-			out.Values[i] = ec._ExtendLifecycleIdPayload_userErrors(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -19848,6 +19848,11 @@ func (ec *executionContext) unmarshalNCreateAccessibilityRequestNoteInput2github
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNCreateSystemIntakeActionExtendLifecycleIdInput2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐCreateSystemIntakeActionExtendLifecycleIDInput(ctx context.Context, v interface{}) (model.CreateSystemIntakeActionExtendLifecycleIDInput, error) {
+	res, err := ec.unmarshalInputCreateSystemIntakeActionExtendLifecycleIdInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNCreateSystemIntakeInput2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐCreateSystemIntakeInput(ctx context.Context, v interface{}) (model.CreateSystemIntakeInput, error) {
 	res, err := ec.unmarshalInputCreateSystemIntakeInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -19886,11 +19891,6 @@ func (ec *executionContext) marshalNEstimatedLifecycleCost2ᚖgithubᚗcomᚋcms
 		return graphql.Null
 	}
 	return ec._EstimatedLifecycleCost(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalNExtendLifecycleIdInput2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐExtendLifecycleIDInput(ctx context.Context, v interface{}) (model.ExtendLifecycleIDInput, error) {
-	res, err := ec.unmarshalInputExtendLifecycleIdInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalNGRTFeedback2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐGRTFeedbackᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.GRTFeedback) graphql.Marshaler {
@@ -21057,6 +21057,13 @@ func (ec *executionContext) marshalOCreateAccessibilityRequestPayload2ᚖgithub�
 	return ec._CreateAccessibilityRequestPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalOCreateSystemIntakeActionExtendLifecycleIdPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐCreateSystemIntakeActionExtendLifecycleIDPayload(ctx context.Context, sel ast.SelectionSet, v *model.CreateSystemIntakeActionExtendLifecycleIDPayload) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._CreateSystemIntakeActionExtendLifecycleIdPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOCreateTestDatePayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐCreateTestDatePayload(ctx context.Context, sel ast.SelectionSet, v *model.CreateTestDatePayload) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -21137,13 +21144,6 @@ func (ec *executionContext) marshalOEstimatedLifecycleCost2ᚕᚖgithubᚗcomᚋ
 	}
 
 	return ret
-}
-
-func (ec *executionContext) marshalOExtendLifecycleIdPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐExtendLifecycleIDPayload(ctx context.Context, sel ast.SelectionSet, v *model.ExtendLifecycleIDPayload) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._ExtendLifecycleIdPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOGRTFeedbackType2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐGRTFeedbackType(ctx context.Context, v interface{}) (models.GRTFeedbackType, error) {

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -219,6 +219,11 @@ type ComplexityRoot struct {
 		Year           func(childComplexity int) int
 	}
 
+	ExtendLifecycleIDPayload struct {
+		SystemIntake func(childComplexity int) int
+		UserErrors   func(childComplexity int) int
+	}
+
 	GRTFeedback struct {
 		CreatedAt    func(childComplexity int) int
 		Feedback     func(childComplexity int) int
@@ -262,6 +267,7 @@ type ComplexityRoot struct {
 		DeleteAccessibilityRequest                       func(childComplexity int, input model.DeleteAccessibilityRequestInput) int
 		DeleteAccessibilityRequestDocument               func(childComplexity int, input model.DeleteAccessibilityRequestDocumentInput) int
 		DeleteTestDate                                   func(childComplexity int, input model.DeleteTestDateInput) int
+		ExtendLifecycleID                                func(childComplexity int, input model.ExtendLifecycleIDInput) int
 		GeneratePresignedUploadURL                       func(childComplexity int, input model.GeneratePresignedUploadURLInput) int
 		IssueLifecycleID                                 func(childComplexity int, input model.IssueLifecycleIDInput) int
 		MarkSystemIntakeReadyForGrb                      func(childComplexity int, input model.AddGRTFeedbackInput) int
@@ -552,6 +558,7 @@ type MutationResolver interface {
 	UpdateSystemIntakeContactDetails(ctx context.Context, input model.UpdateSystemIntakeContactDetailsInput) (*model.UpdateSystemIntakePayload, error)
 	UpdateSystemIntakeRequestDetails(ctx context.Context, input model.UpdateSystemIntakeRequestDetailsInput) (*model.UpdateSystemIntakePayload, error)
 	UpdateSystemIntakeContractDetails(ctx context.Context, input model.UpdateSystemIntakeContractDetailsInput) (*model.UpdateSystemIntakePayload, error)
+	ExtendLifecycleID(ctx context.Context, input model.ExtendLifecycleIDInput) (*model.ExtendLifecycleIDPayload, error)
 }
 type QueryResolver interface {
 	AccessibilityRequest(ctx context.Context, id uuid.UUID) (*models.AccessibilityRequest, error)
@@ -1320,6 +1327,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.EstimatedLifecycleCost.Year(childComplexity), true
 
+	case "ExtendLifecycleIdPayload.systemIntake":
+		if e.complexity.ExtendLifecycleIDPayload.SystemIntake == nil {
+			break
+		}
+
+		return e.complexity.ExtendLifecycleIDPayload.SystemIntake(childComplexity), true
+
+	case "ExtendLifecycleIdPayload.userErrors":
+		if e.complexity.ExtendLifecycleIDPayload.UserErrors == nil {
+			break
+		}
+
+		return e.complexity.ExtendLifecycleIDPayload.UserErrors(childComplexity), true
+
 	case "GRTFeedback.createdAt":
 		if e.complexity.GRTFeedback.CreatedAt == nil {
 			break
@@ -1629,6 +1650,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DeleteTestDate(childComplexity, args["input"].(model.DeleteTestDateInput)), true
+
+	case "Mutation.extendLifecycleId":
+		if e.complexity.Mutation.ExtendLifecycleID == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_extendLifecycleId_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.ExtendLifecycleID(childComplexity, args["input"].(model.ExtendLifecycleIDInput)), true
 
 	case "Mutation.generatePresignedUploadURL":
 		if e.complexity.Mutation.GeneratePresignedUploadURL == nil {
@@ -3358,6 +3391,16 @@ input UpdateSystemIntakeContractDetailsInput {
   contract: SystemIntakeContractInput
 }
 
+input ExtendLifecycleIdInput {
+  id: UUID!
+  expirationDate: Time
+}
+
+type ExtendLifecycleIdPayload {
+  systemIntake: SystemIntake
+  userErrors: [UserError!]
+}
+
 enum SystemIntakeActionType {
   BIZ_CASE_NEEDS_CHANGES
   CREATE_BIZ_CASE
@@ -3566,6 +3609,7 @@ type Mutation {
   updateSystemIntakeContactDetails(input: UpdateSystemIntakeContactDetailsInput!): UpdateSystemIntakePayload
   updateSystemIntakeRequestDetails(input: UpdateSystemIntakeRequestDetailsInput!): UpdateSystemIntakePayload
   updateSystemIntakeContractDetails(input: UpdateSystemIntakeContractDetailsInput!): UpdateSystemIntakePayload
+  extendLifecycleId(input: ExtendLifecycleIdInput!): ExtendLifecycleIdPayload @hasRole(role: EASI_GOVTEAM)
 }
 
 type Query {
@@ -3936,6 +3980,21 @@ func (ec *executionContext) field_Mutation_deleteTestDate_args(ctx context.Conte
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNDeleteTestDateInput2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐDeleteTestDateInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_extendLifecycleId_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.ExtendLifecycleIDInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNExtendLifecycleIdInput2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐExtendLifecycleIDInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -7638,6 +7697,70 @@ func (ec *executionContext) _EstimatedLifecycleCost_year(ctx context.Context, fi
 	return ec.marshalOLifecycleCostYear2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐLifecycleCostYear(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _ExtendLifecycleIdPayload_systemIntake(ctx context.Context, field graphql.CollectedField, obj *model.ExtendLifecycleIDPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "ExtendLifecycleIdPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SystemIntake, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.SystemIntake)
+	fc.Result = res
+	return ec.marshalOSystemIntake2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐSystemIntake(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ExtendLifecycleIdPayload_userErrors(ctx context.Context, field graphql.CollectedField, obj *model.ExtendLifecycleIDPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "ExtendLifecycleIdPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UserErrors, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.UserError)
+	fc.Result = res
+	return ec.marshalOUserError2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUserErrorᚄ(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _GRTFeedback_id(ctx context.Context, field graphql.CollectedField, obj *models.GRTFeedback) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -9762,6 +9885,69 @@ func (ec *executionContext) _Mutation_updateSystemIntakeContractDetails(ctx cont
 	res := resTmp.(*model.UpdateSystemIntakePayload)
 	fc.Result = res
 	return ec.marshalOUpdateSystemIntakePayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐUpdateSystemIntakePayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_extendLifecycleId(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_extendLifecycleId_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().ExtendLifecycleID(rctx, args["input"].(model.ExtendLifecycleIDInput))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "EASI_GOVTEAM")
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.HasRole == nil {
+				return nil, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, role)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*model.ExtendLifecycleIDPayload); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/cmsgov/easi-app/pkg/graph/model.ExtendLifecycleIDPayload`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.ExtendLifecycleIDPayload)
+	fc.Result = res
+	return ec.marshalOExtendLifecycleIdPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐExtendLifecycleIDPayload(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_accessibilityRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -15583,6 +15769,37 @@ func (ec *executionContext) unmarshalInputDeleteTestDateInput(ctx context.Contex
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputExtendLifecycleIdInput(ctx context.Context, obj interface{}) (model.ExtendLifecycleIDInput, error) {
+	var it model.ExtendLifecycleIDInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	for k, v := range asMap {
+		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "expirationDate":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("expirationDate"))
+			it.ExpirationDate, err = ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputGeneratePresignedUploadURLInput(ctx context.Context, obj interface{}) (model.GeneratePresignedUploadURLInput, error) {
 	var it model.GeneratePresignedUploadURLInput
 	asMap := map[string]interface{}{}
@@ -17461,6 +17678,32 @@ func (ec *executionContext) _EstimatedLifecycleCost(ctx context.Context, sel ast
 	return out
 }
 
+var extendLifecycleIdPayloadImplementors = []string{"ExtendLifecycleIdPayload"}
+
+func (ec *executionContext) _ExtendLifecycleIdPayload(ctx context.Context, sel ast.SelectionSet, obj *model.ExtendLifecycleIDPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, extendLifecycleIdPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ExtendLifecycleIdPayload")
+		case "systemIntake":
+			out.Values[i] = ec._ExtendLifecycleIdPayload_systemIntake(ctx, field, obj)
+		case "userErrors":
+			out.Values[i] = ec._ExtendLifecycleIdPayload_userErrors(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var gRTFeedbackImplementors = []string{"GRTFeedback"}
 
 func (ec *executionContext) _GRTFeedback(ctx context.Context, sel ast.SelectionSet, obj *models.GRTFeedback) graphql.Marshaler {
@@ -17654,6 +17897,8 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec._Mutation_updateSystemIntakeRequestDetails(ctx, field)
 		case "updateSystemIntakeContractDetails":
 			out.Values[i] = ec._Mutation_updateSystemIntakeContractDetails(ctx, field)
+		case "extendLifecycleId":
+			out.Values[i] = ec._Mutation_extendLifecycleId(ctx, field)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -19641,6 +19886,11 @@ func (ec *executionContext) marshalNEstimatedLifecycleCost2ᚖgithubᚗcomᚋcms
 	return ec._EstimatedLifecycleCost(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNExtendLifecycleIdInput2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐExtendLifecycleIDInput(ctx context.Context, v interface{}) (model.ExtendLifecycleIDInput, error) {
+	res, err := ec.unmarshalInputExtendLifecycleIdInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNGRTFeedback2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐGRTFeedbackᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.GRTFeedback) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -20885,6 +21135,13 @@ func (ec *executionContext) marshalOEstimatedLifecycleCost2ᚕᚖgithubᚗcomᚋ
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalOExtendLifecycleIdPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐExtendLifecycleIDPayload(ctx context.Context, sel ast.SelectionSet, v *model.ExtendLifecycleIDPayload) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ExtendLifecycleIdPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOGRTFeedbackType2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐGRTFeedbackType(ctx context.Context, v interface{}) (models.GRTFeedbackType, error) {

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -108,6 +108,16 @@ type CreateAccessibilityRequestPayload struct {
 	UserErrors           []*UserError                 `json:"userErrors"`
 }
 
+type CreateSystemIntakeActionExtendLifecycleIDInput struct {
+	ID             uuid.UUID  `json:"id"`
+	ExpirationDate *time.Time `json:"expirationDate"`
+}
+
+type CreateSystemIntakeActionExtendLifecycleIDPayload struct {
+	SystemIntake *models.SystemIntake `json:"systemIntake"`
+	UserErrors   []*UserError         `json:"userErrors"`
+}
+
 type CreateSystemIntakeInput struct {
 	RequestType models.SystemIntakeRequestType `json:"requestType"`
 	Requester   *SystemIntakeRequesterInput    `json:"requester"`
@@ -160,16 +170,6 @@ type DeleteTestDateInput struct {
 type DeleteTestDatePayload struct {
 	TestDate   *models.TestDate `json:"testDate"`
 	UserErrors []*UserError     `json:"userErrors"`
-}
-
-type ExtendLifecycleIDInput struct {
-	ID             uuid.UUID  `json:"id"`
-	ExpirationDate *time.Time `json:"expirationDate"`
-}
-
-type ExtendLifecycleIDPayload struct {
-	SystemIntake *models.SystemIntake `json:"systemIntake"`
-	UserErrors   []*UserError         `json:"userErrors"`
 }
 
 type GeneratePresignedUploadURLInput struct {

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -162,6 +162,16 @@ type DeleteTestDatePayload struct {
 	UserErrors []*UserError     `json:"userErrors"`
 }
 
+type ExtendLifecycleIDInput struct {
+	ID             uuid.UUID  `json:"id"`
+	ExpirationDate *time.Time `json:"expirationDate"`
+}
+
+type ExtendLifecycleIDPayload struct {
+	SystemIntake *models.SystemIntake `json:"systemIntake"`
+	UserErrors   []*UserError         `json:"userErrors"`
+}
+
 type GeneratePresignedUploadURLInput struct {
 	FileName string `json:"fileName"`
 	MimeType string `json:"mimeType"`

--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"context"
+	"time"
 
 	ldclient "gopkg.in/launchdarkly/go-server-sdk.v5"
 
@@ -30,13 +31,14 @@ type Resolver struct {
 
 // ResolverService holds service methods for use in resolvers
 type ResolverService struct {
-	CreateTestDate           func(context.Context, *models.TestDate) (*models.TestDate, error)
-	AddGRTFeedback           func(context.Context, *models.GRTFeedback, *models.Action, models.SystemIntakeStatus) (*models.GRTFeedback, error)
-	CreateActionUpdateStatus func(context.Context, *models.Action, uuid.UUID, models.SystemIntakeStatus, bool) (*models.SystemIntake, error)
-	IssueLifecycleID         func(context.Context, *models.SystemIntake, *models.Action) (*models.SystemIntake, error)
-	RejectIntake             func(context.Context, *models.SystemIntake, *models.Action) (*models.SystemIntake, error)
-	FetchUserInfo            func(context.Context, string) (*models.UserInfo, error)
-	SubmitIntake             func(context.Context, *models.SystemIntake, *models.Action) error
+	CreateTestDate                func(context.Context, *models.TestDate) (*models.TestDate, error)
+	AddGRTFeedback                func(context.Context, *models.GRTFeedback, *models.Action, models.SystemIntakeStatus) (*models.GRTFeedback, error)
+	CreateActionUpdateStatus      func(context.Context, *models.Action, uuid.UUID, models.SystemIntakeStatus, bool) (*models.SystemIntake, error)
+	CreateActionExtendLifecycleID func(context.Context, *models.Action, uuid.UUID, *time.Time) (*models.SystemIntake, error)
+	IssueLifecycleID              func(context.Context, *models.SystemIntake, *models.Action) (*models.SystemIntake, error)
+	RejectIntake                  func(context.Context, *models.SystemIntake, *models.Action) (*models.SystemIntake, error)
+	FetchUserInfo                 func(context.Context, string) (*models.UserInfo, error)
+	SubmitIntake                  func(context.Context, *models.SystemIntake, *models.Action) error
 }
 
 // NewResolver constructs a resolver

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -618,12 +618,12 @@ input UpdateSystemIntakeContractDetailsInput {
   contract: SystemIntakeContractInput
 }
 
-input ExtendLifecycleIdInput {
+input CreateSystemIntakeActionExtendLifecycleIdInput {
   id: UUID!
   expirationDate: Time
 }
 
-type ExtendLifecycleIdPayload {
+type CreateSystemIntakeActionExtendLifecycleIdPayload {
   systemIntake: SystemIntake
   userErrors: [UserError!]
 }
@@ -807,8 +807,8 @@ type Mutation {
     input: BasicActionInput!
   ): UpdateSystemIntakePayload @hasRole(role: EASI_GOVTEAM)
   createSystemIntakeActionExtendLifecycleId(
-    input: ExtendLifecycleIdInput!
-  ): ExtendLifecycleIdPayload @hasRole(role: EASI_GOVTEAM)
+    input: CreateSystemIntakeActionExtendLifecycleIdInput!
+  ): CreateSystemIntakeActionExtendLifecycleIdPayload @hasRole(role: EASI_GOVTEAM)
   createSystemIntakeNote(input: CreateSystemIntakeNoteInput!): SystemIntakeNote
     @hasRole(role: EASI_GOVTEAM)
   createSystemIntake(input: CreateSystemIntakeInput!): SystemIntake

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -806,6 +806,9 @@ type Mutation {
   createSystemIntakeActionSendEmail(
     input: BasicActionInput!
   ): UpdateSystemIntakePayload @hasRole(role: EASI_GOVTEAM)
+  createSystemIntakeActionExtendLifecycleId(
+    input: ExtendLifecycleIdInput!
+  ): ExtendLifecycleIdPayload @hasRole(role: EASI_GOVTEAM)
   createSystemIntakeNote(input: CreateSystemIntakeNoteInput!): SystemIntakeNote
     @hasRole(role: EASI_GOVTEAM)
   createSystemIntake(input: CreateSystemIntakeInput!): SystemIntake
@@ -836,7 +839,6 @@ type Mutation {
   updateSystemIntakeContactDetails(input: UpdateSystemIntakeContactDetailsInput!): UpdateSystemIntakePayload
   updateSystemIntakeRequestDetails(input: UpdateSystemIntakeRequestDetailsInput!): UpdateSystemIntakePayload
   updateSystemIntakeContractDetails(input: UpdateSystemIntakeContractDetailsInput!): UpdateSystemIntakePayload
-  extendLifecycleId(input: ExtendLifecycleIdInput!): ExtendLifecycleIdPayload @hasRole(role: EASI_GOVTEAM)
 }
 
 type Query {

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -618,6 +618,16 @@ input UpdateSystemIntakeContractDetailsInput {
   contract: SystemIntakeContractInput
 }
 
+input ExtendLifecycleIdInput {
+  id: UUID!
+  expirationDate: Time
+}
+
+type ExtendLifecycleIdPayload {
+  systemIntake: SystemIntake
+  userErrors: [UserError!]
+}
+
 enum SystemIntakeActionType {
   BIZ_CASE_NEEDS_CHANGES
   CREATE_BIZ_CASE
@@ -826,6 +836,7 @@ type Mutation {
   updateSystemIntakeContactDetails(input: UpdateSystemIntakeContactDetailsInput!): UpdateSystemIntakePayload
   updateSystemIntakeRequestDetails(input: UpdateSystemIntakeRequestDetailsInput!): UpdateSystemIntakePayload
   updateSystemIntakeContractDetails(input: UpdateSystemIntakeContractDetailsInput!): UpdateSystemIntakePayload
+  extendLifecycleId(input: ExtendLifecycleIdInput!): ExtendLifecycleIdPayload @hasRole(role: EASI_GOVTEAM)
 }
 
 type Query {

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -6,6 +6,7 @@ package graph
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"strconv"
 	"time"
@@ -1051,6 +1052,10 @@ func (r *mutationResolver) UpdateSystemIntakeContractDetails(ctx context.Context
 	return &model.UpdateSystemIntakePayload{
 		SystemIntake: savedIntake,
 	}, err
+}
+
+func (r *mutationResolver) ExtendLifecycleID(ctx context.Context, input model.ExtendLifecycleIDInput) (*model.ExtendLifecycleIDPayload, error) {
+	panic(fmt.Errorf("not implemented"))
 }
 
 func (r *queryResolver) AccessibilityRequest(ctx context.Context, id uuid.UUID) (*models.AccessibilityRequest, error) {

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -730,9 +730,9 @@ func (r *mutationResolver) CreateSystemIntakeActionSendEmail(ctx context.Context
 	}, err
 }
 
-func (r *mutationResolver) CreateSystemIntakeActionExtendLifecycleID(ctx context.Context, input model.ExtendLifecycleIDInput) (*model.ExtendLifecycleIDPayload, error) {
+func (r *mutationResolver) CreateSystemIntakeActionExtendLifecycleID(ctx context.Context, input model.CreateSystemIntakeActionExtendLifecycleIDInput) (*model.CreateSystemIntakeActionExtendLifecycleIDPayload, error) {
 	if input.ExpirationDate == nil {
-		return &model.ExtendLifecycleIDPayload{
+		return &model.CreateSystemIntakeActionExtendLifecycleIDPayload{
 			UserErrors: []*model.UserError{{Message: "Must provide a valid future date", Path: []string{"expirationDate"}}},
 		}, nil
 	}
@@ -748,7 +748,7 @@ func (r *mutationResolver) CreateSystemIntakeActionExtendLifecycleID(ctx context
 		return nil, err
 	}
 
-	return &model.ExtendLifecycleIDPayload{
+	return &model.CreateSystemIntakeActionExtendLifecycleIDPayload{
 		SystemIntake: intake,
 	}, nil
 }

--- a/pkg/models/action.go
+++ b/pkg/models/action.go
@@ -25,6 +25,8 @@ const (
 	ActionTypePROVIDEFEEDBACKNEEDBIZCASE ActionType = "PROVIDE_FEEDBACK_NEED_BIZ_CASE"
 	// ActionTypeISSUELCID captures enum value ISSUE_LCID
 	ActionTypeISSUELCID ActionType = "ISSUE_LCID"
+	// ActionTypeEXTENDLCID captures enum value EXTEND_LCID
+	ActionTypeEXTENDLCID ActionType = "EXTEND_LCID"
 	// ActionTypeCREATEBIZCASE captures enum value CREATE_BIZ_CASE
 	ActionTypeCREATEBIZCASE ActionType = "CREATE_BIZ_CASE"
 	// ActionTypeSUBMITBIZCASE captures enum value SUBMIT_BIZ_CASE

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -196,6 +196,14 @@ func (s *Server) routes(
 					store.UpdateBusinessCase,
 				),
 			),
+			CreateActionExtendLifecycleID: services.NewCreateActionExtendLifecycleID(
+				serviceConfig,
+				saveAction,
+				cedarLDAPClient.FetchUserInfo,
+				store.FetchSystemIntakeByID,
+				store.UpdateSystemIntake,
+				emailClient.SendSystemIntakeReviewEmail,
+			),
 			IssueLifecycleID: services.NewUpdateLifecycleFields(
 				serviceConfig,
 				services.AuthorizeRequireGRTJobCode,

--- a/src/queries/CreateSystemIntakeActionExtendLifecycleIdQuery.ts
+++ b/src/queries/CreateSystemIntakeActionExtendLifecycleIdQuery.ts
@@ -1,0 +1,14 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  mutation CreateSystemIntakeActionExtendLifecycleId(
+    $input: CreateSystemIntakeActionExtendLifecycleIdInput!
+  ) {
+    createSystemIntakeActionExtendLifecycleId(input: $input) {
+      systemIntake {
+        id
+        lcidExpiresAt
+      }
+    }
+  }
+`;

--- a/src/queries/types/CreateSystemIntakeActionExtendLifecycleId.ts
+++ b/src/queries/types/CreateSystemIntakeActionExtendLifecycleId.ts
@@ -1,0 +1,29 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { CreateSystemIntakeActionExtendLifecycleIdInput } from "./../../types/graphql-global-types";
+
+// ====================================================
+// GraphQL mutation operation: CreateSystemIntakeActionExtendLifecycleId
+// ====================================================
+
+export interface CreateSystemIntakeActionExtendLifecycleId_createSystemIntakeActionExtendLifecycleId_systemIntake {
+  __typename: "SystemIntake";
+  id: UUID;
+  lcidExpiresAt: Time | null;
+}
+
+export interface CreateSystemIntakeActionExtendLifecycleId_createSystemIntakeActionExtendLifecycleId {
+  __typename: "CreateSystemIntakeActionExtendLifecycleIdPayload";
+  systemIntake: CreateSystemIntakeActionExtendLifecycleId_createSystemIntakeActionExtendLifecycleId_systemIntake | null;
+}
+
+export interface CreateSystemIntakeActionExtendLifecycleId {
+  createSystemIntakeActionExtendLifecycleId: CreateSystemIntakeActionExtendLifecycleId_createSystemIntakeActionExtendLifecycleId | null;
+}
+
+export interface CreateSystemIntakeActionExtendLifecycleIdVariables {
+  input: CreateSystemIntakeActionExtendLifecycleIdInput;
+}

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -130,6 +130,11 @@ export interface CreateAccessibilityRequestNoteInput {
   shouldSendEmail: boolean;
 }
 
+export interface CreateSystemIntakeActionExtendLifecycleIdInput {
+  id: UUID;
+  expirationDate?: Time | null;
+}
+
 export interface CreateSystemIntakeInput {
   requestType: SystemIntakeRequestType;
   requester: SystemIntakeRequesterInput;


### PR DESCRIPTION
# ES-880

## Changes proposed in this pull request

Tasks:

- [x] Add new System Intake Action type
- [x] Update the LCID expiration date in a new mutation
- [x] Call mutation from UI and redirect when complete
- [ ] Display action on notes page according to design _(will do in a new PR)_

## Setup

If you run `scripts/dev reset`, there will be a closed request called "With LCID Issued" that can be used to test this workflow.

## Code Review Verification Steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for BE resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
      functions, or e2e tests as necessary

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed