### PR TITLE
allow extend lcid action even if it doesnt have a business case

### DIFF
--- a/src/views/GovernanceReviewTeam/Actions/ChooseAction.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ChooseAction.tsx
@@ -210,41 +210,39 @@ const ChooseAction = ({ systemIntake, businessCase }: ChooseActionProps) => {
   let availableActions: Array<any> = [];
   let availableHiddenActions: Array<any> = [];
 
-  if (systemIntake.requestType) {
-    if (systemIntake.requestType === 'SHUTDOWN') {
-      availableActions = [
-        SendEmail,
-        GuideReceivedClose,
-        NotRespondingClose,
-        NotITRequest
-      ];
-      availableHiddenActions = [];
-    } else if (businessCaseExists) {
-      availableActions = [BizCaseNeedsChanges];
-      availableHiddenActions = [
-        ReadyForGRT,
-        ReadyForGRB,
-        ProvideFeedbackKeepDraft,
-        ProvideFeedbackNeedFinal,
-        IssueLifecycleId,
-        NoFurtherGovernance,
-        RejectIntake
-      ];
+  if (systemIntake.requestType === 'SHUTDOWN') {
+    availableActions = [
+      SendEmail,
+      GuideReceivedClose,
+      NotRespondingClose,
+      NotITRequest
+    ];
+    availableHiddenActions = [];
+  } else if (businessCaseExists) {
+    availableActions = [BizCaseNeedsChanges];
+    availableHiddenActions = [
+      ReadyForGRT,
+      ReadyForGRB,
+      ProvideFeedbackKeepDraft,
+      ProvideFeedbackNeedFinal,
+      IssueLifecycleId,
+      NoFurtherGovernance,
+      RejectIntake
+    ];
+  } else {
+    availableActions = [NotITRequest, NeedBizCase];
+    availableHiddenActions = [
+      ReadyForGRT,
+      ProvideFeedbackNeedBizCase,
+      ReadyForGRB,
+      NoFurtherGovernance,
+      IssueLifecycleId
+    ];
+  }
 
-      if (flags.lcidExtension) {
-        if (systemIntake.status === SystemIntakeStatus.LCID_ISSUED) {
-          availableActions.unshift(ExtendLifecycleID);
-        }
-      }
-    } else {
-      availableActions = [NotITRequest, NeedBizCase];
-      availableHiddenActions = [
-        ReadyForGRT,
-        ProvideFeedbackNeedBizCase,
-        ReadyForGRB,
-        NoFurtherGovernance,
-        IssueLifecycleId
-      ];
+  if (flags.lcidExtension) {
+    if (systemIntake.status === SystemIntakeStatus.LCID_ISSUED) {
+      availableActions.unshift(ExtendLifecycleID);
     }
   }
 


### PR DESCRIPTION
# ES-000

Currently, the user is only allowed to extend an LCID if the intake has a business case. In most cases, business owners will need to fill out a business case before getting an LCID.

However there is a rare edge case where business owners can get fast forwarded to an LCID. To account for this edge case, an LCID should be able to be extended as long as the status of the intake is `LCID_ISSUED`.

## Code Review Verification Steps

### As the original developer, I have

- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
