### PR TITLE
change when we display submission dates on intake review

### DIFF
--- a/src/components/SystemIntakeReview/index.tsx
+++ b/src/components/SystemIntakeReview/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { DateTime } from 'luxon';
 
 import ReviewRow from 'components/ReviewRow';
 import {
@@ -10,6 +9,7 @@ import {
 import contractStatus from 'constants/enums/contractStatus';
 import { yesNoMap } from 'data/common';
 import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetSystemIntake';
+import { SystemIntakeStatus } from 'types/graphql-global-types';
 import convertBoolToYesNo from 'utils/convertBoolToYesNo';
 import { formatContractDate, formatDate } from 'utils/date';
 
@@ -20,7 +20,7 @@ type SystemIntakeReviewProps = {
 export const SystemIntakeReview = ({
   systemIntake
 }: SystemIntakeReviewProps) => {
-  const { contract } = systemIntake;
+  const { contract, status, submittedAt } = systemIntake;
 
   const fundingDefinition = () => {
     const {
@@ -44,19 +44,25 @@ export const SystemIntakeReview = ({
     return hasIsso;
   };
 
+  const getSubmissionDate = () => {
+    if (status === SystemIntakeStatus.INTAKE_DRAFT) {
+      return 'Not yet submitted';
+    }
+
+    if (submittedAt) {
+      return formatDate(submittedAt);
+    }
+
+    return 'N/A';
+  };
+
   return (
     <div>
       <DescriptionList title="System Request">
         <ReviewRow>
           <div>
             <DescriptionTerm term="Submission Date" />
-            <DescriptionDefinition
-              definition={
-                systemIntake.submittedAt
-                  ? formatDate(systemIntake.submittedAt)
-                  : DateTime.local().toLocaleString(DateTime.DATE_MED)
-              }
-            />
+            <DescriptionDefinition definition={getSubmissionDate()} />
           </div>
         </ReviewRow>
       </DescriptionList>


### PR DESCRIPTION
# ES-889

Currently, users see today's date for intakes that don't have a `submittedAt` date for intakes that don't have a submitted at date. That's not working anymore because there are imported(?) intakes that don't have a submitted at date.This PR semi-fixes the issue.

If an intake has the status `INTAKE_DRAFT`, we display `Not submitted yet` for any place showing submission date.

If an intake has a `submittedAt` date, we display that date.

If an intake is not `INTAKE_DRAFT` and does not have a `submittedAt` date, we display nothing.

This is not a perfect solution, because there is still confusion since there's no date displaying if the date is `null`. However, the benefit is that it doesn't display any inaccurate data.

We still need to figure out what to do about intakes that don't have submission dates. This will require greater investigation into the imported intakes. I don't see any evidence that `submittedAt` dates are getting cleared out anywhere.

## Code Review Verification Steps

### As the original developer, I have

- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
