### PR TITLE
Update local cypress run to match CI

### DIFF
--- a/scripts/run-cypress-test-docker
+++ b/scripts/run-cypress-test-docker
@@ -33,9 +33,11 @@ else
 
   docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.cypress_local.yml build --parallel
 
-  docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.cypress_local.yml up -d minio minio_mc
-  docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.cypress_local.yml up -d db db_migrate
-  docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.cypress_local.yml up -d db_seed
+  docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.cypress_local.yml up -d db
+  docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.cypress_local.yml up --exit-code-from db_migrate db_migrate
+  docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.cypress_local.yml up --exit-code-from db_seed db_seed
+  docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.cypress_local.yml up -d minio
+  docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.cypress_local.yml up --exit-code-from minio_mc minio_mc
   docker-compose --project-name "${PROJECT_NAME}" -f docker-compose.yml -f docker-compose.cypress_local.yml up -d easi easi_client
 
   EASI_EXIT_CODE=$(docker container inspect --format='{{.State.ExitCode}}' "${EASI_CONTAINER}")


### PR DESCRIPTION
# ES-000

<!--
    If applicable, insert the Jira story number in the markdown header above
    The hyperlink will be filled in by GitHub magic
--->

## Changes proposed in this pull request

Update the local portion of the cypress runner script so that the
ordering of starting the docker services is consistent. Adding the check
for exit code on some services should also help control the start up so
that all dependent services are running before the backend starts. This
should address an intermittent error where the backend would error on
initial connection to the db because it was attempting to the connect to
the db before the db migrations had completed.

## Reviewer Notes

Run `./scripts/run-cypress-test-docker` locally to verify that the Cypress tests run successfully on your local machine.

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
