### PR TITLE
fix: Set AWS credential env vars in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - AWS_SES_SOURCE=no-reply-$APP_ENV@info.easi.cms.gov
       - AWS_SES_SOURCE_ARN
       - AWS_S3_FILE_UPLOAD_BUCKET=easi-app-file-uploads
+      - AWS_ACCESS_KEY_ID=1
+      - AWS_SECRET_ACCESS_KEY=1
       - PGHOST=db
       - PGPORT=5432
       - PGDATABASE=postgres


### PR DESCRIPTION
# ES-784

This allows the aws SDK to call through to the lambci-based lambda emulation
that we use locally. Without these being set, the Go backend fails with a
'NoCredentialProviders: no valid providers in chain. Deprecated.' error.



## Changes proposed in this pull request

- Set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in `docker-compose.yml`. I had to set them to have a value in order for the AWS SDK to agree to call the local prince lambda.

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer Notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

```console
$ scripts/dev down
$ scripts/dev reset
```

Then log into the app with the gov team job code, pick any intake in the table, and then scroll down to click on the "Download as PDF" link. After a few seconds, the PDF should be downloaded by your browser.

If things don't work, check the logs for the `easi` or `prince` Docker containers.

## Code Review Verification Steps

### As the original developer, I have

- [x] Met the acceptance criteria, or will meet them in a subsequent PR

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed