### PR TITLE
Replace intake form fields with react-uswds components

### DIFF
--- a/src/views/SystemIntake/ContactDetails/GovernanceTeamOptions.tsx
+++ b/src/views/SystemIntake/ContactDetails/GovernanceTeamOptions.tsx
@@ -49,8 +49,7 @@ const GovernanceTeamOptions = ({ formikProps }: GovernanceTeamOptionsProps) => {
                       const removeIndex = values.governanceTeams.teams
                         ?.map(t => t.name)
                         .indexOf(e.target.value);
-
-                      if (removeIndex) {
+                      if (typeof removeIndex === 'number' && removeIndex > -1) {
                         arrayHelpers.remove(removeIndex);
                       }
                     }

--- a/src/views/SystemIntake/ContactDetails/index.tsx
+++ b/src/views/SystemIntake/ContactDetails/index.tsx
@@ -2,22 +2,24 @@ import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
-import { Button } from '@trussworks/react-uswds';
+import {
+  Button,
+  Checkbox,
+  Dropdown,
+  Label,
+  Radio,
+  TextInput
+} from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 
 import MandatoryFieldsAlert from 'components/MandatoryFieldsAlert';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
 import AutoSave from 'components/shared/AutoSave';
-import CheckboxField from 'components/shared/CheckboxField';
-import { DropdownField, DropdownItem } from 'components/shared/DropdownField';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
-import Label from 'components/shared/Label';
-import { RadioField } from 'components/shared/RadioField';
-import TextField from 'components/shared/TextField';
 import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
 import GetSystemIntakeQuery from 'queries/GetSystemIntakeQuery';
 import { UpdateSystemIntakeContactDetails as UpdateSystemIntakeContactDetailsQuery } from 'queries/SystemIntakeQueries';
@@ -126,14 +128,9 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
 
   const cmsDivionsAndOfficesOptions = (fieldId: string) =>
     cmsDivisionsAndOffices.map((office: any) => (
-      <Field
-        as={DropdownItem}
-        key={`${fieldId}-${office.acronym}`}
-        name={
-          office.acronym ? `${office.name} (${office.acronym})` : office.name
-        }
-        value={office.name}
-      />
+      <option key={`${fieldId}-${office.acronym}`} value={office.name}>
+        {office.acronym ? `${office.name} (${office.acronym})` : office.name}
+      </option>
     ));
 
   const saveExitLink = (() => {
@@ -210,7 +207,7 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                   </Label>
                   <FieldErrorMsg>{flatErrors['requester.name']}</FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!flatErrors['requester.name']}
                     id="IntakeForm-Requester"
                     maxLength={50}
@@ -231,8 +228,7 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                     {flatErrors['requester.component']}
                   </FieldErrorMsg>
                   <Field
-                    as={DropdownField}
-                    error={!!flatErrors['requester.component']}
+                    as={Dropdown}
                     id="IntakeForm-RequesterComponent"
                     name="requester.component"
                     onChange={(e: any) => {
@@ -251,12 +247,9 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                       setFieldValue('requester.component', e.target.value);
                     }}
                   >
-                    <Field
-                      as={DropdownItem}
-                      name="Select an option"
-                      value=""
-                      disabled
-                    />
+                    <option value="" disabled>
+                      Select an option
+                    </option>
                     {cmsDivionsAndOfficesOptions('RequesterComponent')}
                   </Field>
                 </FieldGroup>
@@ -276,7 +269,7 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                     {t('contactDetails.businessOwner.helpText')}
                   </HelpText>
                   <Field
-                    as={CheckboxField}
+                    as={Checkbox}
                     id="IntakeForm-IsBusinessOwnerSameAsRequester"
                     label="CMS Business Owner is same as requester"
                     name="isBusinessOwnerSameAsRequester"
@@ -301,7 +294,7 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                     {flatErrors['businessOwner.name']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!flatErrors['businessOwner.name']}
                     disabled={isReqAndBusOwnerSame}
                     id="IntakeForm-BusinessOwner"
@@ -323,18 +316,14 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                     {flatErrors['businessOwner.component']}
                   </FieldErrorMsg>
                   <Field
-                    as={DropdownField}
+                    as={Dropdown}
                     disabled={isReqAndBusOwnerSame}
-                    error={!!flatErrors['businessOwner.component']}
                     id="IntakeForm-BusinessOwnerComponent"
                     name="businessOwner.component"
                   >
-                    <Field
-                      as={DropdownItem}
-                      name="Select an option"
-                      value=""
-                      disabled
-                    />
+                    <option value="" disabled>
+                      Select an option
+                    </option>
                     {cmsDivionsAndOfficesOptions('BusinessOwnerComponent')}
                   </Field>
                 </FieldGroup>
@@ -354,7 +343,7 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                     {t('contactDetails.productManager.helpText')}
                   </HelpText>
                   <Field
-                    as={CheckboxField}
+                    as={Checkbox}
                     id="IntakeForm-IsProductManagerSameAsRequester"
                     label="CMS Project/Product Manager, or lead is same as requester"
                     name="isProductManagerSameAsRequester"
@@ -379,7 +368,7 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                     {flatErrors['productManager.name']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!flatErrors['productManager.name']}
                     id="IntakeForm-ProductManager"
                     maxLength={50}
@@ -401,19 +390,15 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                     {flatErrors['productManager.component']}
                   </FieldErrorMsg>
                   <Field
-                    as={DropdownField}
-                    error={!!flatErrors['productManager.component']}
+                    as={Dropdown}
                     id="IntakeForm-ProductManagerComponent"
                     label="Product Manager Component"
                     name="productManager.component"
                     disabled={isReqAndProductManagerSame}
                   >
-                    <Field
-                      as={DropdownItem}
-                      name="Select an option"
-                      value=""
-                      disabled
-                    />
+                    <option value="" disabled>
+                      Select an option
+                    </option>
                     {cmsDivionsAndOfficesOptions('ProductManagerComponent')}
                   </Field>
                 </FieldGroup>
@@ -438,7 +423,7 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                     </FieldErrorMsg>
 
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.isso.isPresent === true}
                       id="IntakeForm-HasIssoYes"
                       name="isso.isPresent"
@@ -467,7 +452,7 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                             {flatErrors['isso.name']}
                           </FieldErrorMsg>
                           <Field
-                            as={TextField}
+                            as={TextInput}
                             error={!!flatErrors['isso.name']}
                             id="IntakeForm-IssoName"
                             maxLength={50}
@@ -477,7 +462,7 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                       </div>
                     )}
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.isso.isPresent === false}
                       id="IntakeForm-HasIssoNo"
                       name="isso.isPresent"
@@ -511,7 +496,7 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                     </FieldErrorMsg>
 
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.governanceTeams.isPresent === true}
                       id="IntakeForm-YesGovernanceTeams"
                       name="governanceTeams.isPresent"
@@ -536,7 +521,7 @@ const ContactDetails = ({ systemIntake }: ContactDetailsProps) => {
                     </div>
 
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.governanceTeams.isPresent === false}
                       id="IntakeForm-NoGovernanceTeam"
                       name="governanceTeams.isPresent"

--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -1,7 +1,15 @@
 import React, { useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
-import { Button, Link } from '@trussworks/react-uswds';
+import {
+  Button,
+  Dropdown,
+  Label,
+  Link,
+  Radio,
+  Textarea,
+  TextInput
+} from '@trussworks/react-uswds';
 import classnames from 'classnames';
 import { Field, Form, Formik, FormikProps } from 'formik';
 import { DateTime } from 'luxon';
@@ -15,15 +23,10 @@ import {
   DateInputMonth,
   DateInputYear
 } from 'components/shared/DateInput';
-import { DropdownField, DropdownItem } from 'components/shared/DropdownField';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
-import Label from 'components/shared/Label';
-import { RadioField } from 'components/shared/RadioField';
-import TextAreaField from 'components/shared/TextAreaField';
-import TextField from 'components/shared/TextField';
 import fundingSources from 'constants/enums/fundingSources';
 import processStages from 'constants/enums/processStages';
 import { yesNoMap } from 'data/common';
@@ -187,26 +190,25 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                   </HelpText>
                   <FieldErrorMsg>{flatErrors.CurrentStage}</FieldErrorMsg>
                   <Field
-                    as={DropdownField}
-                    error={!!flatErrors.currentStage}
+                    as={Dropdown}
                     id="IntakeForm-CurrentStage"
                     name="currentStage"
                     aria-describedby="IntakeForm-ProcessHelp"
                   >
-                    <Field
-                      as={DropdownItem}
-                      name="Select an option"
-                      value=""
-                      disabled
-                    />
-                    {processStages.map(stage => (
-                      <Field
-                        as={DropdownItem}
-                        key={`ProcessStageComponent-${stage.value}`}
-                        name={stage.name}
-                        value={stage.name}
-                      />
-                    ))}
+                    <option value="" disabled>
+                      Select an option
+                    </option>
+                    {processStages.map(stage => {
+                      const { name, value } = stage;
+                      return (
+                        <option
+                          key={`ProcessStageComponent-${value}`}
+                          value={name}
+                        >
+                          {name}
+                        </option>
+                      );
+                    })}
                   </Field>
                 </FieldGroup>
 
@@ -230,7 +232,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                       {flatErrors['fundingSource.isFunded']}
                     </FieldErrorMsg>
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.fundingSource.isFunded === true}
                       id="IntakeForm-HasFundingSourceYes"
                       name="fundingSource.isFunded"
@@ -259,8 +261,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                             {flatErrors['fundingSource.source']}
                           </FieldErrorMsg>
                           <Field
-                            as={DropdownField}
-                            error={!!flatErrors['fundingSource.source']}
+                            as={Dropdown}
                             id="IntakeForm-FundingSource"
                             name="fundingSource.source"
                             // manual onChange to catch case where user selects 'Unknown' funding source
@@ -280,19 +281,16 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                               }
                             }}
                           >
-                            <Field
-                              as={DropdownItem}
-                              name="Select an option"
-                              value=""
-                              disabled
-                            />
+                            <option value="" disabled>
+                              Select an option
+                            </option>
                             {fundingSources.map(source => (
-                              <Field
-                                as={DropdownItem}
+                              <option
                                 key={source.split(' ').join('-')}
-                                name={source}
                                 value={source}
-                              />
+                              >
+                                {source}
+                              </option>
                             ))}
                           </Field>
                         </FieldGroup>
@@ -311,7 +309,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                           </FieldErrorMsg>
                           <Field
                             className="width-card-lg"
-                            as={TextField}
+                            as={TextInput}
                             error={!!flatErrors['fundingSource.fundingNumber']}
                             id="IntakeForm-FundingNumber"
                             maxLength={6}
@@ -344,7 +342,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                       </div>
                     )}
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.fundingSource.isFunded === false}
                       id="IntakeForm-HasFundingSourceNo"
                       name="fundingSource.isFunded"
@@ -379,7 +377,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                       {flatErrors['costs.isExpectingIncrease']}
                     </FieldErrorMsg>
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.costs.isExpectingIncrease === 'YES'}
                       id="IntakeForm-CostsExpectingIncreaseYes"
                       name="costs.isExpectingIncrease"
@@ -413,7 +411,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                             {flatErrors['costs.expectedIncreaseAmount']}
                           </FieldErrorMsg>
                           <Field
-                            as={TextAreaField}
+                            as={Textarea}
                             className="system-intake__cost-amount"
                             error={!!flatErrors['costs.expectedIncreaseAmount']}
                             id="IntakeForm-CostsExpectedIncrease"
@@ -425,7 +423,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                       </div>
                     )}
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.costs.isExpectingIncrease === 'NO'}
                       id="IntakeForm-CostsExpectingIncreaseNo"
                       name="costs.isExpectingIncrease"
@@ -437,7 +435,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                       }}
                     />
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.costs.isExpectingIncrease === 'NOT_SURE'}
                       id="IntakeForm-CostsExpectingIncreaseNotSure"
                       name="costs.isExpectingIncrease"
@@ -472,7 +470,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                       {flatErrors['contract.hasContract']}
                     </FieldErrorMsg>
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.contract.hasContract === 'HAVE_CONTRACT'}
                       id="IntakeForm-ContractHaveContract"
                       name="contract.hasContract"
@@ -500,7 +498,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                             {flatErrors['contract.contractor']}
                           </FieldErrorMsg>
                           <Field
-                            as={TextField}
+                            as={TextInput}
                             error={!!flatErrors['contract.contractor']}
                             id="IntakeForm-Contractor"
                             maxLength={100}
@@ -521,7 +519,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                             {flatErrors['contract.vehicle']}
                           </FieldErrorMsg>
                           <Field
-                            as={TextField}
+                            as={TextInput}
                             error={!!flatErrors['contract.vehicle']}
                             id="IntakeForm-Vehicle"
                             maxLength={100}
@@ -685,7 +683,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                       </div>
                     )}
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.contract.hasContract === 'IN_PROGRESS'}
                       id="IntakeForm-ContractInProgress"
                       name="contract.hasContract"
@@ -712,7 +710,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                             {flatErrors['contract.contractor']}
                           </FieldErrorMsg>
                           <Field
-                            as={TextField}
+                            as={TextInput}
                             error={!!flatErrors['contract.contractor']}
                             id="IntakeForm-Contractor"
                             maxLength={100}
@@ -733,7 +731,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                             {flatErrors['contract.vehicle']}
                           </FieldErrorMsg>
                           <Field
-                            as={TextField}
+                            as={TextInput}
                             error={!!flatErrors['contract.vehicle']}
                             id="IntakeForm-Vehicle"
                             maxLength={100}
@@ -917,7 +915,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                       </div>
                     )}
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.contract.hasContract === 'NOT_STARTED'}
                       id="IntakeForm-ContractNotStarted"
                       name="contract.hasContract"
@@ -936,7 +934,7 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                       }}
                     />
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.contract.hasContract === 'NOT_NEEDED'}
                       id="IntakeForm-ContractNotNeeded"
                       name="contract.hasContract"

--- a/src/views/SystemIntake/RequestDetails/index.tsx
+++ b/src/views/SystemIntake/RequestDetails/index.tsx
@@ -1,7 +1,13 @@
 import React, { useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
-import { Button } from '@trussworks/react-uswds';
+import {
+  Button,
+  Label,
+  Radio,
+  Textarea,
+  TextInput
+} from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 
 import CharacterCounter from 'components/CharacterCounter';
@@ -14,10 +20,6 @@ import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
-import Label from 'components/shared/Label';
-import { RadioField } from 'components/shared/RadioField';
-import TextAreaField from 'components/shared/TextAreaField';
-import TextField from 'components/shared/TextField';
 import GetSystemIntakeQuery from 'queries/GetSystemIntakeQuery';
 import { UpdateSystemIntakeRequestDetails as UpdateSystemIntakeRequestDetailsQuery } from 'queries/SystemIntakeQueries';
 import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetSystemIntake';
@@ -144,7 +146,7 @@ const RequestDetails = ({ systemIntake }: RequestDetailsProps) => {
                   <Label htmlFor="IntakeForm-RequestName">Project Name</Label>
                   <FieldErrorMsg>{flatErrors.requestName}</FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!flatErrors.requestName}
                     id="IntakeForm-RequestName"
                     maxLength={50}
@@ -191,7 +193,7 @@ const RequestDetails = ({ systemIntake }: RequestDetailsProps) => {
                   </HelpText>
                   <FieldErrorMsg>{flatErrors.businessNeed}</FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors.businessNeed}
                     id="IntakeForm-BusinessNeed"
                     maxLength={2000}
@@ -219,7 +221,7 @@ const RequestDetails = ({ systemIntake }: RequestDetailsProps) => {
                   </HelpText>
                   <FieldErrorMsg>{flatErrors.businessSolution}</FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors.businessSolution}
                     id="IntakeForm-BusinessSolution"
                     maxLength={2000}
@@ -250,7 +252,7 @@ const RequestDetails = ({ systemIntake }: RequestDetailsProps) => {
                     </HelpText>
                     <FieldErrorMsg>{flatErrors.needsEaSupport}</FieldErrorMsg>
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.needsEaSupport === true}
                       id="IntakeForm-NeedsEaSupportYes"
                       name="needsEaSupport"
@@ -263,7 +265,7 @@ const RequestDetails = ({ systemIntake }: RequestDetailsProps) => {
                     />
 
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.needsEaSupport === false}
                       id="IntakeForm-NeedsEaSupportNo"
                       name="needsEaSupport"


### PR DESCRIPTION
This PR leverages the USWDS form components on the system intake form. The fields are nearly identical because they leverage USWDS, but the fields from `react-uswds` capture edge cases and are better documented/tested.

## Code Review Verification Steps

### As the original developer, I have

- [x] It works

### As the code reviewer, I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
