### PR TITLE
Replace business case form fields with react-uswds components

### DIFF
--- a/src/components/EstimatedLifecycleCost/index.tsx
+++ b/src/components/EstimatedLifecycleCost/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { Checkbox, Label, TextInput } from '@trussworks/react-uswds';
 import { Field, FieldArray } from 'formik';
 import { DateTime } from 'luxon';
 
-import CheckboxField from 'components/shared/CheckboxField/';
 import {
   DescriptionDefinition,
   DescriptionList,
@@ -10,8 +10,6 @@ import {
 } from 'components/shared/DescriptionGroup';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
-import Label from 'components/shared/Label';
-import TextField from 'components/shared/TextField';
 import { LifecycleCosts } from 'types/estimatedLifecycle';
 import { getFiscalYear } from 'utils/date';
 import formatDollars from 'utils/formatDollars';
@@ -56,7 +54,7 @@ const Phase = ({
               </legend>
 
               <Field
-                as={CheckboxField}
+                as={Checkbox}
                 checked={values.development.isPresent}
                 id={`BusinessCase-${formikKey}.Year${year}.development.isPresent`}
                 name={`${formikKey}.year${year}.development.isPresent`}
@@ -82,7 +80,7 @@ const Phase = ({
                   </Label>
                   <FieldErrorMsg>{errors?.development?.cost}</FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!errors?.development?.cost}
                     className="width-card-lg"
                     id={`BusinessCase-${formikKey}.Year${year}.development.cost`}
@@ -95,7 +93,7 @@ const Phase = ({
               )}
 
               <Field
-                as={CheckboxField}
+                as={Checkbox}
                 checked={values.operationsMaintenance.isPresent}
                 id={`BusinessCase-${formikKey}.Year${year}.operationsMaintenance.isPresent`}
                 name={`${formikKey}.year${year}.operationsMaintenance.isPresent`}
@@ -123,7 +121,7 @@ const Phase = ({
                     {errors?.operationsMaintenance?.cost}
                   </FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!errors?.operationsMaintenance?.cost}
                     className="width-card-lg"
                     id={`BusinessCase-${formikKey}.Year${year}.operationsMaintenance.cost`}
@@ -136,7 +134,7 @@ const Phase = ({
               )}
 
               <Field
-                as={CheckboxField}
+                as={Checkbox}
                 checked={values.other.isPresent}
                 id={`BusinessCase-${formikKey}.Year${year}.other.isPresent`}
                 name={`${formikKey}.year${year}.other.isPresent`}
@@ -162,7 +160,7 @@ const Phase = ({
                   </Label>
                   <FieldErrorMsg>{errors?.other?.cost}</FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!errors?.other?.cost}
                     className="width-card-lg"
                     id={`BusinessCase-${formikKey}.Year${year}.other.cost`}

--- a/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionFields.tsx
+++ b/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionFields.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Label, Radio, Textarea, TextInput } from '@trussworks/react-uswds';
 import { Field, FormikProps } from 'formik';
 
 import CharacterCounter from 'components/CharacterCounter';
@@ -6,10 +7,6 @@ import EstimatedLifecycleCost from 'components/EstimatedLifecycleCost';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
-import Label from 'components/shared/Label';
-import { RadioField } from 'components/shared/RadioField';
-import TextAreaField from 'components/shared/TextAreaField';
-import TextField from 'components/shared/TextField';
 import { yesNoMap } from 'data/common';
 import flattenErrors from 'utils/flattenErrors';
 
@@ -41,7 +38,7 @@ const AlternativeSolutionFields = ({
           </Label>
           <FieldErrorMsg>{flatErrors[`${altId}.title`]}</FieldErrorMsg>
           <Field
-            as={TextField}
+            as={TextInput}
             error={!!flatErrors[`${altId}.title`]}
             id={`BusinessCase-${altId}Title`}
             maxLength={50}
@@ -78,7 +75,7 @@ const AlternativeSolutionFields = ({
           </HelpText>
           <FieldErrorMsg>{flatErrors[`${altId}.summary`]}</FieldErrorMsg>
           <Field
-            as={TextAreaField}
+            as={Textarea}
             error={!!flatErrors[`${altId}.summary`]}
             id={`BusinessCase-${altId}Summary`}
             maxLength={2000}
@@ -110,7 +107,7 @@ const AlternativeSolutionFields = ({
             {flatErrors[`${altId}.acquisitionApproach`]}
           </FieldErrorMsg>
           <Field
-            as={TextAreaField}
+            as={Textarea}
             error={flatErrors[`${altId}.acquisitionApproach`]}
             id={`BusinessCase-${altId}AcquisitionApproach`}
             maxLength={2000}
@@ -139,7 +136,7 @@ const AlternativeSolutionFields = ({
               {flatErrors[`${altId}.security.isApproved`]}
             </FieldErrorMsg>
             <Field
-              as={RadioField}
+              as={Radio}
               checked={values[`${altId}`].security.isApproved === true}
               id={`BusinessCase-${altId}SecurityApproved`}
               name={`${altId}.security.isApproved`}
@@ -151,7 +148,7 @@ const AlternativeSolutionFields = ({
             />
 
             <Field
-              as={RadioField}
+              as={Radio}
               checked={values[`${altId}`].security.isApproved === false}
               id={`BusinessCase-${altId}SecurityNotApproved`}
               name={`${altId}.security.isApproved`}
@@ -184,7 +181,7 @@ const AlternativeSolutionFields = ({
                 {flatErrors[`${altId}.security.isBeingReviewed`]}
               </FieldErrorMsg>
               <Field
-                as={RadioField}
+                as={Radio}
                 checked={values[`${altId}`].security.isBeingReviewed === 'YES'}
                 id={`BusinessCase-${altId}SecurityIsBeingReviewedYed`}
                 name={`${altId}.security.isBeingReviewed`}
@@ -193,7 +190,7 @@ const AlternativeSolutionFields = ({
                 aria-describedby={`BusinessCase-${altId}SecurityReviewHelp`}
               />
               <Field
-                as={RadioField}
+                as={Radio}
                 checked={values[`${altId}`].security.isBeingReviewed === 'NO'}
                 id={`BusinessCase-${altId}SecurityIsBeingReviewedNo`}
                 name={`${altId}.security.isBeingReviewed`}
@@ -201,7 +198,7 @@ const AlternativeSolutionFields = ({
                 value="NO"
               />
               <Field
-                as={RadioField}
+                as={Radio}
                 checked={
                   values[`${altId}`].security.isBeingReviewed === 'NOT_SURE'
                 }
@@ -225,7 +222,7 @@ const AlternativeSolutionFields = ({
             <FieldErrorMsg>{flatErrors[`${altId}.hosting.type`]}</FieldErrorMsg>
 
             <Field
-              as={RadioField}
+              as={Radio}
               checked={values[`${altId}`].hosting.type === 'cloud'}
               id={`BusinessCase-${altId}HostingCloud`}
               name={`${altId}.hosting.type`}
@@ -251,7 +248,7 @@ const AlternativeSolutionFields = ({
                     {flatErrors[`${altId}.hosting.location`]}
                   </FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!flatErrors[`${altId}.hosting.location`]}
                     id={`BusinessCase-${altId}CloudLocation`}
                     maxLength={50}
@@ -271,7 +268,7 @@ const AlternativeSolutionFields = ({
                     {flatErrors[`${altId}.hosting.cloudServiceType`]}
                   </FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!flatErrors[`${altId}.hosting.cloudServiceType`]}
                     id={`BusinessCase-${altId}CloudServiceType`}
                     maxLength={50}
@@ -281,7 +278,7 @@ const AlternativeSolutionFields = ({
               </>
             )}
             <Field
-              as={RadioField}
+              as={Radio}
               checked={values[`${altId}`].hosting.type === 'dataCenter'}
               id={`BusinessCase-${altId}HostingDataCenter`}
               name={`${altId}.hosting.type`}
@@ -306,7 +303,7 @@ const AlternativeSolutionFields = ({
                   {flatErrors[`${altId}.hosting.location`]}
                 </FieldErrorMsg>
                 <Field
-                  as={TextField}
+                  as={TextInput}
                   error={!!flatErrors[`${altId}.hosting.location`]}
                   id={`BusinessCase-${altId}DataCenterLocation`}
                   maxLength={50}
@@ -315,7 +312,7 @@ const AlternativeSolutionFields = ({
               </FieldGroup>
             )}
             <Field
-              as={RadioField}
+              as={Radio}
               checked={values[`${altId}`].hosting.type === 'none'}
               id={`BusinessCase-${altId}HostingNone`}
               name={`${altId}.hosting.type`}
@@ -344,7 +341,7 @@ const AlternativeSolutionFields = ({
             </FieldErrorMsg>
 
             <Field
-              as={RadioField}
+              as={Radio}
               checked={values[`${altId}`].hasUserInterface === 'YES'}
               id={`BusinessCase-${altId}HasUserInferfaceYes`}
               name={`${altId}.hasUserInterface`}
@@ -352,7 +349,7 @@ const AlternativeSolutionFields = ({
               value="YES"
             />
             <Field
-              as={RadioField}
+              as={Radio}
               checked={values[`${altId}`].hasUserInterface === 'NO'}
               id={`BusinessCase-${altId}HasUserInferfaceNo`}
               name={`${altId}.hasUserInterface`}
@@ -361,7 +358,7 @@ const AlternativeSolutionFields = ({
             />
 
             <Field
-              as={RadioField}
+              as={Radio}
               checked={values[`${altId}`].hasUserInterface === 'NOT_SURE'}
               id={`BusinessCase-${altId}HasUserInferfaceNotSure`}
               name={`${altId}.hasUserInterface`}
@@ -384,7 +381,7 @@ const AlternativeSolutionFields = ({
           </HelpText>
           <FieldErrorMsg>{flatErrors[`${altId}.pros`]}</FieldErrorMsg>
           <Field
-            as={TextAreaField}
+            as={Textarea}
             error={!!flatErrors[`${altId}.pros`]}
             id={`BusinessCase-${altId}Pros`}
             maxLength={2000}
@@ -410,7 +407,7 @@ const AlternativeSolutionFields = ({
           </HelpText>
           <FieldErrorMsg>{flatErrors[`${altId}.cons`]}</FieldErrorMsg>
           <Field
-            as={TextAreaField}
+            as={Textarea}
             error={!!flatErrors[`${altId}.cons`]}
             id={`BusinessCase-${altId}Cons`}
             maxLength={2000}
@@ -471,7 +468,7 @@ const AlternativeSolutionFields = ({
           </HelpText>
           <FieldErrorMsg>{flatErrors[`${altId}.costSavings`]}</FieldErrorMsg>
           <Field
-            as={TextAreaField}
+            as={Textarea}
             error={!!flatErrors[`${altId}.costSavings`]}
             id={`BusinessCase-${altId}CostSavings`}
             maxLength={2000}

--- a/src/views/BusinessCase/AsIsSolution/index.tsx
+++ b/src/views/BusinessCase/AsIsSolution/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { Button } from '@trussworks/react-uswds';
+import { Button, Label, Textarea, TextInput } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 
 import CharacterCounter from 'components/CharacterCounter';
@@ -13,9 +13,6 @@ import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
-import Label from 'components/shared/Label';
-import TextAreaField from 'components/shared/TextAreaField';
-import TextField from 'components/shared/TextField';
 import { alternativeSolutionHasFilledFields } from 'data/businessCase';
 import { AsIsSolutionForm, BusinessCaseModel } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
@@ -114,7 +111,7 @@ const AsIsSolution = ({
                     {flatErrors['asIsSolution.title']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!flatErrors['asIsSolution.title']}
                     id="BusinessCase-AsIsSolutionTitle"
                     maxLength={50}
@@ -154,7 +151,7 @@ const AsIsSolution = ({
                     {flatErrors['asIsSolution.summary']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors['asIsSolution.summary']}
                     id="BusinessCase-AsIsSolutionSummary"
                     maxLength={2000}
@@ -185,7 +182,7 @@ const AsIsSolution = ({
                     {flatErrors['asIsSolution.pros']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors['asIsSolution.pros']}
                     id="BusinessCase-AsIsSolutionPros"
                     maxLength={2000}
@@ -216,7 +213,7 @@ const AsIsSolution = ({
                     {flatErrors['asIsSolution.cons']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors['asIsSolution.cons']}
                     id="BusinessCase-AsIsSolutionCons"
                     maxLength={2000}
@@ -284,7 +281,7 @@ const AsIsSolution = ({
                     {flatErrors['asIsSolution.costSavings']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors['asIsSolution.costSavings']}
                     id="BusinessCase-AsIsSolutionCostSavings"
                     maxLength={2000}

--- a/src/views/BusinessCase/GeneralRequestInfo/index.tsx
+++ b/src/views/BusinessCase/GeneralRequestInfo/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { Button } from '@trussworks/react-uswds';
+import { Button, Label, TextInput } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 
 import MandatoryFieldsAlert from 'components/MandatoryFieldsAlert';
@@ -11,8 +11,6 @@ import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
-import Label from 'components/shared/Label';
-import TextField from 'components/shared/TextField';
 import { alternativeSolutionHasFilledFields } from 'data/businessCase';
 import { BusinessCaseModel, GeneralRequestInfoForm } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
@@ -100,7 +98,7 @@ const GeneralRequestInfo = ({
                   <Label htmlFor="BusinessCase-RequestName">Project Name</Label>
                   <FieldErrorMsg>{flatErrors.requestName}</FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!flatErrors.requestName}
                     id="BusinessCase-RequestName"
                     maxLength={50}
@@ -115,7 +113,7 @@ const GeneralRequestInfo = ({
                   <Label htmlFor="BusinessCase-RequesterName">Requester</Label>
                   <FieldErrorMsg>{flatErrors['requester.name']}</FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!flatErrors['requester.name']}
                     id="BusinessCase-RequesterName"
                     maxLength={50}
@@ -134,7 +132,7 @@ const GeneralRequestInfo = ({
                     {flatErrors['businessOwner.name']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!flatErrors['businessOwner.name']}
                     id="BusinessCase-BusinessOwnerName"
                     maxLength={50}
@@ -157,7 +155,7 @@ const GeneralRequestInfo = ({
                   </FieldErrorMsg>
                   <div className="width-card-lg">
                     <Field
-                      as={TextField}
+                      as={TextInput}
                       error={!!flatErrors['requester.phoneNumber']}
                       id="BusinessCase-RequesterPhoneNumber"
                       maxLength={20}

--- a/src/views/BusinessCase/PreferredSolution/index.tsx
+++ b/src/views/BusinessCase/PreferredSolution/index.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { Button } from '@trussworks/react-uswds';
+import {
+  Button,
+  Label,
+  Radio,
+  Textarea,
+  TextInput
+} from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 
 import CharacterCounter from 'components/CharacterCounter';
@@ -13,10 +19,6 @@ import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
-import Label from 'components/shared/Label';
-import { RadioField } from 'components/shared/RadioField';
-import TextAreaField from 'components/shared/TextAreaField';
-import TextField from 'components/shared/TextField';
 import { alternativeSolutionHasFilledFields } from 'data/businessCase';
 import { yesNoMap } from 'data/common';
 import { BusinessCaseModel, PreferredSolutionForm } from 'types/businessCase';
@@ -124,7 +126,7 @@ const PreferredSolution = ({
                     {flatErrors['preferredSolution.title']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextField}
+                    as={TextInput}
                     error={!!flatErrors['preferredSolution.title']}
                     id="BusinessCase-PreferredSolutionTitle"
                     maxLength={50}
@@ -163,7 +165,7 @@ const PreferredSolution = ({
                     {flatErrors['preferredSolution.summary']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors['preferredSolution.summary']}
                     id="BusinessCase-PreferredSolutionSummary"
                     maxLength={2000}
@@ -196,7 +198,7 @@ const PreferredSolution = ({
                     {flatErrors['preferredSolution.acquisitionApproach']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={
                       !!flatErrors['preferredSolution.acquisitionApproach']
                     }
@@ -227,7 +229,7 @@ const PreferredSolution = ({
                       {flatErrors['preferredSolution.security.isApproved']}
                     </FieldErrorMsg>
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={
                         values.preferredSolution.security.isApproved === true
                       }
@@ -243,7 +245,7 @@ const PreferredSolution = ({
                     />
 
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={
                         values.preferredSolution.security.isApproved === false
                       }
@@ -289,7 +291,7 @@ const PreferredSolution = ({
                         }
                       </FieldErrorMsg>
                       <Field
-                        as={RadioField}
+                        as={Radio}
                         checked={
                           values.preferredSolution.security.isBeingReviewed ===
                           'YES'
@@ -301,7 +303,7 @@ const PreferredSolution = ({
                         aria-describedby="BusinessCase-PreferredSolutionApprovalHelp"
                       />
                       <Field
-                        as={RadioField}
+                        as={Radio}
                         checked={
                           values.preferredSolution.security.isBeingReviewed ===
                           'NO'
@@ -312,7 +314,7 @@ const PreferredSolution = ({
                         value="NO"
                       />
                       <Field
-                        as={RadioField}
+                        as={Radio}
                         checked={
                           values.preferredSolution.security.isBeingReviewed ===
                           'NOT_SURE'
@@ -339,7 +341,7 @@ const PreferredSolution = ({
                     </FieldErrorMsg>
 
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={
                         values.preferredSolution.hosting.type === 'cloud'
                       }
@@ -375,7 +377,7 @@ const PreferredSolution = ({
                             {flatErrors['preferredSolution.hosting.location']}
                           </FieldErrorMsg>
                           <Field
-                            as={TextField}
+                            as={TextInput}
                             error={
                               !!flatErrors['preferredSolution.hosting.location']
                             }
@@ -405,7 +407,7 @@ const PreferredSolution = ({
                             }
                           </FieldErrorMsg>
                           <Field
-                            as={TextField}
+                            as={TextInput}
                             error={
                               !!flatErrors[
                                 'preferredSolution.hosting.cloudServiceType'
@@ -419,7 +421,7 @@ const PreferredSolution = ({
                       </>
                     )}
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={
                         values.preferredSolution.hosting.type === 'dataCenter'
                       }
@@ -454,7 +456,7 @@ const PreferredSolution = ({
                           {flatErrors['preferredSolution.hosting.location']}
                         </FieldErrorMsg>
                         <Field
-                          as={TextField}
+                          as={TextInput}
                           error={
                             !!flatErrors['preferredSolution.hosting.location']
                           }
@@ -465,7 +467,7 @@ const PreferredSolution = ({
                       </FieldGroup>
                     )}
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={values.preferredSolution.hosting.type === 'none'}
                       id="BusinessCase-PreferredSolutionHostingNone"
                       name="preferredSolution.hosting.type"
@@ -496,7 +498,7 @@ const PreferredSolution = ({
                     </FieldErrorMsg>
 
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={
                         values.preferredSolution.hasUserInterface === 'YES'
                       }
@@ -506,7 +508,7 @@ const PreferredSolution = ({
                       value="YES"
                     />
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={
                         values.preferredSolution.hasUserInterface === 'NO'
                       }
@@ -517,7 +519,7 @@ const PreferredSolution = ({
                     />
 
                     <Field
-                      as={RadioField}
+                      as={Radio}
                       checked={
                         values.preferredSolution.hasUserInterface === 'NOT_SURE'
                       }
@@ -547,7 +549,7 @@ const PreferredSolution = ({
                     {flatErrors['preferredSolution.pros']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors['preferredSolution.pros']}
                     id="BusinessCase-PreferredSolutionPros"
                     maxLength={2000}
@@ -578,7 +580,7 @@ const PreferredSolution = ({
                     {flatErrors['preferredSolution.cons']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors['preferredSolution.cons']}
                     id="BusinessCase-PreferredSolutionCons"
                     maxLength={2000}
@@ -643,7 +645,7 @@ const PreferredSolution = ({
                     {flatErrors['preferredSolution.costSavings']}
                   </FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors['preferredSolution.costSavings']}
                     id="BusinessCase-PreferredSolutionCostSavings"
                     maxLength={2000}

--- a/src/views/BusinessCase/RequestDescription/index.tsx
+++ b/src/views/BusinessCase/RequestDescription/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { Button } from '@trussworks/react-uswds';
+import { Button, Label, Textarea } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 
 import CharacterCounter from 'components/CharacterCounter';
@@ -12,8 +12,6 @@ import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
-import Label from 'components/shared/Label';
-import TextAreaField from 'components/shared/TextAreaField';
 import { alternativeSolutionHasFilledFields } from 'data/businessCase';
 import { BusinessCaseModel, RequestDescriptionForm } from 'types/businessCase';
 import flattenErrors from 'utils/flattenErrors';
@@ -124,7 +122,7 @@ const RequestDescription = ({
                   </HelpText>
                   <FieldErrorMsg>{flatErrors.businessNeed}</FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors.businessNeed}
                     id="BusinessCase-BusinessNeed"
                     maxLength={2000}
@@ -155,7 +153,7 @@ const RequestDescription = ({
                   </HelpText>
                   <FieldErrorMsg>{flatErrors.cmsBenefit}</FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors.cmsBenefit}
                     id="BusinessCase-CmsBenefit"
                     maxLength={2000}
@@ -185,7 +183,7 @@ const RequestDescription = ({
                   </HelpText>
                   <FieldErrorMsg>{flatErrors.priorityAlignment}</FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors.priorityAlignment}
                     id="BusinessCase-PriorityAlignment"
                     maxLength={2000}
@@ -215,7 +213,7 @@ const RequestDescription = ({
                   </HelpText>
                   <FieldErrorMsg>{flatErrors.successIndicators}</FieldErrorMsg>
                   <Field
-                    as={TextAreaField}
+                    as={Textarea}
                     error={!!flatErrors.successIndicators}
                     id="BusinessCase-SuccessIndicators"
                     maxLength={2000}


### PR DESCRIPTION
This PR leverages the USWDS form components on the business case form. The fields are nearly identical because they leverage USWDS, but the fields from `react-uswds` capture edge cases and are better documented/tested.

## Code Review Verification Steps

### As the original developer, I have

- [x] It works

### As the code reviewer, I have

- [x] Pulled this branch locally and tested it
- [x] Reviewed this code and left comments
- [x] Checked that all code is adequately covered by tests
- [x] Made it clear which comments need to be addressed before this work is merged
- [x] Considered marking this as accepted even if there are small changes needed
