### PR TITLE
Use --frozen-lockfile on yarn install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           restore-keys: |
             v1-yarn-
       - name: Install yarn dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Install go modules
         run: go mod download
       - name: Announce failure

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -9,7 +9,7 @@ FROM base AS modules
 COPY package.json ./
 COPY yarn.lock ./
 
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 FROM modules AS src
 

--- a/scripts/release_static
+++ b/scripts/release_static
@@ -46,7 +46,7 @@ export REACT_APP_GRAPHQL_ADDRESS="${EASI_URL}/api/graph/query"
 s3_err="$(aws s3 ls "$STATIC_S3_BUCKET" 1>/dev/null 2>&1)"
 if [[ -z "$s3_err" ]] ; then
   ( set -x -u ;
-    yarn install
+    yarn install --frozen-lockfile
     yarn run build || exit
     aws s3 sync --no-progress --delete build/ s3://"$STATIC_S3_BUCKET"/
   )


### PR DESCRIPTION
# ES-000

## Changes proposed in this pull request

- Use the `--frozen-lockfile` flag for `yarn install` in Dockerfile.client and `scripts/release_static` in order to use _exactly_ the same versions of dependencies as specified in `yarn.lock`. 