### PR TITLE
Add script support for running local dev without frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,32 +37,34 @@ commands it currently supports:
 $ scripts/dev
 Please provide a task to run:
 
-scripts/dev build           # Build the Go application
-scripts/dev db:clean        # Deletes all rows from all tables
-scripts/dev db:migrate      # Runs database migrations and wait for them to complete
-scripts/dev db:recreate     # Destroys the database container and recreates it
-scripts/dev db:seed         # Load development dataset
-scripts/dev docker:sweep    # Delete all dangling volumes
-scripts/dev down            # Stops all services in the project
-scripts/dev gql             # Generate code from GraphQL schema
-scripts/dev hosts:check     # Verify that hosts for local development are configured
-scripts/dev lint            # Run all linters and checks managed by pre-commit
-scripts/dev list            # List available tasks
-scripts/dev minio:clean     # Mark all files in minio as clean (no viruses found)
-scripts/dev minio:infected  # Mark all files in minio as infected (virus found)
-scripts/dev minio:pending   # Mark all files in minio as pending (waiting for scan)
-scripts/dev prereqs         # Check to see if the app's prerequisites are installed
-scripts/dev reset           # Resets application to an empty state
-scripts/dev restart         # Restart the specified container
-scripts/dev tailscale       # Run app and expose to other machines over Tailscale
-scripts/dev test            # Run all tests in parallel
-scripts/dev test:go         # Runs Go tests
-scripts/dev test:go:long    # Runs Go tests, including long ones
-scripts/dev test:go:only    # Run targeted Go tests (pass packages as additional options)
-scripts/dev test:js         # Run JS tests (pass path to scope to that location)
-scripts/dev test:js:named   # Run JS tests with a matching name (pass needle as additional option)
-scripts/dev up              # Starts all services in the project
-scripts/dev up:watch        # Starts all services in the project in the foreground
+scripts/dev build             # Build the Go application
+scripts/dev db:clean          # Deletes all rows from all tables
+scripts/dev db:migrate        # Runs database migrations and wait for them to complete
+scripts/dev db:recreate       # Destroys the database container and recreates it
+scripts/dev db:seed           # Load development dataset
+scripts/dev docker:sweep      # Delete all dangling volumes
+scripts/dev down              # Stops all services in the project
+scripts/dev gql               # Generate code from GraphQL schema
+scripts/dev hosts:check       # Verify that hosts for local development are configured
+scripts/dev lint              # Run all linters and checks managed by pre-commit
+scripts/dev list              # List available tasks
+scripts/dev minio:clean       # Mark all files in minio as clean (no viruses found)
+scripts/dev minio:infected    # Mark all files in minio as infected (virus found)
+scripts/dev minio:pending     # Mark all files in minio as pending (waiting for scan)
+scripts/dev prereqs           # Check to see if the app's prerequisites are installed
+scripts/dev reset             # Resets application to an empty state
+scripts/dev restart           # Restart the specified container
+scripts/dev tailscale         # Run app and expose to other machines over Tailscale
+scripts/dev test              # Run all tests in parallel
+scripts/dev test:go           # Runs Go tests
+scripts/dev test:go:long      # Runs Go tests, including long ones
+scripts/dev test:go:only      # Run targeted Go tests (pass packages as additional options)
+scripts/dev test:js           # Run JS tests (pass path to scope to that location)
+scripts/dev test:js:named     # Run JS tests with a matching name (pass needle as additional option)
+scripts/dev up                # Starts all services in the project
+scripts/dev up:backend        # Starts all services except the frontend (runs more quickly, if frontend isn't needed)
+scripts/dev up:backend:watch  # Starts all services in the foreground except the frontend (runs more quickly, if frontend isn't needed)
+scripts/dev up:watch          # Starts all services in the project in the foreground
 ```
 
 Some additional tools are required to work with the application source directly

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,6 +24,7 @@ services:
     environment:
       - LOCAL_AUTH_ENABLED
   easi_client:
+    profiles: ["frontend"]
     build:
       context: .
       dockerfile: Dockerfile.client

--- a/scripts/dev
+++ b/scripts/dev
@@ -107,11 +107,11 @@ end
 
 ### Tasks
 
-def up(*args)
+def up(frontend_included, *args)
   environment = {
     "COMPOSE_HTTP_TIMEOUT" => "120"
   }
-  command = "docker-compose up --build"
+  command = "docker-compose #{"--profile frontend" if frontend_included } up --build"
 
   if args.any?
     command = "#{command} #{args.join(' ')}"
@@ -120,18 +120,33 @@ def up(*args)
   sh(environment, command, verbose: true)
 
   wait_for_success("Waiting for the back end to build...", "curl --silent --output /dev/null -m 1 localhost:8080/api/v1/healthcheck")
-  wait_for_success("Waiting for the front end to build...", "curl --silent --output /dev/null -m 1 localhost:3000")
+
+  if frontend_included
+    wait_for_success("Waiting for the front end to build...", "curl --silent --output /dev/null -m 1 localhost:3000")
+  end
 end
 
 desc "Starts all services in the project"
 task :up do
-  up("-d")
+  up(true, "-d")
 end
 
 namespace :up do
   desc "Starts all services in the project in the foreground"
   task :watch do
-    up
+    up(true)
+  end
+
+  desc "Starts all services except the frontend (runs more quickly, if frontend isn't needed)"
+  task :backend do
+    up(false, "-d")
+  end
+
+  desc "Starts all services in the foreground except the frontend (runs more quickly, if frontend isn't needed)"
+  namespace :backend do
+    task :watch do
+      up(false)
+    end
   end
 end
 


### PR DESCRIPTION
No Jira ticket for this; I was just irritated by the frontend making it take significantly longer to bring the Docker containers up locally, even when just working on Dockerfile/docker-compose changes that don't affect the frontend. 

## Changes proposed in this pull request

- Add `scripts/dev up:backend` and `scripts/dev up:backend:watch` for bringing the local dev environment up without a frontend container.
