### PR TITLE
Fix go testing tasks in scripts/dev 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ scripts/dev tailscale         # Run app and expose to other machines over Tailsc
 scripts/dev test              # Run all tests in parallel
 scripts/dev test:go           # Runs Go tests
 scripts/dev test:go:long      # Runs Go tests, including long ones
-scripts/dev test:go:only      # Run targeted Go tests (pass packages as additional options)
+scripts/dev test:go:only      # Run targeted Go tests (pass path to package folder as additional options)
 scripts/dev test:js           # Run JS tests (pass path to scope to that location)
 scripts/dev test:js:named     # Run JS tests with a matching name (pass needle as additional option)
 scripts/dev up                # Starts all services in the project
@@ -361,7 +361,9 @@ Run all tests other than Cypress in the project using `scripts/dev test`.
 
 ### Server tests
 
-Run `scripts/dev test:go`.
+- Run `scripts/dev test:go` to run all local-only server-side tests. This requires the database to be running first. Use `scripts/dev up:backend` to start it.
+- Run `scripts/dev test:go:only [path to package folder]` (e.g. `scripts/dev test:go:only "./pkg/cedar/intake`) to run server-side tests for a specific folder. Depending on the tests being run, this may require the database to be running, as above.
+- Run `scripts/dev test:go:long` to run all server-side tests, including ones that contact external services.
 
 ### JS Tests
 

--- a/scripts/dev
+++ b/scripts/dev
@@ -364,16 +364,16 @@ multitask test: ["test:go", "test:js"]
 namespace :test do
   desc "Runs Go tests"
   task :go => "db:clean" do
-    sh "gotest -short -count=1 -p=1 ./..."
+    sh "go test -short -count=1 -p=1 ./..."
   end
   namespace :go do
     desc "Runs Go tests, including long ones"
     task :long => "db:clean" do
-      sh "gotest -count=1 -p=1 ./..."
+      sh "go test -count=1 -p=1 ./..."
     end
     desc "Run targeted Go tests (pass packages as additional options)"
     task :only => ["db:clean", :consume_args] do |t, args|
-      sh "gotest", "-short", "-count=1", "-v", "-p=1", *args
+      sh "go", "test", "-short", "-count=1", "-v", "-p=1", *args
     end
   end
 

--- a/scripts/dev
+++ b/scripts/dev
@@ -371,7 +371,7 @@ namespace :test do
     task :long => "db:clean" do
       sh "go test -count=1 -p=1 ./..."
     end
-    desc "Run targeted Go tests (pass packages as additional options)"
+    desc "Run targeted Go tests (pass path to package folder as additional options)"
     task :only => ["db:clean", :consume_args] do |t, args|
       sh "go", "test", "-short", "-count=1", "-v", "-p=1", *args
     end


### PR DESCRIPTION
No Jira ticket, just some problems with running Go tests locally through `scripts/dev`. It looks like Truss was using the third-party [gotest](https://github.com/rakyll/gotest) package to format/color their test output when running locally; rather than adding that as a dependency, I just switched `scripts/dev` to use the built-in `go test` command. There's also some additional documentation in the README on running Go tests locally.

## Changes proposed in this pull request

- Use built-in `go test` instead of `gotest` library.
- Add notes to README on running Go tests locally.

## Setup & How to test

- Run `scripts/dev go:test` and make sure it works without errors.