### PR TITLE
Add workflow check to identify TypeScript errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
-      contents: write
+      pull-requests: write
       issues: write
     steps:
       - name: Check out code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,8 +160,36 @@ jobs:
           restore-keys: |
             v1-yarn-
       - name: Run typechecking
-        run: yarn build:ts
+        id: typechecker
+        run: |
+          yarn build:ts 2>&1 | tee test.log
+          result_code=${PIPESTATUS[0]}
+          echo "::set-output name=tsTypeCheckOutput::$(cat test.log)"
+          exit $result_code
         continue-on-error: true
+      - name: Post comment with TypeScript type errors
+        uses: actions/github-script@v5
+        if: ${{ steps.typechecker.outcome == 'failure' }}
+        with:
+          tsLog: ${{ steps.typechecker.outputs.tsTypeCheckOutput }}
+          script: |
+            const typeScriptLog = env.tsLog;
+            const commentBody = `
+              <details>
+                <summary>TypeScript compile errors</summary>
+
+                ```shell
+                ${typeScriptLog}
+                ```
+              </details>
+            `;
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: commentBody
+            });
 
   client_test:
     needs: pre_deps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,13 +177,16 @@ jobs:
         if: ${{ steps.typechecker.outcome == 'failure' }}
         with:
           script: |
-            const typeScriptLog = process.env.TS_LOG;
+            const rawTypeScriptLog = process.env.TS_LOG;
+            const escapedNewline = encodeURIComponent("\n");
+            const escapedLog = rawTypeScriptLog.replace(/\n/g, escapedNewline);
+
             const commentBody = `
               <details>
                 <summary>TypeScript compile errors</summary>
 
                 \`\`\`shell
-                ${typeScriptLog}
+                ${escapedLog}
                 \`\`\`
               </details>
             `;
@@ -194,6 +197,8 @@ jobs:
               repo: context.repo.repo,
               body: commentBody
             });
+      - name: Typecheck with marketplace action
+        uses: gozala/typescript-error-reporter-action@v1.0.5
 
   client_test:
     needs: pre_deps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,35 @@ jobs:
         run: |
           ./scripts/github-action-announce-broken-branch
 
+  client_typecheck:
+    needs: lint
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Check out code
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.3.4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set up node
+        uses: actions/setup-node@04c56d2f954f1e4c69436aa54cfef261a018f458 # v2.1.5
+        with:
+          node-version: ${{ env.EASI_APP_NODE_VERSION }}
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Configure yarn cache
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            ./node_modules
+          key: v1-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            v1-yarn-
+      - name: Run typechecking
+        run: yarn build:ts
+
   client_test:
     needs: pre_deps
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
-      contents: read
+      contents: write
       issues: write
     steps:
       - name: Check out code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
               </details>
             `;
 
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,7 @@ jobs:
             v1-yarn-
       - name: Run typechecking
         run: yarn build:ts
+        continue-on-error: true
 
   client_test:
     needs: pre_deps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,9 +179,9 @@ jobs:
               <details>
                 <summary>TypeScript compile errors</summary>
 
-                ```shell
+                \`\`\`shell
                 ${typeScriptLog}
-                ```
+                \`\`\`
               </details>
             `;
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,19 +177,16 @@ jobs:
         if: ${{ steps.typechecker.outcome == 'failure' }}
         with:
           script: |
-            const rawTypeScriptLog = process.env.TS_LOG;
-            const escapedNewline = encodeURIComponent("\n");
-            const escapedLog = rawTypeScriptLog.replace(/\n/g, escapedNewline);
+            const typeScriptLog = process.env.TS_LOG;
 
             const commentBody = `
-              <details>
-                <summary>TypeScript compile errors</summary>
+            <details>
+            <summary>TypeScript compile errors</summary>
 
-                \`\`\`shell
-                ${escapedLog}
-                \`\`\`
-              </details>
-            `;
+            \`\`\`shell
+            ${typeScriptLog}
+            \`\`\`
+            </details>`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -197,8 +194,6 @@ jobs:
               repo: context.repo.repo,
               body: commentBody
             });
-      - name: Typecheck with marketplace action
-        uses: gozala/typescript-error-reporter-action@v1.0.5
 
   client_test:
     needs: pre_deps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,17 +164,17 @@ jobs:
         run: |
           yarn build:ts 2>&1 | tee test.log
           result_code=${PIPESTATUS[0]}
-          echo "::set-output name=tsTypeCheckOutput::$(cat test.log)"
+          echo 'TS_LOG<<EOF' >> $GITHUB_ENV
+          cat test.log >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
           exit $result_code
         continue-on-error: true
       - name: Post comment with TypeScript type errors
         uses: actions/github-script@v5
         if: ${{ steps.typechecker.outcome == 'failure' }}
-        env:
-          tsLog: ${{ steps.typechecker.outputs.tsTypeCheckOutput }}
         with:
           script: |
-            const typeScriptLog = process.env.tsLog;
+            const typeScriptLog = process.env.TS_LOG;
             const commentBody = `
               <details>
                 <summary>TypeScript compile errors</summary>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,10 +170,11 @@ jobs:
       - name: Post comment with TypeScript type errors
         uses: actions/github-script@v5
         if: ${{ steps.typechecker.outcome == 'failure' }}
-        with:
+        env:
           tsLog: ${{ steps.typechecker.outputs.tsTypeCheckOutput }}
+        with:
           script: |
-            const typeScriptLog = env.tsLog;
+            const typeScriptLog = process.env.tsLog;
             const commentBody = `
               <details>
                 <summary>TypeScript compile errors</summary>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,9 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Check out code
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.3.4

--- a/craco.config.js
+++ b/craco.config.js
@@ -12,5 +12,8 @@ module.exports = {
         ]
       }
     }
-  ]
+  ],
+  typescript: {
+    enableTypeChecking: false
+  }
 };

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "redux-saga": "^1.1.1",
     "redux-saga-routines": "^3.2.2",
     "sass-loader": "10.2.0",
-    "typescript": "3.7.5",
+    "typescript": "^4.5.2",
     "uswds": "^2.10.3",
     "wait-on": "^5.2.1",
     "yup": "^0.32.8"
@@ -75,6 +75,7 @@
   "scripts": {
     "start": "craco -r @cypress/instrument-cra start",
     "build": "CI=true craco build",
+    "build:ts": "tsc",
     "test": "craco test",
     "test:coverage": "craco test --coverage --watchAll=false",
     "eject": "react-scripts eject",

--- a/src/views/Accessibility/AccessibilityRequest/Create/index.test.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Create/index.test.tsx
@@ -5,6 +5,7 @@ import { MockedProvider } from '@apollo/client/testing';
 import {
   render,
   screen,
+  waitFor,
   waitForElementToBeRemoved
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -190,6 +191,10 @@ describe('Create 508 Request page', () => {
 
     screen.getByRole('button', { name: /send 508 testing request/i }).click();
     await screen.findByTestId('page-loading');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('page-loading')).not.toBeInTheDocument();
+    });
 
     expect(
       screen.getByText(/508 testing request created/i)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -19073,10 +19073,10 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 u2f-api-polyfill@0.4.3:
   version "0.4.3"


### PR DESCRIPTION
# EASI-1391

## Changes proposed in this pull request

- Upgrade TypeScript version
- Add job to workflow to check for TypeScript errors (build continues even if job fails)