### PR TITLE
Changes to enable CEDAR system intake api

### DIFF
--- a/pkg/services/action.go
+++ b/pkg/services/action.go
@@ -115,6 +115,11 @@ func NewSubmitSystemIntake(
 		if submitToCEDARErr != nil {
 			appcontext.ZLogger(ctx).Error("Submission to CEDAR failed", zap.Error(submitToCEDARErr))
 		} else {
+			// If submission to CEDAR was successful, update the intake with the alfabetID
+			// AlfabetID can be null if:
+			// - The intake was not submitted to CEDAR (due to the feature flag being off
+			// or the Intake being imported from SharePoint)
+			// - An error is encountered when sending the data to CEDAR.
 			intake.AlfabetID = null.StringFrom(alfabetID)
 		}
 

--- a/pkg/services/action.go
+++ b/pkg/services/action.go
@@ -83,7 +83,7 @@ func NewSubmitSystemIntake(
 	config Config,
 	authorize func(context.Context, *models.SystemIntake) (bool, error),
 	update func(context.Context, *models.SystemIntake) (*models.SystemIntake, error),
-	validateAndSubmit func(context.Context, *models.SystemIntake) (string, error),
+	submitToCEDAR func(context.Context, *models.SystemIntake) (string, error),
 	saveAction func(context.Context, *models.Action) error,
 	emailReviewer func(ctx context.Context, requestName string, intakeID uuid.UUID) error,
 ) ActionExecuter {
@@ -111,9 +111,9 @@ func NewSubmitSystemIntake(
 
 		// Send SystemIntake to CEDAR Intake API
 		intake.SubmittedAt = &updatedTime
-		alfabetID, validateAndSubmitErr := validateAndSubmit(ctx, intake)
-		if validateAndSubmitErr != nil {
-			appcontext.ZLogger(ctx).Error("Submission to CEDAR failed", zap.Error(validateAndSubmitErr))
+		alfabetID, submitToCEDARErr := submitToCEDAR(ctx, intake)
+		if submitToCEDARErr != nil {
+			appcontext.ZLogger(ctx).Error("Submission to CEDAR failed", zap.Error(submitToCEDARErr))
 		} else {
 			intake.AlfabetID = null.StringFrom(alfabetID)
 		}

--- a/pkg/services/action_test.go
+++ b/pkg/services/action_test.go
@@ -136,27 +136,10 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 		s.IsType(&apperrors.QueryError{}, err)
 	})
 
-	s.Run("returns nil and sends email even if validation fails", func() {
-		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
-		action := models.Action{ActionType: models.ActionTypeSUBMITINTAKE}
-		failValidationSubmit := func(_ context.Context, intake *models.SystemIntake) (string, error) {
-			return "", &apperrors.ValidationError{
-				Err:     errors.New("validation failed on these fields: ID"),
-				ModelID: intake.ID.String(),
-				Model:   intake,
-			}
-		}
-		submitSystemIntake := NewSubmitSystemIntake(serviceConfig, authorize, update, failValidationSubmit, saveAction, sendSubmitEmail)
-		err := submitSystemIntake(ctx, &intake, &action)
-
-		s.IsType(nil, err)
-		s.Equal(1, submitEmailCount)
-	})
-
 	s.Run("returns nil and sends email even if submission fails", func() {
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		action := models.Action{ActionType: models.ActionTypeSUBMITINTAKE}
-		failValidationSubmit := func(_ context.Context, intake *models.SystemIntake) (string, error) {
+		failSubmitToCEDAR := func(_ context.Context, intake *models.SystemIntake) (string, error) {
 			return "", &apperrors.ExternalAPIError{
 				Err:       errors.New("CEDAR return result: unexpected failure"),
 				ModelID:   intake.ID.String(),
@@ -165,7 +148,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 				Source:    "CEDAR",
 			}
 		}
-		submitSystemIntake := NewSubmitSystemIntake(serviceConfig, authorize, update, failValidationSubmit, saveAction, sendSubmitEmail)
+		submitSystemIntake := NewSubmitSystemIntake(serviceConfig, authorize, update, failSubmitToCEDAR, saveAction, sendSubmitEmail)
 		err := submitSystemIntake(ctx, &intake, &action)
 
 		s.IsType(nil, err)

--- a/pkg/services/action_test.go
+++ b/pkg/services/action_test.go
@@ -136,7 +136,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 		s.IsType(&apperrors.QueryError{}, err)
 	})
 
-	s.Run("returns error when validation fails", func() {
+	s.Run("returns nil and sends email even if validation fails", func() {
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		action := models.Action{ActionType: models.ActionTypeSUBMITINTAKE}
 		failValidationSubmit := func(_ context.Context, intake *models.SystemIntake) (string, error) {
@@ -149,11 +149,11 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 		submitSystemIntake := NewSubmitSystemIntake(serviceConfig, authorize, update, failValidationSubmit, saveAction, sendSubmitEmail)
 		err := submitSystemIntake(ctx, &intake, &action)
 
-		s.IsType(&apperrors.ValidationError{}, err)
-		s.Equal(0, submitEmailCount)
+		s.IsType(nil, err)
+		s.Equal(1, submitEmailCount)
 	})
 
-	s.Run("returns error when submission fails", func() {
+	s.Run("returns nil and sends email even if submission fails", func() {
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		action := models.Action{ActionType: models.ActionTypeSUBMITINTAKE}
 		failValidationSubmit := func(_ context.Context, intake *models.SystemIntake) (string, error) {
@@ -168,8 +168,8 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 		submitSystemIntake := NewSubmitSystemIntake(serviceConfig, authorize, update, failValidationSubmit, saveAction, sendSubmitEmail)
 		err := submitSystemIntake(ctx, &intake, &action)
 
-		s.IsType(&apperrors.ExternalAPIError{}, err)
-		s.Equal(0, submitEmailCount)
+		s.IsType(nil, err)
+		s.Equal(2, submitEmailCount)
 	})
 
 	s.Run("returns error when intake has already been submitted", func() {
@@ -182,7 +182,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 		err := submitSystemIntake(ctx, &alreadySubmittedIntake, &action)
 
 		s.IsType(&apperrors.ResourceConflictError{}, err)
-		s.Equal(0, submitEmailCount)
+		s.Equal(2, submitEmailCount)
 	})
 
 	s.Run("returns query error if update fails", func() {

--- a/pkg/services/action_test.go
+++ b/pkg/services/action_test.go
@@ -152,7 +152,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 		err := submitSystemIntake(ctx, &intake, &action)
 
 		s.IsType(nil, err)
-		s.Equal(2, submitEmailCount)
+		s.Equal(1, submitEmailCount)
 	})
 
 	s.Run("returns error when intake has already been submitted", func() {
@@ -165,7 +165,7 @@ func (s ServicesTestSuite) TestNewSubmitSystemIntake() {
 		err := submitSystemIntake(ctx, &alreadySubmittedIntake, &action)
 
 		s.IsType(&apperrors.ResourceConflictError{}, err)
-		s.Equal(2, submitEmailCount)
+		s.Equal(1, submitEmailCount)
 	})
 
 	s.Run("returns query error if update fails", func() {


### PR DESCRIPTION
# EASI-000

## Changes proposed in this pull request

- Changes to `action.go`'s `NewSubmitSystemIntake()` that make it so that if the validateAndSubmit returns an error, we just log it and move on. Practically, validateAndSubmit is only used to publish changes to CEDAR. I couldn't find any instance of it being used to validate the input. (Please double check my work here!)

## Reviewer Notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup & How to test

- Pull the branch locally and test it
- Check that all code is adequately covered by tests
- Make comments, even if it's minor!

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

## Screenshots

<!--
    If this PR benefits from showing any visual components, put any screenshots here!
-->
