### PR TITLE
Fix CEDAR datetime to be ISO8601

### DIFF
--- a/pkg/cedar/intake/helpers.go
+++ b/pkg/cedar/intake/helpers.go
@@ -15,8 +15,6 @@ import (
 	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
 )
 
-const iso8601 = "2006-01-02 15:04:05Z07:00"
-
 // pStr is a quick helper for turning a string into a string-pointer
 // inline, without having to clutter your mainline code with the
 // indirection, e.g. when building a type and assigning properties
@@ -37,12 +35,12 @@ func pDate(t *time.Time) *string {
 
 // pDate turns a Time pointer into either an empty string in the
 // negative case, or to a string rin CEDAR's preferred
-// ISO8601 format, e.g. "2006-01-02 15:04:05Z"
+// ISO8601 format, e.g. "2006-01-02T15:04:05Z"
 func pDateTime(t *time.Time) *string {
 	val := ""
 	if t != nil {
 		// val = strfmt.DateTime(*t).String()
-		val = t.UTC().Format(iso8601)
+		val = t.UTC().Format(time.RFC3339)
 	}
 	return pStr(val)
 }


### PR DESCRIPTION
# EASI-000

## Changes proposed in this pull request

- Change the date time objects created when converting data to CEDAR Intake format to follow ISO8601 format (essentially, we weren't including the "T" in the string)

## Reviewer Notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup & How to test

- Pull the branch locally and test it
- Check that all code is adequately covered by tests
- Make comments, even if it's minor!

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

## Screenshots

<!--
    If this PR benefits from showing any visual components, put any screenshots here!
-->
