### PR TITLE
[EASI-1444] System Detail GQL

### DIFF
--- a/pkg/cedar/core/client.go
+++ b/pkg/cedar/core/client.go
@@ -71,10 +71,10 @@ type Client struct {
 }
 
 // GetSystemSummary makes a GET call to the /system/summary endpoint
-func (c *Client) GetSystemSummary(ctx context.Context) (models.CedarSystemSummary, error) {
+func (c *Client) GetSystemSummary(ctx context.Context) ([]*models.CedarSystem, error) {
 	if !c.cedarCoreEnabled(ctx) {
 		appcontext.ZLogger(ctx).Info("CEDAR Core is disabled")
-		return models.CedarSystemSummary{}, nil
+		return []*models.CedarSystem{}, nil
 	}
 
 	// Construct the parameters
@@ -84,22 +84,19 @@ func (c *Client) GetSystemSummary(ctx context.Context) (models.CedarSystemSummar
 	// Make the API call
 	resp, err := c.sdk.System.SystemSummaryFindList(params, c.auth)
 	if err != nil {
-		return models.CedarSystemSummary{}, err
+		return []*models.CedarSystem{}, err
 	}
 
 	if resp.Payload == nil {
-		return models.CedarSystemSummary{}, fmt.Errorf("no body received")
+		return []*models.CedarSystem{}, fmt.Errorf("no body received")
 	}
 
 	// Convert the auto-generated struct to our own pkg/models struct
-	retVal := models.CedarSystemSummary{
-		Count:         *resp.Payload.Count,
-		SystemSummary: []models.CedarSystem{},
-	}
+	retVal := []*models.CedarSystem{}
 
 	// Populate the SystemSummary field by converting each item in resp.Payload.SystemSummary
 	for _, sys := range resp.Payload.SystemSummary {
-		retVal.SystemSummary = append(retVal.SystemSummary, models.CedarSystem{
+		retVal = append(retVal, &models.CedarSystem{
 			ID:                      *sys.ID,
 			Name:                    *sys.Name,
 			Description:             sys.Description,

--- a/pkg/cedar/core/client.go
+++ b/pkg/cedar/core/client.go
@@ -112,7 +112,7 @@ func (c *Client) GetSystemSummary(ctx context.Context) ([]*models.CedarSystem, e
 	return retVal, nil
 }
 
-// GetSystemSummary makes a GET call to the /system/summary endpoint
+// GetSystem makes a GET call to the /system/summary/{id} endpoint
 func (c *Client) GetSystem(ctx context.Context, id string) (*models.CedarSystem, error) {
 	if !c.cedarCoreEnabled(ctx) {
 		appcontext.ZLogger(ctx).Info("CEDAR Core is disabled")

--- a/pkg/cedar/core/client_test.go
+++ b/pkg/cedar/core/client_test.go
@@ -44,22 +44,4 @@ func (s ClientTestSuite) TestClient() {
 		blankSummary := models.CedarSystemSummary{}
 		s.Equal(resp, blankSummary)
 	})
-
-	// s.Run("functional test", func() {
-	// 	c := NewClient(
-	// 		"webmethods-apigw.cedardev.cms.gov",
-	// 		"n/a", // TODO: pull in from env var?
-	// 		ldClient,
-	// 	)
-	// 	c.emitToCedar = func(context.Context) bool { return true }
-
-	// 	err := c.CheckConnection(ctx)
-	// 	s.NoError(err)
-
-	// 	si := testhelpers.NewSystemIntake()
-	// 	si.CreatedAt = si.ContractStartDate
-	// 	si.UpdatedAt = si.ContractStartDate
-	// 	err = c.PublishSnapshot(ctx, &si, nil, nil, nil, nil)
-	// 	s.NoError(err)
-	// })
 }

--- a/pkg/cedar/core/client_test.go
+++ b/pkg/cedar/core/client_test.go
@@ -41,7 +41,7 @@ func (s ClientTestSuite) TestClient() {
 		resp, err := c.GetSystemSummary(ctx)
 		s.NoError(err)
 
-		blankSummary := models.CedarSystemSummary{}
+		blankSummary := models.CedarSystem{}
 		s.Equal(resp, blankSummary)
 	})
 }

--- a/pkg/cedar/core/client_test.go
+++ b/pkg/cedar/core/client_test.go
@@ -36,12 +36,20 @@ func (s ClientTestSuite) TestClient() {
 		s.NotNil(c)
 	})
 
-	s.Run("LD defaults protects invocation", func() {
+	s.Run("LD defaults protects invocation of GetSystemSummary", func() {
 		c := NewClient("fake", "fake", ldClient)
 		resp, err := c.GetSystemSummary(ctx)
 		s.NoError(err)
 
-		blankSummary := models.CedarSystem{}
+		blankSummary := []*models.CedarSystem{}
 		s.Equal(resp, blankSummary)
+	})
+	s.Run("LD defaults protects invocation of GetSystem", func() {
+		c := NewClient("fake", "fake", ldClient)
+		resp, err := c.GetSystem(ctx, "fake")
+		s.NoError(err)
+
+		blankSummary := models.CedarSystem{}
+		s.Equal(*resp, blankSummary)
 	})
 }

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -2890,6 +2890,10 @@ type RequestEdge {
   node: Request!
 }
 
+"""
+CedarSystem represents the response from the /system/detail endpoint from the CEDAR Core API.
+Right now, this does not tie in with any other types defined here, and is a root node until that changes.
+"""
 type CedarSystem {
   id: String!
   name: String!

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -164,6 +164,18 @@ type ComplexityRoot struct {
 		Name      func(childComplexity int) int
 	}
 
+	CedarSystem struct {
+		Acronym                 func(childComplexity int) int
+		BusinessOwnerOrg        func(childComplexity int) int
+		BusinessOwnerOrgComp    func(childComplexity int) int
+		Description             func(childComplexity int) int
+		ID                      func(childComplexity int) int
+		Name                    func(childComplexity int) int
+		Status                  func(childComplexity int) int
+		SystemMaintainerOrg     func(childComplexity int) int
+		SystemMaintainerOrgComp func(childComplexity int) int
+	}
+
 	ContractDate struct {
 		Day   func(childComplexity int) int
 		Month func(childComplexity int) int
@@ -283,6 +295,8 @@ type ComplexityRoot struct {
 	Query struct {
 		AccessibilityRequest  func(childComplexity int, id uuid.UUID) int
 		AccessibilityRequests func(childComplexity int, after *string, first int) int
+		CedarSystem           func(childComplexity int, id string) int
+		CedarSystems          func(childComplexity int) int
 		CurrentUser           func(childComplexity int) int
 		Requests              func(childComplexity int, after *string, first int) int
 		SystemIntake          func(childComplexity int, id uuid.UUID) int
@@ -568,6 +582,8 @@ type QueryResolver interface {
 	SystemIntake(ctx context.Context, id uuid.UUID) (*models.SystemIntake, error)
 	Systems(ctx context.Context, after *string, first int) (*model.SystemConnection, error)
 	CurrentUser(ctx context.Context) (*model.CurrentUser, error)
+	CedarSystem(ctx context.Context, id string) (*models.CedarSystem, error)
+	CedarSystems(ctx context.Context) ([]*models.CedarSystem, error)
 }
 type SystemIntakeResolver interface {
 	Actions(ctx context.Context, obj *models.SystemIntake) ([]*model.SystemIntakeAction, error)
@@ -1153,6 +1169,69 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.BusinessOwner.Name(childComplexity), true
+
+	case "CedarSystem.acronym":
+		if e.complexity.CedarSystem.Acronym == nil {
+			break
+		}
+
+		return e.complexity.CedarSystem.Acronym(childComplexity), true
+
+	case "CedarSystem.businessOwnerOrg":
+		if e.complexity.CedarSystem.BusinessOwnerOrg == nil {
+			break
+		}
+
+		return e.complexity.CedarSystem.BusinessOwnerOrg(childComplexity), true
+
+	case "CedarSystem.businessOwnerOrgComp":
+		if e.complexity.CedarSystem.BusinessOwnerOrgComp == nil {
+			break
+		}
+
+		return e.complexity.CedarSystem.BusinessOwnerOrgComp(childComplexity), true
+
+	case "CedarSystem.description":
+		if e.complexity.CedarSystem.Description == nil {
+			break
+		}
+
+		return e.complexity.CedarSystem.Description(childComplexity), true
+
+	case "CedarSystem.id":
+		if e.complexity.CedarSystem.ID == nil {
+			break
+		}
+
+		return e.complexity.CedarSystem.ID(childComplexity), true
+
+	case "CedarSystem.name":
+		if e.complexity.CedarSystem.Name == nil {
+			break
+		}
+
+		return e.complexity.CedarSystem.Name(childComplexity), true
+
+	case "CedarSystem.status":
+		if e.complexity.CedarSystem.Status == nil {
+			break
+		}
+
+		return e.complexity.CedarSystem.Status(childComplexity), true
+
+	case "CedarSystem.systemMaintainerOrg":
+		if e.complexity.CedarSystem.SystemMaintainerOrg == nil {
+			break
+		}
+
+		return e.complexity.CedarSystem.SystemMaintainerOrg(childComplexity), true
+
+	case "CedarSystem.systemMaintainerOrgComp":
+		if e.complexity.CedarSystem.SystemMaintainerOrgComp == nil {
+			break
+		}
+
+		return e.complexity.CedarSystem.SystemMaintainerOrgComp(childComplexity), true
 
 	case "ContractDate.day":
 		if e.complexity.ContractDate.Day == nil {
@@ -1818,6 +1897,25 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.AccessibilityRequests(childComplexity, args["after"].(*string), args["first"].(int)), true
+
+	case "Query.cedarSystem":
+		if e.complexity.Query.CedarSystem == nil {
+			break
+		}
+
+		args, err := ec.field_Query_cedarSystem_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.CedarSystem(childComplexity, args["id"].(string)), true
+
+	case "Query.cedarSystems":
+		if e.complexity.Query.CedarSystems == nil {
+			break
+		}
+
+		return e.complexity.Query.CedarSystems(childComplexity), true
 
 	case "Query.currentUser":
 		if e.complexity.Query.CurrentUser == nil {
@@ -2792,6 +2890,18 @@ type RequestEdge {
   node: Request!
 }
 
+type CedarSystem {
+  id: String!
+  name: String!
+  description: String
+	acronym: String
+	status: String
+	businessOwnerOrg: String
+	businessOwnerOrgComp: String
+	systemMaintainerOrg: String
+	systemMaintainerOrgComp: String
+}
+
 """
 An accessibility request represents a system that needs to go through
 the 508 process.
@@ -3615,6 +3725,8 @@ type Query {
   systemIntake(id: UUID!): SystemIntake
   systems(after: String, first: Int!): SystemConnection
   currentUser: CurrentUser
+  cedarSystem(id: String!): CedarSystem
+  cedarSystems: [CedarSystem]
 }
 
 """
@@ -4227,6 +4339,21 @@ func (ec *executionContext) field_Query_accessibilityRequests_args(ctx context.C
 		}
 	}
 	args["first"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_cedarSystem_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
 	return args, nil
 }
 
@@ -6870,6 +6997,300 @@ func (ec *executionContext) _BusinessOwner_name(ctx context.Context, field graph
 	res := resTmp.(string)
 	fc.Result = res
 	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CedarSystem_id(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystem) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CedarSystem",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CedarSystem_name(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystem) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CedarSystem",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CedarSystem_description(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystem) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CedarSystem",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CedarSystem_acronym(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystem) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CedarSystem",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Acronym, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CedarSystem_status(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystem) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CedarSystem",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CedarSystem_businessOwnerOrg(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystem) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CedarSystem",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BusinessOwnerOrg, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CedarSystem_businessOwnerOrgComp(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystem) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CedarSystem",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BusinessOwnerOrgComp, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CedarSystem_systemMaintainerOrg(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystem) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CedarSystem",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SystemMaintainerOrg, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CedarSystem_systemMaintainerOrgComp(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystem) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CedarSystem",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SystemMaintainerOrgComp, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _ContractDate_day(ctx context.Context, field graphql.CollectedField, obj *model.ContractDate) (ret graphql.Marshaler) {
@@ -10098,6 +10519,77 @@ func (ec *executionContext) _Query_currentUser(ctx context.Context, field graphq
 	res := resTmp.(*model.CurrentUser)
 	fc.Result = res
 	return ec.marshalOCurrentUser2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐCurrentUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_cedarSystem(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_cedarSystem_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().CedarSystem(rctx, args["id"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.CedarSystem)
+	fc.Result = res
+	return ec.marshalOCedarSystem2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐCedarSystem(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_cedarSystems(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().CedarSystems(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*models.CedarSystem)
+	fc.Result = res
+	return ec.marshalOCedarSystem2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐCedarSystem(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -17315,6 +17807,52 @@ func (ec *executionContext) _BusinessOwner(ctx context.Context, sel ast.Selectio
 	return out
 }
 
+var cedarSystemImplementors = []string{"CedarSystem"}
+
+func (ec *executionContext) _CedarSystem(ctx context.Context, sel ast.SelectionSet, obj *models.CedarSystem) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, cedarSystemImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CedarSystem")
+		case "id":
+			out.Values[i] = ec._CedarSystem_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "name":
+			out.Values[i] = ec._CedarSystem_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "description":
+			out.Values[i] = ec._CedarSystem_description(ctx, field, obj)
+		case "acronym":
+			out.Values[i] = ec._CedarSystem_acronym(ctx, field, obj)
+		case "status":
+			out.Values[i] = ec._CedarSystem_status(ctx, field, obj)
+		case "businessOwnerOrg":
+			out.Values[i] = ec._CedarSystem_businessOwnerOrg(ctx, field, obj)
+		case "businessOwnerOrgComp":
+			out.Values[i] = ec._CedarSystem_businessOwnerOrgComp(ctx, field, obj)
+		case "systemMaintainerOrg":
+			out.Values[i] = ec._CedarSystem_systemMaintainerOrg(ctx, field, obj)
+		case "systemMaintainerOrgComp":
+			out.Values[i] = ec._CedarSystem_systemMaintainerOrgComp(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var contractDateImplementors = []string{"ContractDate"}
 
 func (ec *executionContext) _ContractDate(ctx context.Context, sel ast.SelectionSet, obj *model.ContractDate) graphql.Marshaler {
@@ -17904,6 +18442,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_currentUser(ctx, field)
+				return res
+			})
+		case "cedarSystem":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_cedarSystem(ctx, field)
+				return res
+			})
+		case "cedarSystems":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_cedarSystems(ctx, field)
 				return res
 			})
 		case "__type":
@@ -20972,6 +21532,54 @@ func (ec *executionContext) marshalOBusinessCaseSolution2ᚖgithubᚗcomᚋcmsgo
 		return graphql.Null
 	}
 	return ec._BusinessCaseSolution(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOCedarSystem2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐCedarSystem(ctx context.Context, sel ast.SelectionSet, v []*models.CedarSystem) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOCedarSystem2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐCedarSystem(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
+func (ec *executionContext) marshalOCedarSystem2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐCedarSystem(ctx context.Context, sel ast.SelectionSet, v *models.CedarSystem) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._CedarSystem(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOCreateAccessibilityRequestDocumentPayload2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐCreateAccessibilityRequestDocumentPayload(ctx context.Context, sel ast.SelectionSet, v *model.CreateAccessibilityRequestDocumentPayload) graphql.Marshaler {

--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -6,6 +6,7 @@ import (
 
 	ldclient "gopkg.in/launchdarkly/go-server-sdk.v5"
 
+	cedarcore "github.com/cmsgov/easi-app/pkg/cedar/core"
 	"github.com/cmsgov/easi-app/pkg/email"
 	"github.com/cmsgov/easi-app/pkg/models"
 	"github.com/cmsgov/easi-app/pkg/storage"
@@ -22,11 +23,12 @@ import (
 
 // Resolver is a resolver.
 type Resolver struct {
-	store       *storage.Store
-	service     ResolverService
-	s3Client    *upload.S3Client
-	emailClient *email.Client
-	ldClient    *ldclient.LDClient
+	store           *storage.Store
+	service         ResolverService
+	s3Client        *upload.S3Client
+	emailClient     *email.Client
+	ldClient        *ldclient.LDClient
+	cedarCoreClient *cedarcore.Client
 }
 
 // ResolverService holds service methods for use in resolvers
@@ -48,6 +50,7 @@ func NewResolver(
 	s3Client *upload.S3Client,
 	emailClient *email.Client,
 	ldClient *ldclient.LDClient,
+	cedarCoreClient *cedarcore.Client,
 ) *Resolver {
-	return &Resolver{store: store, service: service, s3Client: s3Client, emailClient: emailClient, ldClient: ldClient}
+	return &Resolver{store: store, service: service, s3Client: s3Client, emailClient: emailClient, ldClient: ldClient, cedarCoreClient: cedarCoreClient}
 }

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -31,6 +31,10 @@ type RequestEdge {
   node: Request!
 }
 
+"""
+CedarSystem represents the response from the /system/detail endpoint from the CEDAR Core API.
+Right now, this does not tie in with any other types defined here, and is a root node until that changes.
+"""
 type CedarSystem {
   id: String!
   name: String!

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -31,6 +31,18 @@ type RequestEdge {
   node: Request!
 }
 
+type CedarSystem {
+  id: String!
+  name: String!
+  description: String
+	acronym: String
+	status: String
+	businessOwnerOrg: String
+	businessOwnerOrgComp: String
+	systemMaintainerOrg: String
+	systemMaintainerOrgComp: String
+}
+
 """
 An accessibility request represents a system that needs to go through
 the 508 process.
@@ -854,6 +866,8 @@ type Query {
   systemIntake(id: UUID!): SystemIntake
   systems(after: String, first: Int!): SystemConnection
   currentUser: CurrentUser
+  cedarSystem(id: String!): CedarSystem
+  cedarSystems: [CedarSystem]
 }
 
 """

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -6,6 +6,7 @@ package graph
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"strconv"
 	"time"
@@ -1204,6 +1205,17 @@ func (r *queryResolver) CurrentUser(ctx context.Context) (*model.CurrentUser, er
 		},
 	}
 	return &currentUser, nil
+}
+
+func (r *queryResolver) CedarSystem(ctx context.Context, id string) (*models.CedarSystem, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+
+func (r *queryResolver) CedarSystems(ctx context.Context) ([]*models.CedarSystem, error) {
+	fmt.Println("query resolver: cedar systems")
+	cedarSystems, _ := r.cedarCoreClient.GetSystemSummary(ctx)
+	fmt.Println("systems", cedarSystems)
+	return cedarSystems, nil
 }
 
 func (r *systemIntakeResolver) Actions(ctx context.Context, obj *models.SystemIntake) ([]*model.SystemIntakeAction, error) {

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1207,12 +1207,18 @@ func (r *queryResolver) CurrentUser(ctx context.Context) (*model.CurrentUser, er
 }
 
 func (r *queryResolver) CedarSystem(ctx context.Context, id string) (*models.CedarSystem, error) {
-	cedarSystem, _ := r.cedarCoreClient.GetSystem(ctx, id)
+	cedarSystem, err := r.cedarCoreClient.GetSystem(ctx, id)
+	if err != nil {
+		return nil, err
+	}
 	return cedarSystem, nil
 }
 
 func (r *queryResolver) CedarSystems(ctx context.Context) ([]*models.CedarSystem, error) {
-	cedarSystems, _ := r.cedarCoreClient.GetSystemSummary(ctx)
+	cedarSystems, err := r.cedarCoreClient.GetSystemSummary(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return cedarSystems, nil
 }
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -6,7 +6,6 @@ package graph
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/url"
 	"strconv"
 	"time"
@@ -1208,13 +1207,12 @@ func (r *queryResolver) CurrentUser(ctx context.Context) (*model.CurrentUser, er
 }
 
 func (r *queryResolver) CedarSystem(ctx context.Context, id string) (*models.CedarSystem, error) {
-	panic(fmt.Errorf("not implemented"))
+	cedarSystem, _ := r.cedarCoreClient.GetSystem(ctx, id)
+	return cedarSystem, nil
 }
 
 func (r *queryResolver) CedarSystems(ctx context.Context) ([]*models.CedarSystem, error) {
-	fmt.Println("query resolver: cedar systems")
 	cedarSystems, _ := r.cedarCoreClient.GetSystemSummary(ctx)
-	fmt.Println("systems", cedarSystems)
 	return cedarSystems, nil
 }
 

--- a/pkg/graph/schema.resolvers_test.go
+++ b/pkg/graph/schema.resolvers_test.go
@@ -22,6 +22,7 @@ import (
 	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
 
 	"github.com/cmsgov/easi-app/pkg/appconfig"
+	cedarcore "github.com/cmsgov/easi-app/pkg/cedar/core"
 	"github.com/cmsgov/easi-app/pkg/email"
 	"github.com/cmsgov/easi-app/pkg/graph/generated"
 	"github.com/cmsgov/easi-app/pkg/graph/model"
@@ -146,6 +147,8 @@ func TestGraphQLTestSuite(t *testing.T) {
 
 	cedarLdapClient := local.NewCedarLdapClient(logger)
 
+	cedarCoreClient := cedarcore.NewClient("fake", "fake", ldClient)
+
 	directives := generated.DirectiveRoot{HasRole: func(ctx context.Context, obj interface{}, next graphql.Resolver, role model.Role) (res interface{}, err error) {
 		return next(ctx)
 	}}
@@ -191,7 +194,7 @@ func TestGraphQLTestSuite(t *testing.T) {
 		emailClient.SendSystemIntakeReviewEmail,
 	)
 
-	resolver := NewResolver(store, resolverService, &s3Client, &emailClient, ldClient)
+	resolver := NewResolver(store, resolverService, &s3Client, &emailClient, ldClient, cedarCoreClient)
 	schema := generated.NewExecutableSchema(generated.Config{Resolvers: resolver, Directives: directives})
 	graphQLClient := client.New(handler.NewDefaultServer(schema))
 

--- a/pkg/models/cedar_system.go
+++ b/pkg/models/cedar_system.go
@@ -1,13 +1,6 @@
 package models
 
-// CedarSystemSummary is the model for the list of Sytems from the /system/summary endpoint
-// of the CEDAR Core API
-type CedarSystemSummary struct {
-	Count         int32         `json:"count"`
-	SystemSummary []CedarSystem `json:"SystemSummary"`
-}
-
-// CedarSystem is the model for a single system
+// CedarSystem is the model for a single system that comes back from the CEDAR Core API
 type CedarSystem struct {
 	ID                      string `json:"id"`
 	Name                    string `json:"name"`

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -251,6 +250,7 @@ func (s *Server) routes(
 		&s3Client,
 		&emailClient,
 		ldClient,
+		coreClient,
 	)
 	gqlDirectives := generated.DirectiveRoot{HasRole: func(ctx context.Context, obj interface{}, next graphql.Resolver, role model.Role) (res interface{}, err error) {
 		hasRole, err := services.HasRole(ctx, role)
@@ -313,22 +313,6 @@ func (s *Server) routes(
 		),
 	)
 	api.Handle("/system_intakes", systemIntakesHandler.Handle())
-	s.router.HandleFunc("/system-info-DEBUG", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		systemSummary, sserr := coreClient.GetSystemSummary(r.Context())
-		if sserr != nil {
-			s.logger.Error("Failed to get system summary", zap.Error(sserr))
-			_, werr := w.Write([]byte("ERROR"))
-			if werr != nil {
-				s.logger.Error("Failed to write response", zap.Error(werr))
-			}
-		} else {
-			summaryJSON, _ := json.Marshal(systemSummary)
-			_, werr := w.Write(summaryJSON)
-			if werr != nil {
-				s.logger.Error("Failed to write response", zap.Error(werr))
-			}
-		}
-	}))
 
 	businessCaseHandler := handlers.NewBusinessCaseHandler(
 		base,


### PR DESCRIPTION
# EASI-1444

## Changes proposed in this pull request

- Remove the system info debugging route on the API
- Add a new GraphQL type and resolver for a single CEDAR System or a list of Systems

## Reviewer Notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup & How to test

- Ensure you have a `.envrc.local` file that defines a valid `CEDAR_API_URL` and `CEDAR_API_KEY`. You can get these from the AWS Console (Systems Manager -> Parameter Store), or 1Password
- Modify `pkg/cedar/core/client.go` by setting `cedarCoreEnabledDefault` to `true` (maybe there's a better way to debug this)
- Start the server with `scripts/dev up:backend`
- Ensure you're connected to the CMS VPN
- Visit the GraphQL playground by going to http://localhost:8080/api/graph/playground
- Make some sample queries! Here is one to get started:
```graphql
query {
  cedarSystems {
    name
    id
  }
}
```
- Here is another query (that works on CEDAR IMPL)
```graphql
query {
  cedarSystem(id: "326-689-0") {
    id
    name
    description
    acronym
    status
    businessOwnerOrg
    businessOwnerOrgComp
    systemMaintainerOrg
    systemMaintainerOrgComp
  }
}
```

- Check that all code is adequately covered by tests
- Make comments, even if it's minor!

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

## Screenshots

<!--
    If this PR benefits from showing any visual components, put any screenshots here!
-->
