### PR TITLE
[NOREF] Added goimports pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,11 @@ repos:
             docs/adr/index.md
           )$
 
+  - repo: git://github.com/Bahjat/pre-commit-golang
+    rev: c3086eea8af86847dbdff2e46b85a5fe3c9d9656
+    hooks:
+      - id: go-fmt-import
+
   - repo: git://github.com/golangci/golangci-lint
     rev: v1.41.1
     hooks:


### PR DESCRIPTION
# EASI-000

## Changes proposed in this pull request

- Added a copy of `go-fmt-import` from https://github.com/Bahjat/pre-commit-golang.
  - This is a supported hook - it can be seen in the [official pre-commit list](https://pre-commit.com/hooks.html)

## Reviewer Notes

## Setup & How to test

- Pull this branch
- Attempt to modify `pkg/models/note.go` by moving the `"time"` import beneath the other two import statements
- Save the file
    - Note: If using VSCode, open the command palette and choose the "Save without Formatting" option. This ensures the reordering will not be undone by the go formatter.
 - Attempt to add and commit the file.
 - You should see an error, and the file should be modified. If `goimports` catches any errors, you have to check them in again (this is intended so that you're aware of the changes before committing them)

- Make comments, even if it's minor!

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

## Screenshots

![image](https://user-images.githubusercontent.com/15203744/147974348-d80138a7-39da-4de1-a418-737c1f6433e8.png)
