### PR TITLE
Remove unnecessary prettierrc file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "singleQuote": true,
-  "jsxSingleQuote": false
-}


### PR DESCRIPTION
No Jira ticket, just a quick cleanup.

Prettier settings are specified in our `.eslintrc` file (search for `prettier/prettier`) in that file. 

The two settings in our `.prettierrc` file were `singleQuote: true` and `jsxSingleQuote: false`. `.eslintrc` already specifies `singleQuote: true`, and `jsxSingleQuote` defaults to false. ([Prettier docs](https://prettier.io/docs/en/next/options.html#jsx-quotes))