### PR TITLE
Enable sandbox route to show up as a navigation tab

### DIFF
--- a/src/components/NavigationBar/index.scss
+++ b/src/components/NavigationBar/index.scss
@@ -1,4 +1,8 @@
-.usa-nav__primary-item {    
+.usa-nav {
+    margin-left: -1em
+}
+
+.usa-nav__primary-item {
     .easi-nav {
         display: flex;
 

--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -37,6 +37,11 @@ export const navLinks = (flags: Flags) => [
     isEnabled: true
   },
   {
+    link: '/sandbox',
+    label: 'sandbox',
+    isEnabled: flags.sandbox
+  },
+  {
     link: '/help',
     label: 'help',
     isEnabled: flags.help

--- a/src/i18n/en-US/header.ts
+++ b/src/i18n/en-US/header.ts
@@ -7,7 +7,8 @@ const header = {
   returnHome: 'EASi home',
   signIn: 'Sign In',
   signOut: 'Sign Out',
-  systems: 'Systems'
+  systems: 'Systems',
+  sandbox: 'Sandbox'
 };
 
 export default header;

--- a/src/views/AccessibilityStatement/__snapshots__/index.test.tsx.snap
+++ b/src/views/AccessibilityStatement/__snapshots__/index.test.tsx.snap
@@ -299,6 +299,9 @@ exports[`The Accessibility Statement static page matches the snapshot 1`] = `
             <li
               className="usa-nav__primary-item"
             />
+            <li
+              className="usa-nav__primary-item"
+            />
           </ul>
         </nav>
       </div>
@@ -408,6 +411,9 @@ exports[`The Accessibility Statement static page matches the snapshot 1`] = `
                     </a>
                   </div>
                 </li>
+                <li
+                  className="usa-nav__primary-item"
+                />
                 <li
                   className="usa-nav__primary-item"
                 />

--- a/src/views/Cookies/__snapshots__/index.test.tsx.snap
+++ b/src/views/Cookies/__snapshots__/index.test.tsx.snap
@@ -299,6 +299,9 @@ exports[`The Cookies static page matches the snapshot 1`] = `
             <li
               className="usa-nav__primary-item"
             />
+            <li
+              className="usa-nav__primary-item"
+            />
           </ul>
         </nav>
       </div>
@@ -408,6 +411,9 @@ exports[`The Cookies static page matches the snapshot 1`] = `
                     </a>
                   </div>
                 </li>
+                <li
+                  className="usa-nav__primary-item"
+                />
                 <li
                   className="usa-nav__primary-item"
                 />

--- a/src/views/GovernanceOverview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceOverview/__snapshots__/index.test.tsx.snap
@@ -299,6 +299,9 @@ exports[`The governance overview page matches the snapshot (w/ id param) 1`] = `
             <li
               className="usa-nav__primary-item"
             />
+            <li
+              className="usa-nav__primary-item"
+            />
           </ul>
         </nav>
       </div>
@@ -407,6 +410,9 @@ exports[`The governance overview page matches the snapshot (w/ id param) 1`] = `
                     </a>
                   </div>
                 </li>
+                <li
+                  className="usa-nav__primary-item"
+                />
                 <li
                   className="usa-nav__primary-item"
                 />
@@ -1075,6 +1081,9 @@ exports[`The governance overview page matches the snapshot (w/o id param) 1`] = 
             <li
               className="usa-nav__primary-item"
             />
+            <li
+              className="usa-nav__primary-item"
+            />
           </ul>
         </nav>
       </div>
@@ -1183,6 +1192,9 @@ exports[`The governance overview page matches the snapshot (w/o id param) 1`] = 
                     </a>
                   </div>
                 </li>
+                <li
+                  className="usa-nav__primary-item"
+                />
                 <li
                   className="usa-nav__primary-item"
                 />

--- a/src/views/MakingARequest/__snapshots__/index.test.tsx.snap
+++ b/src/views/MakingARequest/__snapshots__/index.test.tsx.snap
@@ -300,6 +300,9 @@ exports[`The making a request page matches the snapshot 1`] = `
             <li
               className="usa-nav__primary-item"
             />
+            <li
+              className="usa-nav__primary-item"
+            />
           </ul>
         </nav>
       </div>
@@ -409,6 +412,9 @@ exports[`The making a request page matches the snapshot 1`] = `
                     </a>
                   </div>
                 </li>
+                <li
+                  className="usa-nav__primary-item"
+                />
                 <li
                   className="usa-nav__primary-item"
                 />

--- a/src/views/NotFound/__snapshots__/index.test.tsx.snap
+++ b/src/views/NotFound/__snapshots__/index.test.tsx.snap
@@ -299,6 +299,9 @@ exports[`The Not Found Page matches the snapshot 1`] = `
             <li
               className="usa-nav__primary-item"
             />
+            <li
+              className="usa-nav__primary-item"
+            />
           </ul>
         </nav>
       </div>
@@ -408,6 +411,9 @@ exports[`The Not Found Page matches the snapshot 1`] = `
                     </a>
                   </div>
                 </li>
+                <li
+                  className="usa-nav__primary-item"
+                />
                 <li
                   className="usa-nav__primary-item"
                 />

--- a/src/views/PrepareForGRB/__snapshots__/index.test.tsx.snap
+++ b/src/views/PrepareForGRB/__snapshots__/index.test.tsx.snap
@@ -299,6 +299,9 @@ exports[`The prepare for GRB info page matches the snapshot 1`] = `
             <li
               className="usa-nav__primary-item"
             />
+            <li
+              className="usa-nav__primary-item"
+            />
           </ul>
         </nav>
       </div>
@@ -408,6 +411,9 @@ exports[`The prepare for GRB info page matches the snapshot 1`] = `
                     </a>
                   </div>
                 </li>
+                <li
+                  className="usa-nav__primary-item"
+                />
                 <li
                   className="usa-nav__primary-item"
                 />

--- a/src/views/PrepareForGRT/__snapshots__/index.test.tsx.snap
+++ b/src/views/PrepareForGRT/__snapshots__/index.test.tsx.snap
@@ -299,6 +299,9 @@ exports[`The prepare for GRT info page matches the snapshot 1`] = `
             <li
               className="usa-nav__primary-item"
             />
+            <li
+              className="usa-nav__primary-item"
+            />
           </ul>
         </nav>
       </div>
@@ -408,6 +411,9 @@ exports[`The prepare for GRT info page matches the snapshot 1`] = `
                     </a>
                   </div>
                 </li>
+                <li
+                  className="usa-nav__primary-item"
+                />
                 <li
                   className="usa-nav__primary-item"
                 />

--- a/src/views/PrivacyPolicy/__snapshots__/index.test.tsx.snap
+++ b/src/views/PrivacyPolicy/__snapshots__/index.test.tsx.snap
@@ -299,6 +299,9 @@ exports[`The Privacy Policy static page matches the snapshot 1`] = `
             <li
               className="usa-nav__primary-item"
             />
+            <li
+              className="usa-nav__primary-item"
+            />
           </ul>
         </nav>
       </div>
@@ -408,6 +411,9 @@ exports[`The Privacy Policy static page matches the snapshot 1`] = `
                     </a>
                   </div>
                 </li>
+                <li
+                  className="usa-nav__primary-item"
+                />
                 <li
                   className="usa-nav__primary-item"
                 />

--- a/src/views/TermsAndConditions/__snapshots__/index.test.tsx.snap
+++ b/src/views/TermsAndConditions/__snapshots__/index.test.tsx.snap
@@ -299,6 +299,9 @@ exports[`The Terms & Conditions page matches the snapshot 1`] = `
             <li
               className="usa-nav__primary-item"
             />
+            <li
+              className="usa-nav__primary-item"
+            />
           </ul>
         </nav>
       </div>
@@ -408,6 +411,9 @@ exports[`The Terms & Conditions page matches the snapshot 1`] = `
                     </a>
                   </div>
                 </li>
+                <li
+                  className="usa-nav__primary-item"
+                />
                 <li
                   className="usa-nav__primary-item"
                 />


### PR DESCRIPTION
# EASI-000

## Changes proposed in this pull request

- Adds a tab to the new Navigation bar for when the sandbox flag is enabled. Now you don't have to type `/sandbox` 😁 

## Reviewer Notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup & How to test

- If you don't have a local connection to LaunchDarkly configured, you can (temporarily) edit `src/views/FlagsWrapper/index.tsx` to turn on/off the sandbox.

- Pull the branch locally and test it
- Check that all code is adequately covered by tests
- Make comments, even if it's minor!

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

## Screenshots

![image](https://user-images.githubusercontent.com/15203744/148441545-5e2677ea-2093-47e4-9011-3842ff49dbb0.png)
