### PR TITLE
[EASI-1378]/nullable previous and next columns

### DIFF
--- a/migrations/V98__Convert_LCID_Extension_Columns_To_NULL.sql
+++ b/migrations/V98__Convert_LCID_Extension_Columns_To_NULL.sql
@@ -1,8 +1,8 @@
--- Some actions were created in some deployed environments with "" as the value for these columns instead of NULL.
+-- Some actions were created in some deployed environments with '' as the value for these columns instead of NULL.
 
-ALTER TABLE actions ADD COLUMN lcid_expiration_change_new_scope text;
-ALTER TABLE actions ADD COLUMN lcid_expiration_change_previous_scope text;
-ALTER TABLE actions ADD COLUMN lcid_expiration_change_new_next_steps text;
-ALTER TABLE actions ADD COLUMN lcid_expiration_change_previous_next_steps text;
-ALTER TABLE actions ADD COLUMN lcid_expiration_change_new_cost_baseline text;
-ALTER TABLE actions ADD COLUMN lcid_expiration_change_previous_cost_baseline text;
+UPDATE actions SET lcid_expiration_change_new_scope = NULL WHERE lcid_expiration_change_new_scope = '';
+UPDATE actions SET lcid_expiration_change_previous_scope = NULL WHERE lcid_expiration_change_previous_scope = '';
+UPDATE actions SET lcid_expiration_change_new_next_steps = NULL WHERE lcid_expiration_change_new_next_steps = '';
+UPDATE actions SET lcid_expiration_change_previous_next_steps = NULL WHERE lcid_expiration_change_previous_next_steps = '';
+UPDATE actions SET lcid_expiration_change_new_cost_baseline = NULL WHERE lcid_expiration_change_new_cost_baseline = '';
+UPDATE actions SET lcid_expiration_change_previous_cost_baseline = NULL WHERE lcid_expiration_change_previous_cost_baseline = '';

--- a/migrations/V98__Convert_LCID_Extension_Columns_To_NULL.sql
+++ b/migrations/V98__Convert_LCID_Extension_Columns_To_NULL.sql
@@ -1,0 +1,8 @@
+-- Some actions were created in some deployed environments with "" as the value for these columns instead of NULL.
+
+ALTER TABLE actions ADD COLUMN lcid_expiration_change_new_scope text;
+ALTER TABLE actions ADD COLUMN lcid_expiration_change_previous_scope text;
+ALTER TABLE actions ADD COLUMN lcid_expiration_change_new_next_steps text;
+ALTER TABLE actions ADD COLUMN lcid_expiration_change_previous_next_steps text;
+ALTER TABLE actions ADD COLUMN lcid_expiration_change_new_cost_baseline text;
+ALTER TABLE actions ADD COLUMN lcid_expiration_change_previous_cost_baseline text;

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -4255,12 +4255,12 @@ lifecycle ID
 type SystemIntakeLCIDExpirationChange {
   previousDate: Time!
   newDate: Time!
-  previousScope: String!
-  newScope: String!
-  previousNextSteps: String!
-  newNextSteps: String!
-  previousCostBaseline: String!
-  newCostBaseline: String!
+  previousScope: String
+  newScope: String
+  previousNextSteps: String
+  newNextSteps: String
+  previousCostBaseline: String
+  newCostBaseline: String
  }
 
 """
@@ -15956,14 +15956,11 @@ func (ec *executionContext) _SystemIntakeLCIDExpirationChange_previousScope(ctx 
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _SystemIntakeLCIDExpirationChange_newScope(ctx context.Context, field graphql.CollectedField, obj *model.SystemIntakeLCIDExpirationChange) (ret graphql.Marshaler) {
@@ -15991,14 +15988,11 @@ func (ec *executionContext) _SystemIntakeLCIDExpirationChange_newScope(ctx conte
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _SystemIntakeLCIDExpirationChange_previousNextSteps(ctx context.Context, field graphql.CollectedField, obj *model.SystemIntakeLCIDExpirationChange) (ret graphql.Marshaler) {
@@ -16026,14 +16020,11 @@ func (ec *executionContext) _SystemIntakeLCIDExpirationChange_previousNextSteps(
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _SystemIntakeLCIDExpirationChange_newNextSteps(ctx context.Context, field graphql.CollectedField, obj *model.SystemIntakeLCIDExpirationChange) (ret graphql.Marshaler) {
@@ -16061,14 +16052,11 @@ func (ec *executionContext) _SystemIntakeLCIDExpirationChange_newNextSteps(ctx c
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _SystemIntakeLCIDExpirationChange_previousCostBaseline(ctx context.Context, field graphql.CollectedField, obj *model.SystemIntakeLCIDExpirationChange) (ret graphql.Marshaler) {
@@ -16096,14 +16084,11 @@ func (ec *executionContext) _SystemIntakeLCIDExpirationChange_previousCostBaseli
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _SystemIntakeLCIDExpirationChange_newCostBaseline(ctx context.Context, field graphql.CollectedField, obj *model.SystemIntakeLCIDExpirationChange) (ret graphql.Marshaler) {
@@ -16131,14 +16116,11 @@ func (ec *executionContext) _SystemIntakeLCIDExpirationChange_newCostBaseline(ct
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _SystemIntakeNote_author(ctx context.Context, field graphql.CollectedField, obj *model.SystemIntakeNote) (ret graphql.Marshaler) {
@@ -22345,34 +22327,16 @@ func (ec *executionContext) _SystemIntakeLCIDExpirationChange(ctx context.Contex
 			}
 		case "previousScope":
 			out.Values[i] = ec._SystemIntakeLCIDExpirationChange_previousScope(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "newScope":
 			out.Values[i] = ec._SystemIntakeLCIDExpirationChange_newScope(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "previousNextSteps":
 			out.Values[i] = ec._SystemIntakeLCIDExpirationChange_previousNextSteps(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "newNextSteps":
 			out.Values[i] = ec._SystemIntakeLCIDExpirationChange_newNextSteps(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "previousCostBaseline":
 			out.Values[i] = ec._SystemIntakeLCIDExpirationChange_previousCostBaseline(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "newCostBaseline":
 			out.Values[i] = ec._SystemIntakeLCIDExpirationChange_newCostBaseline(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -417,12 +417,12 @@ type SystemIntakeISSOInput struct {
 type SystemIntakeLCIDExpirationChange struct {
 	PreviousDate         time.Time `json:"previousDate"`
 	NewDate              time.Time `json:"newDate"`
-	PreviousScope        string    `json:"previousScope"`
-	NewScope             string    `json:"newScope"`
-	PreviousNextSteps    string    `json:"previousNextSteps"`
-	NewNextSteps         string    `json:"newNextSteps"`
-	PreviousCostBaseline string    `json:"previousCostBaseline"`
-	NewCostBaseline      string    `json:"newCostBaseline"`
+	PreviousScope        *string   `json:"previousScope"`
+	NewScope             *string   `json:"newScope"`
+	PreviousNextSteps    *string   `json:"previousNextSteps"`
+	NewNextSteps         *string   `json:"newNextSteps"`
+	PreviousCostBaseline *string   `json:"previousCostBaseline"`
+	NewCostBaseline      *string   `json:"newCostBaseline"`
 }
 
 // A note added to a system request

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -969,12 +969,12 @@ lifecycle ID
 type SystemIntakeLCIDExpirationChange {
   previousDate: Time!
   newDate: Time!
-  previousScope: String!
-  newScope: String!
-  previousNextSteps: String!
-  newNextSteps: String!
-  previousCostBaseline: String!
-  newCostBaseline: String!
+  previousScope: String
+  newScope: String
+  previousNextSteps: String
+  newNextSteps: String
+  previousCostBaseline: String
+  newCostBaseline: String
  }
 
 """

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1413,12 +1413,12 @@ func (r *systemIntakeResolver) Actions(ctx context.Context, obj *models.SystemIn
 			graphAction.LcidExpirationChange = &model.SystemIntakeLCIDExpirationChange{
 				NewDate:              *action.LCIDExpirationChangeNewDate,
 				PreviousDate:         *action.LCIDExpirationChangePreviousDate,
-				NewScope:             action.LCIDExpirationChangeNewScope,
-				PreviousScope:        action.LCIDExpirationChangePreviousScope,
-				NewNextSteps:         action.LCIDExpirationChangeNewNextSteps,
-				PreviousNextSteps:    action.LCIDExpirationChangePreviousNextSteps,
-				NewCostBaseline:      action.LCIDExpirationChangeNewCostBaseline,
-				PreviousCostBaseline: action.LCIDExpirationChangePreviousCostBaseline,
+				NewScope:             action.LCIDExpirationChangeNewScope.Ptr(),
+				PreviousScope:        action.LCIDExpirationChangePreviousScope.Ptr(),
+				NewNextSteps:         action.LCIDExpirationChangeNewNextSteps.Ptr(),
+				PreviousNextSteps:    action.LCIDExpirationChangePreviousNextSteps.Ptr(),
+				NewCostBaseline:      action.LCIDExpirationChangeNewCostBaseline.Ptr(),
+				PreviousCostBaseline: action.LCIDExpirationChangePreviousCostBaseline.Ptr(),
 			}
 		}
 		results = append(results, &graphAction)

--- a/pkg/models/action.go
+++ b/pkg/models/action.go
@@ -64,10 +64,10 @@ type Action struct {
 	CreatedAt                                *time.Time   `json:"createdAt" db:"created_at"`
 	LCIDExpirationChangeNewDate              *time.Time   `db:"lcid_expiration_change_new_date"`
 	LCIDExpirationChangePreviousDate         *time.Time   `db:"lcid_expiration_change_previous_date"`
-	LCIDExpirationChangeNewScope             string       `db:"lcid_expiration_change_new_scope"`
-	LCIDExpirationChangePreviousScope        string       `db:"lcid_expiration_change_previous_scope"`
-	LCIDExpirationChangeNewNextSteps         string       `db:"lcid_expiration_change_new_next_steps"`
-	LCIDExpirationChangePreviousNextSteps    string       `db:"lcid_expiration_change_previous_next_steps"`
-	LCIDExpirationChangeNewCostBaseline      string       `db:"lcid_expiration_change_new_cost_baseline"`
-	LCIDExpirationChangePreviousCostBaseline string       `db:"lcid_expiration_change_previous_cost_baseline"`
+	LCIDExpirationChangeNewScope             null.String  `db:"lcid_expiration_change_new_scope"`
+	LCIDExpirationChangePreviousScope        null.String  `db:"lcid_expiration_change_previous_scope"`
+	LCIDExpirationChangeNewNextSteps         null.String  `db:"lcid_expiration_change_new_next_steps"`
+	LCIDExpirationChangePreviousNextSteps    null.String  `db:"lcid_expiration_change_previous_next_steps"`
+	LCIDExpirationChangeNewCostBaseline      null.String  `db:"lcid_expiration_change_new_cost_baseline"`
+	LCIDExpirationChangePreviousCostBaseline null.String  `db:"lcid_expiration_change_previous_cost_baseline"`
 }

--- a/pkg/services/action.go
+++ b/pkg/services/action.go
@@ -397,14 +397,14 @@ func NewCreateActionExtendLifecycleID(
 		action.LCIDExpirationChangeNewDate = expirationDate
 		action.LCIDExpirationChangePreviousDate = intake.LifecycleExpiresAt
 
-		action.LCIDExpirationChangeNewScope = scope
-		action.LCIDExpirationChangePreviousScope = intake.LifecycleScope.String
+		action.LCIDExpirationChangeNewScope = null.StringFrom(scope)
+		action.LCIDExpirationChangePreviousScope = null.StringFrom(intake.LifecycleScope.String)
 
-		action.LCIDExpirationChangeNewNextSteps = *nextSteps
-		action.LCIDExpirationChangePreviousNextSteps = intake.DecisionNextSteps.String
+		action.LCIDExpirationChangeNewNextSteps = null.StringFromPtr(nextSteps)
+		action.LCIDExpirationChangePreviousNextSteps = null.StringFrom(intake.DecisionNextSteps.String)
 
-		action.LCIDExpirationChangeNewCostBaseline = *costBaseline
-		action.LCIDExpirationChangePreviousCostBaseline = intake.LifecycleCostBaseline.String
+		action.LCIDExpirationChangeNewCostBaseline = null.StringFromPtr(costBaseline)
+		action.LCIDExpirationChangePreviousCostBaseline = null.StringFrom(intake.LifecycleCostBaseline.String)
 
 		actionErr := saveAction(ctx, action)
 		if actionErr != nil {

--- a/src/i18n/en-US/governanceReviewTeam.ts
+++ b/src/i18n/en-US/governanceReviewTeam.ts
@@ -145,6 +145,8 @@ const governanceReviewTeam = {
       oldNextSteps: 'Old Next Steps',
       newCostBaseline: 'New Cost Baseline',
       oldCostBaseline: 'Old Cost Baseline',
+      noScope: 'No Scope Specified',
+      noNextSteps: 'No Next Steps Specified',
       noCostBaseline: 'No Cost Baseline Specified'
     }
   },

--- a/src/queries/types/GetAdminNotesAndActions.ts
+++ b/src/queries/types/GetAdminNotesAndActions.ts
@@ -27,12 +27,12 @@ export interface GetAdminNotesAndActions_systemIntake_actions_lcidExpirationChan
   __typename: "SystemIntakeLCIDExpirationChange";
   previousDate: Time;
   newDate: Time;
-  previousScope: string;
-  newScope: string;
-  previousNextSteps: string;
-  newNextSteps: string;
-  previousCostBaseline: string;
-  newCostBaseline: string;
+  previousScope: string | null;
+  newScope: string | null;
+  previousNextSteps: string | null;
+  newNextSteps: string | null;
+  previousCostBaseline: string | null;
+  newCostBaseline: string | null;
 }
 
 export interface GetAdminNotesAndActions_systemIntake_actions_actor {

--- a/src/views/GovernanceReviewTeam/Notes/index.tsx
+++ b/src/views/GovernanceReviewTeam/Notes/index.tsx
@@ -154,68 +154,83 @@ const Notes = () => {
                     id="new-lcid-scope"
                     label="less"
                     closeLabel="more"
-                    text={lcidExpirationChange.newScope}
+                    text={
+                      lcidExpirationChange.newScope ||
+                      t('notes.extendLcid.noScope')
+                    }
                     charLimit={freeFormTextCharLimit}
                   />
                 </dd>
+
                 <dt>{t('notes.extendLcid.oldScope')}</dt>
                 <dd>
                   <TruncatedText
                     id="previous-lcid-scope"
                     label="less"
                     closeLabel="more"
-                    text={lcidExpirationChange.previousScope}
+                    text={
+                      lcidExpirationChange.previousScope ||
+                      t('notes.extendLcid.noScope')
+                    }
                     charLimit={freeFormTextCharLimit}
                   />
                 </dd>
+
                 <dt>{t('notes.extendLcid.newNextSteps')}</dt>
                 <dd>
                   <TruncatedText
                     id="new-lcid-next-steps"
                     label="less"
                     closeLabel="more"
-                    text={lcidExpirationChange.newNextSteps}
+                    text={
+                      lcidExpirationChange.newNextSteps ||
+                      t('notes.extendLcid.noNextSteps')
+                    }
                     charLimit={freeFormTextCharLimit}
                   />
                 </dd>
+
                 <dt>{t('notes.extendLcid.oldNextSteps')}</dt>
                 <dd>
                   <TruncatedText
                     id="previous-lcid-next-steps"
                     label="less"
                     closeLabel="more"
-                    text={lcidExpirationChange.previousNextSteps}
+                    text={
+                      lcidExpirationChange.previousNextSteps ||
+                      t('notes.extendLcid.noNextSteps')
+                    }
                     charLimit={freeFormTextCharLimit}
                   />
                 </dd>
+
                 <dt>{t('notes.extendLcid.newCostBaseline')}</dt>
-                {lcidExpirationChange.newCostBaseline ? (
-                  <dd>
-                    <TruncatedText
-                      id="new-lcid-cost-baseline"
-                      label="less"
-                      closeLabel="more"
-                      text={lcidExpirationChange.newCostBaseline}
-                      charLimit={freeFormTextCharLimit}
-                    />
-                  </dd>
-                ) : (
-                  <dd>{t('notes.extendLcid.noCostBaseline')}</dd>
-                )}
+                <dd>
+                  <TruncatedText
+                    id="new-lcid-cost-baseline"
+                    label="less"
+                    closeLabel="more"
+                    text={
+                      lcidExpirationChange.newCostBaseline ||
+                      t('notes.extendLcid.noCostBaseline')
+                    }
+                    charLimit={freeFormTextCharLimit}
+                  />
+                </dd>
+
                 <dt>{t('notes.extendLcid.oldCostBaseline')}</dt>
-                {lcidExpirationChange.previousCostBaseline ? (
-                  <dd>
-                    <TruncatedText
-                      id="previous-lcid-cost-baseline"
-                      label="less"
-                      closeLabel="more"
-                      text={lcidExpirationChange.previousCostBaseline}
-                      charLimit={freeFormTextCharLimit}
-                    />
-                  </dd>
-                ) : (
-                  <dd>{t('notes.extendLcid.noCostBaseline')}</dd>
-                )}
+                <dd>
+                  <TruncatedText
+                    id="previous-lcid-cost-baseline"
+                    label="less"
+                    closeLabel="more"
+                    text={
+                      lcidExpirationChange.previousCostBaseline ||
+                      t('notes.extendLcid.noCostBaseline')
+                    }
+                    charLimit={freeFormTextCharLimit}
+                  />
+                </dd>
               </dl>
             )}
             {feedback && (


### PR DESCRIPTION
# EASI-1378

- lcid_expiration_change_new_scope
- lcid_expiration_change_previous_scope
- lcid_expiration_change_new_next_steps
- lcid_expiration_change_previous_next_steps
- lcid_expiration_change_new_cost_baseline
- lcid_expiration_change_previous_cost_baseline

All of the above columns were NULLable in the database, but the Go structs / GraphQL schema defined them as not nullable, leading to `""` being created when storing actions. This isn't problematic, except for when we deployed this code to IMPL, and the structs tried to convert NULL (which was in IMPL from previous versions of the code) to a string, which results in an error on the backend (the `string` type in Go is not nullable) 

## Changes proposed in this pull request

- Make SystemIntakeLCIDExpirationChange "new" and "previous" string fields nullable
- Autogenerated code to support the above change
- Introduce a migration to "fix" the empty string data that exists in IMPL (So that our data in IMPL has the same constraints as the data in PROD)

## Reviewer Notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup & How to test

- Pull the branch locally and test it
- Check that all code is adequately covered by tests
- Make comments, even if it's minor!

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

## Screenshots

<!--
    If this PR benefits from showing any visual components, put any screenshots here!
-->
