### PR TITLE
System profile sub component structure tweaks

### DIFF
--- a/src/views/SystemProfile/__snapshots__/index.test.tsx.snap
+++ b/src/views/SystemProfile/__snapshots__/index.test.tsx.snap
@@ -345,75 +345,90 @@ exports[`The making a request page matches snapshot 1`] = `
               </ul>
             </div>
             <div
-              class="desktop:grid-col-6 padding-left-5 padding-right-5"
-              data-testid="grid"
-            >
-              <ul
-                class="usa-card-group"
-                data-testid="CardGroup"
-              >
-                <li
-                  class="usa-card grid-col-12"
-                  data-testid="system-card"
-                >
-                  <div
-                    class="usa-card__container"
-                  >
-                    <div
-                      class="grid-col-12"
-                    />
-                  </div>
-                </li>
-              </ul>
-            </div>
-            <div
-              class="desktop:grid-col-3"
+              class="desktop:grid-col-9"
               data-testid="grid"
             >
               <div
-                class="top-divider"
-              />
-              <p>
-                Point of Contact
-              </p>
-              <dt
-                class="text-bold margin-bottom-05 system-profile__subheader"
+                class="grid-container"
+                data-testid="grid"
               >
-                Geraldine Hobbs
-              </dt>
-              <dd
-                class="description-definition margin-0"
-              >
-                Business Owner
-              </dd>
-              <p>
-                <a
-                  class="usa-link usa-link--external line-height-body-5"
-                  href="/"
-                  target="_blank"
+                <div
+                  class="grid-row"
+                  data-testid="grid"
                 >
-                  Send and email
-                  <span
-                    aria-hidden="true"
+                  <div
+                    class="desktop:grid-col-9"
+                    data-testid="grid"
                   >
-                     
-                  </span>
-                </a>
-              </p>
-              <p>
-                <a
-                  class="usa-link usa-link--external line-height-body-5"
-                  href="/"
-                  target="_blank"
-                >
-                  More points of contact
-                  <span
-                    aria-hidden="true"
+                    <ul
+                      class="usa-card-group"
+                      data-testid="CardGroup"
+                    >
+                      <li
+                        class="usa-card grid-col-12"
+                        data-testid="system-card"
+                      >
+                        <div
+                          class="usa-card__container"
+                        >
+                          <div
+                            class="grid-col-12"
+                          />
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                  <div
+                    class="desktop:grid-col-3"
+                    data-testid="grid"
                   >
-                     
-                  </span>
-                </a>
-              </p>
+                    <div
+                      class="top-divider"
+                    />
+                    <p>
+                      Point of Contact
+                    </p>
+                    <dt
+                      class="text-bold margin-bottom-05 system-profile__subheader"
+                    >
+                      Geraldine Hobbs
+                    </dt>
+                    <dd
+                      class="description-definition margin-0"
+                    >
+                      Business Owner
+                    </dd>
+                    <p>
+                      <a
+                        class="usa-link usa-link--external line-height-body-5"
+                        href="/"
+                        target="_blank"
+                      >
+                        Send and email
+                        <span
+                          aria-hidden="true"
+                        >
+                           
+                        </span>
+                      </a>
+                    </p>
+                    <p>
+                      <a
+                        class="usa-link usa-link--external line-height-body-5"
+                        href="/"
+                        target="_blank"
+                      >
+                        More points of contact
+                        <span
+                          aria-hidden="true"
+                        >
+                           
+                        </span>
+                      </a>
+                    </p>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/views/SystemProfile/components/SystemHome/index.tsx
+++ b/src/views/SystemProfile/components/SystemHome/index.tsx
@@ -1,22 +1,74 @@
 import React from 'react';
-import { Card, CardGroup } from '@trussworks/react-uswds';
+import { useTranslation } from 'react-i18next';
+import { Card, CardGroup, Grid } from '@trussworks/react-uswds';
 import classnames from 'classnames';
+
+import UswdsReactLink from 'components/LinkWrapper';
+import {
+  DescriptionDefinition,
+  DescriptionTerm
+} from 'components/shared/DescriptionGroup';
+import { GetCedarSystems_cedarSystems as CedarSystemProps } from 'queries/types/GetCedarSystems';
 
 type SystemHomeProps = {
   className?: string;
   children?: React.ReactNode;
+  system: CedarSystemProps;
 };
 
-const SystemHome = ({ className, children }: SystemHomeProps) => {
+const SystemHome = ({ className, children, system }: SystemHomeProps) => {
+  const { t } = useTranslation('systemProfile');
   return (
-    <CardGroup>
-      <Card
-        data-testid="system-card"
-        className={classnames('grid-col-12', className)}
-      >
-        <div className="grid-col-12">{children}</div>
-      </Card>
-    </CardGroup>
+    <Grid className="grid-container">
+      <Grid row>
+        <Grid desktop={{ col: 9 }}>
+          <CardGroup>
+            <Card
+              data-testid="system-card"
+              className={classnames('grid-col-12', className)}
+            >
+              <div className="grid-col-12">{children}</div>
+            </Card>
+          </CardGroup>
+        </Grid>
+        {/* Point of contact/ miscellaneous info */}
+        <Grid desktop={{ col: 3 }}>
+          <div className="top-divider" />
+          <p>{t('singleSystem.pointOfContact')}</p>
+          <DescriptionTerm
+            className="system-profile__subheader"
+            term={system.businessOwnerOrgComp || ''}
+          />
+          <DescriptionDefinition
+            definition={t('singleSystem.summary.subheader2')}
+          />
+          <p>
+            <UswdsReactLink
+              aria-label={t('singleSystem.sendEmail')}
+              className="line-height-body-5"
+              to="/" // TODO: Get link from CEDAR?
+              variant="external"
+              target="_blank"
+            >
+              {t('singleSystem.sendEmail')}
+              <span aria-hidden>&nbsp;</span>
+            </UswdsReactLink>
+          </p>
+          <p>
+            <UswdsReactLink
+              aria-label={t('singleSystem.moreContact')}
+              className="line-height-body-5"
+              to="/" // TODO: Get link from CEDAR?
+              variant="external"
+              target="_blank"
+            >
+              {t('singleSystem.moreContact')}
+              <span aria-hidden>&nbsp;</span>
+            </UswdsReactLink>
+          </p>
+        </Grid>
+      </Grid>
+    </Grid>
   );
 };
 

--- a/src/views/SystemProfile/components/index.tsx
+++ b/src/views/SystemProfile/components/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { GetCedarSystems_cedarSystems as CedarSystemProps } from 'queries/types/GetCedarSystems';
+
 import SystemHome from './SystemHome';
 
 type sideNavItemProps = {
@@ -14,53 +16,53 @@ interface sideNavProps {
 
 // groupEnd value is used to designate the end of navigation related grouping
 
-const sideNavItems = (id: string): sideNavProps => ({
+const sideNavItems = (system: CedarSystemProps): sideNavProps => ({
   home: {
     groupEnd: true,
-    component: <SystemHome />,
-    route: `/system-profile/${id}/home`
+    component: <SystemHome system={system} />,
+    route: `/system-profile/${system.id}/home`
   },
   details: {
-    component: <SystemHome />,
-    route: `/system-profile/${id}/details`
+    component: <SystemHome system={system} />,
+    route: `/system-profile/${system.id}/details`
   },
   'team-and-contract': {
-    component: <SystemHome />,
-    route: `/system-profile/${id}/team-and-contract`
+    component: <SystemHome system={system} />,
+    route: `/system-profile/${system.id}/team-and-contract`
   },
   'funding-and-budget': {
-    component: <SystemHome />,
-    route: `/system-profile/${id}/funding-and-budget`
+    component: <SystemHome system={system} />,
+    route: `/system-profile/${system.id}/funding-and-budget`
   },
   'tools-and-software': {
     groupEnd: true,
-    component: <SystemHome />,
-    route: `/system-profile/${id}/tools-and-software`
+    component: <SystemHome system={system} />,
+    route: `/system-profile/${system.id}/tools-and-software`
   },
   ato: {
-    component: <SystemHome />,
-    route: `/system-profile/${id}/ato`
+    component: <SystemHome system={system} />,
+    route: `/system-profile/${system.id}/ato`
   },
   'lifecycle-id': {
-    component: <SystemHome />,
-    route: `/system-profile/${id}/lifecycle-id`
+    component: <SystemHome system={system} />,
+    route: `/system-profile/${system.id}/lifecycle-id`
   },
   'section-508': {
     groupEnd: true,
-    component: <SystemHome />,
-    route: `/system-profile/${id}/section-508`
+    component: <SystemHome system={system} />,
+    route: `/system-profile/${system.id}/section-508`
   },
   'sub-systems': {
-    component: <SystemHome />,
-    route: `/system-profile/${id}/sub-systems`
+    component: <SystemHome system={system} />,
+    route: `/system-profile/${system.id}/sub-systems`
   },
   'system-data': {
-    component: <SystemHome />,
-    route: `/system-profile/${id}/system-data`
+    component: <SystemHome system={system} />,
+    route: `/system-profile/${system.id}/system-data`
   },
   documents: {
-    component: <SystemHome />,
-    route: `/system-profile/${id}/documents`
+    component: <SystemHome system={system} />,
+    route: `/system-profile/${system.id}/documents`
   }
 });
 

--- a/src/views/SystemProfile/index.tsx
+++ b/src/views/SystemProfile/index.tsx
@@ -196,17 +196,16 @@ const SystemProfile = () => {
                 {/* Side navigation for single system */}
                 {!isMobile ? (
                   <SideNav
-                    items={Object.keys(sideNavItems(systemInfo.id)).map(
+                    items={Object.keys(sideNavItems(systemInfo)).map(
                       (key: string) => (
                         <NavLink
-                          to={sideNavItems(systemInfo.id)[key].route}
+                          to={sideNavItems(systemInfo)[key].route}
                           key={key}
                           activeClassName="usa-current"
                           className={classnames({
-                            'nav-group-border': sideNavItems(systemInfo.id)[key]
+                            'nav-group-border': sideNavItems(systemInfo)[key]
                               .groupEnd
                           })}
-                          exact
                         >
                           {t(`navigation.${key}`)}
                         </NavLink>
@@ -222,19 +221,17 @@ const SystemProfile = () => {
                       }
                       mobileExpanded={isMobileSideNavExpanded}
                       aria-label="Side navigation"
-                      items={Object.keys(sideNavItems(systemInfo.id)).map(
+                      items={Object.keys(sideNavItems(systemInfo)).map(
                         (key: string) => (
                           <NavLink
-                            to={sideNavItems(systemInfo.id)[key].route}
+                            to={sideNavItems(systemInfo)[key].route}
                             key={key}
                             onClick={() => setIsMobileSideNavExpanded(false)}
                             activeClassName="usa-current"
                             className={classnames({
-                              'nav-group-border': sideNavItems(systemInfo.id)[
-                                key
-                              ].groupEnd
+                              'nav-group-border': sideNavItems(systemInfo)[key]
+                                .groupEnd
                             })}
-                            exact
                           >
                             {t(`navigation.${key}`)}
                           </NavLink>
@@ -245,48 +242,9 @@ const SystemProfile = () => {
                 )}
               </Grid>
 
-              <Grid
-                desktop={{ col: 6 }}
-                className="padding-left-5 padding-right-5"
-              >
+              <Grid desktop={{ col: 9 }}>
                 {/* This renders the selected sidenav central component */}
-                {sideNavItems(systemInfo.id)[subinfo || 'home'].component}
-              </Grid>
-              {/* Point of contact/ miscellaneous info */}
-              <Grid desktop={{ col: 3 }}>
-                <div className="top-divider" />
-                <p>{t('singleSystem.pointOfContact')}</p>
-                <DescriptionTerm
-                  className="system-profile__subheader"
-                  term={systemInfo.businessOwnerOrgComp || ''}
-                />
-                <DescriptionDefinition
-                  definition={t('singleSystem.summary.subheader2')}
-                />
-                <p>
-                  <UswdsReactLink
-                    aria-label={t('singleSystem.sendEmail')}
-                    className="line-height-body-5"
-                    to="/" // TODO: Get link from CEDAR?
-                    variant="external"
-                    target="_blank"
-                  >
-                    {t('singleSystem.sendEmail')}
-                    <span aria-hidden>&nbsp;</span>
-                  </UswdsReactLink>
-                </p>
-                <p>
-                  <UswdsReactLink
-                    aria-label={t('singleSystem.moreContact')}
-                    className="line-height-body-5"
-                    to="/" // TODO: Get link from CEDAR?
-                    variant="external"
-                    target="_blank"
-                  >
-                    {t('singleSystem.moreContact')}
-                    <span aria-hidden>&nbsp;</span>
-                  </UswdsReactLink>
-                </p>
+                {sideNavItems(systemInfo)[subinfo || 'home'].component}
               </Grid>
             </Grid>
           </Grid>


### PR DESCRIPTION
## Changes proposed in this pull request

- Removed right column from static system-profile view
- Included the right column as a part of each unique sub-nav component
- Passing entire system info into the sub-component (this may be more tailored - CEDAR dependent)
- Small tweak to active nav class rendering without exact url match

## Reviewer Notes

Made adjustments to structure of system profile sub navigation components so it's easy for two developers to work from without conflicts.  The right-most column is intended to be a unique part of each subcomponent.  Hence it was broken out of the static view, and each developer will render that column with their respective component.

This PR will allow each of us to work on subcomponents with little conflict.

## Setup & How to test

- Pull the branch locally and test it
- Check that all code is adequately covered by tests
- Make comments, even if it's minor!

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

## Screenshots

<!--
    If this PR benefits from showing any visual components, put any screenshots here!
-->
