### PR TITLE
EASI-1595/Fixed bug during validation of new LCID expiration date when extending an LCID

### DIFF
--- a/src/validations/actionSchema.ts
+++ b/src/validations/actionSchema.ts
@@ -60,11 +60,14 @@ export const extendLifecycleIdSchema = Yup.object().shape({
           year: Number(newExpirationYear) || 0
         });
 
+        // validate the old expiration date (some imported systems have invalid dates)
         const oldExpiration = DateTime.fromISO(currentExpiresAt);
         if (!oldExpiration.isValid) {
+          // if the old date isn't valid, we only need to make sure the new one is valid
           return newExpiration.isValid;
         }
 
+        // if the old date is valid, we make sure that it's not before the old one
         return newExpiration.isValid && newExpiration > oldExpiration;
       },
       otherwise: Yup.string().test(

--- a/src/validations/actionSchema.ts
+++ b/src/validations/actionSchema.ts
@@ -60,14 +60,12 @@ export const extendLifecycleIdSchema = Yup.object().shape({
           year: Number(newExpirationYear) || 0
         });
 
-        const oldExpiration = DateTime.fromISO(currentExpiresAt) || 0;
-        if (
-          newExpiration.isValid &&
-          newExpiration.toMillis() > oldExpiration.toMillis()
-        ) {
-          return true;
+        const oldExpiration = DateTime.fromISO(currentExpiresAt);
+        if (!oldExpiration.isValid) {
+          return newExpiration.isValid;
         }
-        return false;
+
+        return newExpiration.isValid && newExpiration > oldExpiration;
       },
       otherwise: Yup.string().test(
         'validDate',


### PR DESCRIPTION
# EASI-1595

## Changes proposed in this pull request

- Added a check for the validity of prior LCID expiration date before attempting to validate the new expiration date when extending an LCID for a system intake

## Setup & How to test

- Pull the branch locally and test it
- Check that all code is adequately covered by tests
- Make comments, even if it's minor!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

## Screenshots

<!--
    If this PR benefits from showing any visual components, put any screenshots here!
-->
