### PR TITLE
Fix regex for check-code-generation hook to properly recognize files under src/queries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
         name: check-code-generation
         entry: scripts/pre-commit-check-code-generation
         language: script
-        files: (pkg/graph/schema.graphql|pkg/graph/schema.resolvers.go|src/queries/*.ts)
+        files: pkg/graph/schema\.graphql|pkg/graph/schema\.resolvers\.go|src/queries/.*\.ts
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
         name: check-code-generation
         entry: scripts/pre-commit-check-code-generation
         language: script
-        files: pkg/graph/schema\.graphql|pkg/graph/schema\.resolvers\.go|src/queries/.*\.ts
+        files: "pkg/graph/schema\\.graphql|pkg/graph/schema\\.resolvers\\.go|src/queries/.*\\.ts"
 
   - repo: local
     hooks:

--- a/scripts/pre-commit-check-code-generation
+++ b/scripts/pre-commit-check-code-generation
@@ -3,13 +3,11 @@
 # Run GraphQL generation for Go files
 go generate ./... || exit
 
-# If in CI environment, install goimports and specify absolute path to the binary
-if [[ -n ${CI-} ]]; then
-  GO111MODULE=off go get golang.org/x/tools/cmd/goimports || exit
-  "$(go env GOPATH)"/bin/goimports -w -local github.com/cmsgov/easi-app pkg/graph/schema.resolvers.go || exit
-else
-  goimports -w -local github.com/cmsgov/easi-app pkg/graph/schema.resolvers.go || exit
+if ! command -v goimports &> /dev/null; then
+  go install golang.org/x/tools/cmd/goimports@latest || exit
 fi
+
+goimports -w -local github.com/cmsgov/easi-app pkg/graph/schema.resolvers.go || exit
 
 # Run GraphQL generation for Typescript files
 yarn generate


### PR DESCRIPTION
No Jira ticket, just a bug I noticed. The regex for the check-code-generation pre-commit hook wasn't triggering on changes to files under `src/queries`. [pre-commit uses Python regexes](https://pre-commit.com/#regular-expressions) (although this would apply with most regex engines); the previous regex of `src/queries/*.ts` was looking for any number of repetitions of `/`, `.*` is needed to get it to match any character.

## Setup & How to test

- Pull the branch
- Make a change to a query in one of the files directly under `src/queries`
- Attempt to commit; the check-code-generation hook should fail due to changing the corresponding file under `src/queries/types`.