### PR TITLE
EASI-1595/fixed expiration date bug when extending LCID

### DIFF
--- a/src/validations/actionSchema.test.ts
+++ b/src/validations/actionSchema.test.ts
@@ -15,63 +15,73 @@ describe('extend lifecycle ID schema', () => {
     ).not.toThrowError();
   });
 
-  it('should throw a validation error when the month is not between 1 and 12', () => {
-    expect(() =>
-      extendLifecycleIdSchema.validateSync({
-        newExpirationMonth: '-2',
-        newExpirationDay: '15',
-        newExpirationYear: '2023',
-        newScope: 'A new scope',
-        newNextSteps: 'Some new next steps'
-      })
-    ).toThrowError(new ValidationError('Enter a valid expiration date'));
-  });
+  try {
+    extendLifecycleIdSchema.validateSync({
+      newExpirationMonth: '-2',
+      newExpirationDay: '15',
+      newExpirationYear: '2023',
+      newScope: 'A new scope',
+      newNextSteps: 'Some new next steps'
+    });
+    throw new Error('Should not validate successfully');
+  } catch (err) {
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).path).toBe('validDate');
+  }
 
-  it('should throw a validation error when the day is not a possible day in a month', () => {
-    expect(() =>
-      extendLifecycleIdSchema.validateSync({
-        newExpirationMonth: '2',
-        newExpirationDay: '150',
-        newExpirationYear: '2023',
-        newScope: 'A new scope',
-        newNextSteps: 'Some new next steps'
-      })
-    ).toThrowError(new ValidationError('Enter a valid expiration date'));
-  });
+  try {
+    extendLifecycleIdSchema.validateSync({
+      newExpirationMonth: '2',
+      newExpirationDay: '150',
+      newExpirationYear: '2023',
+      newScope: 'A new scope',
+      newNextSteps: 'Some new next steps'
+    });
+    throw new Error('Should not validate successfully');
+  } catch (err) {
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).path).toBe('validDate');
+  }
 
-  it('should throw a validation error when an invalid year string is entered for the year', () => {
-    expect(() =>
-      extendLifecycleIdSchema.validateSync({
-        newExpirationMonth: '2',
-        newExpirationDay: '15',
-        newExpirationYear: 'abcd',
-        newScope: 'A new scope',
-        newNextSteps: 'Some new next steps'
-      })
-    ).toThrowError(new ValidationError('Enter a valid expiration date'));
-  });
+  try {
+    extendLifecycleIdSchema.validateSync({
+      newExpirationMonth: '2',
+      newExpirationDay: '15',
+      newExpirationYear: 'abcd',
+      newScope: 'A new scope',
+      newNextSteps: 'Some new next steps'
+    });
+    throw new Error('Should not validate successfully');
+  } catch (err) {
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).path).toBe('validDate');
+  }
 
-  it('should throw a validation error when a new scope is missing', () => {
-    expect(() =>
-      extendLifecycleIdSchema.validateSync({
-        newExpirationMonth: '2',
-        newExpirationDay: '15',
-        newExpirationYear: '2023',
-        newScope: '',
-        newNextSteps: 'Some new next steps'
-      })
-    ).toThrowError(new ValidationError('Please include a scope'));
-  });
+  try {
+    extendLifecycleIdSchema.validateSync({
+      newExpirationMonth: '2',
+      newExpirationDay: '15',
+      newExpirationYear: '2023',
+      newScope: '',
+      newNextSteps: 'Some new next steps'
+    });
+    throw new Error('Should not validate successfully');
+  } catch (err) {
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).path).toBe('newScope');
+  }
 
-  it('should throw a validation error when next steps are not filled out', () => {
-    expect(() =>
-      extendLifecycleIdSchema.validateSync({
-        newExpirationMonth: '2',
-        newExpirationDay: '15',
-        newExpirationYear: '2023',
-        newScope: 'A new scope',
-        newNextSteps: ''
-      })
-    ).toThrowError(new ValidationError('Please fill out next steps'));
-  });
+  try {
+    extendLifecycleIdSchema.validateSync({
+      newExpirationMonth: '2',
+      newExpirationDay: '15',
+      newExpirationYear: '2023',
+      newScope: 'A new scope',
+      newNextSteps: ''
+    });
+    throw new Error('Should not validate successfully');
+  } catch (err) {
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).path).toBe('newNextSteps');
+  }
 });

--- a/src/validations/actionSchema.test.ts
+++ b/src/validations/actionSchema.test.ts
@@ -12,7 +12,7 @@ describe('extend lifecycle ID schema', () => {
         newScope: 'A new scope',
         newNextSteps: 'Some new next steps'
       })
-    );
+    ).not.toThrowError();
   });
 
   it('should throw a validation error when the month is not between 1 and 12', () => {

--- a/src/validations/actionSchema.test.ts
+++ b/src/validations/actionSchema.test.ts
@@ -1,0 +1,77 @@
+import ValidationError from 'yup/lib/ValidationError';
+
+import { extendLifecycleIdSchema } from './actionSchema';
+
+describe('extend lifecycle ID schema', () => {
+  it('should correctly validate a schema that is valid', () => {
+    expect(() =>
+      extendLifecycleIdSchema.validateSync({
+        newExpirationMonth: '2',
+        newExpirationDay: '15',
+        newExpirationYear: '2023',
+        newScope: 'A new scope',
+        newNextSteps: 'Some new next steps'
+      })
+    );
+  });
+
+  it('should throw a validation error when the month is not between 1 and 12', () => {
+    expect(() =>
+      extendLifecycleIdSchema.validateSync({
+        newExpirationMonth: '-2',
+        newExpirationDay: '15',
+        newExpirationYear: '2023',
+        newScope: 'A new scope',
+        newNextSteps: 'Some new next steps'
+      })
+    ).toThrowError(new ValidationError('Enter a valid expiration date'));
+  });
+
+  it('should throw a validation error when the day is not a possible day in a month', () => {
+    expect(() =>
+      extendLifecycleIdSchema.validateSync({
+        newExpirationMonth: '2',
+        newExpirationDay: '150',
+        newExpirationYear: '2023',
+        newScope: 'A new scope',
+        newNextSteps: 'Some new next steps'
+      })
+    ).toThrowError(new ValidationError('Enter a valid expiration date'));
+  });
+
+  it('should throw a validation error when an invalid year string is entered for the year', () => {
+    expect(() =>
+      extendLifecycleIdSchema.validateSync({
+        newExpirationMonth: '2',
+        newExpirationDay: '15',
+        newExpirationYear: 'abcd',
+        newScope: 'A new scope',
+        newNextSteps: 'Some new next steps'
+      })
+    ).toThrowError(new ValidationError('Enter a valid expiration date'));
+  });
+
+  it('should throw a validation error when a new scope is missing', () => {
+    expect(() =>
+      extendLifecycleIdSchema.validateSync({
+        newExpirationMonth: '2',
+        newExpirationDay: '15',
+        newExpirationYear: '2023',
+        newScope: '',
+        newNextSteps: 'Some new next steps'
+      })
+    ).toThrowError(new ValidationError('Please include a scope'));
+  });
+
+  it('should throw a validation error when next steps are not filled out', () => {
+    expect(() =>
+      extendLifecycleIdSchema.validateSync({
+        newExpirationMonth: '2',
+        newExpirationDay: '15',
+        newExpirationYear: '2023',
+        newScope: 'A new scope',
+        newNextSteps: ''
+      })
+    ).toThrowError(new ValidationError('Please fill out next steps'));
+  });
+});

--- a/src/validations/actionSchema.ts
+++ b/src/validations/actionSchema.ts
@@ -41,38 +41,29 @@ export const extendLifecycleIdSchema = Yup.object().shape({
   newExpirationDay: Yup.string().trim().required('Please include a day'),
   newExpirationYear: Yup.string().trim().required('Please include a year'),
   validDate: Yup.string().when(
-    [
-      'newExpirationMonth',
-      'newExpirationDay',
-      'newExpirationYear',
-      'currentExpiresAt'
-    ],
+    ['newExpirationMonth', 'newExpirationDay', 'newExpirationYear'],
     {
       is: (
         newExpirationMonth: string,
         newExpirationDay: string,
-        newExpirationYear: string,
-        currentExpiresAt: string
+        newExpirationYear: string
       ) => {
-        const newExpiration = DateTime.fromObject({
-          month: Number(newExpirationMonth) || 0,
-          day: Number(newExpirationDay) || 0,
-          year: Number(newExpirationYear) || 0
-        });
+        const month = Number(newExpirationMonth);
+        const day = Number(newExpirationDay);
+        const year = Number(newExpirationYear);
 
-        // validate the old expiration date (some imported systems have invalid dates)
-        const oldExpiration = DateTime.fromISO(currentExpiresAt);
-        if (!oldExpiration.isValid) {
-          // if the old date isn't valid, we only need to make sure the new one is valid
-          return newExpiration.isValid;
-        }
-
-        // if the old date is valid, we make sure that it's not before the old one
-        return newExpiration.isValid && newExpiration > oldExpiration;
+        return (
+          !(Number.isNaN(month) || Number.isNaN(day) || Number.isNaN(year)) &&
+          DateTime.fromObject({
+            month,
+            day,
+            year
+          }).isValid
+        );
       },
       otherwise: Yup.string().test(
         'validDate',
-        'Enter a valid expiration date that is later than the current expiration date',
+        'Enter a valid expiration date',
         () => false
       )
     }

--- a/src/validations/actionSchema.ts
+++ b/src/validations/actionSchema.ts
@@ -60,11 +60,14 @@ export const extendLifecycleIdSchema = Yup.object().shape({
           year: Number(newExpirationYear) || 0
         });
 
+        // validate the old expiration date (some imported systems have invalid dates)
         const oldExpiration = DateTime.fromISO(currentExpiresAt);
         if (!oldExpiration.isValid) {
+          // if the old date isn't valid, we only need to make sure the new one is valid
           return newExpiration.isValid;
         }
 
+        // if the old date is valid, we make sure that it's not before the old one
         return newExpiration.isValid && newExpiration > oldExpiration;
       },
       otherwise: Yup.string().test(

--- a/src/validations/actionSchema.ts
+++ b/src/validations/actionSchema.ts
@@ -60,14 +60,12 @@ export const extendLifecycleIdSchema = Yup.object().shape({
           year: Number(newExpirationYear) || 0
         });
 
-        const oldExpiration = DateTime.fromISO(currentExpiresAt) || 0;
-        if (
-          newExpiration.isValid &&
-          newExpiration.toMillis() > oldExpiration.toMillis()
-        ) {
-          return true;
+        const oldExpiration = DateTime.fromISO(currentExpiresAt);
+        if (!oldExpiration.isValid) {
+          return newExpiration.isValid;
         }
-        return false;
+
+        return newExpiration.isValid && newExpiration > oldExpiration;
       },
       otherwise: Yup.string().test(
         'validDate',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "noFallthroughCasesInSwitch": true
   },
   "include": [


### PR DESCRIPTION
# EASI-1595

## Changes proposed in this pull request

Updated the validation logic when extending an LCID, preventing a bug that occurred for systems that were imported with invalid LCID expiration dates. Based on discussion, I updated the logic to no longer depend on the previous date at all, removing the check that required the new expiration date to be after the old one.

I also added some automated tests to the schema validation function.

## Reviewer Notes 

I am pretty new to this automated testing paradigm, so please let me know if I'm approaching it correctly.

## Setup & How to test

- Pull the branch locally and test it
- Check that all code is adequately covered by tests
- Make comments, even if it's minor!

You can run this command to test these specific changes:
```
yarn run craco test -t 'extend lifecycle ID schema'
```

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

