### PR TITLE
EASI-1527/Added optional cedar system ID when updating system intake request details

### DIFF
--- a/migrations/V100__Add_Cedar_System_Id_To_System_Intakes_Table.sql
+++ b/migrations/V100__Add_Cedar_System_Id_To_System_Intakes_Table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE system_intakes ADD COLUMN cedar_system_id text;

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -4351,6 +4351,7 @@ input UpdateSystemIntakeRequestDetailsInput {
   businessNeed: String
   businessSolution: String
   needsEaSupport: Boolean
+  cedarSystemId: String
 }
 
 """
@@ -20185,6 +20186,14 @@ func (ec *executionContext) unmarshalInputUpdateSystemIntakeRequestDetailsInput(
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("needsEaSupport"))
 			it.NeedsEaSupport, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "cedarSystemId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("cedarSystemId"))
+			it.CedarSystemID, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -424,6 +424,7 @@ type ComplexityRoot struct {
 		BusinessNeed                func(childComplexity int) int
 		BusinessOwner               func(childComplexity int) int
 		BusinessSolution            func(childComplexity int) int
+		CedarSystemID               func(childComplexity int) int
 		Contract                    func(childComplexity int) int
 		Costs                       func(childComplexity int) int
 		CreatedAt                   func(childComplexity int) int
@@ -763,6 +764,7 @@ type SystemIntakeResolver interface {
 	GrtReviewEmailBody(ctx context.Context, obj *models.SystemIntake) (*string, error)
 
 	LastAdminNote(ctx context.Context, obj *models.SystemIntake) (*model.LastAdminNote, error)
+	CedarSystemID(ctx context.Context, obj *models.SystemIntake) (*string, error)
 }
 
 type executableSchema struct {
@@ -2682,6 +2684,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SystemIntake.BusinessSolution(childComplexity), true
 
+	case "SystemIntake.cedarSystemId":
+		if e.complexity.SystemIntake.CedarSystemID == nil {
+			break
+		}
+
+		return e.complexity.SystemIntake.CedarSystemID(childComplexity), true
+
 	case "SystemIntake.contract":
 		if e.complexity.SystemIntake.Contract == nil {
 			break
@@ -4262,6 +4271,7 @@ type SystemIntake {
   decidedAt: Time
   businessCaseId: UUID
   lastAdminNote: LastAdminNote!
+  cedarSystemId: String
 }
 
 """
@@ -15681,6 +15691,38 @@ func (ec *executionContext) _SystemIntake_lastAdminNote(ctx context.Context, fie
 	return ec.marshalNLastAdminNote2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐLastAdminNote(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _SystemIntake_cedarSystemId(ctx context.Context, field graphql.CollectedField, obj *models.SystemIntake) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "SystemIntake",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.SystemIntake().CedarSystemID(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _SystemIntakeAction_id(ctx context.Context, field graphql.CollectedField, obj *model.SystemIntakeAction) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -23025,6 +23067,17 @@ func (ec *executionContext) _SystemIntake(ctx context.Context, sel ast.Selection
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}
+				return res
+			})
+		case "cedarSystemId":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._SystemIntake_cedarSystemId(ctx, field, obj)
 				return res
 			})
 		default:

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -526,6 +526,7 @@ type UpdateSystemIntakeRequestDetailsInput struct {
 	BusinessNeed     *string   `json:"businessNeed"`
 	BusinessSolution *string   `json:"businessSolution"`
 	NeedsEaSupport   *bool     `json:"needsEaSupport"`
+	CedarSystemID    *string   `json:"cedarSystemId"`
 }
 
 // Input data used to update GRT and GRB dates for a system request

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -896,6 +896,7 @@ input UpdateSystemIntakeRequestDetailsInput {
   businessNeed: String
   businessSolution: String
   needsEaSupport: Boolean
+  cedarSystemId: String
 }
 
 """

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -807,6 +807,7 @@ type SystemIntake {
   decidedAt: Time
   businessCaseId: UUID
   lastAdminNote: LastAdminNote!
+  cedarSystemId: String
 }
 
 """

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1782,6 +1782,10 @@ func (r *systemIntakeResolver) LastAdminNote(ctx context.Context, obj *models.Sy
 	}, nil
 }
 
+func (r *systemIntakeResolver) CedarSystemID(ctx context.Context, obj *models.SystemIntake) (*string, error) {
+	return obj.CedarSystemID.Ptr(), nil
+}
+
 // AccessibilityRequest returns generated.AccessibilityRequestResolver implementation.
 func (r *Resolver) AccessibilityRequest() generated.AccessibilityRequestResolver {
 	return &accessibilityRequestResolver{r}

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1200,6 +1200,16 @@ func (r *mutationResolver) UpdateSystemIntakeRequestDetails(ctx context.Context,
 	intake.Solution = null.StringFromPtr(input.BusinessSolution)
 	intake.EASupportRequest = null.BoolFromPtr(input.NeedsEaSupport)
 
+	cedarSystemID := null.StringFromPtr(input.CedarSystemID)
+	cedarSystemIDStr := cedarSystemID.ValueOrZero()
+	if input.CedarSystemID != nil && len(*input.CedarSystemID) > 0 {
+		_, err = r.cedarCoreClient.GetSystem(ctx, cedarSystemIDStr)
+		if err != nil {
+			return nil, err
+		}
+		intake.CedarSystemID = null.StringFromPtr(input.CedarSystemID)
+	}
+
 	savedIntake, err := r.store.UpdateSystemIntake(ctx, intake)
 	return &model.UpdateSystemIntakePayload{
 		SystemIntake: savedIntake,

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -132,6 +132,7 @@ type SystemIntake struct {
 	AdminLead                   null.String             `json:"adminLead" db:"admin_lead"`
 	LastAdminNoteContent        null.String             `json:"lastAdminNoteContent" db:"last_admin_note_content"`
 	LastAdminNoteCreatedAt      *time.Time              `json:"lastAdminNoteCreatedAt" db:"last_admin_note_created_at"`
+	CedarSystemID               null.String             `json:"cedarSystemId" db:"cedar_system_id"`
 }
 
 // SystemIntakes is a list of System Intakes

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -184,7 +184,8 @@ func (s *Store) UpdateSystemIntake(ctx context.Context, intake *models.SystemInt
 			decision_next_steps = :decision_next_steps,
 			lcid_cost_baseline = :lcid_cost_baseline,
 			rejection_reason = :rejection_reason,
-			admin_lead = :admin_lead
+			admin_lead = :admin_lead,
+			cedar_system_id = :cedar_system_id
 		WHERE system_intakes.id = :id
 	`
 	_, err := s.db.NamedExec(

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -422,6 +422,7 @@ export interface UpdateSystemIntakeRequestDetailsInput {
   businessNeed?: string | null;
   businessSolution?: string | null;
   needsEaSupport?: boolean | null;
+  cedarSystemId?: string | null;
 }
 
 /**


### PR DESCRIPTION
# EASI-1527

## Changes proposed in this pull request

- Added a migration to include CedarSystemID column on the system_intakes table
- Added this new column to the Go model for SystemIntake
- Added an optional cedarSystemId string field on the input to the UpdateSystemIntakeRequestDetails mutation
- If this field is present on the input when updating intake request details, the mutation will validate that it is a system that exists in CEDAR, and if so, set that field on the system intake

## Setup & How to test

- Pull the branch locally and test it
- Check that all code is adequately covered by tests
- Make comments, even if it's minor!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

