### PR TITLE
Easi 1648/fix date column sort

### DIFF
--- a/cmd/devdata/main.go
+++ b/cmd/devdata/main.go
@@ -54,6 +54,7 @@ func main() {
 	makeAccessibilityRequest("Seeded 508 Request", store, func(i *models.AccessibilityRequest) {
 		i.ID = uuid.MustParse("6e224030-09d5-46f7-ad04-4bb851b36eab")
 	})
+
 	// Test date is one day after the 508 request is created
 	makeTestDate(logger, store, func(i *models.TestDate) {
 		i.ID = uuid.MustParse("18624c5b-4c00-49a7-960f-ac6d8b2c58df")

--- a/src/components/AccessibilityRequestsTable/index.test.tsx
+++ b/src/components/AccessibilityRequestsTable/index.test.tsx
@@ -14,6 +14,27 @@ import AccessibilityRequestsTable from './index';
 const requests: AccessibilityRequests[] = [
   {
     __typename: 'AccessibilityRequest',
+    id: '123',
+    name: 'Burrito v1',
+    submittedAt: '2021-06-10T19:22:40Z',
+    relevantTestDate: null,
+    system: {
+      __typename: 'System',
+      lcid: '0000',
+      businessOwner: {
+        __typename: 'BusinessOwner',
+        name: 'Shade',
+        component: 'OIT'
+      }
+    },
+    statusRecord: {
+      __typename: 'AccessibilityRequestStatusRecord',
+      status: AccessibilityRequestStatus.OPEN,
+      createdAt: '2021-06-10T19:22:40Z'
+    }
+  },
+  {
+    __typename: 'AccessibilityRequest',
     id: '124',
     name: 'Burrito v2',
     relevantTestDate: {
@@ -34,27 +55,6 @@ const requests: AccessibilityRequests[] = [
       __typename: 'AccessibilityRequestStatusRecord',
       status: AccessibilityRequestStatus.IN_REMEDIATION,
       createdAt: '2021-06-11T19:22:40Z'
-    }
-  },
-  {
-    __typename: 'AccessibilityRequest',
-    id: '123',
-    name: 'Burrito v1',
-    submittedAt: '2021-06-10T19:22:40Z',
-    relevantTestDate: null,
-    system: {
-      __typename: 'System',
-      lcid: '0000',
-      businessOwner: {
-        __typename: 'BusinessOwner',
-        name: 'Shade',
-        component: 'OIT'
-      }
-    },
-    statusRecord: {
-      __typename: 'AccessibilityRequestStatusRecord',
-      status: AccessibilityRequestStatus.OPEN,
-      createdAt: '2021-06-10T19:22:40Z'
     }
   }
 ];

--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -19,6 +19,7 @@ import TableResults from 'components/TableResults';
 import { GetAccessibilityRequests_accessibilityRequests_edges_node as AccessibilityRequests } from 'queries/types/GetAccessibilityRequests';
 import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
 import { formatDate } from 'utils/date';
+import globalTableFilter from 'utils/globalTableFilter';
 import {
   currentTableSortDescription,
   getColumnSortStatus,
@@ -54,9 +55,10 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
       },
       {
         Header: t('requestTable.header.submissionDate'),
-        accessor: (value: AccessibilityRequests) => {
-          if (value.submittedAt) {
-            return formatDate(value.submittedAt);
+        accessor: 'submittedAt',
+        Cell: ({ value }: any) => {
+          if (value) {
+            return formatDate(value);
           }
           return '';
         },
@@ -68,9 +70,10 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
       },
       {
         Header: t('requestTable.header.testDate'),
-        accessor: (value: any) => {
-          if (value.relevantTestDate) {
-            return formatDate(value.relevantTestDate);
+        accessor: 'relevantTestDate',
+        Cell: ({ value }: any) => {
+          if (value) {
+            return formatDate(value);
           }
           return t('requestTable.emptyTestDate');
         },
@@ -165,6 +168,7 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
           );
         }
       },
+      globalFilter: useMemo(() => globalTableFilter, []),
       requests,
       autoResetSortBy: false,
       autoResetPage: false,

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -32,6 +32,7 @@ import { AppState } from 'reducers/rootReducer';
 import { fetchSystemIntakes } from 'types/routines';
 import { SystemIntakeForm } from 'types/systemIntake';
 import { formatDate } from 'utils/date';
+import globalTableFilter from 'utils/globalTableFilter';
 import {
   getColumnSortStatus,
   getHeaderSortIcon,
@@ -60,10 +61,12 @@ const RequestRepository = () => {
 
   const submissionDateColumn = {
     Header: t('intake:fields.submissionDate'),
-    accessor: (value: SystemIntakeForm) => {
-      if (value.submittedAt) {
-        return formatDate(value.submittedAt);
+    accessor: 'submittedAt',
+    Cell: ({ value }: any) => {
+      if (value) {
+        return DateTime.fromISO(value).toLocaleString(DateTime.DATE_FULL);
       }
+
       return t('requestRepository.table.submissionDate.null');
     }
   };
@@ -113,15 +116,9 @@ const RequestRepository = () => {
 
   const grtDateColumn = {
     Header: t('intake:fields.grtDate'),
-    accessor: (value: SystemIntakeForm) => {
-      if (value.grtDate) {
-        return formatDate(value.grtDate);
-      }
-      return t('requestRepository.table.addDate');
-    },
+    accessor: 'grtDate',
     Cell: ({ row, value }: any) => {
-      if (value === t('requestRepository.table.addDate')) {
-        // If date is null, return button that takes user to page to add date
+      if (!value) {
         return (
           <UswdsReactLink
             data-testid="add-grt-date-cta"
@@ -131,31 +128,25 @@ const RequestRepository = () => {
           </UswdsReactLink>
         );
       }
-      return value;
+      return formatDate(value);
     }
   };
 
   const grbDateColumn = {
     Header: t('intake:fields.grbDate'),
-    accessor: (value: SystemIntakeForm) => {
-      if (value.grbDate) {
-        return formatDate(value.grbDate);
-      }
-      return t('requestRepository.table.addDate');
-    },
+    accessor: 'grbDate',
     Cell: ({ row, value }: any) => {
-      if (value === t('requestRepository.table.addDate')) {
-        // If date is null, return button that takes user to page to add date
+      if (!value) {
         return (
           <UswdsReactLink
-            data-testid="add-grb-date-cta"
+            data-testid="add-grt-date-cta"
             to={`/governance-review-team/${row.original.id}/dates`}
           >
             {t('requestRepository.table.addDate')}
           </UswdsReactLink>
         );
       }
-      return value;
+      return formatDate(value);
     }
   };
 
@@ -289,6 +280,7 @@ const RequestRepository = () => {
           );
         }
       },
+      globalFilter: useMemo(() => globalTableFilter, []),
       data,
       autoResetSortBy: false,
       autoResetPage: false,

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -139,7 +139,7 @@ const RequestRepository = () => {
       if (!value) {
         return (
           <UswdsReactLink
-            data-testid="add-grt-date-cta"
+            data-testid="add-grb-date-cta"
             to={`/governance-review-team/${row.original.id}/dates`}
           >
             {t('requestRepository.table.addDate')}

--- a/src/utils/globalTableFilter.test.ts
+++ b/src/utils/globalTableFilter.test.ts
@@ -1,0 +1,36 @@
+import { DateTime } from 'luxon';
+
+import globalTableFilter from './globalTableFilter';
+
+const rows = [
+  {
+    values: {
+      name: 'John',
+      date: DateTime.local(2022, 1),
+      number: 5
+    }
+  },
+  {
+    values: {
+      name: 'Mary',
+      date: DateTime.local(2022, 2),
+      number: 0
+    }
+  },
+  {
+    values: {
+      name: 'Beth',
+      date: DateTime.local(2022, 3),
+      number: 12
+    }
+  }
+] as any;
+
+describe('globalTableFilter', () => {
+  it('return matching rows', () => {
+    expect(globalTableFilter(rows, [''], 'John')).toEqual([rows[0]]);
+    expect(globalTableFilter(rows, [''], 'February')).toEqual([rows[1]]);
+    expect(globalTableFilter(rows, [''], '12')).toEqual([rows[2]]);
+    expect(globalTableFilter(rows, [''], '2022')).toEqual(rows);
+  });
+});

--- a/src/utils/globalTableFilter.tsx
+++ b/src/utils/globalTableFilter.tsx
@@ -1,0 +1,54 @@
+// Global filter for React-Table
+// Converts DateTime and numbers to string for proper filtering
+// Leave DateTime in tact for proper column sorting
+
+import { IdType, Row } from 'react-table';
+import { DateTime } from 'luxon';
+
+import { formatDate } from 'utils/date';
+
+const globalTableFilter = (
+  rows: Row[],
+  ids: IdType<string>[],
+  query: string
+) => {
+  return rows.filter(row => {
+    let foundValue = false;
+    Object.keys(row.values).forEach((key: any) => {
+      const data = row.values[key];
+      const lowerCaseQuery = query.toLowerCase();
+
+      // Null checks for columns with data potentially empty (LCID Expiration, Admin Notes, etc.)
+      if (!data) {
+        return;
+      }
+
+      // If string, convert to lowercase and search
+      if (
+        typeof data === 'string' &&
+        data.toLowerCase().includes(lowerCaseQuery)
+      ) {
+        foundValue = true;
+      }
+
+      // If number, convert to string and search
+      if (
+        typeof data === 'number' &&
+        data.toString().includes(lowerCaseQuery)
+      ) {
+        foundValue = true;
+      }
+
+      // If type of DateTime - convert to string, convert to lowercase, and search
+      if (data instanceof DateTime) {
+        const stringDate = formatDate(data);
+        if (stringDate.toLowerCase().includes(lowerCaseQuery)) {
+          foundValue = true;
+        }
+      }
+    });
+    return foundValue;
+  });
+};
+
+export default globalTableFilter;

--- a/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
+++ b/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
               </button>
             </th>
             <th
-              aria-sort="descending"
+              aria-sort="none"
               class="table-header"
               colspan="1"
               role="columnheader"
@@ -119,7 +119,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
               >
                 Submission date
                 <span
-                  class="margin-left-1 fa fa-caret-down position-absolute"
+                  class="margin-left-1 fa fa-sort caret position-absolute"
                 />
               </button>
             </th>
@@ -177,81 +177,28 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             >
               <a
                 class="usa-link"
-                href="/508/requests/123"
+                href="/governance-task-list/789"
               >
-                508 Test 1
+                Intake 2
               </a>
             </th>
             <td
               role="cell"
               style="width: 150px;"
             >
-              Section 508
+              IT Governance
             </td>
             <td
               role="cell"
               style="width: 150px;"
             >
-              May 25 2021
+              May 20, 2021
             </td>
             <td
               role="cell"
               style="width: 200px;"
             >
-              <span>
-                Open
-                <span
-                  class="text-base-dark font-body-3xs"
-                >
-                   - Changed on May 25 2021
-                </span>
-              </span>
-            </td>
-            <td
-              role="cell"
-              style="width: 220px;"
-            >
-              None
-            </td>
-          </tr>
-          <tr
-            role="row"
-          >
-            <th
-              role="cell"
-              scope="row"
-            >
-              <a
-                class="usa-link"
-                href="/508/requests/909"
-              >
-                508 Test 2
-              </a>
-            </th>
-            <td
-              role="cell"
-              style="width: 150px;"
-            >
-              Section 508
-            </td>
-            <td
-              role="cell"
-              style="width: 150px;"
-            >
-              May 25 2021
-            </td>
-            <td
-              role="cell"
-              style="width: 200px;"
-            >
-              <span>
-                In remediation
-                <span
-                  class="text-base-dark font-body-3xs"
-                >
-                   - Changed on May 26 2021
-                </span>
-              </span>
+              Lifecycle ID issued: A123456: A123456
             </td>
             <td
               role="cell"
@@ -284,7 +231,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
               role="cell"
               style="width: 150px;"
             >
-              May 22 2021
+              May 22, 2021
             </td>
             <td
               role="cell"
@@ -308,28 +255,81 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             >
               <a
                 class="usa-link"
-                href="/governance-task-list/789"
+                href="/508/requests/909"
               >
-                Intake 2
+                508 Test 2
               </a>
             </th>
             <td
               role="cell"
               style="width: 150px;"
             >
-              IT Governance
+              Section 508
             </td>
             <td
               role="cell"
               style="width: 150px;"
             >
-              May 20 2021
+              May 25, 2021
             </td>
             <td
               role="cell"
               style="width: 200px;"
             >
-              Lifecycle ID issued: A123456: A123456
+              <span>
+                In remediation
+                <span
+                  class="text-base-dark font-body-3xs"
+                >
+                   - Changed on May 26 2021
+                </span>
+              </span>
+            </td>
+            <td
+              role="cell"
+              style="width: 220px;"
+            >
+              None
+            </td>
+          </tr>
+          <tr
+            role="row"
+          >
+            <th
+              role="cell"
+              scope="row"
+            >
+              <a
+                class="usa-link"
+                href="/508/requests/123"
+              >
+                508 Test 1
+              </a>
+            </th>
+            <td
+              role="cell"
+              style="width: 150px;"
+            >
+              Section 508
+            </td>
+            <td
+              role="cell"
+              style="width: 150px;"
+            >
+              May 25, 2021
+            </td>
+            <td
+              role="cell"
+              style="width: 200px;"
+            >
+              <span>
+                Open
+                <span
+                  class="text-base-dark font-body-3xs"
+                >
+                   - Changed on May 25 2021
+                </span>
+              </span>
             </td>
             <td
               role="cell"
@@ -372,7 +372,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
       aria-live="polite"
       class="usa-sr-only usa-table__announcement-region"
     >
-      Requests table sorted by Submission date descending
+      Requests table reset to default sort order
     </div>
   </div>
 </DocumentFragment>

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-table';
 import { useQuery } from '@apollo/client';
 import { Table as UswdsTable } from '@trussworks/react-uswds';
+import { DateTime } from 'luxon';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import Spinner from 'components/Spinner';
@@ -18,6 +19,7 @@ import TableResults from 'components/TableResults';
 import GetRequestsQuery from 'queries/GetRequestsQuery';
 import { GetRequests, GetRequestsVariables } from 'queries/types/GetRequests';
 import { formatDate } from 'utils/date';
+import globalTableFilter from 'utils/globalTableFilter';
 import {
   currentTableSortDescription,
   getColumnSortStatus,
@@ -67,7 +69,19 @@ const Table = () => {
       },
       {
         Header: t('requestsTable.headers.submittedAt'),
-        accessor: 'submittedAt'
+        accessor: (value: any) => {
+          if (value.submittedAt) {
+            return DateTime.fromISO(value.submittedAt);
+          }
+          return null;
+        },
+        Cell: ({ value }: any) => {
+          if (value) {
+            return DateTime.fromISO(value).toLocaleString(DateTime.DATE_FULL);
+          }
+
+          return t('requestsTable.defaultSubmittedAt');
+        }
       },
       {
         Header: t('requestsTable.headers.status'),
@@ -101,7 +115,19 @@ const Table = () => {
       },
       {
         Header: t('requestsTable.headers.nextMeetingDate'),
-        accessor: 'nextMeetingDate',
+        accessor: (value: any) => {
+          if (value.nextMeetingDate) {
+            return DateTime.fromISO(value.nextMeetingDate);
+          }
+          return null;
+        },
+        Cell: ({ value }: any) => {
+          if (value) {
+            return DateTime.fromISO(value).toLocaleString(DateTime.DATE_FULL);
+          }
+
+          return 'None';
+        },
         className: 'next-meeting-date',
         width: '220px'
       }
@@ -145,6 +171,7 @@ const Table = () => {
           );
         }
       },
+      globalFilter: useMemo(() => globalTableFilter, []),
       autoResetSortBy: false,
       autoResetPage: false,
       initialState: {

--- a/src/views/MyRequests/Table/tableMap.ts
+++ b/src/views/MyRequests/Table/tableMap.ts
@@ -1,10 +1,8 @@
 import { TFunction } from 'i18next';
-import { DateTime } from 'luxon';
 
 import { GetRequests } from 'queries/types/GetRequests';
 import { RequestType } from 'types/graphql-global-types';
 import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
-import { formatDate } from 'utils/date';
 
 // React table sorts on the data passed table.  The column configuration uses the accessor to access the field of the original dataset.
 // Column cell configuration is meant to wrap data in JSX components, not modify data for sorting
@@ -17,19 +15,11 @@ const tableMap = (tableData: GetRequests, t: TFunction) => {
   });
 
   const mappedData = requests?.map(request => {
-    const submittedAt = request.submittedAt
-      ? formatDate(DateTime.fromISO(request.submittedAt))
-      : t('requestsTable.defaultSubmittedAt');
-
     const name = request.name ? request.name : 'Draft';
 
     const type: string = request.type
       ? t(`requestsTable.types.${request.type}`)
       : '';
-
-    const nextMeetingDate = request.nextMeetingDate
-      ? formatDate(request.submittedAt)
-      : 'None';
 
     let status;
     switch (request.type) {
@@ -57,8 +47,6 @@ const tableMap = (tableData: GetRequests, t: TFunction) => {
 
     return {
       ...request,
-      submittedAt,
-      nextMeetingDate,
       name,
       type,
       status

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true
   },
   "include": [


### PR DESCRIPTION
# EASI-1648

## Changes proposed in this pull request

- Added custom global filter for tables
- Updated cells and accessors to properly use type DateTime when sorting, and String when searching with filter
- Added/updated unit tests

## Reviewer Notes

The global filter requires type String comparisons.  The proper sorting on columns require DateTime.  Ensured DateTime for column values, while filtering coverts to string.

Not all date fields come from GQL as actual DateTime objects.   Some come back as ISO strings.  This added complexity to standardizing all dates.

## Setup & How to test

- Pull the branch locally and test it
- Check that all code is adequately covered by tests
- Make comments, even if it's minor!

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

## Screenshots

<!--
    If this PR benefits from showing any visual components, put any screenshots here!
-->
