### PR TITLE
Last admin note fix

### DIFF
--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -28,7 +28,7 @@ import TablePagination from 'components/TablePagination';
 import TableResults from 'components/TableResults';
 import { convertIntakeToCSV } from 'data/systemIntake';
 import useCheckResponsiveScreen from 'hooks/checkMobile';
-import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetSystemIntake';
+import { GetSystemIntake_systemIntake_lastAdminNote as LastAdminNote } from 'queries/types/GetSystemIntake';
 import { AppState } from 'reducers/rootReducer';
 import { fetchSystemIntakes } from 'types/routines';
 import { SystemIntakeForm } from 'types/systemIntake';
@@ -195,9 +195,10 @@ const RequestRepository = () => {
 
   const lastAdminNoteColumn = {
     Header: t('intake:fields.lastAdminNote'),
-    accessor: (intake: SystemIntake) => {
-      if (intake?.lastAdminNote?.content) {
-        return intake.lastAdminNote.content;
+    accessor: ({ lastAdminNote }: { lastAdminNote: LastAdminNote }) => {
+      if (lastAdminNote?.content) {
+        /* eslint react/prop-types: 0 */
+        return lastAdminNote.content;
       }
       return null;
     },

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -28,6 +28,7 @@ import TablePagination from 'components/TablePagination';
 import TableResults from 'components/TableResults';
 import { convertIntakeToCSV } from 'data/systemIntake';
 import useCheckResponsiveScreen from 'hooks/checkMobile';
+import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetSystemIntake';
 import { AppState } from 'reducers/rootReducer';
 import { fetchSystemIntakes } from 'types/routines';
 import { SystemIntakeForm } from 'types/systemIntake';
@@ -194,7 +195,12 @@ const RequestRepository = () => {
 
   const lastAdminNoteColumn = {
     Header: t('intake:fields.lastAdminNote'),
-    accessor: 'lastAdminNote',
+    accessor: (intake: SystemIntake) => {
+      if (intake?.lastAdminNote?.content) {
+        return intake.lastAdminNote.content;
+      }
+      return null;
+    },
     Cell: ({ value }: any) => {
       if (value) {
         return (
@@ -204,7 +210,7 @@ const RequestRepository = () => {
             id="last-admin-note"
             label="less"
             closeLabel="more"
-            text={value.content}
+            text={value}
             charLimit={freeFormTextCharLimit}
           />
         );


### PR DESCRIPTION
## Changes proposed in this pull request

- lasAdminNote column was configured to sort on an object instead of a string.  Changed the existing column definition to sort on the 'content' field of the lastAdminNote object.

## Setup & How to test

- Pull the branch locally and test it
- Check that all code is adequately covered by tests
- Make comments, even if it's minor!

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

## Screenshots

<!--
    If this PR benefits from showing any visual components, put any screenshots here!
-->
