### PR TITLE
Sub-Route Navigation Underline

### DIFF
--- a/src/components/BookmarkCard/__snapshots__/index.test.tsx.snap
+++ b/src/components/BookmarkCard/__snapshots__/index.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`BookmarkCard matches the snapshot 1`] = `
           >
             <a
               class="usa-link"
-              href="/system-profile/1/home/top"
+              href="/systems/1/home/top"
             >
               Happiness Achievement Module
             </a>

--- a/src/components/BookmarkCard/index.tsx
+++ b/src/components/BookmarkCard/index.tsx
@@ -56,7 +56,7 @@ const BookmarkCard = ({
       <div className="grid-col-12">
         <div className="bookmark__header easi-header__basic">
           <h2 className="bookmark__title margin-top-0 margin-bottom-1">
-            <UswdsReactLink to={`/system-profile/${id}/home/top`}>
+            <UswdsReactLink to={`/systems/${id}/home/top`}>
               {name}
             </UswdsReactLink>
           </h2>

--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -22,7 +22,7 @@ export const navLinks = (flags: Flags) => [
     isEnabled: true
   },
   {
-    link: '/system-profile',
+    link: '/systems',
     label: 'systems',
     isEnabled: flags.systemProfile
   },

--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -32,7 +32,7 @@ export const navLinks = (flags: Flags) => [
     isEnabled: true
   },
   {
-    link: '/508/making-a-request',
+    link: '/508',
     label: 'add508Request',
     isEnabled: true
   },

--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -66,7 +66,7 @@ const NavigationBar = ({
             activeClassName="usa-current"
             className="easi-nav__link"
             onClick={() => toggle(false)}
-            exact
+            exact={route.link === '/'}
           >
             <em
               className="usa-logo__text easi-nav__label"

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -70,6 +70,7 @@ const AppRoutes = () => {
       <SecureRoute path="/my-requests" component={MyRequests} />
 
       {/* 508 / Accessibility Team Routes */}
+      <Redirect exact from="/508" to="/508/making-a-request" />
       <SecureRoute path="/508" component={Accessibility} />
 
       {/* GRT/GRB Routes */}

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -131,18 +131,18 @@ const AppRoutes = () => {
         component={SystemIntake}
       />
       {flags.systemProfile && (
-        <SecureRoute exact path="/system-profile" component={SystemList} />
+        <SecureRoute exact path="/systems" component={SystemList} />
       )}
       {flags.systemProfile && (
         <SecureRoute
-          path="/system-profile/:systemId"
+          path="/systems/:systemId"
           exact
           component={SystemProfile}
         />
       )}
       {flags.systemProfile && (
         <SecureRoute
-          path="/system-profile/:systemId/:subinfo/:top?"
+          path="/systems/:systemId/:subinfo/:top?"
           exact
           component={SystemProfile}
         />

--- a/src/views/App/scrollConfig.ts
+++ b/src/views/App/scrollConfig.ts
@@ -1,4 +1,4 @@
-const scrollBlackList = ['system-profile'];
+const scrollBlackList = ['systems'];
 
 const shouldScroll = (path: string) =>
   !scrollBlackList.includes(path.split('/')[1]); // Checking for only first path as possible blacklist, as subsequent paths contain variable ids

--- a/src/views/SystemList/Table.tsx
+++ b/src/views/SystemList/Table.tsx
@@ -113,7 +113,7 @@ export const Table = ({
         accessor: 'name',
         id: 'systemName',
         Cell: ({ row }: { row: Row<CedarSystem> }) => (
-          <UswdsReactLink to={`/system-profile/${row.original.id}/home/top`}>
+          <UswdsReactLink to={`/systems/${row.original.id}/home/top`}>
             {row.original.name}
           </UswdsReactLink>
         )

--- a/src/views/SystemList/__snapshots__/index.test.tsx.snap
+++ b/src/views/SystemList/__snapshots__/index.test.tsx.snap
@@ -267,7 +267,7 @@ exports[`System List View when there are requests matches snapshot 1`] = `
             >
               <a
                 class="usa-link"
-                href="/system-profile/3/home/top"
+                href="/systems/3/home/top"
               >
                 Government
               </a>
@@ -316,7 +316,7 @@ exports[`System List View when there are requests matches snapshot 1`] = `
             >
               <a
                 class="usa-link"
-                href="/system-profile/1/home/top"
+                href="/systems/1/home/top"
               >
                 Happiness Achievement Module
               </a>
@@ -365,7 +365,7 @@ exports[`System List View when there are requests matches snapshot 1`] = `
             >
               <a
                 class="usa-link"
-                href="/system-profile/326-9-0/home/top"
+                href="/systems/326-9-0/home/top"
               >
                 Medicare Beneficiary Contact Center
               </a>
@@ -414,7 +414,7 @@ exports[`System List View when there are requests matches snapshot 1`] = `
             >
               <a
                 class="usa-link"
-                href="/system-profile/326-1-0/home/top"
+                href="/systems/326-1-0/home/top"
               >
                 Systems
               </a>

--- a/src/views/SystemProfile/components/ATO/index.test.tsx
+++ b/src/views/SystemProfile/components/ATO/index.test.tsx
@@ -14,8 +14,8 @@ import ATO from './index';
 describe('ATO sub page for System Profile', () => {
   it('renders the progress page when status of In Progress', async () => {
     render(
-      <MemoryRouter initialEntries={['/system-profile/326-9-0/ato']}>
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/ato']}>
+        <Route path="/systems/:systemId/:subinfo">
           <ATO
             system={{
               ...mockSystemInfo[3],
@@ -112,8 +112,8 @@ describe('ATO sub page for System Profile', () => {
 
   it('matches snapshot', async () => {
     const { asFragment } = render(
-      <MemoryRouter initialEntries={['/system-profile/326-9-0/ato']}>
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/ato']}>
+        <Route path="/systems/:systemId/:subinfo">
           <ATO
             system={{
               ...mockSystemInfo[3],

--- a/src/views/SystemProfile/components/FundingAndBudget/index.test.tsx
+++ b/src/views/SystemProfile/components/FundingAndBudget/index.test.tsx
@@ -14,10 +14,8 @@ import FundingAndBudget from './index';
 describe('The making a request page', () => {
   it('renders without errors', async () => {
     render(
-      <MemoryRouter
-        initialEntries={['/system-profile/326-9-0/funding-and-budget']}
-      >
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/funding-and-budget']}>
+        <Route path="/systems/:systemId/:subinfo">
           <FundingAndBudget
             system={{
               ...mockSystemInfo[3],
@@ -39,8 +37,8 @@ describe('The making a request page', () => {
 
   it('matches snapshot', async () => {
     const { asFragment } = render(
-      <MemoryRouter initialEntries={['/system-profile/326-9-0/details']}>
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/details']}>
+        <Route path="/systems/:systemId/:subinfo">
           <FundingAndBudget
             system={{
               ...mockSystemInfo[3],

--- a/src/views/SystemProfile/components/SubSystems/__snapshots__/index.test.tsx.snap
+++ b/src/views/SystemProfile/components/SubSystems/__snapshots__/index.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`System Sub-systems subpage matches snapshot 1`] = `
                       >
                         <a
                           class="usa-link"
-                          href="/system-profile/326-9-0/todo"
+                          href="/systems/326-9-0/todo"
                         >
                           Test Ocular Fiction Utensil
                         </a>
@@ -115,7 +115,7 @@ exports[`System Sub-systems subpage matches snapshot 1`] = `
                       >
                         <a
                           class="usa-link"
-                          href="/system-profile/326-9-0/todo"
+                          href="/systems/326-9-0/todo"
                         >
                           Bio-Energy Engagement File
                         </a>

--- a/src/views/SystemProfile/components/SubSystems/index.test.tsx
+++ b/src/views/SystemProfile/components/SubSystems/index.test.tsx
@@ -9,8 +9,8 @@ import SubSystems from './index';
 describe('System Sub-systems subpage', () => {
   it('renders without errors', async () => {
     render(
-      <MemoryRouter initialEntries={['/system-profile/326-9-0/sub-systems']}>
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/sub-systems']}>
+        <Route path="/systems/:systemId/:subinfo">
           <SubSystems
             system={{
               ...mockSystemInfo[3],
@@ -33,8 +33,8 @@ describe('System Sub-systems subpage', () => {
 
   it('matches snapshot', async () => {
     const { asFragment } = render(
-      <MemoryRouter initialEntries={['/system-profile/326-9-0/sub-systems']}>
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/sub-systems']}>
+        <Route path="/systems/:systemId/:subinfo">
           <SubSystems
             system={{
               ...mockSystemInfo[3],

--- a/src/views/SystemProfile/components/SystemData/__snapshots__/index.test.tsx.snap
+++ b/src/views/SystemProfile/components/SystemData/__snapshots__/index.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`System Data sub page for System Profile matches snapshot 1`] = `
                 </dd>
                 <a
                   class="usa-link"
-                  href="/system-profile/326-9-0/tools-and-software"
+                  href="/systems/326-9-0/tools-and-software"
                 >
                   View gateway information
                 </a>

--- a/src/views/SystemProfile/components/SystemData/index.test.tsx
+++ b/src/views/SystemProfile/components/SystemData/index.test.tsx
@@ -9,8 +9,8 @@ import SystemData from './index';
 describe('System Data sub page for System Profile', () => {
   it('matches snapshot', async () => {
     const { asFragment } = render(
-      <MemoryRouter initialEntries={['/system-profile/326-9-0/system-data']}>
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/system-data']}>
+        <Route path="/systems/:systemId/:subinfo">
           <SystemData
             system={{
               ...mockSystemInfo[3],

--- a/src/views/SystemProfile/components/SystemDetails/index.test.tsx
+++ b/src/views/SystemProfile/components/SystemDetails/index.test.tsx
@@ -13,8 +13,8 @@ import SystemDetails from './index';
 describe('The making a request page', () => {
   it('renders without errors', async () => {
     render(
-      <MemoryRouter initialEntries={['/system-profile/326-9-0/details']}>
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/details']}>
+        <Route path="/systems/:systemId/:subinfo">
           <SystemDetails
             system={{
               ...mockSystemInfo[3],
@@ -36,8 +36,8 @@ describe('The making a request page', () => {
 
   it('matches snapshot', async () => {
     const { asFragment } = render(
-      <MemoryRouter initialEntries={['/system-profile/326-9-0/details']}>
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/details']}>
+        <Route path="/systems/:systemId/:subinfo">
           <SystemDetails
             system={{
               ...mockSystemInfo[3],

--- a/src/views/SystemProfile/components/ToolsAndSoftware/index.test.tsx
+++ b/src/views/SystemProfile/components/ToolsAndSoftware/index.test.tsx
@@ -9,10 +9,8 @@ import ToolsAndSoftware from './index';
 describe('System Tools and Software subpage', () => {
   it('renders without errors', async () => {
     render(
-      <MemoryRouter
-        initialEntries={['/system-profile/326-9-0/tools-and-software']}
-      >
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/tools-and-software']}>
+        <Route path="/systems/:systemId/:subinfo">
           <ToolsAndSoftware
             system={{
               ...mockSystemInfo[3],
@@ -32,10 +30,8 @@ describe('System Tools and Software subpage', () => {
 
   it('matches snapshot', async () => {
     const { asFragment } = render(
-      <MemoryRouter
-        initialEntries={['/system-profile/326-9-0/tools-and-software']}
-      >
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/tools-and-software']}>
+        <Route path="/systems/:systemId/:subinfo">
           <ToolsAndSoftware
             system={{
               ...mockSystemInfo[3],

--- a/src/views/SystemProfile/components/index.tsx
+++ b/src/views/SystemProfile/components/index.tsx
@@ -26,49 +26,49 @@ const sideNavItems = (system: CedarSystemProps): sideNavProps => ({
   home: {
     groupEnd: true,
     component: <SystemHome system={system} />,
-    route: `/system-profile/${system.id}/home`
+    route: `/systems/${system.id}/home`
   },
   details: {
     component: <SystemDetails system={system} />,
-    route: `/system-profile/${system.id}/details`
+    route: `/systems/${system.id}/details`
   },
   'team-and-contract': {
     component: <TeamAndContract system={system} />,
-    route: `/system-profile/${system.id}/team-and-contract`
+    route: `/systems/${system.id}/team-and-contract`
   },
   'funding-and-budget': {
     component: <FundingAndBudget system={system} />,
-    route: `/system-profile/${system.id}/funding-and-budget`
+    route: `/systems/${system.id}/funding-and-budget`
   },
   'tools-and-software': {
     groupEnd: true,
     component: <ToolsAndSoftware system={system} />,
-    route: `/system-profile/${system.id}/tools-and-software`
+    route: `/systems/${system.id}/tools-and-software`
   },
   ato: {
     component: <ATO system={system} />,
-    route: `/system-profile/${system.id}/ato`
+    route: `/systems/${system.id}/ato`
   },
   'lifecycle-id': {
     component: <SystemHome system={system} />,
-    route: `/system-profile/${system.id}/lifecycle-id`
+    route: `/systems/${system.id}/lifecycle-id`
   },
   'section-508': {
     groupEnd: true,
     component: <SystemHome system={system} />,
-    route: `/system-profile/${system.id}/section-508`
+    route: `/systems/${system.id}/section-508`
   },
   'sub-systems': {
     component: <SubSystems system={system} />,
-    route: `/system-profile/${system.id}/sub-systems`
+    route: `/systems/${system.id}/sub-systems`
   },
   'system-data': {
     component: <SystemHome system={system} />,
-    route: `/system-profile/${system.id}/system-data`
+    route: `/systems/${system.id}/system-data`
   },
   documents: {
     component: <SystemHome system={system} />,
-    route: `/system-profile/${system.id}/documents`
+    route: `/systems/${system.id}/documents`
   }
 });
 

--- a/src/views/SystemProfile/index.test.tsx
+++ b/src/views/SystemProfile/index.test.tsx
@@ -27,10 +27,8 @@ const mocks = [
 describe('The making a request page', () => {
   it('renders without errors', async () => {
     render(
-      <MemoryRouter
-        initialEntries={['/system-profile/326-9-0/tools-and-software']}
-      >
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/tools-and-software']}>
+        <Route path="/systems/:systemId/:subinfo">
           <MockedProvider mocks={mocks} addTypename={false}>
             <SystemProfile />
           </MockedProvider>
@@ -47,10 +45,8 @@ describe('The making a request page', () => {
 
   it('matches snapshot', async () => {
     const { asFragment } = render(
-      <MemoryRouter
-        initialEntries={['/system-profile/326-9-0/tools-and-software']}
-      >
-        <Route path="/system-profile/:systemId/:subinfo">
+      <MemoryRouter initialEntries={['/systems/326-9-0/tools-and-software']}>
+        <Route path="/systems/:systemId/:subinfo">
           <MockedProvider mocks={mocks} addTypename={false}>
             <SystemProfile />
           </MockedProvider>

--- a/src/views/SystemProfile/index.tsx
+++ b/src/views/SystemProfile/index.tsx
@@ -168,7 +168,7 @@ const SystemProfile = () => {
               >
                 <Breadcrumb>
                   <span>&larr; </span>
-                  <BreadcrumbLink asCustom={Link} to="/system-profile">
+                  <BreadcrumbLink asCustom={Link} to="/systems">
                     <span>{t('singleSystem.summary.back')}</span>
                   </BreadcrumbLink>
                 </Breadcrumb>


### PR DESCRIPTION
# EASI-1606

## Changes proposed in this pull request

- `/508` & `/systems` are new NavLink base paths
- Rename `/system-profile` base path to `/systems`
  - `system-profile` still used in styles
- NavLink exact condition check on root path
- NavLinks to associated subpages/paths will become active

## Reviewer Notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup & How to test

- Pull the branch locally and test it
- Check that all code is adequately covered by tests
- Make comments, even if it's minor!

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR
- [ ] Added or updated tests for backend resolvers or other functions as needed
- [ ] Added or updated client tests for new components, parent components,
functions, or e2e tests as necessary
- [ ] Tested user-facing changes with voice-over and
the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys
  - [ ] Deployed this branch to the remote dev environment via CI

## Screenshots

<!--
    If this PR benefits from showing any visual components, put any screenshots here!
-->
