### PR TITLE
Change CEDAR core client to return empty arrays when no roles/deployments found

### DIFF
--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -7,7 +7,10 @@ Cypress.Commands.add('login', () => {
   cy.visit('/signin');
 
   cy.get('#okta-signin-username').type(Cypress.env('username'), { log: false });
-  cy.get('#okta-signin-password').type(Cypress.env('password'), { log: false });
+  cy.get('#okta-signin-password').type(Cypress.env('password'), {
+    log: false,
+    parseSpecialCharSequences: false
+  });
   cy.get('#okta-signin-submit').click();
 
   cy.get('.beacon-loading').should('not.exist');

--- a/pkg/cedar/core/deployment.go
+++ b/pkg/cedar/core/deployment.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
-	"github.com/cmsgov/easi-app/pkg/apperrors"
 	apideployments "github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/deployment"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
@@ -56,12 +55,6 @@ func (c *Client) GetDeployments(ctx context.Context, systemID string, optionalPa
 
 	if resp.Payload == nil {
 		return []*models.CedarDeployment{}, fmt.Errorf("no body received")
-	}
-
-	responseArray := resp.Payload.Deployments
-
-	if len(responseArray) == 0 {
-		return nil, &apperrors.ResourceNotFoundError{Err: fmt.Errorf("no deployments found"), Resource: []*models.CedarDeployment{}}
 	}
 
 	// Convert the auto-generated struct to our own pkg/models struct

--- a/pkg/cedar/core/role.go
+++ b/pkg/cedar/core/role.go
@@ -9,7 +9,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
-	"github.com/cmsgov/easi-app/pkg/apperrors"
 	apiroles "github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/role"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
@@ -56,10 +55,6 @@ func (c *Client) GetRolesBySystem(ctx context.Context, systemID string, roleType
 
 	if resp.Payload == nil {
 		return []*models.CedarRole{}, fmt.Errorf("no body received")
-	}
-
-	if len(resp.Payload.Roles) == 0 {
-		return nil, &apperrors.ResourceNotFoundError{Err: fmt.Errorf("no roles found"), Resource: []*models.CedarRole{}}
 	}
 
 	// Convert the auto-generated struct to our own pkg/models struct

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -6,6 +6,7 @@ package graph
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"strconv"
 	"time"
@@ -1461,6 +1462,11 @@ func (r *queryResolver) Deployments(ctx context.Context, systemID string, deploy
 	if err != nil {
 		return nil, err
 	}
+
+	if len(cedarDeployments) == 0 {
+		return nil, &apperrors.ResourceNotFoundError{Err: fmt.Errorf("no deployments found"), Resource: []*models.CedarDeployment{}}
+	}
+
 	return cedarDeployments, nil
 }
 
@@ -1469,6 +1475,11 @@ func (r *queryResolver) Roles(ctx context.Context, systemID string, roleTypeID *
 	if err != nil {
 		return nil, err
 	}
+
+	if len(cedarRoles) == 0 {
+		return nil, &apperrors.ResourceNotFoundError{Err: fmt.Errorf("no roles found"), Resource: []*models.CedarRole{}}
+	}
+
 	return cedarRoles, nil
 }
 


### PR DESCRIPTION
No Jira ticket - this is the result of a [Slack discussion](https://cmsgov.slack.com/archives/CNU2B59UH/p1644949782328829).

## Changes proposed in this pull request

- CEDAR Core client's method's for fetching roles/deployments return an empty array instead of an error if none are found. The GraphQL endpoints need to return an error, so that check's done in the resolvers instead.
