### PR TITLE
Display current status of request in GRT Summary page

### DIFF
--- a/cypress/integration/governanceReviewTeam.spec.js
+++ b/cypress/integration/governanceReviewTeam.spec.js
@@ -163,12 +163,12 @@ describe('Governance Review Team', () => {
     ).click();
 
     cy.contains('h1', 'Decision - Approved');
-    cy.get('[data-testid="grt-lcid"]')
+    cy.get('[data-testid="grt-current-status"]')
       .invoke('text')
       .then(text => {
-        expect(text.length).to.equal(6);
+        expect(text.length).to.equal(27);
       });
-    cy.contains('p', 'LCID issued');
+    cy.contains('dt', 'Lifecycle ID issued');
 
     cy.get(
       'a[href="/governance-review-team/af7a3924-3ff7-48ec-8a54-b8b4bc95610b/lcid"]'

--- a/src/utils/systemIntake.ts
+++ b/src/utils/systemIntake.ts
@@ -85,9 +85,10 @@ export const translateStatus = (
 
   if (statusEnum === 'LCID_ISSUED') {
     // if status is LCID_ISSUED, translate from enum to i18n and append LCID
-    statusTranslation = `${i18next.t(
-      `intake:statusMap.${statusEnum}`
-    )}: ${lcid}`;
+    // Display not available message if LCID is null (usually due to bad SharePoint data migration)
+    statusTranslation = `${i18next.t(`intake:statusMap.${statusEnum}`)}: ${
+      lcid || 'ID Not Available'
+    }`;
   } else {
     // if not just translate from enum to i18n
     statusTranslation = i18next.t(`intake:statusMap.${statusEnum}`);

--- a/src/utils/systemIntake.ts
+++ b/src/utils/systemIntake.ts
@@ -4,7 +4,8 @@ import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
 import {
   closedIntakeStatuses,
   openIntakeStatuses,
-  RequestType
+  RequestType,
+  SystemIntakeStatus
 } from 'types/systemIntake';
 
 // NOTE: these utility functions take strings rather than more restricted types so they can operate on values coming from GraphQL queries,
@@ -70,6 +71,29 @@ export const getAcronymForComponent = (componentToTranslate: string) => {
 
   // TODO: what do we return if not found? (should be impossible)
   return component ? component.acronym : 'Other';
+};
+
+/**
+ * Translate the API status enum to a human readable string
+ * @param statusEnum - intake status represented by enum value
+ */
+export const translateStatus = (
+  statusEnum: SystemIntakeStatus,
+  lcid: string | null
+) => {
+  let statusTranslation = '';
+
+  if (statusEnum === 'LCID_ISSUED') {
+    // if status is LCID_ISSUED, translate from enum to i18n and append LCID
+    statusTranslation = `${i18next.t(
+      `intake:statusMap.${statusEnum}`
+    )}: ${lcid}`;
+  } else {
+    // if not just translate from enum to i18n
+    statusTranslation = i18next.t(`intake:statusMap.${statusEnum}`);
+  }
+
+  return statusTranslation;
 };
 
 /**

--- a/src/views/GovernanceReviewTeam/Summary/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/Summary/index.test.tsx
@@ -100,7 +100,9 @@ describe('The GRT Review page', () => {
     );
 
     expect(
-      within(screen.getByTestId('grt-lcid')).getByText('123456')
+      within(screen.getByTestId('grt-current-status')).getByText(
+        'Lifecycle ID issued: 123456'
+      )
     ).toBeInTheDocument();
   });
 });

--- a/src/views/GovernanceReviewTeam/Summary/index.tsx
+++ b/src/views/GovernanceReviewTeam/Summary/index.tsx
@@ -22,7 +22,8 @@ import { formatDate } from 'utils/date';
 import {
   isIntakeClosed,
   isIntakeOpen,
-  translateRequestType
+  translateRequestType,
+  translateStatus
 } from 'utils/systemIntake';
 
 type RequestSummaryProps = {
@@ -161,12 +162,11 @@ const RequestSummary = ({
               >
                 {isIntakeClosed(status) ? t('status.closed') : t('status.open')}
               </dd>
-              {lcid && (
-                <>
-                  <dt>{t('intake:lifecycleId')}:&nbsp;</dt>
-                  <dd data-testid="grt-lcid">{lcid}</dd>
-                </>
-              )}
+              <>
+                <dt data-testid="grt-current-status">
+                  {translateStatus(status, lcid)}
+                </dt>
+              </>
             </div>
             <div className="text-gray-90">
               <dt className="text-bold">{t('intake:fields.adminLead')}</dt>

--- a/src/views/GovernanceReviewTeam/index.scss
+++ b/src/views/GovernanceReviewTeam/index.scss
@@ -68,9 +68,6 @@
   }
 
   &__status-info {
-    display: flex;
-    justify-content: space-between;
-
     dd {
       margin: 0 1em 0 0;
     }


### PR DESCRIPTION
# EASI-1170

## Changes and Description

- Add human readable status to the GRT Request Summary page

## How to test this change

Ensure that correct status translation shows/updates based on different stages of a request. Example screenshots below:

**Before Change:**
![image](https://user-images.githubusercontent.com/68014929/155426152-cf2b139d-8adc-4ca8-af7b-f2c3e117f00c.png)


**After Change:**
![image](https://user-images.githubusercontent.com/68014929/155425851-b94997ea-9423-4d9a-9cba-d5118ada99ca.png)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
