### PR TITLE
Link to docs on CEDAR from main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This application has the following main components:
 - [Testing locally](./docs/local_testing.md)
 - [Docker Compose files and usage](./docs/docker_compose.md)
 - [Deployment Process](./docs/operations/deployment_process.md)
+- [Interacting with CEDAR](./docs/cedar.md) - CEDAR is a CMS system whose API we interact with; this includes instructions on how to connect to it
 
 
 ## Repository Structure


### PR DESCRIPTION
No Jira ticket, just missing a reference in the main README index that would be helpful for devs getting oriented in the codebase.