### PR TITLE
[EASI-1657] Change zap to always use NewProduction()

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -34,12 +34,7 @@ func NewServer(config *viper.Viper) *Server {
 		log.Fatalf("Unable to set environment: %v", err)
 	}
 
-	var zapLogger *zap.Logger
-	if environment.Dev() || environment.Local() {
-		zapLogger, err = zap.NewDevelopment()
-	} else {
-		zapLogger, err = zap.NewProduction()
-	}
+	zapLogger, err := zap.NewProduction()
 	if err != nil {
 		log.Fatalf("Failed to initial logger: %v", err)
 	}


### PR DESCRIPTION
# EASI-1657

## Changes and Description

- Changed zap logger to always instantiate with `NewProduction()` instead of using `NewDevelopment()`.
  - The difference between these two, is that [NewProduction](https://pkg.go.dev/go.uber.org/zap@v1.19.1?utm_source=gopls#NewProduction) produces JSON logs, while [NewDevelopment](https://pkg.go.dev/go.uber.org/zap@v1.19.1?utm_source=gopls#NewDevelopment) produces "human friendly" logs

### NewDevelopment Log Example
```
2022-02-25T16:57:29.857Z     INFO    core/system_summary.go:88       Refreshed System Summary cache
```

### NewProduction Log Example
```json
{"level":"info","ts":1645808468.2489672,"caller":"core/system_summary.go:88","msg":"Refreshed System Summary cache"}
```

## How to test this change

- Run `scripts/dev up` to start the application
- Run `docker compose logs -f easi` to tail the application logs
- Ensure that JSON logs are being output

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [x] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [x] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
