### PR TITLE
[NOREF] Add filters to the /system/summary endpoint

### DIFF
--- a/pkg/cedar/core/system_summary.go
+++ b/pkg/cedar/core/system_summary.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/guregu/null"
+
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/apperrors"
 	apisystems "github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/system"
@@ -34,6 +36,9 @@ func (c *Client) GetSystemSummary(ctx context.Context, tryCache bool) ([]*models
 
 	// Construct the parameters
 	params := apisystems.NewSystemSummaryFindListParams()
+	params.SetVersion(null.StringFrom("22").Ptr()) // TODO: This is really nasty, and should be removed upon completion of https://jiraent.cms.gov/browse/CI-168
+	params.SetState(null.StringFrom("active").Ptr())
+	params.SetIncludeInSurvey(null.BoolFrom(true).Ptr())
 	params.HTTPClient = c.hc
 
 	// Make the API call


### PR DESCRIPTION
# No Ticket

## Changes and Description

I am not convinced this is a pretty solution (hard coding `22` feels odd, even though we're likely to have the long-term solve for this well before we get new version IDs)

- Added hard-coded filters to /system/summary endpoint per [this discussion](https://cmsgov.slack.com/archives/CNU2B59UH/p1646077151888089) on Slack

<!-- Put a description here! -->

## How to test this change

- Ensure your VPN is enabled
- `scripts/dev up`
- Navigate to `http://localhost:3000/systems`
- Ensure only ~174 systems load, rather than over 1,000

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
