### PR TITLE
[NOREF] Remove system summary hard-coded version filter

### DIFF
--- a/pkg/cedar/core/system_summary.go
+++ b/pkg/cedar/core/system_summary.go
@@ -36,7 +36,6 @@ func (c *Client) GetSystemSummary(ctx context.Context, tryCache bool) ([]*models
 
 	// Construct the parameters
 	params := apisystems.NewSystemSummaryFindListParams()
-	params.SetVersion(null.StringFrom("22").Ptr()) // TODO: This is really nasty, and should be removed upon completion of https://jiraent.cms.gov/browse/CI-168
 	params.SetState(null.StringFrom("active").Ptr())
 	params.SetIncludeInSurvey(null.BoolFrom(true).Ptr())
 	params.HTTPClient = c.hc


### PR DESCRIPTION
# No ticket

## Changes and Description

This is a continuation of #1507

- Removed hard-coded `version=22` filter on `/system/summary`
  - This is because `state=active` automatically calculates the most recent version, and we're already applying that!

<!-- Put a description here! -->

## How to test this change

* Ensure your VPN is enabled
* `scripts/dev up`
* Navigate to http://localhost:3000/systems
* Ensure only ~174 systems load (the same as before!)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
