### PR TITLE
Change wildcard pattern to run workflow on *all* branches in PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     branches:
-      - '*'
+      - '**'
 
 env:
   EASI_APP_NODE_VERSION: '16.14.0'


### PR DESCRIPTION
Small change to the workflow trigger; [this PR](https://github.com/CMSgov/easi-app/pull/1527) didn't trigger actions to be run. The [syntax for Github actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) specifies that `*` does **not** match `/` characters; the `**` glob pattern is needed to match those.