### PR TITLE
EASI-1703 - Changed route param businessCaseId to id

### DIFF
--- a/src/components/Spinner/index.scss
+++ b/src/components/Spinner/index.scss
@@ -1,11 +1,11 @@
 @mixin spinner-size($inner-size, $outer-size) {
   height: $outer-size;
   width: $outer-size;
-  $padding: (($outer-size - $inner-size) / 2);
+  $padding: calc(($outer-size - $inner-size) / 2);
 
   &::before,
   &::after {
-    border-width: ($inner-size / 8);
+    border-width: calc($inner-size / 8);
     height: $inner-size;
     left: $padding;
     top: $padding;

--- a/src/stylesheets/_variables.module.scss
+++ b/src/stylesheets/_variables.module.scss
@@ -4,7 +4,7 @@ $desktop: 1024px;
 
 // division by 1px removes the unit
 :export {
-    mobile: $mobile / 1px;
-    tablet: $tablet / 1px;
-    desktop: $desktop / 1px;
+    mobile: calc($mobile / 1px);
+    tablet: calc($tablet / 1px);
+    desktop: calc($desktop / 1px);
 }

--- a/src/views/GovernanceTaskList/TaskListCta.tsx
+++ b/src/views/GovernanceTaskList/TaskListCta.tsx
@@ -62,7 +62,6 @@ export const BusinessCaseDraftCta = ({
   systemIntake: SystemIntake;
 }) => {
   const { id, status, businessCaseId } = systemIntake || {};
-  console.log(systemIntake);
   const history = useHistory();
   switch (status) {
     case 'NEED_BIZ_CASE':

--- a/src/views/GovernanceTaskList/TaskListCta.tsx
+++ b/src/views/GovernanceTaskList/TaskListCta.tsx
@@ -62,6 +62,7 @@ export const BusinessCaseDraftCta = ({
   systemIntake: SystemIntake;
 }) => {
   const { id, status, businessCaseId } = systemIntake || {};
+  console.log(systemIntake);
   const history = useHistory();
   switch (status) {
     case 'NEED_BIZ_CASE':
@@ -130,7 +131,7 @@ export const BusinessCaseDraftCta = ({
             data-testid="prepare-for-grt-cta"
             className="display-table margin-bottom-3 usa-button"
             variant="unstyled"
-            to={`/governance-task-list/${businessCaseId}/prepare-for-grt`}
+            to={`/governance-task-list/${id}/prepare-for-grt`}
           >
             Prepare for review team meeting
           </UswdsReactLink>


### PR DESCRIPTION
# EASI-1703

## Changes and Description

- Changed route param variable from `businessCaseId` to `id`
- Dart-sass was failing to compile a deprecated division method - switch method to recommended

The route `/governance-task-list/:systemId/prepare-for-grt` should have a system id rather than a businessCaseId.

## How to test this change

Changing the intake status 'Easy Access to System Information' after seeded to 'READY_FOR_GRT' will allow you to hit the view that pertains to this bug.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
