### PR TITLE
EASI-1195/cost baseline in lcid issuance mail 2

### DIFF
--- a/pkg/email/issue_lcid.go
+++ b/pkg/email/issue_lcid.go
@@ -11,20 +11,22 @@ import (
 )
 
 type issueLCID struct {
-	LifecycleID string
-	ExpiresAt   string
-	Scope       string
-	NextSteps   string
-	Feedback    string
+	LifecycleID           string
+	ExpiresAt             string
+	Scope                 string
+	LifecycleCostBaseline string
+	NextSteps             string
+	Feedback              string
 }
 
-func (c Client) issueLCIDBody(lcid string, expiresAt *time.Time, scope string, nextSteps string, feedback string) (string, error) {
+func (c Client) issueLCIDBody(lcid string, expiresAt *time.Time, scope string, nextSteps string, costBaseline string, feedback string) (string, error) {
 	data := issueLCID{
-		LifecycleID: lcid,
-		ExpiresAt:   expiresAt.Format("January 2, 2006"),
-		Scope:       scope,
-		NextSteps:   nextSteps,
-		Feedback:    feedback,
+		LifecycleID:           lcid,
+		ExpiresAt:             expiresAt.Format("January 2, 2006"),
+		Scope:                 scope,
+		LifecycleCostBaseline: costBaseline,
+		NextSteps:             nextSteps,
+		Feedback:              feedback,
 	}
 	var b bytes.Buffer
 	if c.templates.issueLCIDTemplate == nil {
@@ -38,9 +40,9 @@ func (c Client) issueLCIDBody(lcid string, expiresAt *time.Time, scope string, n
 }
 
 // SendIssueLCIDEmail sends an email for issuing an LCID
-func (c Client) SendIssueLCIDEmail(ctx context.Context, recipient models.EmailAddress, lcid string, expirationDate *time.Time, scope string, nextSteps string, feedback string) error {
+func (c Client) SendIssueLCIDEmail(ctx context.Context, recipient models.EmailAddress, lcid string, expirationDate *time.Time, scope string, lifecycleCostBaseline string, nextSteps string, feedback string) error {
 	subject := "Your request has been approved"
-	body, err := c.issueLCIDBody(lcid, expirationDate, scope, nextSteps, feedback)
+	body, err := c.issueLCIDBody(lcid, expirationDate, scope, lifecycleCostBaseline, nextSteps, feedback)
 	if err != nil {
 		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}
 	}

--- a/pkg/email/issue_lcid.go
+++ b/pkg/email/issue_lcid.go
@@ -19,12 +19,12 @@ type issueLCID struct {
 	Feedback              string
 }
 
-func (c Client) issueLCIDBody(lcid string, expiresAt *time.Time, scope string, nextSteps string, costBaseline string, feedback string) (string, error) {
+func (c Client) issueLCIDBody(lcid string, expiresAt *time.Time, scope string, lifecycleCostBaseline string, nextSteps string, feedback string) (string, error) {
 	data := issueLCID{
 		LifecycleID:           lcid,
 		ExpiresAt:             expiresAt.Format("January 2, 2006"),
 		Scope:                 scope,
-		LifecycleCostBaseline: costBaseline,
+		LifecycleCostBaseline: lifecycleCostBaseline,
 		NextSteps:             nextSteps,
 		Feedback:              feedback,
 	}

--- a/pkg/email/issue_lcid_test.go
+++ b/pkg/email/issue_lcid_test.go
@@ -15,6 +15,7 @@ func (s *EmailTestSuite) TestSendIssueLCIDEmail() {
 	lcid := "123456"
 	expiresAt, _ := time.Parse("2006-01-02", "2021-12-25")
 	scope := "scope"
+	lifecycleCostBaseline := "lifecycleCostBaseline"
 	nextSteps := "nextSteps"
 	feedback := "feedback"
 
@@ -22,9 +23,12 @@ func (s *EmailTestSuite) TestSendIssueLCIDEmail() {
 		client, err := NewClient(s.config, &sender)
 		s.NoError(err)
 
-		expectedEmail := "<p>Lifecycle ID: 123456</p>\n<p>Expiration Date: December 25, 2021</p>\n<p>Scope: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">scope</pre></p>\n" +
-			"<p>Next Steps: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">nextSteps</pre></p>\n\n<p>Feedback: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">feedback</pre></p>"
-		err = client.SendIssueLCIDEmail(ctx, recipient, lcid, &expiresAt, scope, nextSteps, feedback)
+		expectedEmail := "<p>Lifecycle ID: 123456</p>\n<p>Expiration Date: December 25, 2021</p>\n" +
+			"<p>Scope: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">scope</pre></p>\n" +
+			"<p>Project Cost Baseline: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">lifecycleCostBaseline</pre></p>\n" +
+			"<p>Next Steps: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">nextSteps</pre></p>\n\n" +
+			"<p>Feedback: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">feedback</pre></p>"
+		err = client.SendIssueLCIDEmail(ctx, recipient, lcid, &expiresAt, scope, lifecycleCostBaseline, nextSteps, feedback)
 
 		s.NoError(err)
 		s.Equal(recipient, sender.toAddress)
@@ -35,10 +39,10 @@ func (s *EmailTestSuite) TestSendIssueLCIDEmail() {
 	s.Run("successful call has the right content with no next steps", func() {
 		client, err := NewClient(s.config, &sender)
 		s.NoError(err)
-
-		expectedEmail := "<p>Lifecycle ID: 123456</p>\n<p>Expiration Date: December 25, 2021</p>\n<p>Scope: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">scope</pre></p>" +
-			"\n\n<p>Feedback: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">feedback</pre></p>"
-		err = client.SendIssueLCIDEmail(ctx, recipient, lcid, &expiresAt, scope, "", feedback)
+		expectedEmail := "<p>Lifecycle ID: 123456</p>\n<p>Expiration Date: December 25, 2021</p>\n" +
+			"<p>Scope: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">scope</pre></p>\n" +
+			"<p>Project Cost Baseline: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">lifecycleCostBaseline</pre></p>\n"
+		err = client.SendIssueLCIDEmail(ctx, recipient, lcid, &expiresAt, scope, lifecycleCostBaseline, "", feedback)
 
 		s.NoError(err)
 		s.Equal(recipient, sender.toAddress)
@@ -51,7 +55,7 @@ func (s *EmailTestSuite) TestSendIssueLCIDEmail() {
 		s.NoError(err)
 		client.templates = templates{}
 
-		err = client.SendIssueLCIDEmail(ctx, recipient, lcid, &expiresAt, scope, nextSteps, feedback)
+		err = client.SendIssueLCIDEmail(ctx, recipient, lcid, &expiresAt, scope, lifecycleCostBaseline, nextSteps, feedback)
 
 		s.Error(err)
 		s.IsType(err, &apperrors.NotificationError{})
@@ -65,7 +69,7 @@ func (s *EmailTestSuite) TestSendIssueLCIDEmail() {
 		s.NoError(err)
 		client.templates.issueLCIDTemplate = mockFailedTemplateCaller{}
 
-		err = client.SendIssueLCIDEmail(ctx, recipient, lcid, &expiresAt, scope, nextSteps, feedback)
+		err = client.SendIssueLCIDEmail(ctx, recipient, lcid, &expiresAt, scope, lifecycleCostBaseline, nextSteps, feedback)
 
 		s.Error(err)
 		s.IsType(err, &apperrors.NotificationError{})
@@ -80,7 +84,7 @@ func (s *EmailTestSuite) TestSendIssueLCIDEmail() {
 		client, err := NewClient(s.config, &sender)
 		s.NoError(err)
 
-		err = client.SendIssueLCIDEmail(ctx, recipient, lcid, &expiresAt, scope, nextSteps, feedback)
+		err = client.SendIssueLCIDEmail(ctx, recipient, lcid, &expiresAt, scope, lifecycleCostBaseline, nextSteps, feedback)
 
 		s.Error(err)
 		s.IsType(err, &apperrors.NotificationError{})

--- a/pkg/email/issue_lcid_test.go
+++ b/pkg/email/issue_lcid_test.go
@@ -41,7 +41,8 @@ func (s *EmailTestSuite) TestSendIssueLCIDEmail() {
 		s.NoError(err)
 		expectedEmail := "<p>Lifecycle ID: 123456</p>\n<p>Expiration Date: December 25, 2021</p>\n" +
 			"<p>Scope: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">scope</pre></p>\n" +
-			"<p>Project Cost Baseline: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">lifecycleCostBaseline</pre></p>\n"
+			"<p>Project Cost Baseline: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">lifecycleCostBaseline</pre></p>\n\n" +
+			"<p>Feedback: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">feedback</pre></p>"
 		err = client.SendIssueLCIDEmail(ctx, recipient, lcid, &expiresAt, scope, lifecycleCostBaseline, "", feedback)
 
 		s.NoError(err)

--- a/pkg/email/issue_lcid_test.go
+++ b/pkg/email/issue_lcid_test.go
@@ -26,7 +26,7 @@ func (s *EmailTestSuite) TestSendIssueLCIDEmail() {
 		expectedEmail := "<p>Lifecycle ID: 123456</p>\n<p>Expiration Date: December 25, 2021</p>\n" +
 			"<p>Scope: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">scope</pre></p>\n" +
 			"<p>Project Cost Baseline: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">lifecycleCostBaseline</pre></p>\n" +
-			"<p>Next Steps: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">nextSteps</pre></p>\n\n" +
+			"<p>Next Steps: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">nextSteps</pre></p>\n" +
 			"<p>Feedback: <pre style=\"white-space: pre-wrap; word-break: keep-all;\">feedback</pre></p>"
 		err = client.SendIssueLCIDEmail(ctx, recipient, lcid, &expiresAt, scope, lifecycleCostBaseline, nextSteps, feedback)
 

--- a/pkg/email/templates/issue_lcid.gohtml
+++ b/pkg/email/templates/issue_lcid.gohtml
@@ -1,6 +1,8 @@
 <p>Lifecycle ID: {{.LifecycleID}}</p>
 <p>Expiration Date: {{.ExpiresAt}}</p>
 <p>Scope: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.Scope}}</pre></p>
-{{if .LifecycleCostBaseline}}<p>Project Cost Baseline: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.LifecycleCostBaseline}}</pre></p>{{end}}
-{{if .NextSteps}}<p>Next Steps: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.NextSteps}}</pre></p>{{end}}
+{{if .LifecycleCostBaseline}}<p>Project Cost Baseline: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.LifecycleCostBaseline}}</pre></p>
+{{end}}
+{{if .NextSteps}}<p>Next Steps: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.NextSteps}}</pre></p>
+{{end}}
 <p>Feedback: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.Feedback}}</pre></p>

--- a/pkg/email/templates/issue_lcid.gohtml
+++ b/pkg/email/templates/issue_lcid.gohtml
@@ -1,7 +1,6 @@
 <p>Lifecycle ID: {{.LifecycleID}}</p>
 <p>Expiration Date: {{.ExpiresAt}}</p>
 <p>Scope: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.Scope}}</pre></p>
-<p>Project Cost Baseline: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.LifecycleCostBaseline}}</pre></p>
-{{if .NextSteps}}<p>Next Steps: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.NextSteps}}</pre></p>
-{{end}}
+{{if .LifecycleCostBaseline}}<p>Project Cost Baseline: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.LifecycleCostBaseline}}</pre></p>{{end}}
+{{if .NextSteps}}<p>Next Steps: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.NextSteps}}</pre></p>{{end}}
 <p>Feedback: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.Feedback}}</pre></p>

--- a/pkg/email/templates/issue_lcid.gohtml
+++ b/pkg/email/templates/issue_lcid.gohtml
@@ -1,8 +1,6 @@
 <p>Lifecycle ID: {{.LifecycleID}}</p>
 <p>Expiration Date: {{.ExpiresAt}}</p>
 <p>Scope: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.Scope}}</pre></p>
-{{if .LifecycleCostBaseline}}<p>Project Cost Baseline: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.LifecycleCostBaseline}}</pre></p>
-{{end}}
-{{if .NextSteps}}<p>Next Steps: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.NextSteps}}</pre></p>
-{{end}}
+{{if .LifecycleCostBaseline}}<p>Project Cost Baseline: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.LifecycleCostBaseline}}</pre></p>{{end}}
+{{if .NextSteps}}<p>Next Steps: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.NextSteps}}</pre></p>{{end}}
 <p>Feedback: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.Feedback}}</pre></p>

--- a/pkg/email/templates/issue_lcid.gohtml
+++ b/pkg/email/templates/issue_lcid.gohtml
@@ -1,6 +1,7 @@
 <p>Lifecycle ID: {{.LifecycleID}}</p>
 <p>Expiration Date: {{.ExpiresAt}}</p>
 <p>Scope: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.Scope}}</pre></p>
+<p>Project Cost Baseline: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.LifecycleCostBaseline}}</pre></p>
 {{if .NextSteps}}<p>Next Steps: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.NextSteps}}</pre></p>
 {{end}}
 <p>Feedback: <pre style="white-space: pre-wrap; word-break: keep-all;">{{.Feedback}}</pre></p>

--- a/pkg/services/system_intakes.go
+++ b/pkg/services/system_intakes.go
@@ -231,7 +231,7 @@ func NewUpdateLifecycleFields(
 	update func(context.Context, *models.SystemIntake) (*models.SystemIntake, error),
 	saveAction func(context.Context, *models.Action) error,
 	fetchUserInfo func(context.Context, string) (*models.UserInfo, error),
-	sendIssueLCIDEmail func(context.Context, models.EmailAddress, string, *time.Time, string, string, string) error,
+	sendIssueLCIDEmail func(context.Context, models.EmailAddress, string, *time.Time, string, string, string, string) error,
 	generateLCID func(context.Context) (string, error),
 ) func(context.Context, *models.SystemIntake, *models.Action) (*models.SystemIntake, error) {
 	return func(ctx context.Context, intake *models.SystemIntake, action *models.Action) (*models.SystemIntake, error) {
@@ -310,13 +310,13 @@ func NewUpdateLifecycleFields(
 			}
 		}
 
-		// TODO: put cost baseline in email?
 		err = sendIssueLCIDEmail(
 			ctx,
 			requesterInfo.Email,
 			updated.LifecycleID.String,
 			updated.LifecycleExpiresAt,
 			updated.LifecycleScope.String,
+			updated.LifecycleCostBaseline.String,
 			updated.DecisionNextSteps.String,
 			action.Feedback.String)
 		if err != nil {

--- a/pkg/services/system_intakes_test.go
+++ b/pkg/services/system_intakes_test.go
@@ -360,7 +360,7 @@ func (s ServicesTestSuite) TestUpdateLifecycleFields() {
 	}
 	reviewEmailCount := 0
 	feedbackForEmailText := ""
-	fnSendLCIDEmail := func(_ context.Context, _ models.EmailAddress, _ string, _ *time.Time, _ string, _string, emailText string) error {
+	fnSendLCIDEmail := func(_ context.Context, _ models.EmailAddress, _ string, _ *time.Time, _ string, _ string, _string, emailText string) error {
 		feedbackForEmailText = emailText
 		reviewEmailCount++
 		return nil
@@ -407,7 +407,7 @@ func (s ServicesTestSuite) TestUpdateLifecycleFields() {
 	fnFetchUserInfoErr := func(_ context.Context, euaID string) (*models.UserInfo, error) {
 		return nil, errors.New("fetch user info error")
 	}
-	fnSendLCIDEmailErr := func(_ context.Context, _ models.EmailAddress, _ string, _ *time.Time, _ string, _ string, _ string) error {
+	fnSendLCIDEmailErr := func(_ context.Context, _ models.EmailAddress, _ string, _ *time.Time, _ string, _ string, _ string, _ string) error {
 		return errors.New("send email error")
 	}
 	fnGenerateErr := func(context.Context) (string, error) { return "", errors.New("gen error") }


### PR DESCRIPTION
# EASI-1195

## Changes and Description

- Updated LCID issuance email template to include project cost baseline
- Added the additional parameter to the objects and methods that required it
- Updated automated tests to test the new email
- Includes changes to 508 mutation to make CEDAR system ID required when editing it (can't edit it to be null)

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
