### PR TITLE
EASI-1689/DB Migration for associating additional EUAs to Intakes

### DIFF
--- a/migrations/V102__Add_System_Intake_Contact_Table.sql
+++ b/migrations/V102__Add_System_Intake_Contact_Table.sql
@@ -1,0 +1,6 @@
+create table system_intake_contacts (
+  eua_user_id text not null CHECK (eua_user_id ~ '^[A-Z0-9]{4}$'),
+  system_intake_id uuid not null REFERENCES system_intakes(id),
+  created_at timestamp with time zone,
+  PRIMARY KEY (eua_user_id, system_intake_id)
+);

--- a/pkg/models/system_intake_contact.go
+++ b/pkg/models/system_intake_contact.go
@@ -1,0 +1,14 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SystemIntakeContact represents an EUA user has that is associated with a system intake
+type SystemIntakeContact struct {
+	EUAUserID      string     `json:"euaUserId" db:"eua_user_id"`
+	SystemIntakeID uuid.UUID  `json:"systemIntakeId" db:"system_intake_id"`
+	CreatedAt      *time.Time `db:"created_at"`
+}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -44,6 +44,7 @@ func (s StoreTestSuite) emptyDatabaseTables() error {
 	DELETE FROM estimated_lifecycle_costs;
 	DELETE FROM business_cases;
 	DELETE FROM grt_feedback;
+	DELETE FROM system_intake_contacts;
 	DELETE FROM system_intakes;
 `
 	_, err := s.db.Exec(statement)

--- a/pkg/storage/system_intake_contact.go
+++ b/pkg/storage/system_intake_contact.go
@@ -1,0 +1,81 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/google/uuid"
+
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+// CreateSystemIntakeContact creates a new system intake contact object in the database
+func (s *Store) CreateSystemIntakeContact(ctx context.Context, systemIntakeContact *models.SystemIntakeContact) (*models.SystemIntakeContact, error) {
+	euaUserID := appcontext.Principal(ctx).ID()
+	createAt := s.clock.Now().UTC()
+
+	systemIntakeContact.CreatedAt = &createAt
+	systemIntakeContact.EUAUserID = euaUserID
+	const createSystemIntakeContactSQL = `
+		INSERT INTO system_intake_contacts (
+			eua_user_id,
+			system_intake_id,
+			created_at
+		)
+		VALUES (
+			:eua_user_id,
+			:system_intake_id,
+			:created_at
+		) ON CONFLICT ON CONSTRAINT system_intake_contacts_pkey DO UPDATE SET created_at = :created_at`
+	_, err := s.db.NamedExecContext(
+		ctx,
+		createSystemIntakeContactSQL,
+		systemIntakeContact,
+	)
+	if err != nil {
+		appcontext.ZLogger(ctx).Error("Failed to create system intake contact with error %s", zap.Error(err))
+		return nil, err
+	}
+	return systemIntakeContact, nil
+}
+
+// FetchSystemIntakeContactsBySystemIntakeID queries the DB for all the system intake contacts matching the given system intake ID
+func (s *Store) FetchSystemIntakeContactsBySystemIntakeID(ctx context.Context, systemIntakeID uuid.UUID) ([]*models.SystemIntakeContact, error) {
+	results := []*models.SystemIntakeContact{}
+
+	err := s.db.SelectContext(ctx, &results, `SELECT * FROM system_intake_contacts WHERE system_intake_id=$1`, systemIntakeID)
+
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		appcontext.ZLogger(ctx).Error("Failed to fetch system intake contacts", zap.Error(err), zap.String("id", systemIntakeID.String()))
+		return nil, &apperrors.QueryError{
+			Err:       err,
+			Model:     models.SystemIntakeContact{},
+			Operation: apperrors.QueryFetch,
+		}
+	}
+	return results, nil
+}
+
+// DeleteSystemIntakeContact deletes an existing system intake contact object in the database
+func (s *Store) DeleteSystemIntakeContact(ctx context.Context, systemIntakeContact *models.SystemIntakeContact) (*models.SystemIntakeContact, error) {
+	euaUserID := appcontext.Principal(ctx).ID()
+
+	const deleteSystemIntakeContactSQL = `
+		DELETE FROM system_intake_contacts
+		WHERE eua_user_id = $1
+		AND system_intake_id = $2;`
+
+	_, err := s.db.Exec(deleteSystemIntakeContactSQL, euaUserID, systemIntakeContact.SystemIntakeID)
+
+	if err != nil {
+		appcontext.ZLogger(ctx).Error("Failed to delete system intake contact with error %s", zap.Error(err))
+		return nil, err
+	}
+
+	return systemIntakeContact, nil
+}

--- a/pkg/storage/system_intake_contact_test.go
+++ b/pkg/storage/system_intake_contact_test.go
@@ -1,0 +1,60 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"github.com/cmsgov/easi-app/pkg/models"
+	"github.com/cmsgov/easi-app/pkg/testhelpers"
+
+	"github.com/facebookgo/clock"
+)
+
+func (s StoreTestSuite) TestCreateSystemIntakeContact() {
+	ctx := context.Background()
+	intake := testhelpers.NewSystemIntake()
+	_, err := s.store.CreateSystemIntake(ctx, &intake)
+	s.NoError(err)
+
+	s.Run("create a system intake contact", func() {
+		contact := models.SystemIntakeContact{
+			EUAUserID:      "ANON",
+			SystemIntakeID: intake.ID,
+		}
+		_, err := s.store.CreateSystemIntakeContact(ctx, &contact)
+		s.NoError(err)
+	})
+
+	s.Run("fetches system intake contacts", func() {
+		fetched, err := s.store.FetchSystemIntakeContactsBySystemIntakeID(ctx, intake.ID)
+		s.NoError(err)
+		s.True(len(fetched) > 0)
+	})
+}
+
+func (s StoreTestSuite) TestDuplicateSystemIntakeContact() {
+	ctx := context.Background()
+	intake := testhelpers.NewSystemIntake()
+	_, err := s.store.CreateSystemIntake(ctx, &intake)
+	s.NoError(err)
+
+	mockClock := clock.NewMock()
+	settableClock := testhelpers.SettableClock{Mock: mockClock}
+	s.store.clock = &settableClock
+
+	s.Run("create a duplicate system intake contact and verify created_at updates", func() {
+		contact := models.SystemIntakeContact{
+			EUAUserID:      "ANON",
+			SystemIntakeID: intake.ID,
+		}
+		created, err := s.store.CreateSystemIntakeContact(ctx, &contact)
+		createdAt := (*created.CreatedAt).Unix()
+		s.NoError(err)
+
+		mockClock.Add(time.Minute)
+
+		duplicate, dupeErr := s.store.CreateSystemIntakeContact(ctx, &contact)
+		s.NoError(dupeErr)
+		s.Greater((*duplicate.CreatedAt).Unix(), createdAt)
+	})
+}


### PR DESCRIPTION
# EASI-1689

## Changes and Description

- Added a new system_intake_contacts table representing a one-to-many relationship between a system intake and EUA ID
- Added the Go model for this table
- Added automated tests to create, fetch from this table and to test the compound primary key constraint

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
