### PR TITLE
Easi 1718 restrict concurrent deployments

### DIFF
--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -34,6 +34,8 @@ env:
 
 jobs: 
   deploy: 
+    concurrency:
+      group: ${{ inputs.env }}
     if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.env }}

--- a/scripts/release_static
+++ b/scripts/release_static
@@ -5,7 +5,7 @@ set -eu -o pipefail
 
 case "$APP_ENV" in
   "dev")
-    STATIC_S3_BUCKET="$STATIC_S3_BUCKET_DEV"
+    STATIC_S3_BUCKET="$STATIC_S3_BUCKET"
     EASI_URL="https://dev.easi.cms.gov"
     export REACT_APP_OKTA_DOMAIN="https://test.idp.idm.cms.gov"
     export REACT_APP_OKTA_CLIENT_ID="$OKTA_CLIENT_ID_DEV"
@@ -13,7 +13,7 @@ case "$APP_ENV" in
     export REACT_APP_LD_CLIENT_ID="$LD_CLIENT_ID_DEV"
     ;;
   "impl")
-    STATIC_S3_BUCKET="$STATIC_S3_BUCKET_IMPL"
+    STATIC_S3_BUCKET="$STATIC_S3_BUCKET"
     EASI_URL="https://impl.easi.cms.gov"
     export REACT_APP_OKTA_DOMAIN="https://impl.idp.idm.cms.gov"
     export REACT_APP_OKTA_CLIENT_ID="$OKTA_CLIENT_ID_IMPL"
@@ -21,7 +21,7 @@ case "$APP_ENV" in
     export REACT_APP_LD_CLIENT_ID="$LD_CLIENT_ID_IMPL"
     ;;
   "prod")
-    STATIC_S3_BUCKET="$STATIC_S3_BUCKET_PROD"
+    STATIC_S3_BUCKET="$STATIC_S3_BUCKET"
     EASI_URL="https://easi.cms.gov"
     export REACT_APP_OKTA_DOMAIN="https://idm.cms.gov"
     export REACT_APP_OKTA_CLIENT_ID="$OKTA_CLIENT_ID_PROD"


### PR DESCRIPTION
# EASI-1718

## Changes and Description

- Adding concurrency at the deployment level

Changing the deployment process to add restrict concurrent deployments. Each deployment environment will have restrictions on the EASI application deployment allowing Dev's to merge applications without having to worry about newer merges writing over their merge.

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:
    
 
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
