### PR TITLE
Easi 1729 it governance tab rework

### DIFF
--- a/src/i18n/en-US/makingARequest.ts
+++ b/src/i18n/en-US/makingARequest.ts
@@ -19,7 +19,8 @@ const makingARequest = {
       'For all other questions, you can reach the CMS IT Governance team at: ',
     email: 'IT_Governance@cms.hhs.gov'
   },
-  nextStep: 'Start a new request'
+  nextStep: 'Start a new request',
+  myRequests: 'My IT Governance Requests'
 };
 
 export default makingARequest;

--- a/src/i18n/en-US/makingARequest.ts
+++ b/src/i18n/en-US/makingARequest.ts
@@ -1,5 +1,5 @@
 const makingARequest = {
-  heading: 'IT Governance',
+  heading: 'IT Governance requests',
   reasonList: {
     intro: 'You can make a request to:',
     options: [
@@ -20,7 +20,7 @@ const makingARequest = {
     email: 'IT_Governance@cms.hhs.gov'
   },
   nextStep: 'Start a new request',
-  myRequests: 'My IT Governance Requests'
+  myRequests: 'My IT governance requests'
 };
 
 export default makingARequest;

--- a/src/i18n/en-US/makingARequest.ts
+++ b/src/i18n/en-US/makingARequest.ts
@@ -1,5 +1,6 @@
 const makingARequest = {
   heading: 'IT Governance requests',
+  subheading: 'Request new Lifecycle IDs for your systems.',
   reasonList: {
     intro: 'You can make a request to:',
     options: [

--- a/src/views/MakingARequest/__snapshots__/index.test.tsx.snap
+++ b/src/views/MakingARequest/__snapshots__/index.test.tsx.snap
@@ -10,28 +10,51 @@ exports[`The making a request page matches the snapshot 1`] = `
 >
   <h1
     aria-live="polite"
-    className="easi-h1"
+    className="easi-h1 margin-bottom-0 margin-top-5"
     tabIndex={-1}
   >
-    IT Governance
+    IT Governance requests
   </h1>
-  <p>
-    You can make a request to:
+  <p
+    className="margin-top-0 font-body-lg"
+  >
+    Request new Lifecycle IDs for your systems.
   </p>
-  <ul>
-    <li>
-      add a new system
-    </li>
-    <li>
-      make major changes or updates
-    </li>
-    <li>
-      re-compete a contract
-    </li>
-    <li>
-      decomission a system
-    </li>
-  </ul>
+  <div
+    className="usa-summary-box easi-request__container margin-bottom-3 padding-x-2 padding-y-1"
+    data-testid="summary-box"
+  >
+    <div
+      className="usa-summary-box__body"
+    >
+      <h3
+        className="usa-summary-box__heading"
+      >
+        
+      </h3>
+      <div
+        className="usa-summary-box__text"
+      >
+        <p>
+          You can make a request to:
+        </p>
+        <ul>
+          <li>
+            add a new system
+          </li>
+          <li>
+            make major changes or updates
+          </li>
+          <li>
+            re-compete a contract
+          </li>
+          <li>
+            decomission a system
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
   <p>
     If you are looking for help with Enterprise Architecture or the Navigator program, please get in touch with them directly at:
      
@@ -63,5 +86,21 @@ exports[`The making a request page matches the snapshot 1`] = `
   >
     Start a new request
   </a>
+  <h2
+    className="padding-top-2 margin-top-5 easi-section__border-top"
+  >
+    My IT governance requests
+  </h2>
+  <div
+    className="text-center"
+    data-testid="table-loading"
+  >
+    <span
+      aria-valuetext="Loading"
+      className="easi-spinner easi-spinner--xl"
+      role="progressbar"
+    />
+    ;
+  </div>
 </main>
 `;

--- a/src/views/MakingARequest/index.test.tsx
+++ b/src/views/MakingARequest/index.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
 import renderer from 'react-test-renderer';
+import { MockedProvider } from '@apollo/client/testing';
 import { render, screen, waitFor } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 
@@ -38,13 +39,15 @@ describe('The making a request page', () => {
 
     render(
       <MemoryRouter initialEntries={['/system/making-a-request']}>
-        <Provider store={defaultStore}>
-          <MessageProvider>
-            <Route path="/system/making-a-request">
-              <MakingARequest />
-            </Route>
-          </MessageProvider>
-        </Provider>
+        <MockedProvider>
+          <Provider store={defaultStore}>
+            <MessageProvider>
+              <Route path="/system/making-a-request">
+                <MakingARequest />
+              </Route>
+            </MessageProvider>
+          </Provider>
+        </MockedProvider>
       </MemoryRouter>
     );
 
@@ -57,7 +60,9 @@ describe('The making a request page', () => {
     const tree = renderer
       .create(
         <MemoryRouter>
-          <MakingARequest />
+          <MockedProvider>
+            <MakingARequest />
+          </MockedProvider>
         </MemoryRouter>
       )
       .toJSON();

--- a/src/views/MakingARequest/index.tsx
+++ b/src/views/MakingARequest/index.tsx
@@ -5,6 +5,8 @@ import { Link as UswdsLink } from '@trussworks/react-uswds';
 
 import MainContent from 'components/MainContent';
 import PageHeading from 'components/PageHeading';
+import { RequestType } from 'types/graphql-global-types';
+import Table from 'views/MyRequests/Table';
 
 const MakingARequest = () => {
   const { t } = useTranslation('makingARequest');
@@ -39,6 +41,13 @@ const MakingARequest = () => {
       <Link to="/system/request-type" className="usa-button">
         {t('nextStep')}
       </Link>
+      <h2 className="padding-top-2 margin-top-5 easi-section__border-top">
+        {t('myRequests')}
+      </h2>
+      <Table
+        type={RequestType.GOVERNANCE_REQUEST}
+        hiddenColumns={['Governance', 'Upcoming meeting date']}
+      />
     </MainContent>
   );
 };

--- a/src/views/MakingARequest/index.tsx
+++ b/src/views/MakingARequest/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Link as UswdsLink } from '@trussworks/react-uswds';
+import { Link as UswdsLink, SummaryBox } from '@trussworks/react-uswds';
 
 import MainContent from 'components/MainContent';
 import PageHeading from 'components/PageHeading';
@@ -17,13 +17,21 @@ const MakingARequest = () => {
       className="grid-container line-height-body-5 margin-bottom-5"
       data-testid="making-a-system-request"
     >
-      <PageHeading>{t('heading')}</PageHeading>
-      <p>{t('reasonList.intro')}</p>
-      <ul>
-        {reasons.map(option => (
-          <li key={option}>{option}</li>
-        ))}
-      </ul>
+      <PageHeading className="margin-bottom-0">{t('heading')}</PageHeading>
+      <p className="margin-top-0 font-body-lg">{t('subheading')}</p>
+
+      <SummaryBox
+        heading=""
+        className="easi-request__container margin-bottom-3 padding-x-2 padding-y-1"
+      >
+        <p>{t('reasonList.intro')}</p>
+        <ul>
+          {reasons.map(option => (
+            <li key={option}>{option}</li>
+          ))}
+        </ul>
+      </SummaryBox>
+
       <p>
         {t('forEnterpriseArchitectureHelp.message')}&nbsp;
         <UswdsLink href={`mailto:${t('forEnterpriseArchitectureHelp.email')}`}>

--- a/src/views/MakingARequest/index.tsx
+++ b/src/views/MakingARequest/index.tsx
@@ -17,7 +17,9 @@ const MakingARequest = () => {
       className="grid-container line-height-body-5 margin-bottom-5"
       data-testid="making-a-system-request"
     >
-      <PageHeading className="margin-bottom-0">{t('heading')}</PageHeading>
+      <PageHeading className="margin-bottom-0 margin-top-5">
+        {t('heading')}
+      </PageHeading>
       <p className="margin-top-0 font-body-lg">{t('subheading')}</p>
 
       <SummaryBox

--- a/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
+++ b/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
               colspan="1"
               role="columnheader"
               scope="col"
-              style="min-width: 140px; width: 140px; position: relative;"
+              style="min-width: 140px; width: 140px; padding-left: 0px; position: relative;"
             >
               <button
                 class="usa-button usa-button--unstyled"
@@ -117,7 +117,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
               colspan="1"
               role="columnheader"
               scope="col"
-              style="min-width: 140px; width: 140px; position: relative;"
+              style="min-width: 140px; width: 140px; padding-left: 0px; position: relative;"
             >
               <button
                 class="usa-button usa-button--unstyled"
@@ -152,7 +152,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
               colspan="1"
               role="columnheader"
               scope="col"
-              style="min-width: 140px; width: 220px; position: relative;"
+              style="min-width: 140px; width: 220px; padding-left: 0px; position: relative;"
             >
               <button
                 class="usa-button usa-button--unstyled"
@@ -187,7 +187,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
               colspan="1"
               role="columnheader"
               scope="col"
-              style="min-width: 140px; width: 140px; position: relative;"
+              style="min-width: 140px; width: 140px; padding-left: 0px; position: relative;"
             >
               <button
                 class="usa-button usa-button--unstyled"
@@ -222,7 +222,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
               colspan="1"
               role="columnheader"
               scope="col"
-              style="min-width: 220px; width: 140px; position: relative;"
+              style="min-width: 220px; width: 140px; padding-left: 0px; position: relative;"
             >
               <button
                 class="usa-button usa-button--unstyled"
@@ -262,6 +262,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             <th
               role="cell"
               scope="row"
+              style="padding-left: 0px;"
             >
               <a
                 class="usa-link"
@@ -272,25 +273,25 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             </th>
             <td
               role="cell"
-              style="width: 150px;"
+              style="width: 150px; padding-left: 0px;"
             >
               IT Governance
             </td>
             <td
               role="cell"
-              style="width: 150px;"
+              style="width: 150px; padding-left: 0px;"
             >
               May 20 2021
             </td>
             <td
               role="cell"
-              style="width: 200px;"
+              style="width: 200px; padding-left: 0px;"
             >
               Lifecycle ID issued: A123456: A123456
             </td>
             <td
               role="cell"
-              style="width: 150px;"
+              style="width: 150px; padding-left: 0px;"
             >
               None
             </td>
@@ -301,6 +302,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             <th
               role="cell"
               scope="row"
+              style="padding-left: 0px;"
             >
               <a
                 class="usa-link"
@@ -311,25 +313,25 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             </th>
             <td
               role="cell"
-              style="width: 150px;"
+              style="width: 150px; padding-left: 0px;"
             >
               IT Governance
             </td>
             <td
               role="cell"
-              style="width: 150px;"
+              style="width: 150px; padding-left: 0px;"
             >
               May 22 2021
             </td>
             <td
               role="cell"
-              style="width: 200px;"
+              style="width: 200px; padding-left: 0px;"
             >
               Intake draft
             </td>
             <td
               role="cell"
-              style="width: 150px;"
+              style="width: 150px; padding-left: 0px;"
             >
               None
             </td>
@@ -340,6 +342,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             <th
               role="cell"
               scope="row"
+              style="padding-left: 0px;"
             >
               <a
                 class="usa-link"
@@ -350,19 +353,19 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             </th>
             <td
               role="cell"
-              style="width: 150px;"
+              style="width: 150px; padding-left: 0px;"
             >
               Section 508
             </td>
             <td
               role="cell"
-              style="width: 150px;"
+              style="width: 150px; padding-left: 0px;"
             >
               May 25 2021
             </td>
             <td
               role="cell"
-              style="width: 200px;"
+              style="width: 200px; padding-left: 0px;"
             >
               <span>
                 In remediation
@@ -375,7 +378,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             </td>
             <td
               role="cell"
-              style="width: 150px;"
+              style="width: 150px; padding-left: 0px;"
             >
               None
             </td>
@@ -386,6 +389,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             <th
               role="cell"
               scope="row"
+              style="padding-left: 0px;"
             >
               <a
                 class="usa-link"
@@ -396,19 +400,19 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             </th>
             <td
               role="cell"
-              style="width: 150px;"
+              style="width: 150px; padding-left: 0px;"
             >
               Section 508
             </td>
             <td
               role="cell"
-              style="width: 150px;"
+              style="width: 150px; padding-left: 0px;"
             >
               May 25 2021
             </td>
             <td
               role="cell"
-              style="width: 200px;"
+              style="width: 200px; padding-left: 0px;"
             >
               <span>
                 Open
@@ -421,7 +425,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             </td>
             <td
               role="cell"
-              style="width: 150px;"
+              style="width: 150px; padding-left: 0px;"
             >
               None
             </td>

--- a/src/views/MyRequests/Table/index.test.tsx
+++ b/src/views/MyRequests/Table/index.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import GetRequestsQuery from 'queries/GetRequestsQuery';
+import { RequestType } from 'types/graphql-global-types';
 
 import Table from '.';
 
@@ -119,6 +120,38 @@ describe('My Requests Table', () => {
       );
 
       expect(await screen.findByRole('table')).toBeInTheDocument();
+    });
+
+    it('displays an IT Goverance request only table with hidden columns', async () => {
+      render(
+        <MemoryRouter>
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <Table
+              type={RequestType.GOVERNANCE_REQUEST}
+              hiddenColumns={['Governance', 'Upcoming meeting date']}
+            />
+          </MockedProvider>
+        </MemoryRouter>
+      );
+
+      expect(
+        await screen.queryByText('Upcoming meeting date')
+      ).not.toBeInTheDocument();
+    });
+
+    it('displays a 508 request only table with hidden columns', async () => {
+      render(
+        <MemoryRouter>
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <Table
+              type={RequestType.ACCESSIBILITY_REQUEST}
+              hiddenColumns={['Governance', 'Upcoming meeting date']}
+            />
+          </MockedProvider>
+        </MemoryRouter>
+      );
+
+      expect(await screen.queryByText('Governance')).not.toBeInTheDocument();
     });
 
     it('displays relevant results from filter', async () => {

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -237,6 +237,7 @@ const Table = ({ type, hiddenColumns }: myRequestsTableProps) => {
                     style={{
                       minWidth: index === 4 ? '220px' : '140px',
                       width: index === 2 ? '220px' : '140px',
+                      paddingLeft: '0',
                       position: 'relative'
                     }}
                   >
@@ -266,7 +267,11 @@ const Table = ({ type, hiddenColumns }: myRequestsTableProps) => {
                   .map((cell, i) => {
                     if (i === 0) {
                       return (
-                        <th {...cell.getCellProps()} scope="row">
+                        <th
+                          {...cell.getCellProps()}
+                          scope="row"
+                          style={{ paddingLeft: '0' }}
+                        >
                           {cell.render('Cell')}
                         </th>
                       );
@@ -274,7 +279,7 @@ const Table = ({ type, hiddenColumns }: myRequestsTableProps) => {
                     return (
                       <td
                         {...cell.getCellProps()}
-                        style={{ width: cell.column.width }}
+                        style={{ width: cell.column.width, paddingLeft: '0' }}
                       >
                         {cell.render('Cell')}
                       </td>

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -18,6 +18,7 @@ import TablePagination from 'components/TablePagination';
 import TableResults from 'components/TableResults';
 import GetRequestsQuery from 'queries/GetRequestsQuery';
 import { GetRequests, GetRequestsVariables } from 'queries/types/GetRequests';
+import { RequestType } from 'types/graphql-global-types';
 import { formatDate } from 'utils/date';
 import globalTableFilter from 'utils/globalTableFilter';
 import {
@@ -31,7 +32,12 @@ import tableMap from './tableMap';
 
 import '../index.scss';
 
-const Table = () => {
+type myRequestsTableProps = {
+  type?: RequestType;
+  hiddenColumns?: string[];
+};
+
+const Table = ({ type, hiddenColumns }: myRequestsTableProps) => {
   const { t } = useTranslation(['home', 'intake', 'accessibility']);
   const { loading, error, data: tableData } = useQuery<
     GetRequests,
@@ -134,10 +140,10 @@ const Table = () => {
   // Modifying data for table sorting and prepping for Cell configuration
   const data = useMemo(() => {
     if (tableData) {
-      return tableMap(tableData, t);
+      return tableMap(tableData, t, type);
     }
     return [];
-  }, [tableData, t]);
+  }, [tableData, t, type]);
 
   const {
     getTableProps,
@@ -219,28 +225,31 @@ const Table = () => {
         <thead>
           {headerGroups.map(headerGroup => (
             <tr {...headerGroup.getHeaderGroupProps()}>
-              {headerGroup.headers.map((column, index) => (
-                <th
-                  {...column.getHeaderProps()}
-                  aria-sort={getColumnSortStatus(column)}
-                  className="table-header"
-                  scope="col"
-                  style={{
-                    minWidth: index === 4 ? '220px' : '140px',
-                    width: index === 2 ? '220px' : '140px',
-                    position: 'relative'
-                  }}
-                >
-                  <button
-                    className="usa-button usa-button--unstyled"
-                    type="button"
-                    {...column.getSortByToggleProps()}
+              {headerGroup.headers
+                // @ts-ignore
+                .filter(column => !hiddenColumns?.includes(column.Header))
+                .map((column, index) => (
+                  <th
+                    {...column.getHeaderProps()}
+                    aria-sort={getColumnSortStatus(column)}
+                    className="table-header"
+                    scope="col"
+                    style={{
+                      minWidth: index === 4 ? '220px' : '140px',
+                      width: index === 2 ? '220px' : '140px',
+                      position: 'relative'
+                    }}
                   >
-                    {column.render('Header')}
-                    {getHeaderSortIcon(column)}
-                  </button>
-                </th>
-              ))}
+                    <button
+                      className="usa-button usa-button--unstyled"
+                      type="button"
+                      {...column.getSortByToggleProps()}
+                    >
+                      {column.render('Header')}
+                      {getHeaderSortIcon(column)}
+                    </button>
+                  </th>
+                ))}
             </tr>
           ))}
         </thead>
@@ -249,23 +258,28 @@ const Table = () => {
             prepareRow(row);
             return (
               <tr {...row.getRowProps()}>
-                {row.cells.map((cell, i) => {
-                  if (i === 0) {
+                {row.cells
+                  .filter(cell => {
+                    // @ts-ignore
+                    return !hiddenColumns?.includes(cell.column.Header);
+                  })
+                  .map((cell, i) => {
+                    if (i === 0) {
+                      return (
+                        <th {...cell.getCellProps()} scope="row">
+                          {cell.render('Cell')}
+                        </th>
+                      );
+                    }
                     return (
-                      <th {...cell.getCellProps()} scope="row">
+                      <td
+                        {...cell.getCellProps()}
+                        style={{ width: cell.column.width }}
+                      >
                         {cell.render('Cell')}
-                      </th>
+                      </td>
                     );
-                  }
-                  return (
-                    <td
-                      {...cell.getCellProps()}
-                      style={{ width: cell.column.width }}
-                    >
-                      {cell.render('Cell')}
-                    </td>
-                  );
-                })}
+                  })}
               </tr>
             );
           })}

--- a/src/views/MyRequests/Table/tableMap.ts
+++ b/src/views/MyRequests/Table/tableMap.ts
@@ -9,46 +9,52 @@ import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
 // Here is where the data can be modified and used appropriately for sorting.
 // Modifed data can then be configured with JSX components in column cell configuration
 
-const tableMap = (tableData: GetRequests, t: TFunction) => {
+const tableMap = (
+  tableData: GetRequests,
+  t: TFunction,
+  requestType?: RequestType
+) => {
   const requests = tableData?.requests?.edges.map(edge => {
     return edge.node;
   });
 
-  const mappedData = requests?.map(request => {
-    const name = request.name ? request.name : 'Draft';
+  const mappedData = requests
+    ?.filter(request => (!requestType ? true : request.type === requestType)) // if filter prop exists, filter by the request type
+    .map(request => {
+      const name = request.name ? request.name : 'Draft';
 
-    const type: string = request.type
-      ? t(`requestsTable.types.${request.type}`)
-      : '';
+      const type: string = request.type
+        ? t(`requestsTable.types.${request.type}`)
+        : '';
 
-    let status;
-    switch (request.type) {
-      case RequestType.ACCESSIBILITY_REQUEST:
-        // Status hasn't changed if the status record created at is the same
-        // as the 508 request's submitted at
-        if (request.submittedAt === request.statusCreatedAt) {
+      let status;
+      switch (request.type) {
+        case RequestType.ACCESSIBILITY_REQUEST:
+          // Status hasn't changed if the status record created at is the same
+          // as the 508 request's submitted at
+          if (request.submittedAt === request.statusCreatedAt) {
+            status = accessibilityRequestStatusMap[request.status];
+          }
           status = accessibilityRequestStatusMap[request.status];
-        }
-        status = accessibilityRequestStatusMap[request.status];
-        break;
-      case RequestType.GOVERNANCE_REQUEST:
-        status = t(`intake:statusMap.${request.status}`);
-        if (request.lcid) {
-          status = `${status}: ${request.lcid}`;
-        }
-        break;
-      default:
-        status = '';
-        break;
-    }
+          break;
+        case RequestType.GOVERNANCE_REQUEST:
+          status = t(`intake:statusMap.${request.status}`);
+          if (request.lcid) {
+            status = `${status}: ${request.lcid}`;
+          }
+          break;
+        default:
+          status = '';
+          break;
+      }
 
-    return {
-      ...request,
-      name,
-      type,
-      status
-    };
-  });
+      return {
+        ...request,
+        name,
+        type,
+        status
+      };
+    });
 
   return mappedData || [];
 };


### PR DESCRIPTION
# EASI-1729

## Changes and Description

- Make view fit into grid-12 instead of grid-10
- Include a My IT Governance requests table beneath standard info
- Update verbiage per [Figma](https://www.figma.com/file/jrc18ENtS3ufj7ttr5vHKW/EASi-Basic-Page-Templates?node-id=2%3A4094)
- Tests where applicable

![Screen Shot 2022-03-22 at 4 08 48 PM](https://user-images.githubusercontent.com/95709965/159567118-3ad95f29-9811-4738-b769-f1517f6d3955.png)

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
