### PR TITLE
Easi 1646 - Scroll validation error fix

### DIFF
--- a/src/components/shared/ErrorAlert/index.tsx
+++ b/src/components/shared/ErrorAlert/index.tsx
@@ -21,6 +21,13 @@ export const ErrorAlert = ({
     classNames
   );
 
+  const childErrors = React.Children.map(children, element => {
+    if (React.isValidElement(element)) {
+      return element.props.errorKey;
+    }
+    return '';
+  })?.toString();
+
   const headingEl = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
@@ -28,7 +35,7 @@ export const ErrorAlert = ({
     if (current) {
       current.focus();
     }
-  }, []);
+  }, [childErrors]);
 
   return (
     <div className={errorAlertClasses} role="alert" data-testid={testId}>
@@ -55,7 +62,6 @@ export const ErrorAlertMessage = ({
     className="usa-error-message usa-alert__text easi-error-alert__message"
     onClick={() => {
       const fieldGroup = document.querySelector(`[data-scroll="${errorKey}"]`);
-
       if (fieldGroup) {
         fieldGroup.scrollIntoView();
       }

--- a/src/components/shared/ErrorAlert/index.tsx
+++ b/src/components/shared/ErrorAlert/index.tsx
@@ -21,13 +21,6 @@ export const ErrorAlert = ({
     classNames
   );
 
-  const childErrors = React.Children.map(children, element => {
-    if (React.isValidElement(element)) {
-      return element.props.errorKey;
-    }
-    return '';
-  })?.toString();
-
   const headingEl = useRef<HTMLHeadingElement>(null);
 
   useEffect(() => {
@@ -35,7 +28,7 @@ export const ErrorAlert = ({
     if (current) {
       current.focus();
     }
-  }, [childErrors]);
+  }, []);
 
   return (
     <div className={errorAlertClasses} role="alert" data-testid={testId}>

--- a/src/views/Accessibility/AccessibilityRequest/Create/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Create/index.tsx
@@ -112,7 +112,12 @@ const Create = () => {
           validateOnMount={false}
         >
           {(formikProps: FormikProps<AccessibilityRequestForm>) => {
-            const { errors, setFieldValue, handleSubmit } = formikProps;
+            const {
+              errors,
+              setErrors,
+              setFieldValue,
+              handleSubmit
+            } = formikProps;
             const flatErrors = flattenErrors(errors);
             return (
               <>
@@ -211,7 +216,7 @@ const Create = () => {
                         <PlainInfo>{t('newRequestForm.info')}</PlainInfo>
                       </div>
                     </div>
-                    <Button type="submit">
+                    <Button type="submit" onClick={() => setErrors({})}>
                       {t('newRequestForm.submitBtn')}
                     </Button>
                   </FormikForm>

--- a/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
+++ b/src/views/Accessibility/AccessibilityRequest/Documents/New/index.tsx
@@ -180,6 +180,7 @@ const New = () => {
           {(formikProps: FormikProps<FileUploadForm>) => {
             const {
               errors,
+              setErrors,
               setFieldValue,
               values,
               handleSubmit,
@@ -342,6 +343,7 @@ const New = () => {
                       </p>
                       <Button
                         type="submit"
+                        onClick={() => setErrors({})}
                         disabled={
                           isSubmitting ||
                           generateURLStatus.loading ||

--- a/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
+++ b/src/views/Accessibility/AccessibilityRequestDetailPage.tsx
@@ -672,7 +672,7 @@ const AccessibilityRequestDetailPage = () => {
                   {(
                     formikProps: FormikProps<DeleteAccessibilityRequestForm>
                   ) => {
-                    const { errors, values } = formikProps;
+                    const { errors, setErrors, values } = formikProps;
                     const flatErrors = flattenErrors(errors);
                     return (
                       <>
@@ -730,7 +730,11 @@ const AccessibilityRequestDetailPage = () => {
                           </FieldGroup>
 
                           <div className="display-flex margin-top-2">
-                            <Button type="submit" className="margin-right-5">
+                            <Button
+                              type="submit"
+                              onClick={() => setErrors({})}
+                              className="margin-right-5"
+                            >
                               {t('requestDetails.modal.confirm')}
                             </Button>
                             <Button

--- a/src/views/GovernanceReviewTeam/Actions/ExtendLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ExtendLifecycleId.tsx
@@ -124,7 +124,7 @@ const ExtendLifecycleId = ({
       validateOnMount={false}
     >
       {(formikProps: FormikProps<ExtendLCIDForm>) => {
-        const { errors } = formikProps;
+        const { errors, setErrors } = formikProps;
         const flatErrors = flattenErrors(errors);
 
         return (
@@ -292,6 +292,7 @@ const ExtendLifecycleId = ({
                 <Button
                   className="margin-y-2"
                   type="submit"
+                  onClick={() => setErrors({})}
                   disabled={extendLifecycleIDStatus.loading}
                 >
                   {t('extendLcid.submit')}

--- a/src/views/GovernanceReviewTeam/Actions/ExtendLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ExtendLifecycleId.tsx
@@ -190,7 +190,7 @@ const ExtendLifecycleId = ({
               </dl>
               <hr />
               <Form>
-                <FieldGroup>
+                <FieldGroup scrollElement="validDate">
                   <fieldset className="usa-fieldset margin-top-2">
                     <legend className="usa-label margin-bottom-1">
                       {t('extendLcid.expirationDate.label')}

--- a/src/views/GovernanceReviewTeam/Actions/ProvideGRTFeedbackToBusinessOwner.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ProvideGRTFeedbackToBusinessOwner.tsx
@@ -66,7 +66,7 @@ const ProvideGRTFeedbackToBusinessOwner = ({
       validateOnMount={false}
     >
       {(formikProps: FormikProps<ProvideGRTFeedbackForm>) => {
-        const { errors, handleSubmit } = formikProps;
+        const { errors, setErrors, handleSubmit } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -140,7 +140,11 @@ const ProvideGRTFeedbackToBusinessOwner = ({
                     name="emailBody"
                   />
                 </FieldGroup>
-                <Button className="margin-top-2" type="submit">
+                <Button
+                  className="margin-top-2"
+                  type="submit"
+                  onClick={() => setErrors({})}
+                >
                   {t('provideGRTFeedback.submit')}
                 </Button>
               </Form>

--- a/src/views/GovernanceReviewTeam/Actions/ProvideGRTRecommendationsToGRB.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ProvideGRTRecommendationsToGRB.tsx
@@ -61,7 +61,7 @@ const ProvideGRTRecommendationsToGRB = () => {
       validateOnMount={false}
     >
       {(formikProps: FormikProps<ProvideGRTFeedbackForm>) => {
-        const { errors, handleSubmit } = formikProps;
+        const { errors, setErrors, handleSubmit } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -133,7 +133,11 @@ const ProvideGRTRecommendationsToGRB = () => {
                     name="emailBody"
                   />
                 </FieldGroup>
-                <Button className="margin-top-2" type="submit">
+                <Button
+                  className="margin-top-2"
+                  type="submit"
+                  onClick={() => setErrors({})}
+                >
                   {t('provideGRTFeedback.submit')}
                 </Button>
               </Form>

--- a/src/views/GovernanceReviewTeam/Actions/RejectIntake.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/RejectIntake.tsx
@@ -70,7 +70,7 @@ const RejectIntake = () => {
       validateOnMount={false}
     >
       {(formikProps: FormikProps<RejectIntakeForm>) => {
-        const { errors, handleSubmit } = formikProps;
+        const { errors, setErrors, handleSubmit } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -165,7 +165,11 @@ const RejectIntake = () => {
                     aria-describedby="RejectIntakeForm-SubmitHelp"
                   />
                 </FieldGroup>
-                <Button className="margin-top-2" type="submit">
+                <Button
+                  className="margin-top-2"
+                  type="submit"
+                  onClick={() => setErrors({})}
+                >
                   {t('rejectIntake.submit')}
                 </Button>
               </Form>

--- a/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
@@ -64,7 +64,7 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
       validateOnMount={false}
     >
       {(formikProps: FormikProps<ActionForm>) => {
-        const { errors, handleSubmit } = formikProps;
+        const { errors, setErrors, handleSubmit } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -127,6 +127,7 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
                 <Button
                   className="margin-top-2"
                   type="submit"
+                  onClick={() => setErrors({})}
                   // disabled={isSubmitting}
                 >
                   {t('submitAction.submit')}

--- a/src/views/GovernanceReviewTeam/Dates/index.tsx
+++ b/src/views/GovernanceReviewTeam/Dates/index.tsx
@@ -103,7 +103,7 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntake }) => {
       validateOnMount={false}
     >
       {(formikProps: FormikProps<SubmitDatesForm>) => {
-        const { errors, handleSubmit } = formikProps;
+        const { errors, setErrors, handleSubmit } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -258,7 +258,11 @@ const Dates = ({ systemIntake }: { systemIntake: SystemIntake }) => {
                   </fieldset>
                 </FieldGroup>
                 {/* End GRB Date Fields */}
-                <Button className="margin-top-2" type="submit">
+                <Button
+                  className="margin-top-2"
+                  type="submit"
+                  onClick={() => setErrors({})}
+                >
                   {t('governanceReviewTeam:dates.submit')}
                 </Button>
               </Form>

--- a/src/views/RequestTypeForm/index.tsx
+++ b/src/views/RequestTypeForm/index.tsx
@@ -95,7 +95,7 @@ const RequestTypeForm = () => {
         validateOnMount={false}
       >
         {(formikProps: FormikProps<{ requestType: string }>) => {
-          const { values, errors, handleSubmit } = formikProps;
+          const { values, errors, setErrors, handleSubmit } = formikProps;
           const flatErrors = flattenErrors(errors);
           return (
             <>
@@ -195,7 +195,11 @@ const RequestTypeForm = () => {
                     indexTwo
                   </Trans>
                 </HelpText>
-                <Button className="margin-top-5 display-block" type="submit">
+                <Button
+                  className="margin-top-5 display-block"
+                  type="submit"
+                  onClick={() => setErrors({})}
+                >
                   Continue
                 </Button>
               </Form>

--- a/src/views/TestDate/Form.tsx
+++ b/src/views/TestDate/Form.tsx
@@ -53,7 +53,13 @@ const TestDateForm = ({
       validateOnMount={false}
     >
       {(formikProps: FormikProps<TestDateFormType>) => {
-        const { errors, setFieldValue, values, handleSubmit } = formikProps;
+        const {
+          errors,
+          setErrors,
+          setFieldValue,
+          values,
+          handleSubmit
+        } = formikProps;
         const flatErrors = flattenErrors(errors);
         return (
           <>
@@ -270,7 +276,11 @@ const TestDateForm = ({
                       )}
                     </fieldset>
                   </FieldGroup>
-                  <Button className="margin-top-4" type="submit">
+                  <Button
+                    className="margin-top-4"
+                    type="submit"
+                    onClick={() => setErrors({})}
+                  >
                     {t(`testDateForm.submitButton.${formType}`)}
                   </Button>
                   <Link


### PR DESCRIPTION
# EASI-1646

## Changes and Description

- Implemented `setError` method on Formik forms to reset errors before submission

This method exists on some existing forms, but not all.  Extended this for any form that displays errors so that users are notified by scrolling on each attempted submission.

Dylan has a video on how to reproduce this effect in the JIRA ticket.

## How to test this change

- Create a GRT intake request.
- Open the intake request (with a GRT team job code).
- Issue a lifecycle ID for the intake request.
- Go to the actions tab -> Extend Lifecycle ID
- Enter an invalid expiration date (but scope and steps are valid).
- Attempt to submit the form. The page should scroll to the date field where the validation error is; this is expected.
- Correct the date to be valid, but remove the text in the scope field to make it invalid.
- Attempt to submit the form again. The page should scroll to the top with the error.  

Even if the same error is submitted, the for should still scroll to the top.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
