### PR TITLE
[EASI-1494] Add retry logic to integration tests

### DIFF
--- a/cmd/easi/test/test.go
+++ b/cmd/easi/test/test.go
@@ -22,6 +22,7 @@ func Server() {
 		"go",
 		"test",
 		"-p=1",
+		"-v",
 		"-coverprofile=go-coverage.out",
 		"./pkg/...")
 	// Replace with some sort of configured writer

--- a/cmd/easi/test/test.go
+++ b/cmd/easi/test/test.go
@@ -22,7 +22,6 @@ func Server() {
 		"go",
 		"test",
 		"-p=1",
-		"-v",
 		"-coverprofile=go-coverage.out",
 		"./pkg/...")
 	// Replace with some sort of configured writer

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -11,7 +11,7 @@ describe('Logging in', () => {
       }
     },
     () => {
-      // Get the current number of retries and sleep 60s before running the test to make sure the One-Time-Password is new
+      // Get the current number of retries and sleep before running the test to make sure the One-Time-Password is new
       const currentRetry = cy.state('runnable')._currentRetry; // eslint-disable-line no-underscore-dangle
       if (currentRetry > 0) {
         cy.log(

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -15,9 +15,9 @@ describe('Logging in', () => {
       const currentRetry = cy.state('runnable')._currentRetry; // eslint-disable-line no-underscore-dangle
       if (currentRetry > 0) {
         cy.log(
-          `[Attempt ${currentRetry + 1}/${maxAttempts}] Sleeping 60s for OTP`
+          `[Attempt ${currentRetry + 1}/${maxAttempts}] Sleeping 30s for OTP`
         );
-        cy.wait(60000);
+        cy.wait(30000);
       }
       cy.login();
       cy.location('pathname', { timeout: 20000 }).should('equal', '/');

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -1,13 +1,27 @@
-import { ACCESSIBILITY_ADMIN_DEV } from '../../src/constants/jobCodes'
+import { ACCESSIBILITY_ADMIN_DEV } from '../../src/constants/jobCodes';
 
 describe('Logging in', () => {
-  it('logs in with okta', () => {
-    cy.login();
-    cy.location('pathname', { timeout: 20000 }).should('equal', '/');
-  });
+  it(
+    'logs in with okta',
+    {
+      retries: {
+        runMode: 2, // 2 retries when running from `cypress run` (3 total attempts)
+        openMode: 0 // 0 retries when running from `cypress open` (1 total attempt)
+      }
+    },
+    () => {
+      // Get the current number of retries and sleep 60s before running the test to make sure the One-Time-Password is new
+      const currentRetry = cy.state('runnable')._currentRetry; // eslint-disable-line no-underscore-dangle
+      if (currentRetry > 0) {
+        cy.wait(60000);
+      }
+      cy.login();
+      cy.location('pathname', { timeout: 20000 }).should('equal', '/');
+    }
+  );
 
   it('logs in with local auth', () => {
-    cy.localLogin({name: 'TEST', role: ACCESSIBILITY_ADMIN_DEV});
+    cy.localLogin({ name: 'TEST', role: ACCESSIBILITY_ADMIN_DEV });
 
     cy.get('h1', { timeout: 20000 }).should('have.text', '508 Requests');
   });

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -1,11 +1,12 @@
 import { ACCESSIBILITY_ADMIN_DEV } from '../../src/constants/jobCodes';
 
+const maxAttempts = 3;
 describe('Logging in', () => {
   it(
     'logs in with okta',
     {
       retries: {
-        runMode: 2, // 2 retries when running from `cypress run` (3 total attempts)
+        runMode: maxAttempts - 1, // 2 retries when running from `cypress run` (3 total attempts)
         openMode: 0 // 0 retries when running from `cypress open` (1 total attempt)
       }
     },
@@ -13,6 +14,9 @@ describe('Logging in', () => {
       // Get the current number of retries and sleep 60s before running the test to make sure the One-Time-Password is new
       const currentRetry = cy.state('runnable')._currentRetry; // eslint-disable-line no-underscore-dangle
       if (currentRetry > 0) {
+        cy.log(
+          `[Attempt ${currentRetry + 1}/${maxAttempts}] Sleeping 60s for OTP`
+        );
         cy.wait(60000);
       }
       cy.login();

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -59,7 +59,7 @@ func TestIntegrationTestSuite(t *testing.T) {
 	for attempts <= maxAttempts {
 		accessToken, err = testhelpers.OktaAccessToken(config)
 		if err != nil {
-			fmt.Printf("[Attempt %d/%d] Failed to get access token for integration testing with error: %s", attempts, maxAttempts, err)
+			t.Logf("[Attempt %d/%d] Failed to get access token for integration testing with error: %s", attempts, maxAttempts, err)
 			attempts++
 			time.Sleep(time.Second * 60) // Wait 60 seconds to make sure One-Time-Password is new
 		} else {

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -61,7 +61,7 @@ func TestIntegrationTestSuite(t *testing.T) {
 		if err != nil {
 			t.Logf("[Attempt %d/%d] Failed to get access token for integration testing with error: %s", attempts, maxAttempts, err)
 			attempts++
-			time.Sleep(time.Second * 60) // Wait 60 seconds to make sure One-Time-Password is new
+			time.Sleep(time.Second * 30) // Wait 30 seconds to make sure One-Time-Password is new
 		} else {
 			break
 		}

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -48,9 +49,23 @@ func TestIntegrationTestSuite(t *testing.T) {
 	testServer := httptest.NewServer(easiServer)
 	defer testServer.Close()
 
-	accessToken, err := testhelpers.OktaAccessToken(config)
-	if err != nil {
-		fmt.Printf("Failed to get access token for integration testing with error: %s", err)
+	// Make 3 attempts at getting a valid Okta Access Token
+	// This requires multiple attempts to help fix test-flakiness when running
+	// multiple of this test in parallel, as the One-Time-Password used to log in to Okta is.... one time!
+	attempts := 0
+	maxAttempts := 3
+	var accessToken string
+	var err error
+	for attempts < maxAttempts {
+		accessToken, err = testhelpers.OktaAccessToken(config)
+		if err != nil {
+			fmt.Printf("[Attempt %d/%d] Failed to get access token for integration testing with error: %s", attempts, maxAttempts, err)
+		}
+		attempts++
+		time.Sleep(time.Second * 60) // Wait 60 seconds to make sure One-Time-Password is new
+	}
+	if attempts >= maxAttempts {
+		fmt.Printf("Failed to get access token for integration testing after %d attempts with error: %s", attempts, err)
 		t.FailNow()
 	}
 

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -52,19 +52,23 @@ func TestIntegrationTestSuite(t *testing.T) {
 	// Make 3 attempts at getting a valid Okta Access Token
 	// This requires multiple attempts to help fix test-flakiness when running
 	// multiple of this test in parallel, as the One-Time-Password used to log in to Okta is.... one time!
-	attempts := 0
+	attempts := 1
 	maxAttempts := 3
 	var accessToken string
 	var err error
-	for attempts < maxAttempts {
+	for attempts <= maxAttempts {
 		accessToken, err = testhelpers.OktaAccessToken(config)
 		if err != nil {
 			fmt.Printf("[Attempt %d/%d] Failed to get access token for integration testing with error: %s", attempts, maxAttempts, err)
+			attempts++
+			time.Sleep(time.Second * 60) // Wait 60 seconds to make sure One-Time-Password is new
+		} else {
+			break
 		}
-		attempts++
-		time.Sleep(time.Second * 60) // Wait 60 seconds to make sure One-Time-Password is new
 	}
-	if attempts >= maxAttempts {
+
+	// If we broke out of the loop with an error, we need to fail the test
+	if err != nil {
 		fmt.Printf("Failed to get access token for integration testing after %d attempts with error: %s", attempts, err)
 		t.FailNow()
 	}


### PR DESCRIPTION
# EASI-1494

## Changes and Description

This adds retry logic to the following tests

- The backend `TestIntegrationTestSuite()` test suite
  - The retry logic added is done before any tests are executed, as the Okta Auth Token (and use of the OTP) happens before we run `suite.Run()`
- The Cypress `login.spec.js` spec
  - This adds a `retries` parameter to the tests configuration. [Cypress test retries are documented here](https://docs.cypress.io/guides/guides/test-retries)

## How to test this change

I'll probably just try to run another branch's tests and this at the same time and see if any of the retry logs are printed for the Cypress or Backend tests. I'll update this comment with my findings!

### Update - got it on video!
https://user-images.githubusercontent.com/15203744/160636749-5f1c4b78-6b7e-4f08-886f-e2d44b1b0b40.mp4


## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [x] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [x] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
