### PR TITLE
Docs - link fixes

### DIFF
--- a/docs/dev_environment_setup.md
+++ b/docs/dev_environment_setup.md
@@ -162,7 +162,7 @@ $
 
 ## Setting up pre-commit Git hooks
 
-This repo uses [`pre-commit`](https://pre-commit.com/) to manage pre-commit Git hooks for maintaining several quality and stylistic standards; see [`.pre-commit-config.yaml`](./.pre-commit-config.yaml) for details.
+This repo uses [`pre-commit`](https://pre-commit.com/) to manage pre-commit Git hooks for maintaining several quality and stylistic standards; see [`.pre-commit-config.yaml`](/.pre-commit-config.yaml) for details.
 
 **MacOS:** Install with `brew install pre-commit`.
 
@@ -223,7 +223,7 @@ sudo apt install swagger
 **Windows+WSL:** From the Ubuntu command line, navigate to the root of this repository, then run `code .` to open VS Code with this repository opened.
 
 **All developers:**
-- VS Code will recommend installing the extensions specified in [`.vscode/extensions.json`](./.vscode/extensions.json). Install all of them.
+- VS Code will recommend installing the extensions specified in [`.vscode/extensions.json`](/.vscode/extensions.json). Install all of them.
 > - **Windows+WSL:** The GitLens extension will likely not work. It is dependent on another extension which VSCode installs on the windows side. If it doesn't work, you can safely ignore it.
 - The Go extension should prompt you to install the analysis tools it uses. Install all of them. See [these instructions](https://github.com/golang/vscode-go/blob/master/README.md#tools) for more details.
 

--- a/docs/dev_environment_setup.md
+++ b/docs/dev_environment_setup.md
@@ -135,7 +135,6 @@ We use [Yarn](https://yarnpkg.com/) to manage our JavaScript dependencies. It ca
 
 **Windows+WSL:** Install Ruby with `sudo apt install ruby-full`.
 
-(#direnv)
 ## Direnv
 
 **MacOS:** Install with `brew install direnv`.

--- a/docs/docker_compose.md
+++ b/docs/docker_compose.md
@@ -5,12 +5,12 @@ docker-compose files exist to support different use cases and environments.
 
 | File                          | Description                                                                                                                       |
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| [docker-compose.yml](../docker-compose.yml)            | Base configuration for `db`, `db_migrate`, `easi` and `easi_client` services                                                      |
-| [docker-compose.override.yml](../docker-compose.override.yml)   | Additional configuration for running the above services locally. Also adds configuration for `minio` and `prince` lambda services |
-| [docker-compose.cypress_ci.yml](../docker-compose.cypress_ci.yml) | Additional configuration for running end-to-end Cypress tests in Github Actions                                                   |
-| [docker-compose.cypress_local.yml](../docker-compose.cypress_local.yml)      | Additional configuration for running end-to-end Cypress tests locally                                                             |
-| [docker-compose.tailscale.yml](../docker-compose.tailscale.yml) | Additional configuration for using Tailscale to expose a locally-running application to other computers
-| [docker-compose.ci_server_test.yml](../docker-compose.ci_server_test.yml) | Additional configuration for running server-side tests in GitHub Actions
+| [docker-compose.yml](/docker-compose.yml)            | Base configuration for `db`, `db_migrate`, `easi` and `easi_client` services                                                      |
+| [docker-compose.override.yml](/docker-compose.override.yml)   | Additional configuration for running the above services locally. Also adds configuration for `minio` and `prince` lambda services |
+| [docker-compose.cypress_ci.yml](/docker-compose.cypress_ci.yml) | Additional configuration for running end-to-end Cypress tests in Github Actions                                                   |
+| [docker-compose.cypress_local.yml](/docker-compose.cypress_local.yml)      | Additional configuration for running end-to-end Cypress tests locally                                                             |
+| [docker-compose.tailscale.yml](/docker-compose.tailscale.yml) | Additional configuration for using Tailscale to expose a locally-running application to other computers
+| [docker-compose.ci_server_test.yml](/docker-compose.ci_server_test.yml) | Additional configuration for running server-side tests in GitHub Actions
 
 ## Use case: Run database and database migrations locally
 

--- a/docs/local_testing.md
+++ b/docs/local_testing.md
@@ -28,7 +28,7 @@ There are multiple ways to run the Cypress tests:
     - Option 2: Set up an X server on Windows and configure WSL to use it. See [this article](https://wilcovanes.ch/articles/setting-up-the-cypress-gui-in-wsl2-ubuntu-for-windows-10/) for details.
   - Note: the database, frontend, and backend must be running prior to starting the Cypress tests. Use `scripts/dev up` to start them.
   - Before each testing run, run `scripts/dev db:clean && scripts/dev db:seed` to reset the database to a pre-seeded state.
-  - The `APP_ENV` environment variable should be set to `test` in `.envrc.local`. After creating `.envrc.local` if necessary and adding `APP_ENV=test` to it, run `direnv allow` to enable it. (See [instructions above](#direnv) on `direnv` usage)
+  - The `APP_ENV` environment variable should be set to `test` in `.envrc.local`. After creating `.envrc.local` if necessary and adding `APP_ENV=test` to it, run `direnv allow` to enable it. (See [instructions above](./dev_environment_setup.md#Direnv) on `direnv` usage)
   - Running `login.spec.js` requires the environment variables `OKTA_TEST_USERNAME`, `OKTA_TEST_PASSWORD`, and `OKTA_TEST_SECRET` to be set in `.envrc.local`. The values can be found in 1Password, as mentioned in the [Authentication section](#authentication).
 - `APP_ENV=test ./scripts/run-cypress-test-docker` : Run the Cypress tests,
   database, migrations, backend, and frontend locally in Docker, similar to how

--- a/docs/local_testing.md
+++ b/docs/local_testing.md
@@ -28,9 +28,9 @@ There are multiple ways to run the Cypress tests:
     - Option 2: Set up an X server on Windows and configure WSL to use it. See [this article](https://wilcovanes.ch/articles/setting-up-the-cypress-gui-in-wsl2-ubuntu-for-windows-10/) for details.
   - Note: the database, frontend, and backend must be running prior to starting the Cypress tests. Use `scripts/dev up` to start them.
   - Before each testing run, run `scripts/dev db:clean && scripts/dev db:seed` to reset the database to a pre-seeded state.
-  - The `APP_ENV` environment variable should be set to `test` in `.envrc.local`. After creating `.envrc.local` if necessary and adding `APP_ENV=test` to it, run `direnv allow` to enable it. (See [instructions above](./dev_environment_setup.md#Direnv) on `direnv` usage)
+  - The `APP_ENV` environment variable should be set to `test` in `.envrc.local`. After creating `.envrc.local` if necessary and adding `APP_ENV=test` to it, run `direnv allow` to enable it. (See [instructions](./dev_environment_setup.md#Direnv) on `direnv` usage)
   - Running `login.spec.js` requires the environment variables `OKTA_TEST_USERNAME`, `OKTA_TEST_PASSWORD`, and `OKTA_TEST_SECRET` to be set in `.envrc.local`. The values can be found in 1Password, as mentioned in the [Authentication section](#authentication).
-- `APP_ENV=test ./scripts/run-cypress-test-docker` : Run the Cypress tests,
+- `APP_ENV=test scripts/run-cypress-test-docker` : Run the Cypress tests,
   database, migrations, backend, and frontend locally in Docker, similar to how
   they run in CI. Running the tests in this way takes time, but is useful
   for troubleshooting integration test failures in CI.

--- a/docs/operations/deployment_process.md
+++ b/docs/operations/deployment_process.md
@@ -24,6 +24,6 @@ If a deployment needs to be rolled back, the current procedure is to use `git re
 
 ## Details of the Deployment Process
 
-While the GitHub Actions workflow orchestrates the deployment process, the bulk of the logic is handled by bash scripts in the `scripts` directory, particularly [`scripts/deploy_service`](../scripts/deploy_service), which deploys Docker containers to Amazon ECS (Elastic Container Service) by invoking a Lambda function, which calls the ECS API. This Lambda's source is [available on GitHub](https://github.com/trussworks/terraform-aws-lambda-ecs-manager/blob/master/functions/manager.py).
+While the GitHub Actions workflow orchestrates the deployment process, the bulk of the logic is handled by bash scripts in the `scripts` directory, particularly [`scripts/deploy_service`](/scripts/deploy_service), which deploys Docker containers to Amazon ECS (Elastic Container Service) by invoking a Lambda function, which calls the ECS API. This Lambda's source is [available on GitHub](https://github.com/trussworks/terraform-aws-lambda-ecs-manager/blob/master/functions/manager.py).
 
-The Go backend is deployed as an ECS service; the React frontend is built as static content, then copied to an AWS S3 bucket by [`scripts/release_static`](../scripts/release_static).
+The Go backend is deployed as an ECS service; the React frontend is built as static content, then copied to an AWS S3 bucket by [`scripts/release_static`](/scripts/release_static).


### PR DESCRIPTION
No Jira ticket, just a few bugfixes I saw in the docs.
* Removing an attempt to set an anchor to the "direnv" heading in dev_environment_setup.md; it's possible to link to that heading without explicitly declaring an anchor.
* Changing most links to absolute links rather than relative; some of these were broken when we broke up the single README file at the root of the repo, and having absolute links means they'll still work even if the doc file is moved.