### PR TITLE
[NOREF] Log lambda response inside db_lambda_invoke

### DIFF
--- a/scripts/db_lambda_invoke
+++ b/scripts/db_lambda_invoke
@@ -13,7 +13,7 @@ cli_read_timeout=240
 
 if (set -x ; aws lambda invoke --qualifier "$lambda_version" --cli-read-timeout "$cli_read_timeout" --function "$function_name" --cli-binary-format raw-in-base64-out --payload "$payload" lambda_response.json) ; then
   # Log lambda_response.json for debugging
-  cat lambda_response.json
+  jq '.' lambda_response.json
 
   # Extract the exit code from the lambda_response.json
   exitCode="$(jq '.data.response.taskStatus.exitCode' < lambda_response.json)"

--- a/scripts/db_lambda_invoke
+++ b/scripts/db_lambda_invoke
@@ -12,6 +12,10 @@ payload="$(jq --null-input ".command = \"runtask\" | .body.cluster_id = \"$clust
 cli_read_timeout=240
 
 if (set -x ; aws lambda invoke --qualifier "$lambda_version" --cli-read-timeout "$cli_read_timeout" --function "$function_name" --cli-binary-format raw-in-base64-out --payload "$payload" lambda_response.json) ; then
+  # Log lambda_response.json for debugging
+  cat lambda_response.json
+
+  # Extract the exit code from the lambda_response.json
   exitCode="$(jq '.data.response.taskStatus.exitCode' < lambda_response.json)"
   if [[ "$exitCode" != 0 ]] ; then
     echo ": task exited non-zero or exit status could not be parsed" 1>&2


### PR DESCRIPTION
# No ticket

## Changes and Description

This change is being introduced to help debug events like [this](https://github.com/CMSgov/easi-app/runs/5740902546?check_suite_focus=true)

- Log the lambda response using JQ

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [x] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [x] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
