### PR TITLE
Notify requester on LCID extension instead of GRT user

### DIFF
--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -36,7 +36,7 @@ type ResolverService struct {
 	CreateTestDate                func(context.Context, *models.TestDate) (*models.TestDate, error)
 	AddGRTFeedback                func(context.Context, *models.GRTFeedback, *models.Action, models.SystemIntakeStatus, bool) (*models.GRTFeedback, error)
 	CreateActionUpdateStatus      func(context.Context, *models.Action, uuid.UUID, models.SystemIntakeStatus, bool, bool) (*models.SystemIntake, error)
-	CreateActionExtendLifecycleID func(context.Context, *models.Action, uuid.UUID, *time.Time, *string, string, *string) (*models.SystemIntake, error)
+	CreateActionExtendLifecycleID func(context.Context, *models.Action, uuid.UUID, *time.Time, *string, string, *string, bool) (*models.SystemIntake, error)
 	IssueLifecycleID              func(context.Context, *models.SystemIntake, *models.Action, bool) (*models.SystemIntake, error)
 	RejectIntake                  func(context.Context, *models.SystemIntake, *models.Action, bool) (*models.SystemIntake, error)
 	FetchUserInfo                 func(context.Context, string) (*models.UserInfo, error)

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -942,12 +942,6 @@ func (r *mutationResolver) CreateSystemIntakeActionSendEmail(ctx context.Context
 }
 
 func (r *mutationResolver) CreateSystemIntakeActionExtendLifecycleID(ctx context.Context, input model.CreateSystemIntakeActionExtendLifecycleIDInput) (*model.CreateSystemIntakeActionExtendLifecycleIDPayload, error) {
-	requesterEUAID := appcontext.Principal(ctx).ID()
-	requesterInfo, err := r.service.FetchUserInfo(ctx, requesterEUAID)
-	if err != nil {
-		return nil, err
-	}
-
 	if input.ExpirationDate == nil {
 		return &model.CreateSystemIntakeActionExtendLifecycleIDPayload{
 			UserErrors: []*model.UserError{{Message: "Must provide a valid future date", Path: []string{"expirationDate"}}},
@@ -961,31 +955,21 @@ func (r *mutationResolver) CreateSystemIntakeActionExtendLifecycleID(ctx context
 	}
 
 	intake, err := r.service.CreateActionExtendLifecycleID(
-		ctx, &models.Action{
+		ctx,
+		&models.Action{
 			IntakeID:   &input.ID,
 			ActionType: models.ActionTypeEXTENDLCID,
-		}, input.ID, input.ExpirationDate, input.NextSteps, input.Scope, input.CostBaseline,
+		},
+		input.ID,
+		input.ExpirationDate,
+		input.NextSteps,
+		input.Scope,
+		input.CostBaseline,
+		input.ShouldSendEmail,
 	)
 
 	if err != nil {
 		return nil, err
-	}
-
-	if input.ShouldSendEmail {
-		err = r.emailClient.SendExtendLCIDEmail(
-			ctx,
-			requesterInfo.Email,
-			input.ID,
-			intake.ProjectName.String,
-			input.ExpirationDate,
-			input.Scope,
-			*input.NextSteps,
-			*input.CostBaseline,
-		)
-
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return &model.CreateSystemIntakeActionExtendLifecycleIDPayload{

--- a/pkg/graph/schema.resolvers_test.go
+++ b/pkg/graph/schema.resolvers_test.go
@@ -192,7 +192,9 @@ func TestGraphQLTestSuite(t *testing.T) {
 		cedarLdapClient.FetchUserInfo,
 		store.FetchSystemIntakeByID,
 		store.UpdateSystemIntake,
-		emailClient.SendSystemIntakeReviewEmail,
+		emailClient.SendExtendLCIDEmail,
+		emailClient.SendIntakeInvalidEUAIDEmail,
+		emailClient.SendIntakeNoEUAIDEmail,
 	)
 
 	resolver := NewResolver(store, resolverService, &s3Client, &emailClient, ldClient, cedarCoreClient)

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -231,7 +231,9 @@ func (s *Server) routes(
 				cedarLDAPClient.FetchUserInfo,
 				store.FetchSystemIntakeByID,
 				store.UpdateSystemIntake,
-				emailClient.SendSystemIntakeReviewEmail,
+				emailClient.SendExtendLCIDEmail,
+				emailClient.SendIntakeInvalidEUAIDEmail,
+				emailClient.SendIntakeNoEUAIDEmail,
 			),
 			IssueLifecycleID: services.NewUpdateLifecycleFields(
 				serviceConfig,


### PR DESCRIPTION
# EASI-1805

## Changes and Description

- When an intake's lifecycle ID is extended, send an email notification to the requester, instead of the GRT user who granted the extension.
- Move email code into the `services` package for consistency instead of being in the GraphQL resolver.

## How to test this change

- Create an intake request with some user (i.e. ABCD).
- Log off and log in with a different user (i.e. WXYZ) with GRT permissions.
- Issue an LCID for the intake request as WXYZ.
- Extend the LCID as WXYZ.
- Check MailCatcher; a notification should be sent to ABCD about the LCID extension, not WXYZ.

GRT user WXYZ granted LCID extension:
![GRT user who granted extension](https://user-images.githubusercontent.com/92891039/161815212-ea5fc40e-be47-4ea1-b56f-37c288e09b6e.PNG)

Notification email for LCID extension sent to requester, ABCD:
![notification email to requester](https://user-images.githubusercontent.com/92891039/161815314-5214cb8f-cde3-4cb5-9484-9543ae25ae1b.PNG)