### PR TITLE
NOREF -- Add Article Card Component full width when smaller than desktop view

### DIFF
--- a/src/components/ArticleCard/__snapshots__/index.test.tsx.snap
+++ b/src/components/ArticleCard/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`RelatedArticle matches the snapshot 1`] = `
 <DocumentFragment>
   <li
-    class="usa-card grid-col-4"
+    class="usa-card desktop:grid-col-4"
     data-testid="article-card"
   >
     <div

--- a/src/components/ArticleCard/index.tsx
+++ b/src/components/ArticleCard/index.tsx
@@ -40,7 +40,7 @@ const ArticleCard = ({
     <Card
       containerProps={{ className: 'radius-md shadow-2' }}
       data-testid="article-card"
-      className={classnames('grid-col-4', className, {
+      className={classnames('desktop:grid-col-4', className, {
         'article-card--isLink': isLink
       })}
       onClick={() => clickHandler(`help${route}`)}

--- a/src/components/RelatedArticles/__snapshots__/index.test.tsx.snap
+++ b/src/components/RelatedArticles/__snapshots__/index.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`RelatedArticle matches the snapshot 1`] = `
         data-testid="CardGroup"
       >
         <li
-          class="usa-card grid-col-4"
+          class="usa-card desktop:grid-col-4"
           data-testid="article-card"
         >
           <div
@@ -68,7 +68,7 @@ exports[`RelatedArticle matches the snapshot 1`] = `
           </div>
         </li>
         <li
-          class="usa-card grid-col-4"
+          class="usa-card desktop:grid-col-4"
           data-testid="article-card"
         >
           <div
@@ -110,7 +110,7 @@ exports[`RelatedArticle matches the snapshot 1`] = `
           </div>
         </li>
         <li
-          class="usa-card grid-col-4"
+          class="usa-card desktop:grid-col-4"
           data-testid="article-card"
         >
           <div


### PR DESCRIPTION
# NOREF

## Changes and Description

- Change class name for the Article Card so that it becomes `grid-col-4` when its big window sizes

|   |    |
|:-:|---|
|Before|![image](https://user-images.githubusercontent.com/2349702/162266755-d0515a39-1e57-4554-82db-a7f1febab705.png)|
|After|![image](https://user-images.githubusercontent.com/2349702/162266896-f3f1d1d6-5db4-4284-b45e-9b77f5887f75.png)|


