### PR TITLE
[NOREF] - Help Section Shared Components

### DIFF
--- a/src/components/HelpBreadcrumb/__snapshots__/index.test.tsx.snap
+++ b/src/components/HelpBreadcrumb/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HelpBreadcrumb matches the snapshot 1`] = `
+<DocumentFragment>
+  <button
+    class="usa-button usa-button--unstyled margin-top-7"
+    data-testid="button"
+    type="button"
+  >
+    <svg
+      class="usa-icon margin-right-05 margin-top-3px text-tbottom"
+      focusable="false"
+      height="1em"
+      role="img"
+      viewBox="0 0 24 24"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M0 0h24v24H0z"
+        fill="none"
+      />
+      <path
+        d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+      />
+    </svg>
+    Back
+  </button>
+</DocumentFragment>
+`;

--- a/src/components/HelpBreadcrumb/__snapshots__/index.test.tsx.snap
+++ b/src/components/HelpBreadcrumb/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`HelpBreadcrumb matches the snapshot 1`] = `
         d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
       />
     </svg>
-    back
+    Back
   </button>
 </DocumentFragment>
 `;

--- a/src/components/HelpBreadcrumb/__snapshots__/index.test.tsx.snap
+++ b/src/components/HelpBreadcrumb/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`HelpBreadcrumb matches the snapshot 1`] = `
         d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
       />
     </svg>
-    Back
+    back
   </button>
 </DocumentFragment>
 `;

--- a/src/components/HelpBreadcrumb/__snapshots__/index.test.tsx.snap
+++ b/src/components/HelpBreadcrumb/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HelpBreadcrumb matches the snapshot 1`] = `
 <DocumentFragment>
   <button
-    class="usa-button usa-button--unstyled margin-top-7"
+    class="usa-button usa-button--unstyled margin-top-6"
     data-testid="button"
     type="button"
   >

--- a/src/components/HelpBreadcrumb/index.test.tsx
+++ b/src/components/HelpBreadcrumb/index.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import HelpBreadcrumb from './index';
+
+describe('HelpBreadcrumb', () => {
+  it('matches the snapshot', () => {
+    const { asFragment } = render(<HelpBreadcrumb type="back" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/HelpBreadcrumb/index.test.tsx
+++ b/src/components/HelpBreadcrumb/index.test.tsx
@@ -5,7 +5,7 @@ import HelpBreadcrumb from './index';
 
 describe('HelpBreadcrumb', () => {
   it('matches the snapshot', () => {
-    const { asFragment } = render(<HelpBreadcrumb type="back" />);
+    const { asFragment } = render(<HelpBreadcrumb type="Back" />);
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/components/HelpBreadcrumb/index.tsx
+++ b/src/components/HelpBreadcrumb/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
+import { Button, IconArrowBack, IconClose } from '@trussworks/react-uswds';
+import classNames from 'classnames';
+
+type HelpBreadcrumbProps = {
+  type: 'back' | 'close';
+  className?: string;
+};
+
+export default function HelpBreadcrumb({
+  type = 'back',
+  className
+}: HelpBreadcrumbProps) {
+  const history = useHistory();
+  const { t } = useTranslation();
+  const handleClick = () => {
+    // TODO: Close functionality is broken
+    if (type === 'close') {
+      window.close();
+    } else {
+      history.goBack();
+    }
+  };
+  return (
+    <Button
+      type="button"
+      unstyled
+      onClick={() => handleClick()}
+      className={classNames('margin-top-7', className)}
+    >
+      {type === 'close' ? (
+        <IconClose className="margin-right-05 margin-top-3px text-tbottom" />
+      ) : (
+        <IconArrowBack className="margin-right-05 margin-top-3px text-tbottom" />
+      )}
+      {t(`${type.charAt(0).toUpperCase()}${type.slice(1)}`)}
+    </Button>
+  );
+}

--- a/src/components/HelpBreadcrumb/index.tsx
+++ b/src/components/HelpBreadcrumb/index.tsx
@@ -28,7 +28,7 @@ export default function HelpBreadcrumb({
       type="button"
       unstyled
       onClick={() => handleClick()}
-      className={classNames('margin-top-7', className)}
+      className={classNames('margin-top-6', className)}
     >
       {type === 'close' ? (
         <IconClose className="margin-right-05 margin-top-3px text-tbottom" />

--- a/src/components/HelpBreadcrumb/index.tsx
+++ b/src/components/HelpBreadcrumb/index.tsx
@@ -5,19 +5,19 @@ import { Button, IconArrowBack, IconClose } from '@trussworks/react-uswds';
 import classNames from 'classnames';
 
 type HelpBreadcrumbProps = {
-  type: 'back' | 'close';
+  type: 'Back' | 'Close';
   className?: string;
 };
 
 export default function HelpBreadcrumb({
-  type = 'back',
+  type = 'Back',
   className
 }: HelpBreadcrumbProps) {
   const history = useHistory();
   const { t } = useTranslation();
   const handleClick = () => {
     // TODO: Close functionality is broken
-    if (type === 'close') {
+    if (type === 'Close') {
       window.close();
     } else {
       history.goBack();
@@ -30,12 +30,12 @@ export default function HelpBreadcrumb({
       onClick={() => handleClick()}
       className={classNames('margin-top-6', className)}
     >
-      {type === 'close' ? (
+      {type === 'Close' ? (
         <IconClose className="margin-right-05 margin-top-3px text-tbottom" />
       ) : (
         <IconArrowBack className="margin-right-05 margin-top-3px text-tbottom" />
       )}
-      {t(`${type.charAt(0).toUpperCase()}${type.slice(1)}`)}
+      {t(type)}
     </Button>
   );
 }

--- a/src/components/HelpContacts/__snapshots__/index.test.tsx.snap
+++ b/src/components/HelpContacts/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HelpContacts matches the snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="padding-bottom-5 padding-top-2"
+  >
+    <h2
+      class="margin-bottom-1"
+    >
+      Additional contacts
+    </h2>
+    <p
+      class="font-body-md"
+    >
+      Still need help? Use the contact information below to contact the group you need.
+    </p>
+    <div
+      class="grid-row grid-gap-lg"
+    >
+      <div
+        class="desktop:grid-col-4 margin-bottom-2"
+      >
+        <h3
+          class="margin-bottom-1 margin-top-2"
+        >
+          Governance Review Admin
+        </h3>
+        <p
+          class="margin-top-1 line-height-body-4"
+        >
+          The Governance Review Admin team can help with questions related to your IT Governance requests.
+        </p>
+        <h4
+          class="margin-y-1"
+        >
+          Email addresses
+        </h4>
+        <a
+          class="usa-link"
+          href="mailto:IT_Governance@cms.hhs.gov"
+        >
+          IT_Governance@cms.hhs.gov
+        </a>
+      </div>
+      <div
+        class="desktop:grid-col-4 margin-bottom-2"
+      >
+        <h3
+          class="margin-bottom-1 margin-top-2"
+        >
+          Enterprise Architecture
+        </h3>
+        <p
+          class="margin-top-1 line-height-body-4"
+        >
+          The Enterprise Architecture team can help with questions related to your Enterprise Architecture needs.
+        </p>
+        <h4
+          class="margin-y-1"
+        >
+          Email addresses
+        </h4>
+        <a
+          class="usa-link"
+          href="mailto:EnterpriseArchitecture@cms.hhs.gov"
+        >
+          EnterpriseArchitecture@cms.hhs.gov
+        </a>
+      </div>
+      <div
+        class="desktop:grid-col-4 margin-bottom-2"
+      >
+        <h3
+          class="margin-bottom-1 margin-top-2"
+        >
+          IT Navigator
+        </h3>
+        <p
+          class="margin-top-1 line-height-body-4"
+        >
+          The IT Navigator team can help with questions related to choosing the type of IT Governance request that fits your needs.
+        </p>
+        <h4
+          class="margin-y-1"
+        >
+          Email addresses
+        </h4>
+        <a
+          class="usa-link"
+          href="mailto:NavigatorInquiries@cms.hhs.gov"
+        >
+          NavigatorInquiries@cms.hhs.gov
+        </a>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/HelpContacts/index.test.tsx
+++ b/src/components/HelpContacts/index.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render } from '@testing-library/react';
+
+import HelpContacts from './index';
+
+describe('HelpContacts', () => {
+  it('matches the snapshot', () => {
+    const { asFragment } = render(
+      <MemoryRouter>
+        <HelpContacts type="IT Governance" />
+      </MemoryRouter>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders correct contacts when array is passed', () => {
+    const { getByText } = render(
+      <MemoryRouter>
+        <HelpContacts type={['IT Governance', 'Section 508']} />
+      </MemoryRouter>
+    );
+
+    expect(getByText('Governance Review Admin')).toBeInTheDocument();
+    expect(getByText('Section 508')).toBeInTheDocument();
+  });
+});

--- a/src/components/HelpContacts/index.tsx
+++ b/src/components/HelpContacts/index.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link as UswdsLink } from '@trussworks/react-uswds';
+import classnames from 'classnames';
+
+import { ArticleTypeProps } from 'types/articles';
+
+type HelpContactProps = {
+  type: ArticleTypeProps | ArticleTypeProps[];
+  className?: string;
+};
+
+type ContactProps = {
+  title: string;
+  content: string;
+  email: string;
+  type: ArticleTypeProps;
+};
+
+export default function HelpContacts({ type, className }: HelpContactProps) {
+  const { t } = useTranslation('help');
+  const contacts: ContactProps[] = t('additionalContacts.contacts', {
+    returnObjects: true
+  });
+
+  const contactKeys = Object.keys(contacts).filter((key: any) => {
+    return type.includes(contacts[key].type);
+  });
+
+  return (
+    <div className={classnames('padding-bottom-5 padding-top-2', className)}>
+      <h2 className="margin-bottom-1">{t('additionalContacts.heading')}</h2>
+      <p className="font-body-md">{t('additionalContacts.subheading')}</p>
+      <div className="grid-row grid-gap-lg">
+        {contactKeys.map((key: any) => {
+          return (
+            <div key={key} className="desktop:grid-col-4 margin-bottom-2">
+              <h3 className="margin-bottom-1 margin-top-2">
+                {contacts[key].title}
+              </h3>
+              <p className="margin-top-1 line-height-body-4">
+                {contacts[key].content}
+              </p>
+              <h4 className="margin-y-1">
+                {t('additionalContacts.emailHeading')}
+              </h4>
+              <UswdsLink href={`mailto:${contacts[key].email}`}>
+                {contacts[key].email}
+              </UswdsLink>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/HelpPageIntro/__snapshots__/index.test.tsx.snap
+++ b/src/components/HelpPageIntro/__snapshots__/index.test.tsx.snap
@@ -13,11 +13,11 @@ exports[`HelpPageIntro matches the snapshot 1`] = `
       Page Heading
     </h1>
     <a
-      class="usa-link"
+      class="usa-link display-inline-block margin-y-1"
       href="/help/it-governance"
     >
       <span
-        class="easi-tag system-profile__tag text-primary-dark bg-primary-lighter padding-bottom-1 margin-y-1"
+        class="easi-tag system-profile__tag text-primary-dark bg-primary-lighter padding-bottom-1"
         data-testid="tag"
       >
         IT Governance

--- a/src/components/HelpPageIntro/__snapshots__/index.test.tsx.snap
+++ b/src/components/HelpPageIntro/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HelpPageIntro matches the snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="help-page-intro margin-bottom-4"
+  >
+    <h1
+      aria-live="polite"
+      class="easi-h1 margin-bottom-0 margin-top-3"
+      tabindex="-1"
+    >
+      Page Heading
+    </h1>
+    <a
+      class="usa-link"
+      href="/help/it-governance"
+    >
+      <span
+        class="easi-tag system-profile__tag text-primary-dark bg-primary-lighter padding-bottom-1 margin-y-1"
+        data-testid="tag"
+      >
+        IT Governance
+      </span>
+    </a>
+    <p
+      class="font-body-lg margin-top-1 margin-bottom-0 line-height-body-5"
+    >
+      This is the intro content that describes the page
+    </p>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/HelpPageIntro/index.test.tsx
+++ b/src/components/HelpPageIntro/index.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render } from '@testing-library/react';
+
+import HelpPageIntro from './index';
+
+describe('HelpPageIntro', () => {
+  it('matches the snapshot', () => {
+    const { asFragment } = render(
+      <MemoryRouter>
+        <HelpPageIntro
+          heading="Page Heading"
+          subheading="This is the intro content that describes the page"
+          type="IT Governance"
+        />
+      </MemoryRouter>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/HelpPageIntro/index.tsx
+++ b/src/components/HelpPageIntro/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import HelpTag from 'components/HelpTag';
 import PageHeading from 'components/PageHeading';
@@ -19,11 +19,11 @@ export default function HelpPageIntro({
   type
 }: HelpPageIntroProps) {
   return (
-    <div className={classNames('help-page-intro margin-bottom-4', className)}>
+    <div className={classnames('help-page-intro margin-bottom-4', className)}>
       <PageHeading className="margin-bottom-0 margin-top-3">
         {heading}
       </PageHeading>
-      {type && <HelpTag type={type} />}
+      {type && <HelpTag type={type} className="margin-y-1" />}
       {subheading && (
         <p className="font-body-lg margin-top-1 margin-bottom-0 line-height-body-5">
           {subheading}

--- a/src/components/HelpPageIntro/index.tsx
+++ b/src/components/HelpPageIntro/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import HelpTag from 'components/HelpTag';
+import PageHeading from 'components/PageHeading';
+import { ArticleTypeProps } from 'types/articles';
+
+type HelpPageIntroProps = {
+  className?: string;
+  heading: string;
+  subheading?: string;
+  type?: ArticleTypeProps;
+};
+
+export default function HelpPageIntro({
+  className,
+  heading,
+  subheading,
+  type
+}: HelpPageIntroProps) {
+  return (
+    <div className={classNames('help-page-intro margin-bottom-4', className)}>
+      <PageHeading className="margin-bottom-0 margin-top-3">
+        {heading}
+      </PageHeading>
+      {type && <HelpTag type={type} />}
+      {subheading && (
+        <p className="font-body-lg margin-top-1 margin-bottom-0 line-height-body-5">
+          {subheading}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/HelpTag/__snapshots__/index.test.tsx.snap
+++ b/src/components/HelpTag/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HelpTag matches the snapshot 1`] = `
+<DocumentFragment>
+  <a
+    class="usa-link"
+    href="/help/it-governance"
+  >
+    <span
+      class="easi-tag system-profile__tag text-primary-dark bg-primary-lighter padding-bottom-1 margin-y-1"
+      data-testid="tag"
+    >
+      IT Governance
+    </span>
+  </a>
+</DocumentFragment>
+`;

--- a/src/components/HelpTag/__snapshots__/index.test.tsx.snap
+++ b/src/components/HelpTag/__snapshots__/index.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`HelpTag matches the snapshot 1`] = `
 <DocumentFragment>
   <a
-    class="usa-link"
+    class="usa-link display-inline-block"
     href="/help/it-governance"
   >
     <span
-      class="easi-tag system-profile__tag text-primary-dark bg-primary-lighter padding-bottom-1 margin-y-1"
+      class="easi-tag system-profile__tag text-primary-dark bg-primary-lighter padding-bottom-1"
       data-testid="tag"
     >
       IT Governance

--- a/src/components/HelpTag/index.test.tsx
+++ b/src/components/HelpTag/index.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render } from '@testing-library/react';
+
+import HelpTag from './index';
+
+describe('HelpTag', () => {
+  it('matches the snapshot', () => {
+    const { asFragment } = render(
+      <MemoryRouter>
+        <HelpTag type="IT Governance" />
+      </MemoryRouter>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/HelpTag/index.tsx
+++ b/src/components/HelpTag/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import classnames from 'classnames';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import Tag from 'components/shared/Tag';
@@ -30,8 +31,11 @@ export default function HelpTag({ type, className }: HelpTagTypes) {
   const { t } = useTranslation();
   const articleType = articleTypes.filter(article => article.type === type)[0];
   return (
-    <UswdsReactLink to={`/help${articleType.route}`} className={className}>
-      <Tag className="system-profile__tag text-primary-dark bg-primary-lighter padding-bottom-1 margin-y-1">
+    <UswdsReactLink
+      to={`/help${articleType.route}`}
+      className={classnames('display-inline-block', className)}
+    >
+      <Tag className="system-profile__tag text-primary-dark bg-primary-lighter padding-bottom-1">
         {t(articleType.type)}
       </Tag>
     </UswdsReactLink>

--- a/src/components/HelpTag/index.tsx
+++ b/src/components/HelpTag/index.tsx
@@ -4,14 +4,9 @@ import classnames from 'classnames';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import Tag from 'components/shared/Tag';
-import { ArticleTypeProps } from 'types/articles';
+import { ArticleRouteProps, ArticleTypeProps } from 'types/articles';
 
-export type ArticleTypes = {
-  type: string;
-  route: string;
-};
-
-const articleTypes: ArticleTypes[] = [
+const articleTypes: ArticleRouteProps[] = [
   {
     type: 'IT Governance',
     route: '/it-governance'

--- a/src/components/HelpTag/index.tsx
+++ b/src/components/HelpTag/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import UswdsReactLink from 'components/LinkWrapper';
+import Tag from 'components/shared/Tag';
+import { ArticleTypeProps } from 'types/articles';
+
+export type ArticleTypes = {
+  type: string;
+  route: string;
+};
+
+const articleTypes: ArticleTypes[] = [
+  {
+    type: 'IT Governance',
+    route: '/it-governance'
+  },
+  {
+    type: 'Section 508',
+    route: '/section-508'
+  }
+];
+
+type HelpTagTypes = {
+  type: ArticleTypeProps;
+  className?: string;
+};
+
+export default function HelpTag({ type, className }: HelpTagTypes) {
+  const { t } = useTranslation();
+  const articleType = articleTypes.filter(article => article.type === type)[0];
+  return (
+    <UswdsReactLink to={`/help${articleType.route}`} className={className}>
+      <Tag className="system-profile__tag text-primary-dark bg-primary-lighter padding-bottom-1 margin-y-1">
+        {t(articleType.type)}
+      </Tag>
+    </UswdsReactLink>
+  );
+}

--- a/src/i18n/en-US/help.ts
+++ b/src/i18n/en-US/help.ts
@@ -2,9 +2,6 @@ const help = {
   read: 'Read',
   relatedHelp: 'Related help articles',
   relatedDescription:
-<<<<<<< Updated upstream
-    'Below are some additional help articles that you may find useful.'
-=======
     'Below are some additional help articles that you may find useful.',
   back: 'Back',
   additionalContacts: {
@@ -43,7 +40,6 @@ const help = {
       }
     }
   }
->>>>>>> Stashed changes
 };
 
 export default help;

--- a/src/i18n/en-US/help.ts
+++ b/src/i18n/en-US/help.ts
@@ -2,7 +2,48 @@ const help = {
   read: 'Read',
   relatedHelp: 'Related help articles',
   relatedDescription:
+<<<<<<< Updated upstream
     'Below are some additional help articles that you may find useful.'
+=======
+    'Below are some additional help articles that you may find useful.',
+  back: 'Back',
+  additionalContacts: {
+    heading: 'Additional contacts',
+    subheading:
+      'Still need help? Use the contact information below to contact the group you need.',
+    emailHeading: 'Email addresses',
+    contacts: {
+      govReview: {
+        title: 'Governance Review Admin',
+        type: 'IT Governance',
+        content:
+          'The Governance Review Admin team can help with questions related to your IT Governance requests.',
+        email: 'IT_Governance@cms.hhs.gov'
+      },
+      enterprise: {
+        title: 'Enterprise Architecture',
+        type: 'IT Governance',
+        content:
+          'The Enterprise Architecture team can help with questions related to your Enterprise Architecture needs.',
+        email: 'EnterpriseArchitecture@cms.hhs.gov'
+      },
+      itNavigator: {
+        title: 'IT Navigator',
+        type: 'IT Governance',
+        content:
+          'The IT Navigator team can help with questions related to choosing the type of IT Governance request that fits your needs.',
+        email: 'NavigatorInquiries@cms.hhs.gov'
+      },
+      section508: {
+        title: 'Section 508',
+        type: 'Section 508',
+        content:
+          'The Section 508 team can help with questions related to your 508 testing requests, including those about COTS and GOTS products.',
+        email: 'CMS_Section508@cms.hhs.gov'
+      }
+    }
+  }
+>>>>>>> Stashed changes
 };
 
 export default help;

--- a/src/types/articles.ts
+++ b/src/types/articles.ts
@@ -5,3 +5,8 @@ export type ArticleProps = {
   type: ArticleTypeProps;
   translation: string;
 };
+
+export type ArticleRouteProps = {
+  type: string;
+  route: string;
+};


### PR DESCRIPTION
## Changes and Description

**Reusable components for the Knowledge Center**

- `<HelpBreadcrumb>`
    - Accepts type prop ("back" or "close") to render breadcrumb button
    - Note: The close tab button functionality does not work yet.
- `<HelpTag>`
    - Linked tag to be used in articles and ArticleCard component
    - Pass article type as prop to render tag with correct path
- `<HelpPageIntro>`
    - Page intro text for help section
- `<HelpContacts>`
    - Additional contacts section
    - Pass article type (string or or multiple types as array) to display additional contacts

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
