### PR TITLE
[Easi-1905] Create "Templates for 508 testing" help article

### DIFF
--- a/src/components/TestingTemplates/__snapshots__/index.test.tsx.snap
+++ b/src/components/TestingTemplates/__snapshots__/index.test.tsx.snap
@@ -35,8 +35,10 @@ exports[`Template for 508 Testing renders help mode without crashing 1`] = `
     <div
       class="margin-bottom-6 padding-2 bg-base-lightest"
     >
-      <h3>
-        Page Contents
+      <h3
+        class="margin-top-0 margin-bottom-2"
+      >
+        Page contents
       </h3>
       <ul
         class="usa-list usa-list--unstyled"
@@ -267,16 +269,14 @@ exports[`Template for 508 Testing renders help mode without crashing 1`] = `
               </svg>
                Do not skip any row in the document. This will result in delays.
             </p>
-            <p>
-              <a
-                class="usa-link usa-link--external"
-                href="/https://www.youtube.com/watch?v=kAkSV9xiJ1A"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Watch tutorial on how to fill out a VPAT (opens in a new tab)
-              </a>
-            </p>
+            <a
+              class="usa-link usa-link--external"
+              href="/https://www.youtube.com/watch?v=kAkSV9xiJ1A"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Watch tutorial on how to fill out a VPAT (opens in a new tab)
+            </a>
           </div>
         </div>
       </div>
@@ -299,7 +299,7 @@ exports[`Template for 508 Testing renders help mode without crashing 1`] = `
         The Test Plan is a document that helps the Section 508 team understand your system and know what areas of your system to test before it goes live. In this document you will provide:
       </p>
       <ul
-        class="usa-list desktop:grid-col-8"
+        class="usa-list desktop:grid-col-8 margin-bottom-4"
       >
         <li
           class="maxw-none margin-bottom-1"
@@ -366,7 +366,7 @@ exports[`Template for 508 Testing renders help mode without crashing 1`] = `
         The Remediation Plan is a document that helps the Section 508 team understand how you plan to fix the issues that were identified from the 508 test. In this document you will provide:
       </p>
       <ul
-        class="usa-list desktop:grid-col-8"
+        class="usa-list desktop:grid-col-8 margin-bottom-4"
       >
         <li
           class="maxw-none margin-bottom-1"
@@ -380,7 +380,7 @@ exports[`Template for 508 Testing renders help mode without crashing 1`] = `
         </li>
       </ul>
       <div
-        class="usa-summary-box desktop:grid-col-6 margin-bottom-6"
+        class="usa-summary-box desktop:grid-col-6"
         data-testid="summary-box"
       >
         <div
@@ -424,8 +424,10 @@ exports[`Template for 508 Testing renders without crashing 1`] = `
     <div
       class="margin-bottom-6 padding-2 bg-base-lightest"
     >
-      <h3>
-        Page Contents
+      <h3
+        class="margin-top-0 margin-bottom-2"
+      >
+        Page contents
       </h3>
       <ul
         class="usa-list usa-list--unstyled"
@@ -656,16 +658,14 @@ exports[`Template for 508 Testing renders without crashing 1`] = `
               </svg>
                Do not skip any row in the document. This will result in delays.
             </p>
-            <p>
-              <a
-                class="usa-link usa-link--external"
-                href="/https://www.youtube.com/watch?v=kAkSV9xiJ1A"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Watch tutorial on how to fill out a VPAT (opens in a new tab)
-              </a>
-            </p>
+            <a
+              class="usa-link usa-link--external"
+              href="/https://www.youtube.com/watch?v=kAkSV9xiJ1A"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Watch tutorial on how to fill out a VPAT (opens in a new tab)
+            </a>
           </div>
         </div>
       </div>
@@ -688,7 +688,7 @@ exports[`Template for 508 Testing renders without crashing 1`] = `
         The Test Plan is a document that helps the Section 508 team understand your system and know what areas of your system to test before it goes live. In this document you will provide:
       </p>
       <ul
-        class="usa-list desktop:grid-col-8"
+        class="usa-list desktop:grid-col-8 margin-bottom-4"
       >
         <li
           class="maxw-none margin-bottom-1"
@@ -755,7 +755,7 @@ exports[`Template for 508 Testing renders without crashing 1`] = `
         The Remediation Plan is a document that helps the Section 508 team understand how you plan to fix the issues that were identified from the 508 test. In this document you will provide:
       </p>
       <ul
-        class="usa-list desktop:grid-col-8"
+        class="usa-list desktop:grid-col-8 margin-bottom-4"
       >
         <li
           class="maxw-none margin-bottom-1"
@@ -769,7 +769,7 @@ exports[`Template for 508 Testing renders without crashing 1`] = `
         </li>
       </ul>
       <div
-        class="usa-summary-box desktop:grid-col-6 margin-bottom-6"
+        class="usa-summary-box desktop:grid-col-6"
         data-testid="summary-box"
       >
         <div

--- a/src/components/TestingTemplates/__snapshots__/index.test.tsx.snap
+++ b/src/components/TestingTemplates/__snapshots__/index.test.tsx.snap
@@ -408,3 +408,395 @@ exports[`Template for 508 Testing renders help mode without crashing 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`Template for 508 Testing renders without crashing 1`] = `
+<DocumentFragment>
+  <div
+    class="templates-for-508-testing"
+  >
+    <h1
+      aria-live="polite"
+      class="easi-h1 line-height-heading-2"
+      tabindex="-1"
+    >
+      Templates for 508 testing
+    </h1>
+    <div
+      class="margin-bottom-6 padding-2 bg-base-lightest"
+    >
+      <h3>
+        Page Contents
+      </h3>
+      <ul
+        class="usa-list usa-list--unstyled"
+      >
+        <li
+          class="margin-bottom-1"
+        >
+          <a
+            class="usa-link"
+            href="#vpat"
+          >
+            <span
+              class="display-flex flex-align-center"
+            >
+              Voluntary Product Assessment Template (VPAT)
+              <svg
+                class="usa-icon margin-left-1"
+                focusable="false"
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </span>
+          </a>
+        </li>
+        <li
+          class="margin-bottom-1"
+        >
+          <a
+            class="usa-link"
+            href="#test-plan"
+          >
+            <span
+              class="display-flex flex-align-center"
+            >
+              Test Plan
+              <svg
+                class="usa-icon margin-left-1"
+                focusable="false"
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </span>
+          </a>
+        </li>
+        <li
+          class=""
+        >
+          <a
+            class="usa-link"
+            href="#remediation-plan"
+          >
+            <span
+              class="display-flex flex-align-center"
+            >
+              Remediation Plan
+              <svg
+                class="usa-icon margin-left-1"
+                focusable="false"
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="templates-for-508-testing__section"
+    >
+      <h2
+        class="margin-bottom-2"
+        id="vpat"
+      >
+        Voluntary Product Assessment Template (VPAT)
+      </h2>
+      <p
+        class="margin-bottom-4"
+      >
+        A VPAT is a document that helps CMS and other government agencies understand how you will meet the 508 Standards for IT accessibility.
+      </p>
+      <h3
+        class="margin-bottom-2"
+      >
+        Tips to complete a VPAT
+      </h3>
+      <p
+        class="margin-bottom-1"
+      >
+        For each row in the table, indicate the conformance level. There are 5 levels:
+      </p>
+      <ul
+        class="usa-list usa-list--unstyled desktop:grid-col-8"
+      >
+        <li
+          class="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            class="text-bold display-inline"
+          >
+            Supports:
+          </span>
+           The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.
+        </li>
+        <li
+          class="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            class="text-bold display-inline"
+          >
+            Partially Supports:
+          </span>
+           Some functionality of the product does not meet the criterion.
+        </li>
+        <li
+          class="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            class="text-bold display-inline"
+          >
+            Does Not Support:
+          </span>
+           The majority of product functionality does not meet the criterion.
+        </li>
+        <li
+          class="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            class="text-bold display-inline"
+          >
+            Not Applicable:
+          </span>
+           The criterion is not relevant to the product.
+        </li>
+        <li
+          class="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            class="text-bold display-inline"
+          >
+            Not Evaluated:
+          </span>
+           The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.
+        </li>
+      </ul>
+      <p
+        class="margin-bottom-4"
+      >
+        After indicating the conformance level, provide a detailed explanation in the ‘Remarks and Evaluation’ column.
+      </p>
+      <div
+        class="usa-summary-box desktop:grid-col-6 margin-bottom-6"
+        data-testid="summary-box"
+      >
+        <div
+          class="usa-summary-box__body"
+        >
+          <h3
+            class="usa-summary-box__heading"
+          >
+            Download VPAT template
+          </h3>
+          <div
+            class="usa-summary-box__text"
+          >
+            <p>
+              <a
+                class="usa-link usa-link--external"
+                href="/https://www.itic.org/policy/accessibility/vpat"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Download the current VPAT template (opens in a new tab)
+              </a>
+               from the Information Technology Industry Council (ITI) website.
+            </p>
+            <p
+              class="display-flex flex-row flex-align-center"
+            >
+              <svg
+                class="usa-icon margin-right-1"
+                focusable="false"
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                />
+              </svg>
+               Do not skip any row in the document. This will result in delays.
+            </p>
+            <p>
+              <a
+                class="usa-link usa-link--external"
+                href="/https://www.youtube.com/watch?v=kAkSV9xiJ1A"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Watch tutorial on how to fill out a VPAT (opens in a new tab)
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="easi-divider margin-bottom-4"
+      />
+    </div>
+    <div
+      class="templates-for-508-testing__section"
+    >
+      <h2
+        class="margin-bottom-2"
+        id="test-plan"
+      >
+        Test Plan
+      </h2>
+      <p
+        class="margin-bottom-2 line-height-sans-5 desktop:grid-col-9"
+      >
+        The Test Plan is a document that helps the Section 508 team understand your system and know what areas of your system to test before it goes live. In this document you will provide:
+      </p>
+      <ul
+        class="usa-list desktop:grid-col-8"
+      >
+        <li
+          class="maxw-none margin-bottom-1"
+        >
+          a description of your system
+        </li>
+        <li
+          class="maxw-none margin-bottom-1"
+        >
+          information on how to set up and access it
+        </li>
+        <li
+          class="maxw-none margin-bottom-1"
+        >
+          user scenarios and steps taken to perform actions
+        </li>
+        <li
+          class="maxw-none margin-bottom-1"
+        >
+          and any other constraints, assumptions or risks
+        </li>
+      </ul>
+      <div
+        class="usa-summary-box desktop:grid-col-6 margin-bottom-6"
+        data-testid="summary-box"
+      >
+        <div
+          class="usa-summary-box__body"
+        >
+          <h3
+            class="usa-summary-box__heading"
+          >
+            Download Test Plan template
+          </h3>
+          <div
+            class="usa-summary-box__text"
+          >
+            <a
+              class="usa-link usa-link--external"
+              href="/Section508TestPlanTemplate.pdf"
+              target="_blank"
+            >
+              Download the Test Plan template as a PDF (opens in a new tab)
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="easi-divider margin-bottom-4"
+      />
+    </div>
+    <div
+      class="templates-for-508-testing__section"
+    >
+      <h2
+        class="margin-bottom-2"
+        id="remediation-plan"
+      >
+        Remediation Plan
+      </h2>
+      <p
+        class="margin-bottom-2 line-height-sans-5 desktop:grid-col-9"
+      >
+        The Remediation Plan is a document that helps the Section 508 team understand how you plan to fix the issues that were identified from the 508 test. In this document you will provide:
+      </p>
+      <ul
+        class="usa-list desktop:grid-col-8"
+      >
+        <li
+          class="maxw-none margin-bottom-1"
+        >
+          solutions for each issue
+        </li>
+        <li
+          class="maxw-none margin-bottom-1"
+        >
+          when and how you plan to schedule these changes into your project
+        </li>
+      </ul>
+      <div
+        class="usa-summary-box desktop:grid-col-6 margin-bottom-6"
+        data-testid="summary-box"
+      >
+        <div
+          class="usa-summary-box__body"
+        >
+          <h3
+            class="usa-summary-box__heading"
+          >
+            Download Remediation Plan template
+          </h3>
+          <div
+            class="usa-summary-box__text"
+          >
+            <a
+              class="usa-link usa-link--external"
+              href="/CMS508RemediationPlanTemplate.pdf"
+              target="_blank"
+            >
+              Download the Test Plan template as a PDF (opens in a new tab)
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="easi-divider margin-bottom-4"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/TestingTemplates/__snapshots__/index.test.tsx.snap
+++ b/src/components/TestingTemplates/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,410 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Template for 508 Testing renders help mode without crashing 1`] = `
+<DocumentFragment>
+  <div
+    class="templates-for-508-testing"
+  >
+    <div
+      class="help-page-intro margin-bottom-4"
+    >
+      <h1
+        aria-live="polite"
+        class="easi-h1 margin-bottom-0 margin-top-3"
+        tabindex="-1"
+      >
+        Templates for 508 testing
+      </h1>
+      <a
+        class="usa-link display-inline-block margin-y-1"
+        href="/help/section-508"
+      >
+        <span
+          class="easi-tag system-profile__tag text-primary-dark bg-primary-lighter padding-bottom-1"
+          data-testid="tag"
+        >
+          Section 508
+        </span>
+      </a>
+      <div
+        class="font-body-lg margin-top-1 margin-bottom-0 line-height-body-5"
+      >
+        Download and fill out these templates as needed to complete 508 testing for your system
+      </div>
+    </div>
+    <div
+      class="margin-bottom-6 padding-2 bg-base-lightest"
+    >
+      <h3>
+        Page Contents
+      </h3>
+      <ul
+        class="usa-list usa-list--unstyled"
+      >
+        <li
+          class="margin-bottom-1"
+        >
+          <a
+            class="usa-link"
+            href="#vpat"
+          >
+            <span
+              class="display-flex flex-align-center"
+            >
+              Voluntary Product Assessment Template (VPAT)
+              <svg
+                class="usa-icon margin-left-1"
+                focusable="false"
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </span>
+          </a>
+        </li>
+        <li
+          class="margin-bottom-1"
+        >
+          <a
+            class="usa-link"
+            href="#test-plan"
+          >
+            <span
+              class="display-flex flex-align-center"
+            >
+              Test Plan
+              <svg
+                class="usa-icon margin-left-1"
+                focusable="false"
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </span>
+          </a>
+        </li>
+        <li
+          class=""
+        >
+          <a
+            class="usa-link"
+            href="#remediation-plan"
+          >
+            <span
+              class="display-flex flex-align-center"
+            >
+              Remediation Plan
+              <svg
+                class="usa-icon margin-left-1"
+                focusable="false"
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="templates-for-508-testing__section"
+    >
+      <h2
+        class="margin-bottom-2"
+        id="vpat"
+      >
+        Voluntary Product Assessment Template (VPAT)
+      </h2>
+      <p
+        class="margin-bottom-4"
+      >
+        A VPAT is a document that helps CMS and other government agencies understand how you will meet the 508 Standards for IT accessibility.
+      </p>
+      <h3
+        class="margin-bottom-2"
+      >
+        Tips to complete a VPAT
+      </h3>
+      <p
+        class="margin-bottom-1"
+      >
+        For each row in the table, indicate the conformance level. There are 5 levels:
+      </p>
+      <ul
+        class="usa-list usa-list--unstyled desktop:grid-col-8"
+      >
+        <li
+          class="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            class="text-bold display-inline"
+          >
+            Supports:
+          </span>
+           The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.
+        </li>
+        <li
+          class="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            class="text-bold display-inline"
+          >
+            Partially Supports:
+          </span>
+           Some functionality of the product does not meet the criterion.
+        </li>
+        <li
+          class="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            class="text-bold display-inline"
+          >
+            Does Not Support:
+          </span>
+           The majority of product functionality does not meet the criterion.
+        </li>
+        <li
+          class="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            class="text-bold display-inline"
+          >
+            Not Applicable:
+          </span>
+           The criterion is not relevant to the product.
+        </li>
+        <li
+          class="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            class="text-bold display-inline"
+          >
+            Not Evaluated:
+          </span>
+           The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.
+        </li>
+      </ul>
+      <p
+        class="margin-bottom-4"
+      >
+        After indicating the conformance level, provide a detailed explanation in the ‘Remarks and Evaluation’ column.
+      </p>
+      <div
+        class="usa-summary-box desktop:grid-col-6 margin-bottom-6"
+        data-testid="summary-box"
+      >
+        <div
+          class="usa-summary-box__body"
+        >
+          <h3
+            class="usa-summary-box__heading"
+          >
+            Download VPAT template
+          </h3>
+          <div
+            class="usa-summary-box__text"
+          >
+            <p>
+              <a
+                class="usa-link usa-link--external"
+                href="/https://www.itic.org/policy/accessibility/vpat"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Download the current VPAT template (opens in a new tab)
+              </a>
+               from the Information Technology Industry Council (ITI) website.
+            </p>
+            <p
+              class="display-flex flex-row flex-align-center"
+            >
+              <svg
+                class="usa-icon margin-right-1"
+                focusable="false"
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                />
+              </svg>
+               Do not skip any row in the document. This will result in delays.
+            </p>
+            <p>
+              <a
+                class="usa-link usa-link--external"
+                href="/https://www.youtube.com/watch?v=kAkSV9xiJ1A"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Watch tutorial on how to fill out a VPAT (opens in a new tab)
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="easi-divider margin-bottom-4"
+      />
+    </div>
+    <div
+      class="templates-for-508-testing__section"
+    >
+      <h2
+        class="margin-bottom-2"
+        id="test-plan"
+      >
+        Test Plan
+      </h2>
+      <p
+        class="margin-bottom-2 line-height-sans-5 desktop:grid-col-9"
+      >
+        The Test Plan is a document that helps the Section 508 team understand your system and know what areas of your system to test before it goes live. In this document you will provide:
+      </p>
+      <ul
+        class="usa-list desktop:grid-col-8"
+      >
+        <li
+          class="maxw-none margin-bottom-1"
+        >
+          a description of your system
+        </li>
+        <li
+          class="maxw-none margin-bottom-1"
+        >
+          information on how to set up and access it
+        </li>
+        <li
+          class="maxw-none margin-bottom-1"
+        >
+          user scenarios and steps taken to perform actions
+        </li>
+        <li
+          class="maxw-none margin-bottom-1"
+        >
+          and any other constraints, assumptions or risks
+        </li>
+      </ul>
+      <div
+        class="usa-summary-box desktop:grid-col-6 margin-bottom-6"
+        data-testid="summary-box"
+      >
+        <div
+          class="usa-summary-box__body"
+        >
+          <h3
+            class="usa-summary-box__heading"
+          >
+            Download Test Plan template
+          </h3>
+          <div
+            class="usa-summary-box__text"
+          >
+            <a
+              class="usa-link usa-link--external"
+              href="/Section508TestPlanTemplate.pdf"
+              target="_blank"
+            >
+              Download the Test Plan template as a PDF (opens in a new tab)
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="easi-divider margin-bottom-4"
+      />
+    </div>
+    <div
+      class="templates-for-508-testing__section"
+    >
+      <h2
+        class="margin-bottom-2"
+        id="remediation-plan"
+      >
+        Remediation Plan
+      </h2>
+      <p
+        class="margin-bottom-2 line-height-sans-5 desktop:grid-col-9"
+      >
+        The Remediation Plan is a document that helps the Section 508 team understand how you plan to fix the issues that were identified from the 508 test. In this document you will provide:
+      </p>
+      <ul
+        class="usa-list desktop:grid-col-8"
+      >
+        <li
+          class="maxw-none margin-bottom-1"
+        >
+          solutions for each issue
+        </li>
+        <li
+          class="maxw-none margin-bottom-1"
+        >
+          when and how you plan to schedule these changes into your project
+        </li>
+      </ul>
+      <div
+        class="usa-summary-box desktop:grid-col-6 margin-bottom-6"
+        data-testid="summary-box"
+      >
+        <div
+          class="usa-summary-box__body"
+        >
+          <h3
+            class="usa-summary-box__heading"
+          >
+            Download Remediation Plan template
+          </h3>
+          <div
+            class="usa-summary-box__text"
+          >
+            <a
+              class="usa-link usa-link--external"
+              href="/CMS508RemediationPlanTemplate.pdf"
+              target="_blank"
+            >
+              Download the Test Plan template as a PDF (opens in a new tab)
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/TestingTemplates/index.scss
+++ b/src/components/TestingTemplates/index.scss
@@ -1,0 +1,7 @@
+.templates-for-508-testing {
+  &__section {
+    h2, p {
+      margin-top: 0;
+    }
+  }
+}

--- a/src/components/TestingTemplates/index.test.tsx
+++ b/src/components/TestingTemplates/index.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render } from '@testing-library/react';
+
+import PrepareForGRT from '.';
+
+describe('Prepare for GRT', () => {
+  it('renders without crashing', () => {
+    const { asFragment } = render(<PrepareForGRT />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders help mode without crashing', () => {
+    const { asFragment } = render(
+      <MemoryRouter>
+        <PrepareForGRT helpArticle />
+      </MemoryRouter>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/components/TestingTemplates/index.test.tsx
+++ b/src/components/TestingTemplates/index.test.tsx
@@ -6,7 +6,11 @@ import TestingTemplates from '.';
 
 describe('Template for 508 Testing', () => {
   it('renders without crashing', () => {
-    const { asFragment } = render(<TestingTemplates />);
+    const { asFragment } = render(
+      <MemoryRouter>
+        <TestingTemplates />
+      </MemoryRouter>
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 

--- a/src/components/TestingTemplates/index.test.tsx
+++ b/src/components/TestingTemplates/index.test.tsx
@@ -2,18 +2,18 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';
 
-import PrepareForGRT from '.';
+import TestingTemplates from '.';
 
-describe('Prepare for GRT', () => {
+describe('Template for 508 Testing', () => {
   it('renders without crashing', () => {
-    const { asFragment } = render(<PrepareForGRT />);
+    const { asFragment } = render(<TestingTemplates />);
     expect(asFragment()).toMatchSnapshot();
   });
 
   it('renders help mode without crashing', () => {
     const { asFragment } = render(
       <MemoryRouter>
-        <PrepareForGRT helpArticle />
+        <TestingTemplates helpArticle />
       </MemoryRouter>
     );
     expect(asFragment()).toMatchSnapshot();

--- a/src/components/TestingTemplates/index.tsx
+++ b/src/components/TestingTemplates/index.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { IconError, SummaryBox } from '@trussworks/react-uswds';
+import classNames from 'classnames';
+
+import RemediationPlanDoc from 'assets/files/CMS508RemediationPlanTemplate.pdf';
+import TestPlanDoc from 'assets/files/Section508TestPlanTemplate.pdf';
+import HelpPageIntro from 'components/HelpPageIntro';
+import UswdsReactLink from 'components/LinkWrapper';
+import PageHeading from 'components/PageHeading';
+import Divider from 'components/shared/Divider';
+import { ArticleComponentProps } from 'types/articles';
+
+import './index.scss';
+
+export default ({ helpArticle, className }: ArticleComponentProps) => {
+  const { t } = useTranslation(['accessibility', 'templatesFor508Testing']);
+
+  const vpatConformanceLevels: { name: string; description: string }[] = t(
+    'testingTemplates.vpatSection.subSection.item1.levels',
+    {
+      returnObjects: true
+    }
+  );
+  const testPlanList: string[] = t(
+    'testingTemplates.testPlanSection.itemsToProvide',
+    {
+      returnObjects: true
+    }
+  );
+
+  const remediationPlanList: string[] = t(
+    'testingTemplates.remediationPlanSection.itemsToProvide',
+    {
+      returnObjects: true
+    }
+  );
+
+  return (
+    <div className={classNames('templates-for-508-testing', className)}>
+      {!helpArticle ? (
+        <PageHeading className="line-height-heading-2">
+          {t('testingTemplates.heading')}
+        </PageHeading>
+      ) : (
+        <HelpPageIntro
+          type="Section 508"
+          heading={t('testingTemplates.heading')}
+          subheading={t('templatesFor508Testing:description')}
+        />
+      )}
+      <div className="margin-bottom-6 padding-2 bg-base-lightest">
+        <h3>Page Contents</h3>
+        <ul>
+          <li>TEmportat</li>
+        </ul>
+      </div>
+      <div className="templates-for-508-testing__section">
+        <h2 id="vpat" className="margin-bottom-2">
+          {t('testingTemplates.vpatSection.heading')}
+        </h2>
+        <p className="margin-bottom-4">
+          {t('testingTemplates.vpatSection.description')}
+        </p>
+        <h3 className="margin-bottom-2">
+          {t('testingTemplates.vpatSection.subSection.heading')}
+        </h3>
+        <p className="margin-bottom-1">
+          {t('testingTemplates.vpatSection.subSection.item1.text')}
+        </p>
+        <ul className="usa-list usa-list--unstyle desktop:grid-col-8">
+          {vpatConformanceLevels.map(level => (
+            <li key={level.name} className="maxw-none margin-bottom-1">
+              <span className="text-bold display-inline">{level.name}</span>{' '}
+              {level.description}
+            </li>
+          ))}
+        </ul>
+        <p className="margin-bottom-4">
+          {t('testingTemplates.vpatSection.subSection.item2.text')}
+        </p>
+        <SummaryBox
+          heading={t(
+            'testingTemplates.vpatSection.subSection.downloadVPAT.heading'
+          )}
+          className="desktop:grid-col-6 margin-bottom-6"
+        >
+          <p>
+            <UswdsReactLink
+              to="https://www.itic.org/policy/accessibility/vpat"
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="external"
+            >
+              {t(
+                'testingTemplates.vpatSection.subSection.downloadVPAT.line1.linkText'
+              )}
+            </UswdsReactLink>
+            {` `}
+            {t(
+              'testingTemplates.vpatSection.subSection.downloadVPAT.line1.otherText'
+            )}
+          </p>
+          <p className="display-flex flex-row flex-align-center">
+            <IconError className="margin-right-1" />
+            {` `}
+            {t(
+              'testingTemplates.vpatSection.subSection.downloadVPAT.line2.text'
+            )}
+          </p>
+          <p>
+            <UswdsReactLink
+              to="https://www.youtube.com/watch?v=kAkSV9xiJ1A"
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="external"
+            >
+              {t(
+                'testingTemplates.vpatSection.subSection.downloadVPAT.line3.linkText'
+              )}
+            </UswdsReactLink>
+          </p>
+        </SummaryBox>
+        <Divider />
+      </div>
+      <div className="templates-for-508-testing__section">
+        <h2 id="test-plan" className="margin-bottom-2">
+          {t('testingTemplates.testPlanSection.heading')}
+        </h2>
+        <p className="margin-bottom-2 line-height-sans-5 desktop:grid-col-9">
+          {t('testingTemplates.testPlanSection.description')}
+        </p>
+        <ul className="usa-list usa-list--unstyle desktop:grid-col-8">
+          {testPlanList.map(item => (
+            <li key={item} className="maxw-none margin-bottom-1">
+              {item}
+            </li>
+          ))}
+        </ul>
+        <SummaryBox
+          heading={t('testingTemplates.testPlanSection.download.heading')}
+          className="desktop:grid-col-6 margin-bottom-6"
+        >
+          <UswdsReactLink to={TestPlanDoc} target="_blank" variant="external">
+            {t('testingTemplates.testPlanSection.download.link')}
+          </UswdsReactLink>
+        </SummaryBox>
+        <Divider />
+      </div>
+      <div className="templates-for-508-testing__section">
+        <h2 id="remediation-plan" className="margin-bottom-2">
+          {t('testingTemplates.remediationPlanSection.heading')}
+        </h2>
+        <p className="margin-bottom-2 line-height-sans-5 desktop:grid-col-9">
+          {t('testingTemplates.remediationPlanSection.description')}
+        </p>
+        <ul className="usa-list usa-list--unstyle desktop:grid-col-8">
+          {remediationPlanList.map(item => (
+            <li key={item} className="maxw-none margin-bottom-1">
+              {item}
+            </li>
+          ))}
+        </ul>
+        <SummaryBox
+          heading={t(
+            'testingTemplates.remediationPlanSection.download.heading'
+          )}
+          className="desktop:grid-col-6 margin-bottom-6"
+        >
+          <UswdsReactLink
+            to={RemediationPlanDoc}
+            target="_blank"
+            variant="external"
+          >
+            {t('testingTemplates.testPlanSection.download.link')}
+          </UswdsReactLink>
+        </SummaryBox>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TestingTemplates/index.tsx
+++ b/src/components/TestingTemplates/index.tsx
@@ -98,7 +98,10 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
         </p>
         <ul className="usa-list usa-list--unstyled desktop:grid-col-8">
           {vpatConformanceLevels.map(level => (
-            <li key={level.name} className="maxw-none margin-bottom-1">
+            <li
+              key={level.name}
+              className="maxw-none margin-bottom-1  padding-left-2"
+            >
               <span className="text-bold display-inline">{level.name}</span>{' '}
               {level.description}
             </li>
@@ -158,7 +161,7 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
         <p className="margin-bottom-2 line-height-sans-5 desktop:grid-col-9">
           {t('testingTemplates.testPlanSection.description')}
         </p>
-        <ul className="usa-list usa-list--unstyled desktop:grid-col-8">
+        <ul className="usa-list desktop:grid-col-8">
           {testPlanList.map(item => (
             <li key={item} className="maxw-none margin-bottom-1">
               {item}
@@ -182,7 +185,7 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
         <p className="margin-bottom-2 line-height-sans-5 desktop:grid-col-9">
           {t('testingTemplates.remediationPlanSection.description')}
         </p>
-        <ul className="usa-list usa-list--unstyled desktop:grid-col-8">
+        <ul className="usa-list desktop:grid-col-8">
           {remediationPlanList.map(item => (
             <li key={item} className="maxw-none margin-bottom-1">
               {item}

--- a/src/components/TestingTemplates/index.tsx
+++ b/src/components/TestingTemplates/index.tsx
@@ -55,7 +55,9 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
         />
       )}
       <div className="margin-bottom-6 padding-2 bg-base-lightest">
-        <h3>{t('templatesFor508Testing:pageContents')}</h3>
+        <h3 className="margin-top-0 margin-bottom-2">
+          {t('templatesFor508Testing:pageContents')}
+        </h3>
         <ul className="usa-list usa-list--unstyled">
           <li className="margin-bottom-1">
             <UswdsLink href="#vpat">
@@ -139,18 +141,16 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
               'testingTemplates.vpatSection.subSection.downloadVPAT.line2.text'
             )}
           </p>
-          <p>
-            <UswdsReactLink
-              to="https://www.youtube.com/watch?v=kAkSV9xiJ1A"
-              target="_blank"
-              rel="noopener noreferrer"
-              variant="external"
-            >
-              {t(
-                'testingTemplates.vpatSection.subSection.downloadVPAT.line3.linkText'
-              )}
-            </UswdsReactLink>
-          </p>
+          <UswdsReactLink
+            to="https://www.youtube.com/watch?v=kAkSV9xiJ1A"
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="external"
+          >
+            {t(
+              'testingTemplates.vpatSection.subSection.downloadVPAT.line3.linkText'
+            )}
+          </UswdsReactLink>
         </SummaryBox>
         <Divider className="margin-bottom-4" />
       </div>
@@ -161,7 +161,7 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
         <p className="margin-bottom-2 line-height-sans-5 desktop:grid-col-9">
           {t('testingTemplates.testPlanSection.description')}
         </p>
-        <ul className="usa-list desktop:grid-col-8">
+        <ul className="usa-list desktop:grid-col-8 margin-bottom-4">
           {testPlanList.map(item => (
             <li key={item} className="maxw-none margin-bottom-1">
               {item}
@@ -185,7 +185,7 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
         <p className="margin-bottom-2 line-height-sans-5 desktop:grid-col-9">
           {t('testingTemplates.remediationPlanSection.description')}
         </p>
-        <ul className="usa-list desktop:grid-col-8">
+        <ul className="usa-list desktop:grid-col-8 margin-bottom-4">
           {remediationPlanList.map(item => (
             <li key={item} className="maxw-none margin-bottom-1">
               {item}
@@ -196,7 +196,7 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
           heading={t(
             'testingTemplates.remediationPlanSection.download.heading'
           )}
-          className="desktop:grid-col-6 margin-bottom-6"
+          className="desktop:grid-col-6"
         >
           <UswdsReactLink
             to={RemediationPlanDoc}

--- a/src/components/TestingTemplates/index.tsx
+++ b/src/components/TestingTemplates/index.tsx
@@ -206,6 +206,7 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
             {t('testingTemplates.testPlanSection.download.link')}
           </UswdsReactLink>
         </SummaryBox>
+        {!helpArticle && <Divider className="margin-bottom-4" />}
       </div>
     </div>
   );

--- a/src/components/TestingTemplates/index.tsx
+++ b/src/components/TestingTemplates/index.tsx
@@ -121,7 +121,7 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
             </UswdsReactLink>
           </p>
         </SummaryBox>
-        <Divider />
+        <Divider className="margin-bottom-4" />
       </div>
       <div className="templates-for-508-testing__section">
         <h2 id="test-plan" className="margin-bottom-2">
@@ -145,7 +145,7 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
             {t('testingTemplates.testPlanSection.download.link')}
           </UswdsReactLink>
         </SummaryBox>
-        <Divider />
+        <Divider className="margin-bottom-4" />
       </div>
       <div className="templates-for-508-testing__section">
         <h2 id="remediation-plan" className="margin-bottom-2">

--- a/src/components/TestingTemplates/index.tsx
+++ b/src/components/TestingTemplates/index.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { IconError, SummaryBox } from '@trussworks/react-uswds';
+import {
+  IconArrowForward,
+  IconError,
+  Link as UswdsLink,
+  SummaryBox
+} from '@trussworks/react-uswds';
 import classNames from 'classnames';
 
 import RemediationPlanDoc from 'assets/files/CMS508RemediationPlanTemplate.pdf';
@@ -50,9 +55,26 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
         />
       )}
       <div className="margin-bottom-6 padding-2 bg-base-lightest">
-        <h3>Page Contents</h3>
-        <ul>
-          <li>TEmportat</li>
+        <h3>{t('templatesFor508Testing:pageContents')}</h3>
+        <ul className="usa-list usa-list--unstyled">
+          <li className="margin-bottom-1">
+            <UswdsLink href="#vpat">
+              {t('testingTemplates.vpatSection.heading')}
+              <IconArrowForward />
+            </UswdsLink>
+          </li>
+          <li className="margin-bottom-1">
+            <UswdsLink href="#test-plan">
+              {t('testingTemplates.testPlanSection.heading')}
+              <IconArrowForward />
+            </UswdsLink>
+          </li>
+          <li>
+            <UswdsLink href="#remediation-plan">
+              {t('testingTemplates.remediationPlanSection.heading')}
+              <IconArrowForward />
+            </UswdsLink>
+          </li>
         </ul>
       </div>
       <div className="templates-for-508-testing__section">
@@ -68,7 +90,7 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
         <p className="margin-bottom-1">
           {t('testingTemplates.vpatSection.subSection.item1.text')}
         </p>
-        <ul className="usa-list usa-list--unstyle desktop:grid-col-8">
+        <ul className="usa-list usa-list--unstyled desktop:grid-col-8">
           {vpatConformanceLevels.map(level => (
             <li key={level.name} className="maxw-none margin-bottom-1">
               <span className="text-bold display-inline">{level.name}</span>{' '}
@@ -130,7 +152,7 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
         <p className="margin-bottom-2 line-height-sans-5 desktop:grid-col-9">
           {t('testingTemplates.testPlanSection.description')}
         </p>
-        <ul className="usa-list usa-list--unstyle desktop:grid-col-8">
+        <ul className="usa-list usa-list--unstyled desktop:grid-col-8">
           {testPlanList.map(item => (
             <li key={item} className="maxw-none margin-bottom-1">
               {item}
@@ -154,7 +176,7 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
         <p className="margin-bottom-2 line-height-sans-5 desktop:grid-col-9">
           {t('testingTemplates.remediationPlanSection.description')}
         </p>
-        <ul className="usa-list usa-list--unstyle desktop:grid-col-8">
+        <ul className="usa-list usa-list--unstyled desktop:grid-col-8">
           {remediationPlanList.map(item => (
             <li key={item} className="maxw-none margin-bottom-1">
               {item}

--- a/src/components/TestingTemplates/index.tsx
+++ b/src/components/TestingTemplates/index.tsx
@@ -59,20 +59,26 @@ export default ({ helpArticle, className }: ArticleComponentProps) => {
         <ul className="usa-list usa-list--unstyled">
           <li className="margin-bottom-1">
             <UswdsLink href="#vpat">
-              {t('testingTemplates.vpatSection.heading')}
-              <IconArrowForward />
+              <span className="display-flex flex-align-center">
+                {t('testingTemplates.vpatSection.heading')}
+                <IconArrowForward className="margin-left-1" />
+              </span>
             </UswdsLink>
           </li>
           <li className="margin-bottom-1">
             <UswdsLink href="#test-plan">
-              {t('testingTemplates.testPlanSection.heading')}
-              <IconArrowForward />
+              <span className="display-flex flex-align-center">
+                {t('testingTemplates.testPlanSection.heading')}
+                <IconArrowForward className="margin-left-1" />
+              </span>
             </UswdsLink>
           </li>
-          <li>
+          <li className="">
             <UswdsLink href="#remediation-plan">
-              {t('testingTemplates.remediationPlanSection.heading')}
-              <IconArrowForward />
+              <span className="display-flex flex-align-center">
+                {t('testingTemplates.remediationPlanSection.heading')}
+                <IconArrowForward className="margin-left-1" />
+              </span>
             </UswdsLink>
           </li>
         </ul>

--- a/src/i18n/en-US/accessibility.ts
+++ b/src/i18n/en-US/accessibility.ts
@@ -342,7 +342,7 @@ const accessibility = {
           },
           line3: {
             linkText:
-              'Watch tutorial on how to fill out a VPAT (opens in a new tab).'
+              'Watch tutorial on how to fill out a VPAT (opens in a new tab)'
           }
         }
       }

--- a/src/i18n/en-US/articles/templatesFor508Testing.ts
+++ b/src/i18n/en-US/articles/templatesFor508Testing.ts
@@ -2,7 +2,7 @@ const templatesFor508Testing = {
   title: 'Templates for 508 Testing',
   description:
     'Download and fill out these templates as needed to complete 508 testing for your system',
-  pageContents: 'Page Contents'
+  pageContents: 'Page contents'
 };
 
 export default templatesFor508Testing;

--- a/src/i18n/en-US/articles/templatesFor508Testing.ts
+++ b/src/i18n/en-US/articles/templatesFor508Testing.ts
@@ -1,7 +1,8 @@
 const templatesFor508Testing = {
   title: 'Templates for 508 Testing',
   description:
-    'Download and fill out these templates as needed to complete 508 testing for your system'
+    'Download and fill out these templates as needed to complete 508 testing for your system',
+  pageContents: 'Page Contents'
 };
 
 export default templatesFor508Testing;

--- a/src/views/Accessibility/TestingTemplates/__snapshots__/index.test.tsx.snap
+++ b/src/views/Accessibility/TestingTemplates/__snapshots__/index.test.tsx.snap
@@ -45,8 +45,10 @@ exports[`TestingTemplates matches the snapshot 1`] = `
     <div
       className="margin-bottom-6 padding-2 bg-base-lightest"
     >
-      <h3>
-        Page Contents
+      <h3
+        className="margin-top-0 margin-bottom-2"
+      >
+        Page contents
       </h3>
       <ul
         className="usa-list usa-list--unstyled"
@@ -285,17 +287,15 @@ exports[`TestingTemplates matches the snapshot 1`] = `
                
               Do not skip any row in the document. This will result in delays.
             </p>
-            <p>
-              <a
-                className="usa-link usa-link--external"
-                href="/https://www.youtube.com/watch?v=kAkSV9xiJ1A"
-                onClick={[Function]}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Watch tutorial on how to fill out a VPAT (opens in a new tab)
-              </a>
-            </p>
+            <a
+              className="usa-link usa-link--external"
+              href="/https://www.youtube.com/watch?v=kAkSV9xiJ1A"
+              onClick={[Function]}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Watch tutorial on how to fill out a VPAT (opens in a new tab)
+            </a>
           </div>
         </div>
       </div>
@@ -318,7 +318,7 @@ exports[`TestingTemplates matches the snapshot 1`] = `
         The Test Plan is a document that helps the Section 508 team understand your system and know what areas of your system to test before it goes live. In this document you will provide:
       </p>
       <ul
-        className="usa-list desktop:grid-col-8"
+        className="usa-list desktop:grid-col-8 margin-bottom-4"
       >
         <li
           className="maxw-none margin-bottom-1"
@@ -386,7 +386,7 @@ exports[`TestingTemplates matches the snapshot 1`] = `
         The Remediation Plan is a document that helps the Section 508 team understand how you plan to fix the issues that were identified from the 508 test. In this document you will provide:
       </p>
       <ul
-        className="usa-list desktop:grid-col-8"
+        className="usa-list desktop:grid-col-8 margin-bottom-4"
       >
         <li
           className="maxw-none margin-bottom-1"
@@ -400,7 +400,7 @@ exports[`TestingTemplates matches the snapshot 1`] = `
         </li>
       </ul>
       <div
-        className="usa-summary-box desktop:grid-col-6 margin-bottom-6"
+        className="usa-summary-box desktop:grid-col-6"
         data-testid="summary-box"
       >
         <div

--- a/src/views/Accessibility/TestingTemplates/__snapshots__/index.test.tsx.snap
+++ b/src/views/Accessibility/TestingTemplates/__snapshots__/index.test.tsx.snap
@@ -33,328 +33,431 @@ exports[`TestingTemplates matches the snapshot 1`] = `
     </ol>
   </nav>
   <div
-    className="grid-row grid-gap-lg margin-top-6"
+    className="templates-for-508-testing"
   >
-    <div
-      className="grid-col-9 line-height-body-4"
+    <h1
+      aria-live="polite"
+      className="easi-h1 line-height-heading-2"
+      tabIndex={-1}
     >
-      <div
-        className="tablet:grid-col-10"
+      Templates for 508 testing
+    </h1>
+    <div
+      className="margin-bottom-6 padding-2 bg-base-lightest"
+    >
+      <h3>
+        Page Contents
+      </h3>
+      <ul
+        className="usa-list usa-list--unstyled"
       >
-        <h1
-          aria-live="polite"
-          className="easi-h1 margin-top-0"
-          tabIndex={-1}
+        <li
+          className="margin-bottom-1"
         >
-          Templates for 508 testing
-        </h1>
+          <a
+            className="usa-link"
+            href="#vpat"
+          >
+            <span
+              className="display-flex flex-align-center"
+            >
+              Voluntary Product Assessment Template (VPAT)
+              <svg
+                className="usa-icon margin-left-1"
+                focusable={false}
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </span>
+          </a>
+        </li>
+        <li
+          className="margin-bottom-1"
+        >
+          <a
+            className="usa-link"
+            href="#test-plan"
+          >
+            <span
+              className="display-flex flex-align-center"
+            >
+              Test Plan
+              <svg
+                className="usa-icon margin-left-1"
+                focusable={false}
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </span>
+          </a>
+        </li>
+        <li
+          className=""
+        >
+          <a
+            className="usa-link"
+            href="#remediation-plan"
+          >
+            <span
+              className="display-flex flex-align-center"
+            >
+              Remediation Plan
+              <svg
+                className="usa-icon margin-left-1"
+                focusable={false}
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                />
+              </svg>
+            </span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div
+      className="templates-for-508-testing__section"
+    >
+      <h2
+        className="margin-bottom-2"
+        id="vpat"
+      >
+        Voluntary Product Assessment Template (VPAT)
+      </h2>
+      <p
+        className="margin-bottom-4"
+      >
+        A VPAT is a document that helps CMS and other government agencies understand how you will meet the 508 Standards for IT accessibility.
+      </p>
+      <h3
+        className="margin-bottom-2"
+      >
+        Tips to complete a VPAT
+      </h3>
+      <p
+        className="margin-bottom-1"
+      >
+        For each row in the table, indicate the conformance level. There are 5 levels:
+      </p>
+      <ul
+        className="usa-list usa-list--unstyled desktop:grid-col-8"
+      >
+        <li
+          className="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            className="text-bold display-inline"
+          >
+            Supports:
+          </span>
+           
+          The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.
+        </li>
+        <li
+          className="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            className="text-bold display-inline"
+          >
+            Partially Supports:
+          </span>
+           
+          Some functionality of the product does not meet the criterion.
+        </li>
+        <li
+          className="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            className="text-bold display-inline"
+          >
+            Does Not Support:
+          </span>
+           
+          The majority of product functionality does not meet the criterion.
+        </li>
+        <li
+          className="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            className="text-bold display-inline"
+          >
+            Not Applicable:
+          </span>
+           
+          The criterion is not relevant to the product.
+        </li>
+        <li
+          className="maxw-none margin-bottom-1  padding-left-2"
+        >
+          <span
+            className="text-bold display-inline"
+          >
+            Not Evaluated:
+          </span>
+           
+          The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.
+        </li>
+      </ul>
+      <p
+        className="margin-bottom-4"
+      >
+        After indicating the conformance level, provide a detailed explanation in the ‘Remarks and Evaluation’ column.
+      </p>
+      <div
+        className="usa-summary-box desktop:grid-col-6 margin-bottom-6"
+        data-testid="summary-box"
+      >
         <div
-          className="accessibility-testing-templates"
+          className="usa-summary-box__body"
         >
-          <p
-            className="margin-bottom-1"
+          <h3
+            className="usa-summary-box__heading"
           >
-            Page contents
-          </p>
-          <ul
-            className="accessibility-testing-templates__table-of-contents"
-          >
-            <li>
-              <a
-                className="usa-link"
-                href="#vpat"
-              >
-                Voluntary Product Assessment Template (VPAT)
-              </a>
-            </li>
-            <li>
-              <a
-                className="usa-link"
-                href="#test-plan"
-              >
-                Test Plan
-              </a>
-            </li>
-            <li>
-              <a
-                className="usa-link"
-                href="#remediation-plan"
-              >
-                Remediation Plan
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div>
-          <h2
-            id="vpat"
-          >
-            Voluntary Product Assessment Template (VPAT)
-          </h2>
-          <p>
-            A VPAT is a document that helps CMS and other government agencies understand how you will meet the 508 Standards for IT accessibility.
-          </p>
-          <h3>
-            Tips to complete a VPAT
+            Download VPAT template
           </h3>
-          <ul
-            className="accessibility-testing-templates__vpat-list"
-          >
-            <li>
-              For each row in the table, indicate the conformance level. There are 5 levels:
-              <div
-                className="padding-left-2"
-              >
-                <dl
-                  title="Conformance levels"
-                >
-                  <div>
-                    <dt
-                      className="text-bold display-inline"
-                    >
-                      Supports:
-                    </dt>
-                     
-                    <dd
-                      className="margin-left-0 display-inline"
-                    >
-                      The functionality of the product has at least one method that meets the criterion without known defects or meets with equivalent facilitation.
-                    </dd>
-                  </div>
-                  <div>
-                    <dt
-                      className="text-bold display-inline"
-                    >
-                      Partially Supports:
-                    </dt>
-                     
-                    <dd
-                      className="margin-left-0 display-inline"
-                    >
-                      Some functionality of the product does not meet the criterion.
-                    </dd>
-                  </div>
-                  <div>
-                    <dt
-                      className="text-bold display-inline"
-                    >
-                      Does Not Support:
-                    </dt>
-                     
-                    <dd
-                      className="margin-left-0 display-inline"
-                    >
-                      The majority of product functionality does not meet the criterion.
-                    </dd>
-                  </div>
-                  <div>
-                    <dt
-                      className="text-bold display-inline"
-                    >
-                      Not Applicable:
-                    </dt>
-                     
-                    <dd
-                      className="margin-left-0 display-inline"
-                    >
-                      The criterion is not relevant to the product.
-                    </dd>
-                  </div>
-                  <div>
-                    <dt
-                      className="text-bold display-inline"
-                    >
-                      Not Evaluated:
-                    </dt>
-                     
-                    <dd
-                      className="margin-left-0 display-inline"
-                    >
-                      The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.
-                    </dd>
-                  </div>
-                </dl>
-              </div>
-            </li>
-            <li>
-              After indicating the conformance level, provide a detailed explanation in the ‘Remarks and Evaluation’ column.
-            </li>
-          </ul>
           <div
-            className="usa-summary-box"
-            data-testid="summary-box"
+            className="usa-summary-box__text"
           >
-            <div
-              className="usa-summary-box__body"
+            <p>
+              <a
+                className="usa-link usa-link--external"
+                href="/https://www.itic.org/policy/accessibility/vpat"
+                onClick={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Download the current VPAT template (opens in a new tab)
+              </a>
+               
+              from the Information Technology Industry Council (ITI) website.
+            </p>
+            <p
+              className="display-flex flex-row flex-align-center"
             >
-              <h3
-                className="usa-summary-box__heading"
+              <svg
+                className="usa-icon margin-right-1"
+                focusable={false}
+                height="1em"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                Download VPAT template
-              </h3>
-              <div
-                className="usa-summary-box__text"
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                />
+              </svg>
+               
+              Do not skip any row in the document. This will result in delays.
+            </p>
+            <p>
+              <a
+                className="usa-link usa-link--external"
+                href="/https://www.youtube.com/watch?v=kAkSV9xiJ1A"
+                onClick={[Function]}
+                rel="noopener noreferrer"
+                target="_blank"
               >
-                <p>
-                  <a
-                    className="usa-link"
-                    href="https://www.itic.org/policy/accessibility/vpat"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Download the current VPAT template (opens in a new tab)
-                  </a>
-                   
-                  from the Information Technology Industry Council (ITI) website.
-                </p>
-                <p
-                  className="display-flex flex-row flex-align-center"
-                >
-                  <svg
-                    className="usa-icon margin-right-1"
-                    focusable={false}
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 24 24"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0 0h24v24H0z"
-                      fill="none"
-                    />
-                    <path
-                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
-                    />
-                  </svg>
-                   
-                  Do not skip any row in the document. This will result in delays.
-                </p>
-                <p>
-                  <a
-                    className="usa-link"
-                    href="https://www.youtube.com/watch?v=kAkSV9xiJ1A"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Watch tutorial on how to fill out a VPAT (opens in a new tab).
-                  </a>
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div>
-          <h2
-            id="test-plan"
-          >
-            Test Plan
-          </h2>
-          <p>
-            The Test Plan is a document that helps the Section 508 team understand your system and know what areas of your system to test before it goes live. In this document you will provide:
-          </p>
-          <ul
-            className="accessibility-testing-templates__test-plan-list"
-          >
-            <li>
-              a description of your system
-            </li>
-            <li>
-              information on how to set up and access it
-            </li>
-            <li>
-              user scenarios and steps taken to perform actions
-            </li>
-            <li>
-              and any other constraints, assumptions or risks
-            </li>
-          </ul>
-          <div
-            className="usa-summary-box"
-            data-testid="summary-box"
-          >
-            <div
-              className="usa-summary-box__body"
-            >
-              <h3
-                className="usa-summary-box__heading"
-              >
-                Download Test Plan template
-              </h3>
-              <div
-                className="usa-summary-box__text"
-              >
-                <a
-                  className="usa-link"
-                  href="Section508TestPlanTemplate.pdf"
-                  target="_blank"
-                >
-                  Download the Test Plan template as a PDF (opens in a new tab)
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div>
-          <h2
-            id="remediation-plan"
-          >
-            Remediation Plan
-          </h2>
-          <p>
-            The Remediation Plan is a document that helps the Section 508 team understand how you plan to fix the issues that were identified from the 508 test. In this document you will provide:
-          </p>
-          <ul
-            className="accessibility-testing-templates__remediation-plan-list"
-          >
-            <li>
-              solutions for each issue
-            </li>
-            <li>
-              when and how you plan to schedule these changes into your project
-            </li>
-          </ul>
-          <div
-            className="usa-summary-box"
-            data-testid="summary-box"
-          >
-            <div
-              className="usa-summary-box__body"
-            >
-              <h3
-                className="usa-summary-box__heading"
-              >
-                Download Remediation Plan template
-              </h3>
-              <div
-                className="usa-summary-box__text"
-              >
-                <a
-                  className="usa-link"
-                  href="CMS508RemediationPlanTemplate.pdf"
-                  target="_blank"
-                >
-                  Download the Remediation Plan template as a PDF (opens in a new tab)
-                </a>
-              </div>
-            </div>
+                Watch tutorial on how to fill out a VPAT (opens in a new tab)
+              </a>
+            </p>
           </div>
         </div>
       </div>
+      <div
+        className="easi-divider margin-bottom-4"
+      />
     </div>
     <div
-      className="grid-col-3 accessibility-testing-templates__sidebar"
+      className="templates-for-508-testing__section"
     >
-      <div>
-        <h4>
-          Need help? Contact the Section 508 team
-        </h4>
-        <a
-          className="usa-link"
-          href="mailto:CMS_Section508@cms.hhs.gov"
+      <h2
+        className="margin-bottom-2"
+        id="test-plan"
+      >
+        Test Plan
+      </h2>
+      <p
+        className="margin-bottom-2 line-height-sans-5 desktop:grid-col-9"
+      >
+        The Test Plan is a document that helps the Section 508 team understand your system and know what areas of your system to test before it goes live. In this document you will provide:
+      </p>
+      <ul
+        className="usa-list desktop:grid-col-8"
+      >
+        <li
+          className="maxw-none margin-bottom-1"
         >
-          CMS_Section508@cms.hhs.gov
-        </a>
+          a description of your system
+        </li>
+        <li
+          className="maxw-none margin-bottom-1"
+        >
+          information on how to set up and access it
+        </li>
+        <li
+          className="maxw-none margin-bottom-1"
+        >
+          user scenarios and steps taken to perform actions
+        </li>
+        <li
+          className="maxw-none margin-bottom-1"
+        >
+          and any other constraints, assumptions or risks
+        </li>
+      </ul>
+      <div
+        className="usa-summary-box desktop:grid-col-6 margin-bottom-6"
+        data-testid="summary-box"
+      >
+        <div
+          className="usa-summary-box__body"
+        >
+          <h3
+            className="usa-summary-box__heading"
+          >
+            Download Test Plan template
+          </h3>
+          <div
+            className="usa-summary-box__text"
+          >
+            <a
+              className="usa-link usa-link--external"
+              href="/Section508TestPlanTemplate.pdf"
+              onClick={[Function]}
+              target="_blank"
+            >
+              Download the Test Plan template as a PDF (opens in a new tab)
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        className="easi-divider margin-bottom-4"
+      />
+    </div>
+    <div
+      className="templates-for-508-testing__section"
+    >
+      <h2
+        className="margin-bottom-2"
+        id="remediation-plan"
+      >
+        Remediation Plan
+      </h2>
+      <p
+        className="margin-bottom-2 line-height-sans-5 desktop:grid-col-9"
+      >
+        The Remediation Plan is a document that helps the Section 508 team understand how you plan to fix the issues that were identified from the 508 test. In this document you will provide:
+      </p>
+      <ul
+        className="usa-list desktop:grid-col-8"
+      >
+        <li
+          className="maxw-none margin-bottom-1"
+        >
+          solutions for each issue
+        </li>
+        <li
+          className="maxw-none margin-bottom-1"
+        >
+          when and how you plan to schedule these changes into your project
+        </li>
+      </ul>
+      <div
+        className="usa-summary-box desktop:grid-col-6 margin-bottom-6"
+        data-testid="summary-box"
+      >
+        <div
+          className="usa-summary-box__body"
+        >
+          <h3
+            className="usa-summary-box__heading"
+          >
+            Download Remediation Plan template
+          </h3>
+          <div
+            className="usa-summary-box__text"
+          >
+            <a
+              className="usa-link usa-link--external"
+              href="/CMS508RemediationPlanTemplate.pdf"
+              onClick={[Function]}
+              target="_blank"
+            >
+              Download the Test Plan template as a PDF (opens in a new tab)
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        className="easi-divider margin-bottom-4"
+      />
+    </div>
+  </div>
+  <div
+    className="usa-summary-box desktop:grid-col-6 margin-top-5"
+    data-testid="summary-box"
+  >
+    <div
+      className="usa-summary-box__body"
+    >
+      <h3
+        className="usa-summary-box__heading"
+      >
+        Need help?
+      </h3>
+      <div
+        className="usa-summary-box__text"
+      >
+        <div
+          className="margin-top-2 margin-bottom-05"
+        >
+          Contact the Governance team:
+        </div>
+        <div>
+          <a
+            className="usa-link"
+            href="mailto:IT_Governance@cms.hhs.gov"
+          >
+            IT_Governance@cms.hhs.gov
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/src/views/Accessibility/TestingTemplates/index.tsx
+++ b/src/views/Accessibility/TestingTemplates/index.tsx
@@ -1,173 +1,17 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import {
   Breadcrumb,
   BreadcrumbBar,
-  BreadcrumbLink,
-  IconError,
-  Link as UswdsLink,
-  SummaryBox
+  BreadcrumbLink
 } from '@trussworks/react-uswds';
 
-import RemediationPlanDoc from 'assets/files/CMS508RemediationPlanTemplate.pdf';
-import TestPlanDoc from 'assets/files/Section508TestPlanTemplate.pdf';
-import PageHeading from 'components/PageHeading';
+import TestingTemplatesBase from 'components/TestingTemplates';
+import NeedHelpBox from 'views/Help/InfoBox/NeedHelpBox';
 
 import './index.scss';
 
 const TestingTemplates = () => {
-  const { t } = useTranslation('accessibility');
-  const vpatConformanceLevels: { name: string; description: string }[] = t(
-    'testingTemplates.vpatSection.subSection.item1.levels',
-    {
-      returnObjects: true
-    }
-  );
-  const testPlanList: string[] = t(
-    'testingTemplates.testPlanSection.itemsToProvide',
-    {
-      returnObjects: true
-    }
-  );
-
-  const remediationPlanList: string[] = t(
-    'testingTemplates.remediationPlanSection.itemsToProvide',
-    {
-      returnObjects: true
-    }
-  );
-
-  const tableOfContents = (
-    <div className="accessibility-testing-templates">
-      <p className="margin-bottom-1">Page contents</p>
-      <ul className="accessibility-testing-templates__table-of-contents">
-        <li>
-          <UswdsLink href="#vpat">
-            {t('testingTemplates.vpatSection.heading')}
-          </UswdsLink>
-        </li>
-        <li>
-          <UswdsLink href="#test-plan">
-            {t('testingTemplates.testPlanSection.heading')}
-          </UswdsLink>
-        </li>
-        <li>
-          <UswdsLink href="#remediation-plan">
-            {t('testingTemplates.remediationPlanSection.heading')}
-          </UswdsLink>
-        </li>
-      </ul>
-    </div>
-  );
-
-  const testPlanSection = (
-    <div>
-      <h2 id="test-plan">{t('testingTemplates.testPlanSection.heading')}</h2>
-      <p>{t('testingTemplates.testPlanSection.description')}</p>
-      <ul className="accessibility-testing-templates__test-plan-list">
-        {testPlanList.map(item => (
-          <li key={item}>{item}</li>
-        ))}
-      </ul>
-      <SummaryBox
-        heading={t('testingTemplates.testPlanSection.download.heading')}
-      >
-        <UswdsLink href={TestPlanDoc} target="_blank">
-          {t('testingTemplates.testPlanSection.download.link')}
-        </UswdsLink>
-      </SummaryBox>
-    </div>
-  );
-
-  const remediationPlanSection = (
-    <div>
-      <h2 id="remediation-plan">
-        {t('testingTemplates.remediationPlanSection.heading')}
-      </h2>
-      <p>{t('testingTemplates.remediationPlanSection.description')}</p>
-      <ul className="accessibility-testing-templates__remediation-plan-list">
-        {remediationPlanList.map(item => (
-          <li key={item}>{item}</li>
-        ))}
-      </ul>
-      <SummaryBox
-        heading={t('testingTemplates.remediationPlanSection.download.heading')}
-      >
-        <UswdsLink href={RemediationPlanDoc} target="_blank">
-          {t('testingTemplates.remediationPlanSection.download.link')}
-        </UswdsLink>
-      </SummaryBox>
-    </div>
-  );
-
-  const downloadVPAT = (
-    <SummaryBox
-      heading={t(
-        'testingTemplates.vpatSection.subSection.downloadVPAT.heading'
-      )}
-    >
-      <p>
-        <UswdsLink
-          href="https://www.itic.org/policy/accessibility/vpat"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {t(
-            'testingTemplates.vpatSection.subSection.downloadVPAT.line1.linkText'
-          )}
-        </UswdsLink>
-        {` `}
-        {t(
-          'testingTemplates.vpatSection.subSection.downloadVPAT.line1.otherText'
-        )}
-      </p>
-      <p className="display-flex flex-row flex-align-center">
-        <IconError className="margin-right-1" />
-        {` `}
-        {t('testingTemplates.vpatSection.subSection.downloadVPAT.line2.text')}
-      </p>
-      <p>
-        <UswdsLink
-          href="https://www.youtube.com/watch?v=kAkSV9xiJ1A"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {t(
-            'testingTemplates.vpatSection.subSection.downloadVPAT.line3.linkText'
-          )}
-        </UswdsLink>
-      </p>
-    </SummaryBox>
-  );
-
-  const vpatSection = (
-    <div>
-      <h2 id="vpat">{t('testingTemplates.vpatSection.heading')}</h2>
-      <p>{t('testingTemplates.vpatSection.description')}</p>
-      <h3>{t('testingTemplates.vpatSection.subSection.heading')}</h3>
-      <ul className="accessibility-testing-templates__vpat-list">
-        <li>
-          {t('testingTemplates.vpatSection.subSection.item1.text')}
-          <div className="padding-left-2">
-            <dl title="Conformance levels">
-              {vpatConformanceLevels.map(level => (
-                <div key={level.name}>
-                  <dt className="text-bold display-inline">{level.name}</dt>{' '}
-                  <dd className="margin-left-0 display-inline">
-                    {level.description}
-                  </dd>
-                </div>
-              ))}
-            </dl>
-          </div>
-        </li>
-        <li>{t('testingTemplates.vpatSection.subSection.item2.text')}</li>
-      </ul>
-      {downloadVPAT}
-    </div>
-  );
-
   return (
     <div className="grid-container accessibility-testing-templates">
       <BreadcrumbBar variant="wrap">
@@ -179,27 +23,8 @@ const TestingTemplates = () => {
         <Breadcrumb current>Templates for 508 testing</Breadcrumb>
       </BreadcrumbBar>
 
-      <div className="grid-row grid-gap-lg margin-top-6">
-        <div className="grid-col-9 line-height-body-4">
-          <div className="tablet:grid-col-10">
-            <PageHeading className="margin-top-0">
-              {t('testingTemplates.heading')}
-            </PageHeading>
-            {tableOfContents}
-            {vpatSection}
-            {testPlanSection}
-            {remediationPlanSection}
-          </div>
-        </div>
-        <div className="grid-col-3 accessibility-testing-templates__sidebar">
-          <div>
-            <h4>Need help? Contact the Section 508 team</h4>
-            <UswdsLink href="mailto:CMS_Section508@cms.hhs.gov">
-              CMS_Section508@cms.hhs.gov
-            </UswdsLink>
-          </div>
-        </div>
-      </div>
+      <TestingTemplatesBase />
+      <NeedHelpBox className="desktop:grid-col-6 margin-top-5" />
     </div>
   );
 };

--- a/src/views/FlagsWrapper/index.tsx
+++ b/src/views/FlagsWrapper/index.tsx
@@ -35,7 +35,7 @@ const UserTargetingWrapper = ({ children }: WrapperProps) => {
             downgradeGovTeam: false,
             downgrade508User: false,
             downgrade508Tester: false,
-            help: false,
+            help: true,
             systemProfile: true,
             cedar508Requests: false
           }

--- a/src/views/Help/Section508/TestingTemplate/index.tsx
+++ b/src/views/Help/Section508/TestingTemplate/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const TestingTemplates = () => {
+  return (
+    <div className="grid-container">
+      <>TestingTemplates</>
+    </div>
+  );
+};
+
+export default TestingTemplates;

--- a/src/views/Help/Section508/TestingTemplate/index.tsx
+++ b/src/views/Help/Section508/TestingTemplate/index.tsx
@@ -5,7 +5,7 @@ import MainContent from 'components/MainContent';
 import RelatedArticles from 'components/RelatedArticles';
 import TestingTemplatesBase from 'components/TestingTemplates';
 
-const PrepareForGRT = () => {
+const TestingTemplates = () => {
   return (
     <>
       <MainContent className="grid-container">
@@ -19,4 +19,4 @@ const PrepareForGRT = () => {
   );
 };
 
-export default PrepareForGRT;
+export default TestingTemplates;

--- a/src/views/Help/Section508/TestingTemplate/index.tsx
+++ b/src/views/Help/Section508/TestingTemplate/index.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 import HelpBreadcrumb from 'components/HelpBreadcrumb';
 import MainContent from 'components/MainContent';
 import RelatedArticles from 'components/RelatedArticles';
-import TestingTemplates from 'views/Accessibility/TestingTemplates';
+import TestingTemplatesBase from 'components/TestingTemplates';
 
 const PrepareForGRT = () => {
   return (
     <>
       <MainContent className="grid-container">
         <HelpBreadcrumb type="Close tab" />
-        <TestingTemplates />
+        <TestingTemplatesBase helpArticle />
       </MainContent>
       <div className="margin-top-7">
         <RelatedArticles type="Section 508" />

--- a/src/views/Help/Section508/TestingTemplate/index.tsx
+++ b/src/views/Help/Section508/TestingTemplate/index.tsx
@@ -8,13 +8,11 @@ import TestingTemplatesBase from 'components/TestingTemplates';
 const TestingTemplates = () => {
   return (
     <>
-      <MainContent className="grid-container">
+      <MainContent className="grid-container margin-bottom-7">
         <HelpBreadcrumb type="Close tab" />
         <TestingTemplatesBase helpArticle />
       </MainContent>
-      <div className="margin-top-7">
-        <RelatedArticles type="Section 508" />
-      </div>
+      <RelatedArticles type="Section 508" />
     </>
   );
 };

--- a/src/views/Help/Section508/TestingTemplate/index.tsx
+++ b/src/views/Help/Section508/TestingTemplate/index.tsx
@@ -1,11 +1,22 @@
 import React from 'react';
 
-const TestingTemplates = () => {
+import HelpBreadcrumb from 'components/HelpBreadcrumb';
+import MainContent from 'components/MainContent';
+import RelatedArticles from 'components/RelatedArticles';
+import TestingTemplates from 'views/Accessibility/TestingTemplates';
+
+const PrepareForGRT = () => {
   return (
-    <div className="grid-container">
-      <>TestingTemplates</>
-    </div>
+    <>
+      <MainContent className="grid-container">
+        <HelpBreadcrumb type="Close tab" />
+        <TestingTemplates />
+      </MainContent>
+      <div className="margin-top-7">
+        <RelatedArticles type="Section 508" />
+      </div>
+    </>
   );
 };
 
-export default TestingTemplates;
+export default PrepareForGRT;

--- a/src/views/Help/Section508/articles.ts
+++ b/src/views/Help/Section508/articles.ts
@@ -8,7 +8,7 @@ const section508Articles: ArticleProps[] = [
     translation: 'stepsInvolved508' // Should reference the translation used to index the title and description for cards
   },
   {
-    route: '/section-508/template-508', // route for hitting rendered article component
+    route: '/section-508/templates-for-508-testing', // route for hitting rendered article component
     type: 'Section 508', // Used for tagging of article
     translation: 'templatesFor508Testing' // Should reference the translation used to index the title and description for cards
   }

--- a/src/views/Help/index.tsx
+++ b/src/views/Help/index.tsx
@@ -6,6 +6,7 @@ import NotFound from 'views/NotFound';
 import NewSystem from './ITGovernance/NewSystem';
 import PrepareForGRT from './ITGovernance/PrepareForGRT';
 import StepsInvolved from './Section508/StepsInvolved';
+import TestingTemplates from './Section508/TestingTemplate';
 import AllHelp from './All';
 import HelpHome from './HelpHome';
 import ITGovernance from './ITGovernance';
@@ -41,6 +42,10 @@ const Help = () => {
         <Route
           path="/help/section-508/steps-involved"
           render={() => <StepsInvolved />}
+        />
+        <Route
+          path="/help/section-508/templates-for-508-testing"
+          render={() => <TestingTemplates />}
         />
 
         {/* 404 */}


### PR DESCRIPTION
# EASI-1905

## Changes and Description

- Created new `TestingTemplateBase` for new article 
- Tweaked existing '508 Templates' view/component
- Tweaked existing component to reuse any area within EASI
- Added tests

<!-- Put a description here! -->

## How to test this change

1. Navigate to http://localhost:3000/help
2. Find and click on the link:  `View Section 508 articles`
3. Find and click on the link:  `Templates for 508 testing`
4. Ensure new tab opens with the article.
5. Ensure article look and copy reflects figma

## JIRA Acceptance Criteria

- Reuse existing '508 Templates' view/component
- May need to tweak existing component to be reusable in any area within EASI
- Testing where applicable

