### PR TITLE
Map lowercase assignee types returned from CEDAR to uppercase GQL values

### DIFF
--- a/pkg/cedar/core/role.go
+++ b/pkg/cedar/core/role.go
@@ -15,12 +15,18 @@ import (
 
 const (
 	cedarRoleApplication = "alfabet" // used for queries to GET /role endpoint
+
+	// these need to be separate constants from the CedarAssigneeType enums defined in pkg/models/cedar_role.go;
+	// these values correspond to what's returned from CEDAR
+	// the enums in pkg/models/cedar_role.go represent what's returned by our GraphQL API to our frontend
+	cedarPersonAssignee       = "person"
+	cedarOrganizationAssignee = "organization"
 )
 
 func decodeAssigneeType(rawAssigneeType string) (models.CedarAssigneeType, bool) {
-	if rawAssigneeType == string(models.PersonAssignee) {
+	if rawAssigneeType == cedarPersonAssignee {
 		return models.PersonAssignee, true
-	} else if rawAssigneeType == string(models.OrganizationAssignee) {
+	} else if rawAssigneeType == cedarOrganizationAssignee {
 		return models.OrganizationAssignee, true
 	} else if rawAssigneeType == "" {
 		return "", true

--- a/pkg/models/cedar_role.go
+++ b/pkg/models/cedar_role.go
@@ -5,11 +5,12 @@ import "github.com/guregu/null/zero"
 // CedarAssigneeType represents the possible types of assignees that can receive roles
 type CedarAssigneeType string
 
+// these values need to be in all-caps so that they match the GraphQL enum and match the frontend types generated from the GQL schema
 const (
 	// PersonAssignee represents a person that's been assigned a role
-	PersonAssignee CedarAssigneeType = "person"
+	PersonAssignee CedarAssigneeType = "PERSON"
 	// OrganizationAssignee represents an organization that's been assigned a role
-	OrganizationAssignee CedarAssigneeType = "organization"
+	OrganizationAssignee CedarAssigneeType = "ORGANIZATION"
 )
 
 // CedarRole is the model for the role that a user holds for some system


### PR DESCRIPTION
This is associated with @adamodd's work on [EASI-1936](https://jiraent.cms.gov/browse/EASI-1936), following up a [Slack conversation](https://oddball.slack.com/archives/C037ZNEQ7DH/p1651066570255429).

Changes:
- Have GraphQL return all-caps values for `CedarAssigneeType` fields, to match up with the frontend types that generated from the GraphQL schema.
- Introduce a separate set of constants for the lower-cased AssigneeType values that are returned from CEDAR, which our CEDAR Core client then maps to the all-caps `CedarAssigneeType`.

With these changes:
![uppercase cedar assignee types](https://user-images.githubusercontent.com/92891039/165541934-cd495307-ebf3-475c-9656-f8846089d1e2.PNG)

