### PR TITLE
Fixed incorrect id used in detailed cedar system info query

### DIFF
--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1561,7 +1561,7 @@ func (r *queryResolver) DetailedCedarSystemInfo(ctx context.Context, cedarSystem
 	var cedarRoles []*models.CedarRole
 	var errR error
 	g.Go(func() error {
-		cedarRoles, errS = r.cedarCoreClient.GetRolesBySystem(ctx, cedarSystem.VersionID, null.String{})
+		cedarRoles, errS = r.cedarCoreClient.GetRolesBySystem(ctx, cedarSystemID, null.String{})
 		return errR
 	})
 
@@ -1569,7 +1569,7 @@ func (r *queryResolver) DetailedCedarSystemInfo(ctx context.Context, cedarSystem
 	var errD error
 
 	g.Go(func() error {
-		cedarDeployments, errD = r.cedarCoreClient.GetDeployments(ctx, cedarSystem.VersionID, nil)
+		cedarDeployments, errD = r.cedarCoreClient.GetDeployments(ctx, cedarSystemID, nil)
 		return errD
 	})
 	if err := g.Wait(); err != nil {


### PR DESCRIPTION
# EASI-1971

## Changes and Description

- Quick follow-up to EASI-1971, caught a bug in IMPL with the detailed cedar system info query that was using versionID, changed it to use IctObjectID

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
