### PR TITLE
Add lifecycle cost baseline to system intake data sent to CEDAR

### DIFF
--- a/cmd/test_cedar_intake/main.go
+++ b/cmd/test_cedar_intake/main.go
@@ -76,6 +76,8 @@ func makeTestData() *testData {
 		ContractEndDate:   date(2023, 12, 31),
 		ContractVehicle:   null.StringFrom("Sole source"),
 		Contractor:        null.StringFrom("Contractor Name"),
+
+		LifecycleCostBaseline: null.StringFrom("100 BILLION DOLLARS!"),
 	}
 
 	// borrowed from cmd/devdata/main.go makeSystemIntake()

--- a/pkg/cedar/intake/translation/system_intake.go
+++ b/pkg/cedar/intake/translation/system_intake.go
@@ -61,16 +61,17 @@ func (si *TranslatableSystemIntake) CreateIntakeModel() (*wire.IntakeInput, erro
 		RejectionReason:             si.RejectionReason.Ptr(),
 		AdminLead:                   si.AdminLead.Ptr(),
 
-		ExistingFunding:    si.ExistingFunding.Ptr(),
-		EaSupportRequest:   si.EASupportRequest.Ptr(),
-		ContractStartDate:  pStr(strDate(si.ContractStartDate)),
-		ContractEndDate:    pStr(strDate(si.ContractEndDate)),
-		SubmittedAt:        strDateTime(si.SubmittedAt),
-		DecidedAt:          pStr(strDateTime(si.DecidedAt)),
-		ArchivedAt:         pStr(strDateTime(si.ArchivedAt)),
-		GrbDate:            pStr(strDate(si.GRBDate)),
-		GrtDate:            pStr(strDate(si.GRTDate)),
-		LifecycleExpiresAt: pStr(strDate(si.LifecycleExpiresAt)),
+		ExistingFunding:       si.ExistingFunding.Ptr(),
+		EaSupportRequest:      si.EASupportRequest.Ptr(),
+		ContractStartDate:     pStr(strDate(si.ContractStartDate)),
+		ContractEndDate:       pStr(strDate(si.ContractEndDate)),
+		SubmittedAt:           strDateTime(si.SubmittedAt),
+		DecidedAt:             pStr(strDateTime(si.DecidedAt)),
+		ArchivedAt:            pStr(strDateTime(si.ArchivedAt)),
+		GrbDate:               pStr(strDate(si.GRBDate)),
+		GrtDate:               pStr(strDate(si.GRTDate)),
+		LifecycleExpiresAt:    pStr(strDate(si.LifecycleExpiresAt)),
+		LifecycleCostBaseline: si.LifecycleCostBaseline.Ptr(),
 	}
 
 	blob, err := json.Marshal(&obj)


### PR DESCRIPTION
# EASI-1937

## Changes and Description

- Add lifecycle cost baseline to system intake data sent to CEDAR Intake in translation code
- Add lifecycle cost baseline field to sample data sent to CEDAR Intake in `test_cedar_intake/main.go` script.

## How to test this change

`go run cmd/test_cedar_intake/main.go`
