### PR TITLE
Add IDs to feedback/system intake objects sent to CEDAR Intake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
         name: check-intake-schema-generation
         entry: scripts/gen_intake_schema
         language: script
-        files: cmd/gen_intake_schema/main\.go|pkg/cedar/intake/models/.*\.go|pkg/cedar/intake/schemas/.*\.json
+        files: cmd/gen_intake_schema/main\.go|pkg/cedar/intake/models/.*\.go|pkg/cedar/intake/schemas/.*\.json|pkg/cedar/intake/translation/constants\.go
 
   - repo: local
     hooks:

--- a/pkg/cedar/intake/models/easi_grt_feedback.go
+++ b/pkg/cedar/intake/models/easi_grt_feedback.go
@@ -5,6 +5,7 @@ package models
 
 // EASIGrtFeedback represents an item of feedback from the Governance Review team
 type EASIGrtFeedback struct {
+	FeedbackID   string `json:"feedbackId" jsonschema:"description=Unique UUID of this item of feedback,example=fa62c23b-c16f-497b-9bb6-c42166e82b93"`
 	Feedback     string `json:"feedback"`
 	FeedbackType string `json:"feedbackType"`
 	IntakeID     string `json:"intakeId"`

--- a/pkg/cedar/intake/models/easi_intake.go
+++ b/pkg/cedar/intake/models/easi_intake.go
@@ -7,6 +7,7 @@ package models
 
 // EASIIntake represents a system intake
 type EASIIntake struct {
+	IntakeID                    string  `json:"intakeId" jsonschema:"description=Unique UUID of this system intake,example=0a16ce4e-8d8a-41ab-aeba-9303067f065b"`
 	AdminLead                   *string `json:"adminLead,omitempty" jsonschema:"description=Government Admin responsible for handling request,example=John Doe"`
 	ArchivedAt                  *string `json:"archivedAt,omitempty" jsonschema:"description=Timestamp of when request was archived,example=2022-02-17T14:34:43Z"`
 	BusinessNeed                string  `json:"businessNeed" jsonschema:"description=Business Need for the effort detailed in this request,example=Process takes too long and holds up key stakeholders"`

--- a/pkg/cedar/intake/schemas/easi_grt_feedback.json
+++ b/pkg/cedar/intake/schemas/easi_grt_feedback.json
@@ -5,11 +5,19 @@
   "definitions": {
     "EASIGrtFeedback": {
       "required": [
+        "feedbackId",
         "feedback",
         "feedbackType",
         "intakeId"
       ],
       "properties": {
+        "feedbackId": {
+          "type": "string",
+          "description": "Unique UUID of this item of feedback",
+          "examples": [
+            "fa62c23b-c16f-497b-9bb6-c42166e82b93"
+          ]
+        },
         "feedback": {
           "type": "string"
         },

--- a/pkg/cedar/intake/schemas/easi_grt_feedback.json
+++ b/pkg/cedar/intake/schemas/easi_grt_feedback.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "$ref": "#/definitions/EASIGrtFeedback",
-  "title": "EASIGrtFeedbackV01",
+  "title": "EASIGrtFeedbackV02",
   "definitions": {
     "EASIGrtFeedback": {
       "required": [

--- a/pkg/cedar/intake/schemas/easi_system_intake.json
+++ b/pkg/cedar/intake/schemas/easi_system_intake.json
@@ -5,6 +5,7 @@
   "definitions": {
     "EASIIntake": {
       "required": [
+        "intakeId",
         "businessNeed",
         "businessOwner",
         "businessOwnerComponent",
@@ -23,6 +24,13 @@
         "userEUA"
       ],
       "properties": {
+        "intakeId": {
+          "type": "string",
+          "description": "Unique UUID of this system intake",
+          "examples": [
+            "0a16ce4e-8d8a-41ab-aeba-9303067f065b"
+          ]
+        },
         "adminLead": {
           "type": "string",
           "description": "Government Admin responsible for handling request",

--- a/pkg/cedar/intake/schemas/easi_system_intake.json
+++ b/pkg/cedar/intake/schemas/easi_system_intake.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "$ref": "#/definitions/EASIIntake",
-  "title": "EASIIntakeV02",
+  "title": "EASIIntakeV03",
   "definitions": {
     "EASIIntake": {
       "required": [

--- a/pkg/cedar/intake/translation/constants.go
+++ b/pkg/cedar/intake/translation/constants.go
@@ -39,10 +39,10 @@ const (
 	IntakeInputSchemaEASIBizCaseVersion SchemaVersion = "EASIBizCaseV03"
 
 	// IntakeInputSchemaEASIGrtFeedbackVersion captures the current schema version for GRT Feedback
-	IntakeInputSchemaEASIGrtFeedbackVersion SchemaVersion = "EASIGrtFeedbackV01"
+	IntakeInputSchemaEASIGrtFeedbackVersion SchemaVersion = "EASIGrtFeedbackV02"
 
 	// IntakeInputSchemaEASIIntakeVersion captures the current schema version for System Intakes
-	IntakeInputSchemaEASIIntakeVersion SchemaVersion = "EASIIntakeV02"
+	IntakeInputSchemaEASIIntakeVersion SchemaVersion = "EASIIntakeV03"
 
 	// IntakeInputSchemaEASINoteVersion captures the current schema version for Notes
 	IntakeInputSchemaEASINoteVersion SchemaVersion = "EASINoteV01"

--- a/pkg/cedar/intake/translation/feedback.go
+++ b/pkg/cedar/intake/translation/feedback.go
@@ -24,6 +24,7 @@ func (fb *TranslatableFeedback) ObjectType() string {
 // CreateIntakeModel translates a GRTFeedback into an IntakeInput
 func (fb *TranslatableFeedback) CreateIntakeModel() (*wire.IntakeInput, error) {
 	obj := intakemodels.EASIGrtFeedback{
+		FeedbackID:   fb.ID.String(),
 		IntakeID:     fb.IntakeID.String(),
 		Feedback:     fb.Feedback,
 		FeedbackType: string(fb.FeedbackType),

--- a/pkg/cedar/intake/translation/system_intake.go
+++ b/pkg/cedar/intake/translation/system_intake.go
@@ -24,6 +24,7 @@ func (si *TranslatableSystemIntake) ObjectType() string {
 // CreateIntakeModel translates a SystemIntake into an IntakeInput
 func (si *TranslatableSystemIntake) CreateIntakeModel() (*wire.IntakeInput, error) {
 	obj := &intakemodels.EASIIntake{
+		IntakeID:                    si.ID.String(),
 		UserEUA:                     si.EUAUserID.ValueOrZero(),
 		Status:                      string(si.Status),
 		RequestType:                 string(si.RequestType),


### PR DESCRIPTION
# EASI-2047

## Changes and Description

- Adds an `intakeId` field to the body of system intakes submitted to CEDAR Intake.
- Adds a `feedbackId` field to the body of GRT feedback items submitted to CEDAR Intake.

## Notes
- [Slack thread with discussion with CEDAR team](https://cmsgov.slack.com/archives/C02KTCN3ADD/p1652812332841499?thread_ts=1652727307.282289&cid=C02KTCN3ADD). 
- This isn't strictly essential, we're using the same value in the `clientId` field that's part of the Intake API, but this makes it easier for the CEDAR team to just map data based on the body.