### PR TITLE
[EASI-1939] - Display prepare for GRT/GRB meeting help links

### DIFF
--- a/src/components/GovernanceOverview/__snapshots__/index.test.tsx.snap
+++ b/src/components/GovernanceOverview/__snapshots__/index.test.tsx.snap
@@ -112,6 +112,13 @@ exports[`Governance Overview Content renders default version without crashing 1`
           >
             Discuss your draft Business Case with the Governance Review Team (GRT). They will give you feedback and help you refine your Business Case before you present to the Governance Review Board (GRB).
           </p>
+          <a
+            class="usa-link"
+            href="/help/it-governance/prepare-for-grt"
+            target="_blank"
+          >
+            Prepare for the GRT meeting (opens in new tab)
+          </a>
         </li>
         <li
           class="usa-process-list__item"
@@ -157,6 +164,13 @@ exports[`Governance Overview Content renders default version without crashing 1`
           >
             Present your Business Case to the Governance Review Board. The GRB will discuss and make a decision based on your Business Case as well as any recommendations from the Governance Review Team.
           </p>
+          <a
+            class="usa-link"
+            href="/help/it-governance/prepare-for-grb"
+            target="_blank"
+          >
+            Prepare for the GRB meeting (opens in new tab)
+          </a>
         </li>
         <li
           class="usa-process-list__item"

--- a/src/components/GovernanceOverview/index.test.tsx
+++ b/src/components/GovernanceOverview/index.test.tsx
@@ -6,7 +6,11 @@ import GovernanceOverviewContent from './index';
 
 describe('Governance Overview Content', () => {
   it('renders default version without crashing', () => {
-    const { asFragment } = render(<GovernanceOverviewContent />);
+    const { asFragment } = render(
+      <MemoryRouter>
+        <GovernanceOverviewContent />
+      </MemoryRouter>
+    );
     expect(asFragment()).toMatchSnapshot();
   });
   it('renders help section version without crashing', () => {

--- a/src/components/GovernanceOverview/index.tsx
+++ b/src/components/GovernanceOverview/index.tsx
@@ -103,7 +103,7 @@ const GovernanceOverviewContent = ({
                     {step.heading}
                   </ProcessListHeading>
                   <p className="margin-bottom-1">{step.content}</p>
-                  {helpArticle && step.link && (
+                  {step.link && (
                     <UswdsReactLink to={step.link.path} target="_blank">
                       {step.link.text}
                     </UswdsReactLink>

--- a/src/i18n/en-US/taskList.ts
+++ b/src/i18n/en-US/taskList.ts
@@ -1,4 +1,5 @@
 const taskList = {
+  pageHeading: 'Get governance approval',
   withdraw_modal: {
     header: 'Confirm you want to remove {{-requestName}}.',
     warning: 'You will lose any information you have filled in.',
@@ -24,7 +25,10 @@ const taskList = {
     reasons: 'Reasons',
     nextSteps: 'Next steps',
     completeNextSteps:
-      'Finish these next steps to complete the governance review process.'
+      'Finish these next steps to complete the governance review process.',
+    decision: 'Decision:',
+    alert:
+      'A decision has been made for this request, you can view the decision at the bottom of this page. Please check the email sent to you for further information.'
   },
   navigation: {
     home: 'IT Governance',
@@ -47,6 +51,61 @@ const taskList = {
         'These are the Governance Review Team recommendations for the Business Owner'
     },
     descriptiveDate: 'Feedback given on {{date}}'
+  },
+  lcidAlert: {
+    heading: 'Lifecycle ID Information',
+    label: 'LCID:',
+    link: 'Read about this LCID'
+  },
+  requestForm: {
+    heading: 'Fill in the request form',
+    description:
+      'Tell the Governance Admin Team about your idea. This step lets CMS build context about your request and start preparing for discussions with your team.'
+  },
+  initialReviewFeedback: {
+    heading: 'Feedback from initial review',
+    description:
+      'The Governance Admin Team will review your request and decide if it needs further governance. If it does, they’ll direct you to go through the remaining steps.',
+    alertOne:
+      'To help with that review, someone from the IT Governance team will schedule a phone call with you and Enterprise Architecture (EA).',
+    alertTwo:
+      'After that phone call, the governance team will decide if you need to go through a full governance process.',
+    link: 'Read feedback'
+  },
+  businessCase: {
+    heading: 'Prepare your Business Case for the GRT',
+    descriptionOne:
+      'Draft a business case to communicate the business need, the solutions and its associated costs. Meet with the Governance Review Team to discuss your draft, receive feedback and refine your business case.',
+    descriptionTwo:
+      'This step can take some time due to scheduling and availability. You may go through multiple rounds of editing your business case and receiving feedback.',
+    status: 'Status:'
+  },
+  finalApproval: {
+    heading: 'Submit the business case for final approval',
+    description:
+      'Update the Business Case based on feedback from the review meeting and submit it to the Governance Review Board.',
+    link: 'Review and Submit'
+  },
+  attendGRB: {
+    heading: 'Attend the GRB meeting',
+    description:
+      'The Governance Review Board will discuss and make decisions based on the Business Case and recommendations from the Review Team.'
+  },
+  decisionNextSteps: {
+    heading: 'Decision and next steps',
+    description:
+      'If your Business Case is approved you will receive a unique Lifecycle ID. If it is not approved, you would need to address the concerns to proceed.'
+  },
+  cta: {
+    viewSubmittedRequest: 'View submitted request form',
+    continue: 'Continue',
+    start: 'Start',
+    viewSubmittedBusinessCase: 'View submitted request form',
+    updateDraftBusinessCase: 'Update draft business case',
+    updateSubmittedBusinessCase: 'Update submitted draft business case',
+    prepareGRB: 'Prepare for the GRB meeting (opens in new tab)',
+    prepareGRT: 'Prepare for the GRT meeting (opens in new tab)',
+    readDecision: 'Read decision from board'
   }
 };
 

--- a/src/views/GovernanceOverview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceOverview/__snapshots__/index.test.tsx.snap
@@ -189,6 +189,14 @@ exports[`The governance overview page matches the snapshot (w/ id param) 1`] = `
           >
             Discuss your draft Business Case with the Governance Review Team (GRT). They will give you feedback and help you refine your Business Case before you present to the Governance Review Board (GRB).
           </p>
+          <a
+            className="usa-link"
+            href="/help/it-governance/prepare-for-grt"
+            onClick={[Function]}
+            target="_blank"
+          >
+            Prepare for the GRT meeting (opens in new tab)
+          </a>
         </li>
         <li
           className="usa-process-list__item"
@@ -234,6 +242,14 @@ exports[`The governance overview page matches the snapshot (w/ id param) 1`] = `
           >
             Present your Business Case to the Governance Review Board. The GRB will discuss and make a decision based on your Business Case as well as any recommendations from the Governance Review Team.
           </p>
+          <a
+            className="usa-link"
+            href="/help/it-governance/prepare-for-grb"
+            onClick={[Function]}
+            target="_blank"
+          >
+            Prepare for the GRB meeting (opens in new tab)
+          </a>
         </li>
         <li
           className="usa-process-list__item"
@@ -487,6 +503,14 @@ exports[`The governance overview page matches the snapshot (w/o id param) 1`] = 
           >
             Discuss your draft Business Case with the Governance Review Team (GRT). They will give you feedback and help you refine your Business Case before you present to the Governance Review Board (GRB).
           </p>
+          <a
+            className="usa-link"
+            href="/help/it-governance/prepare-for-grt"
+            onClick={[Function]}
+            target="_blank"
+          >
+            Prepare for the GRT meeting (opens in new tab)
+          </a>
         </li>
         <li
           className="usa-process-list__item"
@@ -532,6 +556,14 @@ exports[`The governance overview page matches the snapshot (w/o id param) 1`] = 
           >
             Present your Business Case to the Governance Review Board. The GRB will discuss and make a decision based on your Business Case as well as any recommendations from the Governance Review Team.
           </p>
+          <a
+            className="usa-link"
+            href="/help/it-governance/prepare-for-grb"
+            onClick={[Function]}
+            target="_blank"
+          >
+            Prepare for the GRB meeting (opens in new tab)
+          </a>
         </li>
         <li
           className="usa-process-list__item"

--- a/src/views/GovernanceTaskList/TaskListCta.tsx
+++ b/src/views/GovernanceTaskList/TaskListCta.tsx
@@ -75,7 +75,7 @@ export const BusinessCaseDraftCta = ({
               }
             });
           }}
-          className="usa-button"
+          className="usa-button margin-top-2"
           data-testid="start-biz-case-btn"
         >
           Start
@@ -85,7 +85,7 @@ export const BusinessCaseDraftCta = ({
       return (
         <UswdsReactLink
           data-testid="continue-biz-case-btn"
-          className="usa-button"
+          className="usa-button margin-top-2"
           variant="unstyled"
           to={`/business/${businessCaseId}/general-request-info`}
         >

--- a/src/views/GovernanceTaskList/TaskListCta.tsx
+++ b/src/views/GovernanceTaskList/TaskListCta.tsx
@@ -104,6 +104,7 @@ export const BusinessCaseDraftCta = ({
       if (businessCaseId) {
         return (
           <UswdsReactLink
+            className="display-block margin-top-2"
             data-testid="view-biz-case-link"
             to={`/business/${businessCaseId}/view`}
           >
@@ -116,7 +117,7 @@ export const BusinessCaseDraftCta = ({
       return (
         <UswdsReactLink
           data-testid="update-biz-case-draft-btn"
-          className="usa-button"
+          className="usa-button margin-top-2"
           variant="unstyled"
           to={`/business/${businessCaseId}/general-request-info`}
         >
@@ -125,23 +126,13 @@ export const BusinessCaseDraftCta = ({
       );
     case 'READY_FOR_GRT':
       return (
-        <>
-          <UswdsReactLink
-            data-testid="prepare-for-grt-cta"
-            className="display-table margin-bottom-2 usa-button"
-            variant="unstyled"
-            to={`/governance-task-list/${id}/prepare-for-grt`}
-          >
-            Prepare for review team meeting
-          </UswdsReactLink>
-
-          <UswdsReactLink
-            data-testid="view-biz-case-cta"
-            to={`/business/${businessCaseId}/general-request-info`}
-          >
-            Update submitted draft business case
-          </UswdsReactLink>
-        </>
+        <UswdsReactLink
+          className="display-block margin-top-2"
+          data-testid="view-biz-case-cta"
+          to={`/business/${businessCaseId}/general-request-info`}
+        >
+          Update submitted draft business case
+        </UswdsReactLink>
       );
     default:
       return <></>;
@@ -150,35 +141,18 @@ export const BusinessCaseDraftCta = ({
 
 // CTA for Task List GRB Meeting
 export const AttendGrbMeetingCta = ({ intake }: { intake: SystemIntake }) => {
-  const { id, status } = intake || {};
-  if (status === 'READY_FOR_GRB') {
-    return (
-      <UswdsReactLink
-        data-testid="prepare-for-grb-btn"
-        className="usa-button margin-top-2"
-        variant="unstyled"
-        to={`/governance-task-list/${id}/prepare-for-grb`}
-      >
-        Prepare for the Review Board meeting
-      </UswdsReactLink>
-    );
-  }
-  if (attendGrbMeetingTag(intake) === 'COMPLETED') {
-    return (
-      <UswdsReactLink
-        data-testid="prepare-for-grb-link"
-        to={`/governance-task-list/${id}/prepare-for-grb`}
-      >
-        Prepare for the Review Board meeting
-      </UswdsReactLink>
-    );
-  }
-
   return (
     <UswdsReactLink
-      className="margin-top-2 display-inline-block"
+      className={`display-inline-block ${
+        intake.status === 'READY_FOR_GRB' ? 'usa-button' : ''
+      }`}
       target="_blank"
       variant="unstyled"
+      data-testid={
+        intake.status === 'READY_FOR_GRB'
+          ? 'prepare-for-grb-btn'
+          : 'prepare-for-grb-link'
+      }
       to="/help/it-governance/prepare-for-grb"
     >
       Prepare for the GRB meeting (opens in new tab)

--- a/src/views/GovernanceTaskList/TaskListCta.tsx
+++ b/src/views/GovernanceTaskList/TaskListCta.tsx
@@ -5,7 +5,6 @@ import { Button } from '@trussworks/react-uswds';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import { isIntakeStarted } from 'data/systemIntake';
-import { attendGrbMeetingTag } from 'data/taskList';
 import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetSystemIntake';
 
 // CTA for Task List Intake Draft

--- a/src/views/GovernanceTaskList/TaskListCta.tsx
+++ b/src/views/GovernanceTaskList/TaskListCta.tsx
@@ -128,7 +128,7 @@ export const BusinessCaseDraftCta = ({
         <>
           <UswdsReactLink
             data-testid="prepare-for-grt-cta"
-            className="display-table margin-bottom-3 usa-button"
+            className="display-table margin-bottom-2 usa-button"
             variant="unstyled"
             to={`/governance-task-list/${id}/prepare-for-grt`}
           >
@@ -155,7 +155,7 @@ export const AttendGrbMeetingCta = ({ intake }: { intake: SystemIntake }) => {
     return (
       <UswdsReactLink
         data-testid="prepare-for-grb-btn"
-        className="usa-button"
+        className="usa-button margin-top-2"
         variant="unstyled"
         to={`/governance-task-list/${id}/prepare-for-grb`}
       >
@@ -163,7 +163,6 @@ export const AttendGrbMeetingCta = ({ intake }: { intake: SystemIntake }) => {
       </UswdsReactLink>
     );
   }
-
   if (attendGrbMeetingTag(intake) === 'COMPLETED') {
     return (
       <UswdsReactLink
@@ -175,7 +174,16 @@ export const AttendGrbMeetingCta = ({ intake }: { intake: SystemIntake }) => {
     );
   }
 
-  return <></>;
+  return (
+    <UswdsReactLink
+      className="margin-top-2 display-inline-block"
+      target="_blank"
+      variant="unstyled"
+      to="/help/it-governance/prepare-for-grb"
+    >
+      Prepare for the GRB meeting (opens in new tab)
+    </UswdsReactLink>
+  );
 };
 
 // CTA for Task List Decision

--- a/src/views/GovernanceTaskList/TaskListCta.tsx
+++ b/src/views/GovernanceTaskList/TaskListCta.tsx
@@ -9,6 +9,7 @@ import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetS
 
 // CTA for Task List Intake Draft
 export const IntakeDraftCta = ({ intake }: { intake: SystemIntake }) => {
+  const { t } = useTranslation('taskList');
   const { id, status } = intake || {};
   switch (status) {
     case 'INTAKE_SUBMITTED':
@@ -17,7 +18,7 @@ export const IntakeDraftCta = ({ intake }: { intake: SystemIntake }) => {
           data-testid="intake-view-link"
           to={`/system/${id}/view`}
         >
-          View Submitted Request Form
+          {t('cta.viewSubmittedRequest')}
         </UswdsReactLink>
       );
     case 'INTAKE_DRAFT':
@@ -28,7 +29,7 @@ export const IntakeDraftCta = ({ intake }: { intake: SystemIntake }) => {
             variant="unstyled"
             to={`/system/${id}/contact-details`}
           >
-            Continue
+            {t('cta.continue')}
           </UswdsReactLink>
         );
       }
@@ -39,7 +40,7 @@ export const IntakeDraftCta = ({ intake }: { intake: SystemIntake }) => {
           variant="unstyled"
           to={`/system/${id || 'new'}/contact-details`}
         >
-          Start
+          {t('cta.start')}
         </UswdsReactLink>
       );
     default:
@@ -48,7 +49,7 @@ export const IntakeDraftCta = ({ intake }: { intake: SystemIntake }) => {
           data-testid="intake-view-link"
           to={`/system/${id}/view`}
         >
-          View Submitted Request Form
+          {t('cta.viewSubmittedRequest')}
         </UswdsReactLink>
       );
   }
@@ -60,6 +61,7 @@ export const BusinessCaseDraftCta = ({
 }: {
   systemIntake: SystemIntake;
 }) => {
+  const { t } = useTranslation('taskList');
   const { id, status, businessCaseId } = systemIntake || {};
   const history = useHistory();
   switch (status) {
@@ -78,7 +80,7 @@ export const BusinessCaseDraftCta = ({
           className="usa-button margin-top-2"
           data-testid="start-biz-case-btn"
         >
-          Start
+          {t('cta.start')}
         </Button>
       );
     case 'BIZ_CASE_DRAFT':
@@ -89,7 +91,7 @@ export const BusinessCaseDraftCta = ({
           variant="unstyled"
           to={`/business/${businessCaseId}/general-request-info`}
         >
-          Continue
+          {t('cta.continue')}
         </UswdsReactLink>
       );
     case 'BIZ_CASE_DRAFT_SUBMITTED':
@@ -107,7 +109,7 @@ export const BusinessCaseDraftCta = ({
             data-testid="view-biz-case-link"
             to={`/business/${businessCaseId}/view`}
           >
-            View submitted business case
+            {t('cta.viewSubmittedBusinessCase')}
           </UswdsReactLink>
         );
       }
@@ -120,7 +122,7 @@ export const BusinessCaseDraftCta = ({
           variant="unstyled"
           to={`/business/${businessCaseId}/general-request-info`}
         >
-          Update draft business case
+          {t('cta.updateDraftBusinessCase')}
         </UswdsReactLink>
       );
     case 'READY_FOR_GRT':
@@ -130,7 +132,7 @@ export const BusinessCaseDraftCta = ({
           data-testid="view-biz-case-cta"
           to={`/business/${businessCaseId}/general-request-info`}
         >
-          Update submitted draft business case
+          {t('cta.updateSubmittedBusinessCase')}
         </UswdsReactLink>
       );
     default:
@@ -140,6 +142,7 @@ export const BusinessCaseDraftCta = ({
 
 // CTA for Task List GRB Meeting
 export const AttendGrbMeetingCta = ({ intake }: { intake: SystemIntake }) => {
+  const { t } = useTranslation('taskList');
   return (
     <UswdsReactLink
       className={`display-inline-block ${
@@ -154,14 +157,14 @@ export const AttendGrbMeetingCta = ({ intake }: { intake: SystemIntake }) => {
       }
       to="/help/it-governance/prepare-for-grb"
     >
-      Prepare for the GRB meeting (opens in new tab)
+      {t('cta.prepareGRB')}
     </UswdsReactLink>
   );
 };
 
 // CTA for Task List Decision
 export const DecisionCta = ({ id, status }: { id: string; status: string }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation('taskList');
   if (['LCID_ISSUED', 'NOT_APPROVED'].includes(status)) {
     return (
       <UswdsReactLink
@@ -170,7 +173,7 @@ export const DecisionCta = ({ id, status }: { id: string; status: string }) => {
         variant="unstyled"
         to={`/governance-task-list/${id}/request-decision`}
       >
-        Read decision from board
+        {t('cta.readDecision')}
       </UswdsReactLink>
     );
   }
@@ -178,8 +181,8 @@ export const DecisionCta = ({ id, status }: { id: string; status: string }) => {
   if (status === 'NOT_IT_REQUEST') {
     return (
       <span data-testid="plain-text-not-it-request-decision">
-        <b>Decision:&nbsp;</b>
-        {t('taskList:decision.notItRequest')}
+        <b>{t('decision.decision')}&nbsp;</b>
+        {t('decision.notItRequest')}
       </span>
     );
   }
@@ -187,7 +190,7 @@ export const DecisionCta = ({ id, status }: { id: string; status: string }) => {
   if (status === 'NO_GOVERNANCE') {
     return (
       <span data-testid="plain-text-no-governance-decision">
-        <b>Decision:&nbsp;</b>
+        <b>{t('decision.decision')}&nbsp;</b>
         {t('taskList:decision.noGovernanceNeeded')}
       </span>
     );

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -317,11 +317,7 @@ const GovernanceTaskList = () => {
                     }`}
                     target="_blank"
                     variant="unstyled"
-                    data-testid={
-                      status === 'READY_FOR_GRT'
-                        ? 'prepare-for-grt-btn'
-                        : 'prepare-for-grt-link'
-                    }
+                    data-testid="prepare-for-grt-cta"
                     to="/help/it-governance/prepare-for-grt"
                   >
                     Prepare for the GRT meeting (opens in new tab)

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -55,7 +55,7 @@ const GovernanceTaskList = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const { showMessageOnNextPage } = useMessage();
-  const { t } = useTranslation();
+  const { t } = useTranslation('taskList');
 
   const { data: grtFeedbackData } = useQuery<
     GetGRTFeedback,
@@ -95,7 +95,7 @@ const GovernanceTaskList = () => {
 
   const archiveIntake = () => {
     const redirect = () => {
-      const message = t('taskList:withdraw_modal.confirmationText', {
+      const message = t('withdraw_modal.confirmationText', {
         context: requestName ? 'name' : 'noName',
         requestName
       });
@@ -145,12 +145,10 @@ const GovernanceTaskList = () => {
         <BreadcrumbBar variant="wrap">
           <Breadcrumb>
             <BreadcrumbLink asCustom={Link} to="/">
-              <span>{t('taskList:navigation.home')}</span>
+              <span>{t('navigation.home')}</span>
             </BreadcrumbLink>
           </Breadcrumb>
-          <Breadcrumb current>
-            {t('taskList:navigation.governanceTaskList')}
-          </Breadcrumb>
+          <Breadcrumb current>{t('navigation.governanceTaskList')}</Breadcrumb>
         </BreadcrumbBar>
       </div>
       {loading && <PageLoading />}
@@ -158,7 +156,7 @@ const GovernanceTaskList = () => {
         <div className="grid-row">
           <div className="tablet:grid-col-9">
             <PageHeading>
-              Get governance approval
+              {t('pageHeading')}
               {requestName && (
                 <span className="display-block line-height-body-5 font-body-lg text-light">
                   {isRecompete
@@ -174,11 +172,7 @@ const GovernanceTaskList = () => {
                 className="margin-bottom-5"
                 data-testid="task-list-closed-alert"
               >
-                <span>
-                  A decision has been made for this request, you can view the
-                  decision at the bottom of this page. Please check the email
-                  sent to you for further information.
-                </span>
+                <span>{t('decision.alert')}</span>
               </Alert>
             )}
             {/* If intake has had an LCID issued but is currently in an open status - display alert directing user to LCID info */}
@@ -186,18 +180,20 @@ const GovernanceTaskList = () => {
               <Alert
                 type="info"
                 noIcon
-                heading="Lifecycle ID Information"
+                heading={t('lcidAlert.heading')}
                 className="margin-bottom-5"
                 data-testid="lcid-issued-alert"
               >
                 <>
-                  <span>LCID: {systemIntake.lcid}</span>
+                  <span>
+                    {t('lcidAlert.label')} {systemIntake.lcid}
+                  </span>
                   <br />
                   <UswdsReactLink
                     variant="unstyled"
                     to={`/governance-task-list/${id}/lcid-info`}
                   >
-                    Read about this LCID
+                    {t('lcidAlert.link')}
                   </UswdsReactLink>
                 </>
               </Alert>
@@ -208,28 +204,22 @@ const GovernanceTaskList = () => {
             >
               <TaskListItem
                 testId="task-list-intake-form"
-                heading="Fill in the request form"
+                heading={t('requestForm.heading')}
                 status={intakeTag(status || '')}
               >
                 <TaskListDescription>
-                  <p className="margin-top-0">
-                    Tell the Governance Admin Team about your idea. This step
-                    lets CMS build context about your request and start
-                    preparing for discussions with your team.
-                  </p>
+                  <p className="margin-top-0">{t('requestForm.description')}</p>
                 </TaskListDescription>
                 <IntakeDraftCta intake={systemIntake} />
               </TaskListItem>
               <TaskListItem
                 testId="task-list-intake-review"
-                heading="Feedback from initial review"
+                heading={t('initialReviewFeedback.heading')}
                 status={initialReviewTag(status || '')}
               >
                 <TaskListDescription>
                   <p className="margin-y-0">
-                    The Governance Admin Team will review your request and
-                    decide if it needs further governance. If it does, they’ll
-                    direct you to go through the remaining steps.
+                    {t('initialReviewFeedback.description')}
                   </p>
                 </TaskListDescription>
                 {/* Only display review Alert if intake is in initial stages (i.e. before review or request for business case) */}
@@ -237,17 +227,10 @@ const GovernanceTaskList = () => {
                   status || ''
                 ) && (
                   <Alert type="info">
-                    <span>
-                      To help with that review, someone from the IT Governance
-                      team will schedule a phone call with you and Enterprise
-                      Architecture (EA).
-                    </span>
+                    <span>{t('initialReviewFeedback.alertOne')}</span>
                     <br />
                     <br />
-                    <span>
-                      After that phone call, the governance team will decide if
-                      you need to go through a full governance process.
-                    </span>
+                    <span>{t('initialReviewFeedback.alertTwo')}</span>
                   </Alert>
                 )}
                 {grtFeedback &&
@@ -260,31 +243,26 @@ const GovernanceTaskList = () => {
                       variant="unstyled"
                       to={`/governance-task-list/${id}/feedback`}
                     >
-                      Read feedback
+                      {t('initialReviewFeedback.link')}
                     </UswdsReactLink>
                   )}
               </TaskListItem>
               <TaskListItem
                 testId="task-list-business-case-draft"
-                heading="Prepare your Business Case for the GRT"
+                heading={t('businessCase.heading')}
                 status={businessCaseTag(systemIntake)}
               >
                 <TaskListDescription>
                   <p className="margin-top-0">
-                    Draft a business case to communicate the business need, the
-                    solutions and its associated costs. Meet with the Governance
-                    Review Team to discuss your draft, receive feedback and
-                    refine your business case.
+                    {t('businessCase.descriptionOne')}
                   </p>
-                  <p>
-                    This step can take some time due to scheduling and
-                    availability. You may go through multiple rounds of editing
-                    your business case and receiving feedback.
-                  </p>
+                  <p>{t('businessCase.descriptionTwo')}</p>
 
                   {businessCaseStage && (
                     <p>
-                      <span className="text-bold">Status:&nbsp;</span>
+                      <span className="text-bold">
+                        {t('businessCase.status')}&nbsp;
+                      </span>
                       <span>{businessCaseStage}</span>
                     </p>
                   )}
@@ -303,7 +281,7 @@ const GovernanceTaskList = () => {
                         variant="unstyled"
                         to={`/governance-task-list/${id}/feedback`}
                       >
-                        Read feedback
+                        {t('initialReviewFeedback.link')}
                       </UswdsReactLink>
                       <br />
                     </>
@@ -319,20 +297,17 @@ const GovernanceTaskList = () => {
                   data-testid="prepare-for-grt-cta"
                   to="/help/it-governance/prepare-for-grt"
                 >
-                  Prepare for the GRT meeting (opens in new tab)
+                  {t('cta.prepareGRT')}
                 </UswdsReactLink>
                 <BusinessCaseDraftCta systemIntake={systemIntake} />
               </TaskListItem>
               <TaskListItem
                 testId="task-list-business-case-final"
-                heading="Submit the business case for final approval"
+                heading={t('finalApproval.heading')}
                 status={finalBusinessCaseTag(systemIntake)}
               >
                 <TaskListDescription>
-                  <p className="margin-y-0">
-                    Update the Business Case based on feedback from the review
-                    meeting and submit it to the Governance Review Board.
-                  </p>
+                  <p className="margin-y-0">{t('finalApproval.description')}</p>
                 </TaskListDescription>
                 {grtFeedback &&
                   grtFeedback.length > 0 &&
@@ -343,7 +318,7 @@ const GovernanceTaskList = () => {
                         variant="unstyled"
                         to={`/governance-task-list/${id}/feedback`}
                       >
-                        Read feedback
+                        {t('initialReviewFeedback.link')}
                       </UswdsReactLink>
                       <br />
                     </>
@@ -354,22 +329,18 @@ const GovernanceTaskList = () => {
                     variant="unstyled"
                     to={`/business/${businessCaseId}/general-request-info`}
                   >
-                    Review and Submit
+                    {t('finalApproval.link')}
                   </UswdsReactLink>
                 )}
               </TaskListItem>
 
               <TaskListItem
                 testId="task-list-grb-meeting"
-                heading="Attend the GRB meeting"
+                heading={t('attendGRB.heading')}
                 status={attendGrbMeetingTag(systemIntake)}
               >
                 <TaskListDescription>
-                  <p className="margin-top-0">
-                    The Governance Review Board will discuss and make decisions
-                    based on the Business Case and recommendations from the
-                    Review Team.
-                  </p>
+                  <p className="margin-top-0">{t('attendGRB.description')}</p>
                   {grbDate && (
                     <p className="governance-task-list__meeting-date margin-bottom-2">
                       {getMeetingDate(grbDate)}
@@ -380,14 +351,12 @@ const GovernanceTaskList = () => {
               </TaskListItem>
               <TaskListItem
                 testId="task-list-decision"
-                heading="Decision and next steps"
+                heading={t('decisionNextSteps.heading')}
                 status={decisionTag(systemIntake)}
               >
                 <TaskListDescription>
                   <p className="margin-top-0">
-                    If your Business Case is approved you will receive a unique
-                    Lifecycle ID. If it is not approved, you would need to
-                    address the concerns to proceed.
+                    {t('decisionNextSteps.description')}
                   </p>
                 </TaskListDescription>
                 <DecisionCta id={id || ''} status={status || ''} />

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -136,6 +136,8 @@ const GovernanceTaskList = () => {
     return <NotFound />;
   }
 
+  console.log(status);
+
   return (
     <MainContent
       className="governance-task-list grid-container margin-bottom-7"
@@ -281,6 +283,7 @@ const GovernanceTaskList = () => {
                     availability. You may go through multiple rounds of editing
                     your business case and receiving feedback.
                   </p>
+
                   {businessCaseStage && (
                     <p>
                       <span className="text-bold">Status:&nbsp;</span>
@@ -288,9 +291,19 @@ const GovernanceTaskList = () => {
                     </p>
                   )}
                   {grtDate && (
-                    <span className="governance-task-list__meeting-date">
+                    <p className="governance-task-list__meeting-date">
                       {getMeetingDate(grtDate)}
-                    </span>
+                    </p>
+                  )}
+                  {status !== 'READY_FOR_GRT' && (
+                    <UswdsReactLink
+                      className="display-inline-block margin-bottom-2"
+                      target="_blank"
+                      variant="unstyled"
+                      to="/help/it-governance/prepare-for-grt"
+                    >
+                      Prepare for the GRT meeting (opens in new tab)
+                    </UswdsReactLink>
                   )}
                 </TaskListDescription>
                 <div>

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -136,8 +136,6 @@ const GovernanceTaskList = () => {
     return <NotFound />;
   }
 
-  console.log(status);
-
   return (
     <MainContent
       className="governance-task-list grid-container margin-bottom-7"

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -294,34 +294,34 @@ const GovernanceTaskList = () => {
                     </p>
                   )}
                 </TaskListDescription>
-                <div>
-                  {grtFeedback &&
-                    grtFeedback.length > 0 &&
-                    status === 'BIZ_CASE_CHANGES_NEEDED' && (
-                      <>
-                        <UswdsReactLink
-                          className="usa-button margin-bottom-2"
-                          variant="unstyled"
-                          to={`/governance-task-list/${id}/feedback`}
-                        >
-                          Read feedback
-                        </UswdsReactLink>
-                        <br />
-                      </>
-                    )}
-                  <UswdsReactLink
-                    className={`display-inline-block ${
-                      status === 'READY_FOR_GRT' ? 'usa-button' : ''
-                    }`}
-                    target="_blank"
-                    variant="unstyled"
-                    data-testid="prepare-for-grt-cta"
-                    to="/help/it-governance/prepare-for-grt"
-                  >
-                    Prepare for the GRT meeting (opens in new tab)
-                  </UswdsReactLink>
-                  <BusinessCaseDraftCta systemIntake={systemIntake} />
-                </div>
+                {grtFeedback &&
+                  grtFeedback.length > 0 &&
+                  status === 'BIZ_CASE_CHANGES_NEEDED' && (
+                    <>
+                      <UswdsReactLink
+                        className="usa-button margin-bottom-2"
+                        variant="unstyled"
+                        to={`/governance-task-list/${id}/feedback`}
+                      >
+                        Read feedback
+                      </UswdsReactLink>
+                      <br />
+                    </>
+                  )}
+                <UswdsReactLink
+                  className={`display-block ${
+                    status === 'READY_FOR_GRT'
+                      ? 'usa-button display-inline-block'
+                      : ''
+                  }`}
+                  target="_blank"
+                  variant="unstyled"
+                  data-testid="prepare-for-grt-cta"
+                  to="/help/it-governance/prepare-for-grt"
+                >
+                  Prepare for the GRT meeting (opens in new tab)
+                </UswdsReactLink>
+                <BusinessCaseDraftCta systemIntake={systemIntake} />
               </TaskListItem>
               <TaskListItem
                 testId="task-list-business-case-final"

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -228,7 +228,7 @@ const GovernanceTaskList = () => {
                 status={initialReviewTag(status || '')}
               >
                 <TaskListDescription>
-                  <p className="margin-top-0">
+                  <p className="margin-y-0">
                     The Governance Admin Team will review your request and
                     decide if it needs further governance. If it does, they’ll
                     direct you to go through the remaining steps.
@@ -295,16 +295,6 @@ const GovernanceTaskList = () => {
                       {getMeetingDate(grtDate)}
                     </p>
                   )}
-                  {status !== 'READY_FOR_GRT' && (
-                    <UswdsReactLink
-                      className="display-inline-block margin-bottom-2"
-                      target="_blank"
-                      variant="unstyled"
-                      to="/help/it-governance/prepare-for-grt"
-                    >
-                      Prepare for the GRT meeting (opens in new tab)
-                    </UswdsReactLink>
-                  )}
                 </TaskListDescription>
                 <div>
                   {grtFeedback &&
@@ -321,6 +311,21 @@ const GovernanceTaskList = () => {
                         <br />
                       </>
                     )}
+                  <UswdsReactLink
+                    className={`display-inline-block ${
+                      status === 'READY_FOR_GRT' ? 'usa-button' : ''
+                    }`}
+                    target="_blank"
+                    variant="unstyled"
+                    data-testid={
+                      status === 'READY_FOR_GRT'
+                        ? 'prepare-for-grt-btn'
+                        : 'prepare-for-grt-link'
+                    }
+                    to="/help/it-governance/prepare-for-grt"
+                  >
+                    Prepare for the GRT meeting (opens in new tab)
+                  </UswdsReactLink>
                   <BusinessCaseDraftCta systemIntake={systemIntake} />
                 </div>
               </TaskListItem>
@@ -330,7 +335,7 @@ const GovernanceTaskList = () => {
                 status={finalBusinessCaseTag(systemIntake)}
               >
                 <TaskListDescription>
-                  <p className="margin-top-0">
+                  <p className="margin-y-0">
                     Update the Business Case based on feedback from the review
                     meeting and submit it to the Governance Review Board.
                   </p>
@@ -340,7 +345,7 @@ const GovernanceTaskList = () => {
                   status === 'BIZ_CASE_FINAL_NEEDED' && (
                     <>
                       <UswdsReactLink
-                        className="usa-button margin-y-2"
+                        className="usa-button margin-top-2"
                         variant="unstyled"
                         to={`/governance-task-list/${id}/feedback`}
                       >
@@ -351,7 +356,7 @@ const GovernanceTaskList = () => {
                   )}
                 {status === 'BIZ_CASE_FINAL_NEEDED' && (
                   <UswdsReactLink
-                    className="usa-button"
+                    className="usa-button margin-top-2"
                     variant="unstyled"
                     to={`/business/${businessCaseId}/general-request-info`}
                   >
@@ -372,9 +377,9 @@ const GovernanceTaskList = () => {
                     Review Team.
                   </p>
                   {grbDate && (
-                    <span className="governance-task-list__meeting-date">
+                    <p className="governance-task-list__meeting-date margin-bottom-2">
                       {getMeetingDate(grbDate)}
-                    </span>
+                    </p>
                   )}
                 </TaskListDescription>
                 <AttendGrbMeetingCta intake={systemIntake} />


### PR DESCRIPTION
# EASI-1939

## Changes and Description

- Display "Prepare for GRB Meeting" and "Prepare for GRT Meeting" help links in IT Governance Task List and IT Governance Steps Overview

<!-- Put a description here! -->

## How to test this change

- Test IT Governance request in both GRT and GRB meeting phases
  - When phase is inactive, link should be unstyled
  - When phase is active, link should be primary CTA button 
- Start new IT Governance request to see steps overview links

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
