### PR TITLE
Add createdAt/updatedAt to test data for sending to CEDAR Intake

### DIFF
--- a/cmd/test_cedar_intake/main.go
+++ b/cmd/test_cedar_intake/main.go
@@ -44,6 +44,9 @@ func makeTestData() *testData {
 	systemIntake := &models.SystemIntake{
 		ID: uuid.New(),
 
+		CreatedAt: &tenMinutesAgo,
+		UpdatedAt: &fiveMinutesAgo,
+
 		EUAUserID: null.StringFrom("ABCD"),
 		Status:    models.SystemIntakeStatusINTAKESUBMITTED,
 
@@ -107,6 +110,8 @@ func makeTestData() *testData {
 	noCost := 0
 	businessCase := &models.BusinessCase{
 		ID:                   uuid.New(),
+		CreatedAt:            &fiveMinutesAgo,
+		UpdatedAt:            &now,
 		SystemIntakeID:       systemIntake.ID,
 		EUAUserID:            "ABCD",
 		Requester:            null.StringFrom("Shane Clark"),


### PR DESCRIPTION
No Jira ticket, just a quick fix to the test data we send over to the CEDAR Intake API - making sure the system intake and business case have createdAt/updatedAt set. In our actual system, these should always be set when intakes/business cases are saved to our database.