### PR TITLE
EASI-2070/Handle errors when system intake contacts include invalid EUAs

### DIFF
--- a/pkg/cedar/cedarldap/translated_client.go
+++ b/pkg/cedar/cedarldap/translated_client.go
@@ -131,13 +131,6 @@ func (c TranslatedClient) FetchUserInfos(ctx context.Context, euaIDs []string) (
 		}
 	}
 
-	// If there's nobody returned, we should throw an error
-	if len(resp.Payload.Persons) == 0 {
-		return nil, &apperrors.InvalidEUAIDError{
-			EUAID: idsStr,
-		}
-	}
-
 	// Convert the response to our UserInfo model
 	userInfos := []*models2.UserInfo{}
 	for _, person := range resp.Payload.Persons {


### PR DESCRIPTION
# EASI-2070

## Changes and Description

Removed an error that was being thrown when no valid contacts were retrieved from CEDAR in FetchUserInfos

## How to test this change

Query systems to find one to use for testing, make sure it doesn't already have any contacts
```GraphQL
query {
  systems(first: 0) {
    edges {
      node {
        id
      }
    }
  }
}

query {
  systemIntakeContacts(id: "testID") {
    systemIntakeContacts {
      euaUserId
      component
      role
      commonName
      email
    }
  }
}
```

Add an invalid contact
```GraphQL
mutation {
  createSystemIntakeContact(input: { euaUserId: "XEEX", systemIntakeId: "testID", role: "Supreme Overlord", component: "IT" }) {
    systemIntakeContact{
      euaUserId
      systemIntakeId
      component
      role
    }
  }
}

```

Query the intake contacts again and make sure it contains "XEEX" in the invalidEUAIDs list, rather than an error

Add a valid contact and query contacts again, making sure no error is thrown and the results are as expected

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
