### PR TITLE
[NOREF] CEDAR Cache logging / error handling

### DIFF
--- a/pkg/cedar/core/client.go
+++ b/pkg/cedar/core/client.go
@@ -86,7 +86,8 @@ func (c *Client) startCacheRefresh(ctx context.Context, cacheRefreshTime time.Du
 		for {
 			err := populateCache(ctx)
 			if err != nil {
-				appcontext.ZLogger(ctx).Error("Failed to refresh cache", zap.Error(err))
+				// This is a Warn() instead of Error() as it happens somewhat frequently, and doesn't necessarily warrant immediate attention
+				appcontext.ZLogger(ctx).Warn("Failed to refresh cache", zap.Error(err))
 			}
 			// Wait for the ticker. This will block the current goroutine until the ticker sends a message over the channel
 			<-ticker.C

--- a/pkg/cedar/core/system_summary.go
+++ b/pkg/cedar/core/system_summary.go
@@ -67,6 +67,13 @@ func (c *Client) GetSystemSummary(ctx context.Context, tryCache bool) ([]*models
 		return []*models.CedarSystem{}, fmt.Errorf("no body received")
 	}
 
+	// This may look like an odd block of code, but should never expect an empty response from CEDAR with the
+	// hard-coded parameters we have set.
+	// This is defensive programming against this case.
+	if len(resp.Payload.SystemSummary) == 0 {
+		return []*models.CedarSystem{}, fmt.Errorf("empty response array received")
+	}
+
 	// Convert the auto-generated struct to our own pkg/models struct
 	retVal := []*models.CedarSystem{}
 	// Populate the SystemSummary field by converting each item in resp.Payload.SystemSummary


### PR DESCRIPTION
# No Ticket

## Changes and Description

This PR introduces 2 changes

- Changes the logging that happens when we get an error refreshing the CEDAR Cache to a `Warn()` instead of an `Error()`
- Modifies `GetSystemSummary` to return an error if an empty response array is returned.
  - This change was made as it would seem that the CEDAR cache would occasionally get flushed

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
