### PR TITLE
[NOREF] - Fix PDF export link spacing issue

### DIFF
--- a/src/components/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/components/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`The Business Case Review Component matches the snapshot 1`] = `
       </h2>
     </div>
     <div
-      className="padding-bottom-8 alternative-analysis-wrapper"
+      className="alternative-analysis-wrapper"
     >
       <div
         className="grid-container"
@@ -1066,7 +1066,7 @@ exports[`The Business Case Review Component matches the snapshot 1`] = `
       </div>
     </div>
     <div
-      className="easi-pdf-export__controls"
+      className="easi-pdf-export__controls margin-top-6"
     >
       <button
         className="usa-button usa-button--unstyled easi-no-print"

--- a/src/components/BusinessCaseReview/index.tsx
+++ b/src/components/BusinessCaseReview/index.tsx
@@ -83,7 +83,7 @@ const BusinessCaseReview = ({
             Alternatives analysis
           </h2>
         </div>
-        <div className="padding-bottom-8 alternative-analysis-wrapper">
+        <div className="alternative-analysis-wrapper">
           <div className={helpArticle ? '' : 'grid-container'}>
             <AlternativeAnalysisReview
               fiscalYear={
@@ -98,7 +98,7 @@ const BusinessCaseReview = ({
           </div>
         </div>
         {grtFeedbacks && grtFeedbacks.length > 0 && (
-          <div className="bg-gray-10 margin-top-3 padding-x-3 padding-top-3 padding-bottom-1 margin-bottom-6">
+          <div className="bg-gray-10 margin-top-3 padding-x-3 padding-top-3 padding-bottom-1">
             <div className="grid-container">
               <GRTFeedbackView grtFeedbacks={grtFeedbacks} />
             </div>

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import axios from 'axios';
+import classNames from 'classnames';
 import { Base64 } from 'js-base64';
 import escape from 'lodash';
 
@@ -100,7 +101,11 @@ const PDFExport = ({
     <div className="easi-pdf-export" ref={divEl}>
       {linkPosition === 'bottom' && children}
 
-      <div className="easi-pdf-export__controls">
+      <div
+        className={classNames('easi-pdf-export__controls', {
+          'margin-top-6': linkPosition === 'bottom'
+        })}
+      >
         <button
           className="usa-button usa-button--unstyled easi-no-print"
           type="button"

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -443,7 +443,7 @@ exports[`The GRT business case review matches the snapshot 1`] = `
       </div>
     </div>
     <div
-      className="easi-pdf-export__controls"
+      className="easi-pdf-export__controls margin-top-6"
     >
       <button
         className="usa-button usa-button--unstyled easi-no-print"

--- a/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
@@ -356,7 +356,7 @@ Array [
         </dl>
       </div>
       <div
-        className="easi-pdf-export__controls"
+        className="easi-pdf-export__controls margin-top-6"
       >
         <button
           className="usa-button usa-button--unstyled easi-no-print"


### PR DESCRIPTION
# EASI-000

## Changes and Description

- Fix for PDF Export button spacing issue introduced in sample business case pr

Before:
![lack_of_spacing_in_business_case_costs](https://user-images.githubusercontent.com/60187543/172718009-bea6babb-49bb-446a-a7af-99ade3164bf8.png)


After:
<img width="879" alt="Screen Shot 2022-06-08 at 4 10 33 PM" src="https://user-images.githubusercontent.com/60187543/172717935-68c8aa2a-56fe-49bf-87a6-999905e57194.png">

<!-- Put a description here! -->

## How to test this change

- Business case review - Download as PDF button should have space between it and costs review table (3rem top margin on button parent div)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
