### PR TITLE
Use Go race detector when running tests (locally and in CI)

### DIFF
--- a/cmd/easi/test/test.go
+++ b/cmd/easi/test/test.go
@@ -21,6 +21,7 @@ func Server() {
 	c := exec.Command(
 		"go",
 		"test",
+		"-race",
 		"-p=1",
 		"-coverprofile=go-coverage.out",
 		"./pkg/...")

--- a/docs/local_testing.md
+++ b/docs/local_testing.md
@@ -7,9 +7,9 @@ Run all tests other than Cypress in the project using `scripts/dev test`.
 - Run `scripts/dev test:go` to run all local-only server-side tests. This requires the database to be running first. Use `scripts/dev up:backend` to start it.
 - Run `scripts/dev test:go:only [full package name]` (e.g. `scripts/dev test:go:only "github.com/cmsgov/easi-app/pkg/cedar/core"`) to run server-side tests for a specific folder. Depending on the tests being run, this may require the database to be running, as above.
 - Run `scripts/dev test:go:long` to run all server-side tests, including ones that contact external services.
-- A single test method in a [`testify`](https://pkg.go.dev/github.com/stretchr/testify@v1.7.0) test suite can be run from the command line with `go test <package name> -testify.m <method name>`. This can be useful in cases where a test suite has many tests or if you just want to run a unit test without running tests that require external dependencies. Example:
+- A single test method in a [`testify`](https://pkg.go.dev/github.com/stretchr/testify@v1.7.0) test suite can be run from the command line with `go test -race <package name> -testify.m <method name>`. This can be useful in cases where a test suite has many tests or if you just want to run a unit test without running tests that require external dependencies. Example:
 ```
-go test "github.com/cmsgov/easi-app/pkg/services" -testify.m TestUpdateRejectionFields
+go test -race "github.com/cmsgov/easi-app/pkg/services" -testify.m TestUpdateRejectionFields
 ```
 This will run the `TestUpdateRejectionFields` method in [`pkg/services/system_intakes_test.go`](/pkg/services/system_intakes_test.go), which is part of the test suite for the entire `services` package.
 

--- a/scripts/dev
+++ b/scripts/dev
@@ -404,16 +404,16 @@ multitask test: ["test:go", "test:js"]
 namespace :test do
   desc "Runs Go tests"
   task :go => "db:clean" do
-    sh "go test -short -count=1 -p=1 ./..."
+    sh "go test -race -short -count=1 -p=1 ./..."
   end
   namespace :go do
     desc "Runs Go tests, including long ones"
     task :long => "db:clean" do
-      sh "go test -count=1 -p=1 ./..."
+      sh "go test -race -count=1 -p=1 ./..."
     end
     desc "Run targeted Go tests (pass full package name as additional options)"
     task :only => ["db:clean", :consume_args] do |t, args|
-      sh "go", "test", "-short", "-count=1", "-v", "-p=1", *args
+      sh "go", "test", "-race", "-short", "-count=1", "-v", "-p=1", *args
     end
   end
 


### PR DESCRIPTION
No Jira ticket, just some small changes to use the [Go race detector](https://go.dev/doc/articles/race_detector) to look for possible race conditions when running tests, failing a test if it detects a race condition during that test.

* Changes to `scripts/dev` add `-race` to tests run locally
* Changes to `cmd/easi/test/test.go` _should_ add `-race` to tests in CI, when the server_test job in run_tests.yml calls `./scripts/testsuite` (going to check this shortly)
* Documentation updated to mention using `-race`

Example code that induces a data race:
```
var wg sync.WaitGroup
wg.Add(5)
for i := 0; i < 5; i++ {
       go func() {
               fmt.Println(i) // Not the 'i' you are looking for.
               wg.Done()
       }()
}
wg.Wait()
```