### PR TITLE
Add early-return to CEDAR Core client for threats when there's no ATOs

### DIFF
--- a/pkg/cedar/core/threat.go
+++ b/pkg/cedar/core/threat.go
@@ -28,6 +28,12 @@ func (c *Client) GetThreat(ctx context.Context, cedarSystemID string) ([]*models
 		return nil, err
 	}
 
+	// if there aren't any ATOS, early return;
+	// otherwise /threat endpoint in CEDAR will return an error when no IDs are specified
+	if len(cedarATOs) == 0 {
+		return []*models.CedarThreat{}, nil
+	}
+
 	// List of ATO ID(s) to be passed into Threat endpoint
 	var atoIDs []string
 


### PR DESCRIPTION
No ticket - fixing a bug observed earlier today (Friday 6/17) where the system profile for a system with no ATOs displayed a 404 error. Prod URL to reproduce: https://easi.cms.gov/systems/408-4567-0/home/top

This just adds an early-return to the CEDAR Core client if no ATOs are returned, to avoid calling CEDAR's `/threat` endpoint with no ATO IDs.

Screenshots with this fix implemented:

System Home:
![fix for threat error from no atos - system home](https://user-images.githubusercontent.com/92891039/174339884-3d07d1e2-f3a5-402b-9279-47117212f673.PNG)

ATO subpage:
![fix for threat error from no atos - ATOs](https://user-images.githubusercontent.com/92891039/174339930-6839626a-6cf5-4c2b-a218-d8e01e378aab.PNG)

