### PR TITLE
Noref/remove python from ci

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -206,10 +206,6 @@ jobs:
         uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923
         with:
           go-version: ${{ env.EASI_APP_GO_VERSION }}
-      - name: Set up python
-        uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6
-        with:
-          python-version: "3.9"
       - name: Configure go cache
         uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
         with:

--- a/scripts/testsuite
+++ b/scripts/testsuite
@@ -20,8 +20,12 @@ go tool cover -html=go-coverage.out -o "go-coverage.html"
 # https://unix.stackexchange.com/questions/305190/remove-last-character-from-string-captured-with-awk
 percent=$(grep '(statements)' "go-coverage.txt" | awk '{print substr($NF, 1, length($NF)-1)}')
 goal_percent=50
-# using a oneline python function to test if percent is less than goal and return a proper exit code
-if python -c "exit(1) if ${percent} < ${goal_percent} else exit()"; then
+
+# use bc to perform floating-point comparison,
+# then use (( )) to have bash use an arithmetic context to interpret bc's output
+# see https://stackoverflow.com/a/11238237 for this specific use case
+# also see https://stackoverflow.com/a/49716000 for background - "The result code of an arithmetic expression is 0 if the result of the arithmetic evaluation was not 0 (or an error)."
+if ((  $(echo "$percent >= $goal_percent" | bc -l) )); then
     # coverage is good
     echo "total coverage is ${percent}%"
 else


### PR DESCRIPTION
No ticket. Inspired by [this dependabot PR](https://github.com/CMSgov/easi-app/pull/1670) for setting up Python in our CI workflow. It shouldn't be needed with this PR; the `pre-commit/action` sets up Python for its own usage, and I changed `scripts/testsuite` to not require Python for floating-point comparison of test coverage percentage. I didn't see anywhere else Python is used in CI.