### PR TITLE
Normalize cedar query parameter order

### DIFF
--- a/docs/operations/add_ssl_certificate.md
+++ b/docs/operations/add_ssl_certificate.md
@@ -2,12 +2,12 @@
 
 ## How to update a certificate
 
-There are a few SSL certificates that we import for our server to use. These certificates are located in the [config/tls](../../config/tls) directory.
+There are a few SSL certificates that we import for our server to use. These certificates are located in the [config/tls](/config/tls) directory.
 
 In order to trust a new certificate, take the following steps:
 
-1. Place a copy of the certificate in the [config/tls](../../config/tls) directory.
-2. Edit the [Dockerfile](../../Dockerfile) to contain a line that copies the certificate from this directory into the `/usr/local/share/ca-certificates/` directory.
+1. Place a copy of the certificate in the [config/tls](/config/tls) directory.
+2. Edit the [Dockerfile](/Dockerfile) to contain a line that copies the certificate from this directory into the `/usr/local/share/ca-certificates/` directory.
    - **NOTE:** The file should always be copied so that it has the `.crt` extension. The `update-ca-certificates` utility that is used will only look for files with this extension in this directory.
 
 ```docker

--- a/pkg/cedar/cedarldap/translated_client.go
+++ b/pkg/cedar/cedarldap/translated_client.go
@@ -113,7 +113,7 @@ func (c TranslatedClient) FetchUserInfos(ctx context.Context, euaIDs []string) (
 	sortedEUAIDs := make([]string, len(euaIDs)) // needs to have the same length as euaIDs for copy() to work
 	copy(sortedEUAIDs, euaIDs)
 
-	sort.StringSlice(sortedEUAIDs).Sort()
+	sort.Strings(sortedEUAIDs)
 
 	idsStr := strings.Join(sortedEUAIDs, ",")
 	params := operations.NewPersonIdsParams()

--- a/pkg/cedar/core/threat.go
+++ b/pkg/cedar/core/threat.go
@@ -43,7 +43,7 @@ func (c *Client) GetThreat(ctx context.Context, cedarSystemID string) ([]*models
 		atoIDs = append(atoIDs, ato.CedarID)
 	}
 
-	sort.StringSlice(atoIDs).Sort()
+	sort.Strings(atoIDs)
 
 	// Construct the parameters
 	params := apithreat.NewThreatFindListParams()

--- a/pkg/cedar/core/threat.go
+++ b/pkg/cedar/core/threat.go
@@ -3,6 +3,7 @@ package cedarcore
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/guregu/null/zero"
 
@@ -41,6 +42,8 @@ func (c *Client) GetThreat(ctx context.Context, cedarSystemID string) ([]*models
 	for _, ato := range cedarATOs {
 		atoIDs = append(atoIDs, ato.CedarID)
 	}
+
+	sort.StringSlice(atoIDs).Sort()
 
 	// Construct the parameters
 	params := apithreat.NewThreatFindListParams()


### PR DESCRIPTION
# EASI-2155

## Changes and Description

- Make sure lists of query parameters are sorted when calling CEDAR, for cache-friendliness
- Change some links in docs to be absolute instead of relative

## How to test this change

TODO 
* Manual testing locally
   * ATO IDs - already sorted when returned from CEDAR/autogenerated client code
   * EUA IDs - local testing doesn't call LDAP
* Automated testing - don't think I can mock autogenerated CEDAR clients/responses 

Will deploy to dev, see if anything breaks

## Notes
- This don't specify the ordering used, it just uses Go's [`sort.Strings()`](https://pkg.go.dev/sort#Strings). As long as that ordering stays the same, though, the details don't matter - the point is that the parameters are in the same order every time.