### PR TITLE
[EASI-2028] Remove cutover environment variables

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -89,8 +89,8 @@ jobs:
           PGHOST: localhost
           PGPORT: 5432
           PGDATABASE: postgres
-          PGUSER: app_user
-          PGPASS: supersecretapp
+          PGUSER: postgres
+          PGPASS: mysecretpassword
           PGSSLMODE: disable
           DB_MAX_CONNECTIONS: 20
           FLAG_SOURCE: LOCAL

--- a/docker-compose.ci_server_test.yml
+++ b/docker-compose.ci_server_test.yml
@@ -13,6 +13,6 @@ services:
       - FLYWAY_USER=postgres
       - FLYWAY_PASSWORD=mysecretpassword
       - FLYWAY_URL=jdbc:postgresql://db/postgres
-      - FLYWAY_PLACEHOLDERS_APP_USER_PASSWORD=supersecretapp
+      - FLYWAY_PLACEHOLDERS_APP_USER_PASSWORD=supersecretapp # Keep this around for legacy migration V88__Add_app_user.sql
     depends_on:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - FLYWAY_USER=postgres
       - FLYWAY_PASSWORD=mysecretpassword
       - FLYWAY_URL=jdbc:postgresql://db/postgres
-      - FLYWAY_PLACEHOLDERS_APP_USER_PASSWORD=supersecretapp
+      - FLYWAY_PLACEHOLDERS_APP_USER_PASSWORD=supersecretapp # Keep this around for legacy migration V88__Add_app_user.sql
     depends_on:
       - db
   easi:
@@ -45,8 +45,8 @@ services:
       - PGHOST=db
       - PGPORT=5432
       - PGDATABASE=postgres
-      - PGUSER=app_user
-      - PGPASS=supersecretapp
+      - PGUSER=postgres
+      - PGPASS=mysecretpassword
       - PGSSLMODE=disable
       - DB_MAX_CONNECTIONS=20
       - FLAG_SOURCE

--- a/migrations/V112__Remove_app_user.sql
+++ b/migrations/V112__Remove_app_user.sql
@@ -1,0 +1,2 @@
+-- Drop the app_user from the DB in favor of using the app_user_iam in deployed envs and the `postgres` master user locally/in CI
+DROP ROLE IF EXISTS app_user;

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -108,9 +108,6 @@ const DBNameConfigKey = "PGDATABASE"
 // DBUsernameConfigKey is the Postgres username config key
 const DBUsernameConfigKey = "PGUSER"
 
-// DBIAMUsernameKey is the IAM username config key
-const DBIAMUsernameKey = "DB_IAM_USER"
-
 // DBPasswordConfigKey is the Postgres password config key
 const DBPasswordConfigKey = "PGPASS"
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -27,28 +27,23 @@ func (s Server) NewDBConfig() storage.DBConfig {
 	s.checkRequiredConfig(appconfig.DBPortConfigKey)
 	s.checkRequiredConfig(appconfig.DBNameConfigKey)
 	s.checkRequiredConfig(appconfig.DBMaxConnections)
-
-	// Populate username dynamically
-	var username string
 	s.checkRequiredConfig(appconfig.DBSSLModeConfigKey)
-	if s.environment.Deployed() {
-		// TEMPORARY: Included to allow a clean cutover from app_user to iam_app_user in DBUsernameConfigKey
-		s.checkRequiredConfig(appconfig.DBIAMUsernameKey)
-		username = s.Config.GetString(appconfig.DBIAMUsernameKey)
-	} else {
-		s.checkRequiredConfig(appconfig.DBUsernameConfigKey)
+	s.checkRequiredConfig(appconfig.DBUsernameConfigKey)
+
+	// Check for password if we're not using IAM authentication
+	useIAM := s.environment.Deployed() // use IAM authentication in deployed environments
+	if !useIAM {
 		s.checkRequiredConfig(appconfig.DBPasswordConfigKey)
-		username = s.Config.GetString(appconfig.DBUsernameConfigKey)
 	}
 
 	return storage.DBConfig{
 		Host:           s.Config.GetString(appconfig.DBHostConfigKey),
 		Port:           s.Config.GetString(appconfig.DBPortConfigKey),
 		Database:       s.Config.GetString(appconfig.DBNameConfigKey),
-		Username:       username,
+		Username:       s.Config.GetString(appconfig.DBUsernameConfigKey),
 		Password:       s.Config.GetString(appconfig.DBPasswordConfigKey),
 		SSLMode:        s.Config.GetString(appconfig.DBSSLModeConfigKey),
-		UseIAM:         s.environment.Deployed(),
+		UseIAM:         useIAM,
 		MaxConnections: s.Config.GetInt(appconfig.DBMaxConnections),
 	}
 }


### PR DESCRIPTION
# EASI-2028

## Changes and Description

This is a follow-up on https://github.com/CMSgov/easi-app/pull/1677

- Remove the use of the `DB_IAM_USER` environment variable
  - This was temporary, and only served to help the cutover to IAM in case we needed to roll back to an older version of code.
- Remove the `app_user` with a new migration.
  - This means that, when running locally with a user/pass, we should use `postgres/mysecretpassword` instead of the app user, since it will no longer exist.

## Questions
- [x] Should a migration exist within this PR to remove the `app_user` PG user, and if so, what do we use locally? The `postgres` user?
  - I decided to remove the `app_user` entirely. This means that in deployed instances, the only user will be the `app_user_iam` and the master user. Locally, we'll just use `postgres` (master user)

## Action Items that need to be completed before deploying this PR to an environment

- [x] Modify `/${env}/easi-app/db/app_user_name` environment variable in SSM to be `app_user_iam` (NOTE: This is for the app_user, not the master user)
  - [x] `dev`
  - [x] `impl`
  - [x] `prod`

## Action Items that need to be completed after deploying this PR to an environment

- [ ] Delete `/${env}/easi-app/db/iam_user_name` environment variable in SSM (cutover variable)
  - [ ] `dev`
  - [ ] `impl`
  - [ ] `prod`
- [ ] Delete `/${env}/easi-app/db/app_user_password` environment variable in SSM (NOTE: This is for the app_user, not the master user/pass - app user uses IAM so app_user passwords are no longer needed in SSM)
  - [ ] `dev`
  - [ ] `impl`
  - [ ] `prod`

## How to test this change

This mainly affects our deployed code, but it should be worth confirming that this works locally by running `scripts/dev up` and ensuring that you can connect to the DB still!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
