### PR TITLE
EASI-2024/Add configuration parameter in Parameter Store for IT Investment mailbox address

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -24,7 +24,7 @@ export REACT_APP_LOCAL_AUTH_ENABLED=true
 # Email variables
 export EMAIL_TEMPLATE_DIR=$APP_DIR/pkg/email/templates
 export GRT_EMAIL=success@simulator.amazonses.com
-export IT_INVESTMENT_EMAIL=success@simulator.amazonses.com
+export IT_INVESTMENT_EMAIL=it_investment_email@cms.gov
 export ACCESSIBILITY_TEAM_EMAIL=success@simulator.amazonses.com
 
 # AWS variables

--- a/.envrc
+++ b/.envrc
@@ -24,6 +24,7 @@ export REACT_APP_LOCAL_AUTH_ENABLED=true
 # Email variables
 export EMAIL_TEMPLATE_DIR=$APP_DIR/pkg/email/templates
 export GRT_EMAIL=success@simulator.amazonses.com
+export IT_INVESTMENT_EMAIL=success@simulator.amazonses.com
 export ACCESSIBILITY_TEAM_EMAIL=success@simulator.amazonses.com
 
 # AWS variables

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -78,6 +78,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: easi-db-migrate
           GRT_EMAIL: success@simulator.amazonses.com
+          IT_INVESTMENT_EMAIL: success@simulator.amazonses.com
           ACCESSIBILITY_TEAM_EMAIL: success@simulator.amazonses.com
           OKTA_CLIENT_ID: 0oa2e913coDQeG19S297
           OKTA_DOMAIN: https://test.idp.idm.cms.gov

--- a/cmd/test_email_templates/main.go
+++ b/cmd/test_email_templates/main.go
@@ -31,6 +31,7 @@ func noErr(err error) {
 func createEmailClient() email.Client {
 	emailConfig := email.Config{
 		GRTEmail:               models.NewEmailAddress("grt_email@cms.gov"),
+		ITInvestmentEmail:      models.NewEmailAddress("it_investment_email@cms.gov"),
 		AccessibilityTeamEmail: models.NewEmailAddress("508_team@cms.gov"),
 		URLHost:                os.Getenv("CLIENT_HOSTNAME"),
 		URLScheme:              os.Getenv("CLIENT_PROTOCOL"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - OKTA_CLIENT_ID=0oa2e913coDQeG19S297
       - OKTA_ISSUER=https://test.idp.idm.cms.gov/oauth2/aus2e96etlbFPnBHt297
       - GRT_EMAIL=success@simulator.amazonses.com
+      - IT_INVESTMENT_EMAIL=success@simulator.amazonses.com
       - ACCESSIBILITY_TEAM_EMAIL=success@simluator.amazonses.com
       - EMAIL_TEMPLATE_DIR=./pkg/email/templates
       - AWS_REGION=us-west-2

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -129,6 +129,9 @@ const AWSSESSourceKey = "AWS_SES_SOURCE"
 // GRTEmailKey is the key for the receiving email for the GRT
 const GRTEmailKey = "GRT_EMAIL"
 
+// ITInvestmentEmailKey is the key for the receiving email for IT investment
+const ITInvestmentEmailKey = "IT_INVESTMENT_EMAIL"
+
 // AccessibilityTeamEmailKey is the key for the receiving email for the 508 team
 const AccessibilityTeamEmailKey = "ACCESSIBILITY_TEAM_EMAIL"
 

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -14,6 +14,7 @@ import (
 // Config holds EASi application specific configs for SES
 type Config struct {
 	GRTEmail               models.EmailAddress
+	ITInvestmentEmail      models.EmailAddress
 	AccessibilityTeamEmail models.EmailAddress
 	URLHost                string
 	URLScheme              string

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -63,6 +63,7 @@ func (s Server) NewEmailConfig() email.Config {
 
 	return email.Config{
 		GRTEmail:               models.NewEmailAddress(s.Config.GetString(appconfig.GRTEmailKey)),
+		ITInvestmentEmail:      models.NewEmailAddress(s.Config.GetString(appconfig.ITInvestmentEmailKey)),
 		AccessibilityTeamEmail: models.NewEmailAddress(s.Config.GetString(appconfig.AccessibilityTeamEmailKey)),
 		URLHost:                s.Config.GetString(appconfig.ClientHostKey),
 		URLScheme:              s.Config.GetString(appconfig.ClientProtocolKey),

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -127,6 +127,7 @@ func (s *Server) routes(
 	if s.environment.Local() {
 		// change these values so it's clear who emails are being sent to
 		emailConfig.GRTEmail = models.NewEmailAddress("grt_email@cms.gov")
+		emailConfig.GRTEmail = models.NewEmailAddress("it_investment_email@cms.gov")
 		emailConfig.AccessibilityTeamEmail = models.NewEmailAddress("508_team@cms.gov")
 
 		postfixSender := local.NewPostfixSender("host.docker.internal:1025") // hardcoded for convenience, can be changed to depend on an environment variable if we need the flexibility

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -125,11 +125,6 @@ func (s *Server) routes(
 
 	// override email client to use MailCatcher when running locally
 	if s.environment.Local() {
-		// change these values so it's clear who emails are being sent to
-		emailConfig.GRTEmail = models.NewEmailAddress("grt_email@cms.gov")
-		emailConfig.GRTEmail = models.NewEmailAddress("it_investment_email@cms.gov")
-		emailConfig.AccessibilityTeamEmail = models.NewEmailAddress("508_team@cms.gov")
-
 		postfixSender := local.NewPostfixSender("host.docker.internal:1025") // hardcoded for convenience, can be changed to depend on an environment variable if we need the flexibility
 		emailClient, err = email.NewClient(emailConfig, postfixSender)
 		if err != nil {


### PR DESCRIPTION
# EASI-2024

## Changes and Description

- Added the parameters to parameter store in dev, impl, and prod as `/{environment}/easi-app/email/it-investment-email`
- Added an environment variable called `IT_INVESTMENT_EMAIL`

<!-- Put a description here! -->

## How to test this change
I'm up for suggestions...

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
