### PR TITLE
[NOREF] Update snapshots for date-based tests

### DIFF
--- a/src/views/SystemProfile/__snapshots__/index.test.tsx.snap
+++ b/src/views/SystemProfile/__snapshots__/index.test.tsx.snap
@@ -430,10 +430,10 @@ exports[`System Profile parent request matches snapshot 1`] = `
                                   class="text-right margin-bottom-0"
                                 >
                                   <span
-                                    class="easi-tag grid-col-12 bg-warning"
+                                    class="easi-tag grid-col-12 bg-error-dark text-white"
                                     data-testid="tag"
                                   >
-                                    Due Soon
+                                    Expired
                                   </span>
                                 </div>
                               </header>

--- a/src/views/SystemProfile/components/ATO/__snapshots__/index.test.tsx.snap
+++ b/src/views/SystemProfile/components/ATO/__snapshots__/index.test.tsx.snap
@@ -16,14 +16,14 @@ exports[`ATO subpage for System Profile matches snapshot 1`] = `
       data-testid="CardGroup"
     >
       <li
-        class="usa-card grid-col-12 bg-warning"
+        class="usa-card grid-col-12 bg-error-dark"
         data-testid="Card"
       >
         <div
           class="usa-card__container"
         >
           <header
-            class="usa-card__header padding-2 padding-bottom-0 text-top text-base-darkest"
+            class="usa-card__header padding-2 padding-bottom-0 text-top text-white"
             data-testid="CardHeader"
           >
             <dt
@@ -34,14 +34,14 @@ exports[`ATO subpage for System Profile matches snapshot 1`] = `
             <dd
               class="description-definition margin-0 line-height-body-3 font-body-lg text-bold margin-bottom-2"
             >
-              Due Soon
+              Expired
             </dd>
             <div
-              class="easi-divider grid-col-12 border-warning-dark"
+              class="easi-divider grid-col-12 border-error-darker"
             />
           </header>
           <div
-            class="usa-card__footer padding-2 text-base-darkest"
+            class="usa-card__footer padding-2 text-white"
             data-testid="CardFooter"
           >
             <dt

--- a/src/views/SystemProfile/components/SystemHome/__snapshots__/index.test.tsx.snap
+++ b/src/views/SystemProfile/components/SystemHome/__snapshots__/index.test.tsx.snap
@@ -129,10 +129,10 @@ exports[`SystemHome subpage for System Profile matches snapshot 1`] = `
               class="text-right margin-bottom-0"
             >
               <span
-                class="easi-tag grid-col-12 bg-warning"
+                class="easi-tag grid-col-12 bg-error-dark text-white"
                 data-testid="tag"
               >
-                Due Soon
+                Expired
               </span>
             </div>
           </header>


### PR DESCRIPTION
# NOREF

## Changes and Description

- Updated snapshots to reflect expired ATO from mock data

https://github.com/CMSgov/easi-app/blob/e96b82a3998500fd76fbf3e231bc811915d6c27c/src/data/mock/systemProfile.ts#L24

There was a line of mock data that had `07-30-2022` as the ATO expiry date, so when we actually passed that date, the snapshots changed to reflect that the ATO was expired. This just updates the snapshots to remedy that, and it shouldn't be an issue going forward in this case!

## How to test this change

- `yarn test`

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
