### PR TITLE
Revert to using older CEDAR Core Swagger that doesn't have errors for SoftwareProductDetails

### DIFF
--- a/pkg/cedar/core/cedar_core.json
+++ b/pkg/cedar/core/cedar_core.json
@@ -12,7 +12,28 @@
   "host" : "webmethods-apigw.cedarimpl.cms.gov",
   "basePath" : "/gateway/CEDAR Core API/1.0.0",
   "tags" : [ {
+    "name" : "authority to operate",
+    "description" : ""
+  }, {
+    "name" : "cost type",
+    "description" : ""
+  }, {
+    "name" : "domain model",
+    "description" : ""
+  }, {
+    "name" : "organization",
+    "description" : ""
+  }, {
+    "name" : "support contact",
+    "description" : ""
+  }, {
+    "name" : "threat",
+    "description" : ""
+  }, {
     "name" : "url",
+    "description" : ""
+  }, {
+    "name" : "budget",
     "description" : ""
   }, {
     "name" : "authority to operate",
@@ -80,6 +101,7 @@
         "summary" : "Retrieve a list of enumerations based on a list of enumeration names passed in.",
         "description" : "Retrieve a list of enumerations based on a list of enumeration names passed in.",
         "operationId" : "enumerationFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "application",
@@ -133,6 +155,7 @@
         "summary" : "Retrieve an existing user in a CEDAR system based on the user name. This interface takes username.",
         "description" : "Retrieve an existing user in a CEDAR system based on the user name. This interface takes username.",
         "operationId" : "userFindByUsername",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "username",
@@ -184,8 +207,7 @@
         }, {
           "in" : "body",
           "name" : "body",
-          "description" : "User information to be updated in CEDAR.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/UserUpdateRequest"
           }
@@ -224,6 +246,7 @@
         "summary" : "Retrieve a list of contracts based on query criteria. If a SystemId is passed, the contract(s) for that system are returned. If no query data is passed in, all contracts for the current year are returned.",
         "description" : "Retrieve a list of contracts based on query criteria. If a SystemId is passed, the contract(s) for that system are returned. If no query data is passed in, all contracts for the current year are returned.",
         "operationId" : "contractFind",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "systemId",
@@ -275,8 +298,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "An array of Contracts to be added to CEDAR Alfabet.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/ContractAddRequest"
           }
@@ -324,8 +346,7 @@
         }, {
           "in" : "body",
           "name" : "body",
-          "description" : "An array of contracts to be updated in Alfabet.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/ContractUpdateRequest"
           }
@@ -362,6 +383,7 @@
         "summary" : "Delete a list of contracts based on an array of contarct ids.",
         "description" : "Delete a list of contracts based on an array of contarct ids.",
         "operationId" : "contractDeleteList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -414,6 +436,7 @@
         "summary" : "Retrieve a system summary based on the provided id.",
         "description" : "Retrieve a system summary based on the provided id.",
         "operationId" : "systemSummaryFindById",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -500,6 +523,7 @@
         "summary" : "Retrieve all versions of a system based on the ICT Object ID.",
         "description" : "Retrieve all versions of a system based on the ICT Object ID.",
         "operationId" : "systemVersionFindById",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "ictObjectIds",
@@ -552,6 +576,7 @@
         "summary" : "Retrieve an existing person or a sigle person record based on the users EUA id.",
         "description" : "Retrieve an existing person or a sigle person record based on the users EUA id.",
         "operationId" : "personFindById",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -594,48 +619,13 @@
         }
       }
     },
-    "/domainModelName" : {
-      "get" : {
-        "tags" : [ "domain model" ],
-        "summary" : "Retrieves a list of available domain reference models",
-        "description" : "Retrieves a list of available domain reference models",
-        "operationId" : "domainModelNameFindList",
-        "produces" : [ "application/json" ],
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/DomainModelNameFindResponse"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Response"
-            }
-          },
-          "401" : {
-            "description" : "Access Denied",
-            "schema" : {
-              "$ref" : "#/definitions/Response"
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "schema" : {
-              "$ref" : "#/definitions/Response"
-            }
-          }
-        }
-      }
-    },
     "/domainModelLevel" : {
       "get" : {
         "tags" : [ "domain model" ],
         "summary" : "Retrieves the model levels associated with a specific domain reference models",
         "description" : "Retrieves the hierarchy levels associated with a specific domain reference models",
         "operationId" : "domainModelLevelFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "model",
@@ -672,12 +662,50 @@
         }
       }
     },
+    "/domainModelName" : {
+      "get" : {
+        "tags" : [ "domain model" ],
+        "summary" : "Retrieves a list of available domain reference models",
+        "description" : "Retrieves a list of available domain reference models",
+        "operationId" : "domainModelNameFindList",
+        "consumes" : [ ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/DomainModelNameFindResponse"
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Response"
+            }
+          },
+          "401" : {
+            "description" : "Access Denied",
+            "schema" : {
+              "$ref" : "#/definitions/Response"
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "schema" : {
+              "$ref" : "#/definitions/Response"
+            }
+          }
+        }
+      }
+    },
     "/costType" : {
       "get" : {
         "tags" : [ "cost type" ],
         "summary" : "Retrieve a list of cost types",
         "description" : "Retrieve a list of cost types",
         "operationId" : "costTypeFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "application",
@@ -722,66 +750,13 @@
         }
       }
     },
-    "/softwareProducts" : {
-      "get" : {
-        "tags" : [ "softwareProducts" ],
-        "summary" : "Retrieve a list of softwareProducts. This interface takes in id and version.",
-        "description" : "Retrieve a list of softwareProducts. This interface takes in id and version.",
-        "operationId" : "softwareProductsFindList",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "query",
-          "description" : "Application ID.",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "version",
-          "in" : "query",
-          "description" : "Stakeholder version.",
-          "required" : false,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/SoftwareProductsFindResponse"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Response"
-            }
-          },
-          "401" : {
-            "description" : "Access Denied",
-            "schema" : {
-              "$ref" : "#/definitions/Response"
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "schema" : {
-              "$ref" : "#/definitions/Response"
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "schema" : {
-              "$ref" : "#/definitions/Response"
-            }
-          }
-        }
-      }
-    },
     "/system/detail/{id}" : {
       "get" : {
         "tags" : [ "system" ],
         "summary" : "Retrieve an existing system based on the provided id.",
         "description" : "Retrieve an existing system based on the provided id.",
         "operationId" : "systemDetailFindById",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -830,6 +805,7 @@
         "summary" : "Retrieve a list of supportContacts based on the inputs passed in.",
         "description" : "Retrieve a list of supportContact records to Alfabet. This interface takes in id, application id, name, title, url, phone and email.",
         "operationId" : "supportContactFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "application",
@@ -875,8 +851,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "supportContact information to be added to Alfabet.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/SupportContactAddRequest"
           }
@@ -913,6 +888,7 @@
         "summary" : "Delete a list of supportContacts by ID.",
         "description" : "Delete a list of supportContacts record to Alfabet. This interface takes an array of supportContact id's.",
         "operationId" : "supportContactDeleteList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -965,6 +941,7 @@
         "summary" : "Retrieve a list of ATO's based on query criteria",
         "description" : "An Authority to Operate (ATO) is official documentation that an IT asset within a defined boundary has met FISMA security requirements for a limited period of time. ATO security boundaries can encompass business systems, data centers, cloud service provider enclaves, or other IT assets.",
         "operationId" : "authorityToOperateFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "systemId",
@@ -1052,6 +1029,7 @@
         "summary" : "Retrieve a list of stakeholders. This interface takes in id, name, version, state, status and idsOnly.",
         "description" : "Retrieve a list of stakeholders. This interface takes in id, name, version, state, status and idsOnly.",
         "operationId" : "stakeholderFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -1132,6 +1110,7 @@
         "summary" : "Retrieves reference model information about Enterprise Architecture assets",
         "description" : "The Federal Enterprise Architecture Framework (FEAF) v2 describes a suite of tools to help government planners implement the Common Approach. At its core is the Consolidated Reference Model (CRM), which equips OMB and Federal agencies with a common language and framework to describe and analyze investments. It consists of a set of interrelated “reference models” that describe the six subarchitecture domains in the framework: Strategy, Business, Data, Applications, Infrastructure, Security: https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/egov_docs/fea_v2.pdf",
         "operationId" : "domainModelFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "model",
@@ -1186,6 +1165,7 @@
         "summary" : "Retrieve a list of deployments based on query criteria (systemId, state, status and deploymentType).",
         "description" : "Retrieve a list of deployments based on query criteria (systemId, state, status and deploymentType).",
         "operationId" : "deploymentFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "systemId",
@@ -1252,8 +1232,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Deployment list to be added to CEDAR",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/DeploymentAddRequest"
           }
@@ -1295,8 +1274,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Deployment list to be updated in Alfabet.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/DeploymentUpdateRequest"
           }
@@ -1333,6 +1311,7 @@
         "summary" : "Delete a list of deployments based on the ids passed in. This interface takes an array of deploymentIds.",
         "description" : "Delete a list of deployments based on the ids passed in. This interface takes an array of deploymentIds.",
         "operationId" : "deploymentDeleteList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -1385,6 +1364,7 @@
         "summary" : "Retrieve a component",
         "description" : "Retrieve a component record based on the id parameter that is passed in.",
         "operationId" : "componentFind",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "componentId",
@@ -1430,8 +1410,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Component record to be added to Alfabet.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/ComponentAddRequest"
           }
@@ -1468,6 +1447,7 @@
         "summary" : "Deletes a component within Alfabet based on the ID that is passed in.",
         "description" : "Deletes a component within Alfabet based on the ID that is passed in.",
         "operationId" : "componentDelete",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "componentId",
@@ -1516,6 +1496,7 @@
         "summary" : "Retrieve a list of budgets based on query criteria listed in the parameters section. Passing a SystemId will cause the interface to return the budget(s) for just that system. Setting onlyIds to true will only return the id's, whereas if not set, the response will also include projectId, systemId, fundingId and funding. This interface has a limit of 5000 records.",
         "description" : "Retrieve a list of budgets based on query criteria listed in the parameters section. Passing a SystemId will cause the interface to return the budget(s) for just that system. Setting onlyIds to true will only return the id's, whereas if not set, the response will also include projectId, systemId, fundingId and funding. This interface has a limit of 5000 records.",
         "operationId" : "budgetFind",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "systemId",
@@ -1585,8 +1566,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Budget(s) to be added to CEDAR.  This required input in a list of Budget documents.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/BudgetAddRequest"
           }
@@ -1628,8 +1608,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Budgets to be updated in CEDAR. This required input in a list of Budget documents (id, projectId, systemId, fundingId and funding).",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/BudgetUpdateRequest"
           }
@@ -1666,6 +1645,7 @@
         "summary" : "Deletes a list of budgets based on an array of budget ids.",
         "description" : "Deletes a list of budgets based on an array of budget ids.",
         "operationId" : "budgetDeleteList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -1718,6 +1698,7 @@
         "summary" : "Retrieve a list of persons based on the inputs passed in.",
         "description" : "Retrieve a list of persons based on the inputs passed in.",
         "operationId" : "personFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -1793,8 +1774,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Person information to be added to Alfabet.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/Person"
           }
@@ -1836,8 +1816,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Person information to be updated in Alfabet.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/Person"
           }
@@ -1876,6 +1855,7 @@
         "summary" : "Retrieve a list of threats based on a comma delimited list of object IDs.",
         "description" : "Retrieve a list of threats (like a Plan of Actions and Milestones POA&M), for a specific object (like an ATO) using the object's unique ID.",
         "operationId" : "threatFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "ids",
@@ -1922,6 +1902,7 @@
         "summary" : "Retrieve a list of URLs associated with an object in CEDAR",
         "description" : "Retrieve a list of URLs associated with an object in CEDAR. An object could include a System, ATO, etc",
         "operationId" : "urlFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -1964,6 +1945,7 @@
         "summary" : "Finds a list of role assignments based on an object's ID and/or role type.",
         "description" : "Finds a list of role assignments based on an object's ID. If objectId and roleTypeId are both provided, a list of role assignments for only those specific role type IDs are returned. If roleId is provided, then objectId and roleTypeId should not be provided and a specific role assignment is returned.",
         "operationId" : "roleFindById",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "application",
@@ -2034,8 +2016,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Role assignment information to be added to a CEDAR application.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/RoleAddRequest"
           }
@@ -2072,6 +2053,7 @@
         "summary" : "Deletes a list of role assignments by ID. This interface takes an application name and an array of roleIds.",
         "description" : "Deletes a list of role assignments by ID. This interface takes an application name and an array of roleIds.",
         "operationId" : "roleDeleteList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "application",
@@ -2131,6 +2113,7 @@
         "summary" : "Finds a list of role types available within an application. This interface takes in application.",
         "description" : "Finds a list of role types available within an application. This interface takes in application.",
         "operationId" : "roleTypeFind",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "application",
@@ -2180,6 +2163,7 @@
         "summary" : "Retrieve an existing user from a CEDAR application. This interface takes an id.",
         "description" : "Retrieve an existing user from a CEDAR application. This interface takes an id.",
         "operationId" : "userFindById",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -2231,8 +2215,7 @@
         }, {
           "in" : "body",
           "name" : "body",
-          "description" : "User information to be updated in CEDAR.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/UserUpdateRequest"
           }
@@ -2271,6 +2254,7 @@
         "summary" : "Retrieves information about the official CMS organizational hierarchy",
         "description" : "Retrieves information about the official CMS organizational hierarchy as maintained and published by the Division of Performance and Organizational Programs (DPOP)",
         "operationId" : "organizationFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -2325,6 +2309,7 @@
         "summary" : "Retrieve a data exchange record from Alfabet. This interface takes in a systemId, direction and version.",
         "description" : "Retrieve a data exchange record from Alfabet. This interface takes in a systemId, direction and version.",
         "operationId" : "exchangeFindById",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -2367,6 +2352,7 @@
         "summary" : "Retrieve a system summary list. This interface takes in state, status, version, includeInSurvey, idsOnly and belongsTo.",
         "description" : "Retrieve a system summary list. This interface takes in state, status, version, includeInSurvey, idsOnly and belongsTo.",
         "operationId" : "systemSummaryFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "state",
@@ -2412,14 +2398,14 @@
           "description" : "Limits the number of systems returned. If no value is provided, the default is 1000",
           "required" : false,
           "type" : "integer",
-          "format" : "int32"
+          "format" : "int64"
         }, {
           "name" : "offset",
           "in" : "query",
           "description" : "Defines the starting position of the first record returned. If no value is provided, the default is 0",
           "required" : false,
           "type" : "integer",
-          "format" : "int32"
+          "format" : "int64"
         } ],
         "responses" : {
           "200" : {
@@ -2461,6 +2447,7 @@
         "summary" : "Retrieve a list of users from a CEDAR application. This interface takes in application, id, userName, firstName, lastName, phone and email.",
         "description" : "Retrieve a list of users from a CEDAR application. This interface takes in application, id, userName, firstName, lastName, phone and email.",
         "operationId" : "userFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "application",
@@ -2543,8 +2530,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "User information to be added to a CEDAR application.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/UserAddRequest"
           }
@@ -2583,6 +2569,7 @@
         "summary" : "Retrieve a list of data centers based on query criteria (id, name, version, state, status and idsOnly). If idsOnlys is true, only the id and name will be returned.",
         "description" : "Retrieve a list of data centers based on query criteria (id, name, version, state, status and idsOnly). If idsOnlys is true, only the id and name will be returned.",
         "operationId" : "dataCenterFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -2663,6 +2650,7 @@
         "summary" : "Retrieve a data exchange record from Alfabet. This interface takes in a systemId, direction and version.",
         "description" : "Retrieve a data exchange record from Alfabet. This interface takes in a systemId, direction and version.",
         "operationId" : "exchangeFindList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "systemId",
@@ -2721,8 +2709,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Data exchange array to be added to Alfabet.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/ExchangeAddRequest"
           }
@@ -2764,8 +2751,7 @@
         "parameters" : [ {
           "in" : "body",
           "name" : "body",
-          "description" : "Data exchange array to be updated in Alfabet.",
-          "required" : true,
+          "required" : false,
           "schema" : {
             "$ref" : "#/definitions/ExchangeUpdateRequest"
           }
@@ -2802,6 +2788,7 @@
         "summary" : "Delete a list of data exchanges by ID. This interface takes an array of exchange ids.",
         "description" : "Delete a list of data exchanges by ID. This interface takes an array of exchange ids.",
         "operationId" : "exchangeDeleteList",
+        "consumes" : [ ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -2861,57 +2848,36 @@
       "type" : "object",
       "required" : [ "cedarId", "uuid" ],
       "properties" : {
-        "countOfTotalPrivilegedUserPopulation" : {
-          "type" : "integer",
-          "format" : "int32"
+        "actualDispositionDate" : {
+          "type" : "string",
+          "format" : "date",
+          "example" : "2021-10-13T00:00:00.000Z"
         },
-        "isAccessedByNonOrganizationalUsers" : {
+        "cedarId" : {
+          "type" : "string",
+          "example" : "157-3632-0"
+        },
+        "containsPersonallyIdentifiableInformation" : {
           "type" : "boolean"
-        },
-        "recoveryPointObjective" : {
-          "type" : "number",
-          "format" : "float"
         },
         "countOfOpenPoams" : {
           "type" : "integer",
           "format" : "int32"
         },
-        "recoveryTimeObjective" : {
-          "type" : "number",
-          "format" : "float"
+        "countOfTotalNonPrivilegedUserPopulation" : {
+          "type" : "integer",
+          "format" : "int32"
         },
-        "uuid" : {
-          "type" : "string",
-          "example" : "806F9F07-C3A5-4EE6-9C6A-C8D50585B7EA"
-        },
-        "lastContingencyPlanCompletionDate" : {
-          "type" : "string",
-          "format" : "date",
-          "example" : "2021-10-13T00:00:00.000Z"
-        },
-        "privacySubjectMatterExpert" : {
-          "type" : "string",
-          "example" : "ABCD"
-        },
-        "isProtectedHealthInformation" : {
-          "type" : "boolean"
-        },
-        "systemOfRecordsNotice" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string",
-            "example" : "03-39-9932"
-          }
-        },
-        "containsPersonallyIdentifiableInformation" : {
-          "type" : "boolean"
-        },
-        "dateAuthorizationMemoSigned" : {
-          "type" : "string",
-          "format" : "date",
-          "example" : "2021-10-13T00:00:00.000Z"
+        "countOfTotalPrivilegedUserPopulation" : {
+          "type" : "integer",
+          "format" : "int32"
         },
         "dateAuthorizationMemoExpires" : {
+          "type" : "string",
+          "format" : "date",
+          "example" : "2021-10-13T00:00:00.000Z"
+        },
+        "dateAuthorizationMemoSigned" : {
           "type" : "string",
           "format" : "date",
           "example" : "2021-10-13T00:00:00.000Z"
@@ -2920,65 +2886,86 @@
           "type" : "string",
           "example" : "3"
         },
-        "tlcPhase" : {
-          "type" : "string",
-          "example" : "Initiate"
-        },
-        "lastPenTestDate" : {
-          "type" : "string",
-          "format" : "date",
-          "example" : "2021-10-13T00:00:00.000Z"
-        },
         "fips199OverallImpactRating" : {
           "type" : "integer",
           "format" : "int32"
-        },
-        "isPiiLimitedToUserNameAndPass" : {
-          "type" : "boolean"
-        },
-        "primaryCyberRiskAdvisor" : {
-          "type" : "string",
-          "example" : "ABCD"
         },
         "fismaSystemAcronym" : {
           "type" : "string",
           "example" : "CEDAR"
         },
-        "piaCompletionDate" : {
-          "type" : "string",
-          "format" : "date",
-          "example" : "2021-10-13T00:00:00.000Z"
-        },
-        "countOfTotalNonPrivilegedUserPopulation" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
         "fismaSystemName" : {
           "type" : "string",
           "example" : "Acumen Web Portals"
+        },
+        "isAccessedByNonOrganizationalUsers" : {
+          "type" : "boolean"
+        },
+        "isPiiLimitedToUserNameAndPass" : {
+          "type" : "boolean"
+        },
+        "isProtectedHealthInformation" : {
+          "type" : "boolean"
         },
         "lastActScaDate" : {
           "type" : "string",
           "format" : "date",
           "example" : "2021-10-13T00:00:00.000Z"
         },
-        "actualDispositionDate" : {
-          "type" : "string",
-          "format" : "date",
-          "example" : "2021-10-13T00:00:00.000Z"
-        },
-        "xlcPhase" : {
-          "type" : "string",
-          "example" : "Operate"
-        },
         "lastAssessmentDate" : {
           "type" : "string",
           "format" : "date",
           "example" : "2021-10-13T00:00:00.000Z"
         },
-        "cedarId" : {
+        "lastContingencyPlanCompletionDate" : {
           "type" : "string",
-          "example" : "157-3632-0"
+          "format" : "date",
+          "example" : "2021-10-13T00:00:00.000Z"
+        },
+        "lastPenTestDate" : {
+          "type" : "string",
+          "format" : "date",
+          "example" : "2021-10-13T00:00:00.000Z"
+        },
+        "piaCompletionDate" : {
+          "type" : "string",
+          "format" : "date",
+          "example" : "2021-10-13T00:00:00.000Z"
+        },
+        "primaryCyberRiskAdvisor" : {
+          "type" : "string",
+          "example" : "ABCD"
+        },
+        "privacySubjectMatterExpert" : {
+          "type" : "string",
+          "example" : "ABCD"
+        },
+        "recoveryPointObjective" : {
+          "type" : "number",
+          "format" : "float"
+        },
+        "recoveryTimeObjective" : {
+          "type" : "number",
+          "format" : "float"
+        },
+        "systemOfRecordsNotice" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "example" : "03-39-9932"
+          }
+        },
+        "tlcPhase" : {
+          "type" : "string",
+          "example" : "Initiate"
+        },
+        "uuid" : {
+          "type" : "string",
+          "example" : "806F9F07-C3A5-4EE6-9C6A-C8D50585B7EA"
+        },
+        "xlcPhase" : {
+          "type" : "string",
+          "example" : "Operate"
         }
       }
     },
@@ -2986,33 +2973,15 @@
       "type" : "object",
       "required" : [ "Roles", "application" ],
       "properties" : {
-        "application" : {
-          "type" : "string",
-          "enum" : [ "all", "alfabet" ]
-        },
         "Roles" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/Role"
           }
-        }
-      }
-    },
-    "Products" : {
-      "type" : "object",
-      "required" : [ "technopedia_id" ],
-      "properties" : {
-        "technopedia_id" : {
-          "type" : "string"
         },
-        "api_gateway_use" : {
-          "type" : "boolean"
-        },
-        "local_component_refstr" : {
-          "type" : "string"
-        },
-        "provides_ai_capability" : {
-          "type" : "boolean"
+        "application" : {
+          "type" : "string",
+          "enum" : [ "all", "alfabet" ]
         }
       }
     },
@@ -3020,15 +2989,15 @@
       "type" : "object",
       "required" : [ "count" ],
       "properties" : {
-        "count" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
         "Budgets" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/Budget"
           }
+        },
+        "count" : {
+          "type" : "integer",
+          "format" : "int32"
         }
       }
     },
@@ -3036,29 +3005,37 @@
       "type" : "object",
       "required" : [ "ictObjectId", "id", "name", "version" ],
       "properties" : {
-        "ictObjectId" : {
-          "type" : "string",
-          "example" : "326-3-0"
-        },
         "acronym" : {
           "type" : "string",
           "example" : "CMSS"
         },
-        "systemMaintainerOrg" : {
+        "belongsTo" : {
           "type" : "string",
-          "example" : "OIT"
+          "example" : "326-10-0"
+        },
+        "businessOwnerOrg" : {
+          "type" : "string",
+          "example" : "Center for Medicare Management"
+        },
+        "businessOwnerOrgComp" : {
+          "type" : "string",
+          "example" : "CM-(FFS)"
         },
         "description" : {
           "type" : "string",
           "example" : "This is a CMS System decription"
         },
-        "uuid" : {
+        "ictObjectId" : {
           "type" : "string",
-          "example" : "12FFF52E-195B-4E48-9A38-669A8BD71234"
+          "example" : "326-3-0"
         },
-        "version" : {
+        "id" : {
           "type" : "string",
-          "example" : "1.0"
+          "example" : "326-2-0"
+        },
+        "name" : {
+          "type" : "string",
+          "example" : "CMS System"
         },
         "nextVersionId" : {
           "type" : "string",
@@ -3068,37 +3045,29 @@
           "type" : "string",
           "example" : "326-3-0"
         },
-        "businessOwnerOrg" : {
-          "type" : "string",
-          "example" : "Center for Medicare Management"
-        },
-        "name" : {
-          "type" : "string",
-          "example" : "CMS System"
-        },
-        "businessOwnerOrgComp" : {
-          "type" : "string",
-          "example" : "CM-(FFS)"
-        },
-        "id" : {
-          "type" : "string",
-          "example" : "326-2-0"
-        },
         "state" : {
           "type" : "string",
           "example" : "Active"
+        },
+        "status" : {
+          "type" : "string",
+          "example" : "Approved"
+        },
+        "systemMaintainerOrg" : {
+          "type" : "string",
+          "example" : "OIT"
         },
         "systemMaintainerOrgComp" : {
           "type" : "string",
           "example" : "Enterprise Architecture and Data Group"
         },
-        "belongsTo" : {
+        "uuid" : {
           "type" : "string",
-          "example" : "326-10-0"
+          "example" : "12FFF52E-195B-4E48-9A38-669A8BD71234"
         },
-        "status" : {
+        "version" : {
           "type" : "string",
-          "example" : "Approved"
+          "example" : "1.0"
         }
       }
     },
@@ -3126,13 +3095,13 @@
           "type" : "string",
           "enum" : [ "all", "alfabet" ]
         },
-        "name" : {
-          "type" : "string"
-        },
         "description" : {
           "type" : "string"
         },
         "id" : {
+          "type" : "string"
+        },
+        "name" : {
           "type" : "string"
         }
       }
@@ -3141,32 +3110,43 @@
       "type" : "object",
       "required" : [ "id", "name", "systemId" ],
       "properties" : {
-        "systemId" : {
-          "type" : "string",
-          "example" : "326-1-0"
-        },
-        "endDate" : {
-          "type" : "string",
-          "format" : "date"
-        },
-        "isHotSite" : {
-          "type" : "string",
-          "example" : "yes"
-        },
-        "description" : {
-          "type" : "string"
+        "DataCenter" : {
+          "$ref" : "#/definitions/DataCenter"
         },
         "contractorName" : {
           "type" : "string",
           "example" : "Acumen"
         },
-        "systemVersion" : {
+        "deploymentElementId" : {
           "type" : "string",
-          "example" : "1"
+          "example" : "69-1-0"
+        },
+        "deploymentType" : {
+          "type" : "string",
+          "enum" : [ "COOP DR", "Development", "Implementation", "Integration", "Production", "Testing", "Training", "Validation", "Other" ]
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "endDate" : {
+          "type" : "string",
+          "format" : "date"
         },
         "hasProductionData" : {
           "type" : "string",
           "example" : "yes"
+        },
+        "id" : {
+          "type" : "string",
+          "example" : "351-1-0"
+        },
+        "isHotSite" : {
+          "type" : "string",
+          "example" : "yes"
+        },
+        "name" : {
+          "type" : "string",
+          "example" : "Accountable Care Organization Management System v.1.0 (COOP DR)"
         },
         "replicatedSystemElements" : {
           "type" : "array",
@@ -3175,40 +3155,29 @@
             "example" : "System Server Software"
           }
         },
-        "deploymentType" : {
+        "startDate" : {
           "type" : "string",
-          "enum" : [ "COOP DR", "Development", "Implementation", "Integration", "Production", "Testing", "Training", "Validation", "Other" ]
-        },
-        "DataCenter" : {
-          "$ref" : "#/definitions/DataCenter"
-        },
-        "systemName" : {
-          "type" : "string",
-          "example" : "Health Insurance and Oversight System"
-        },
-        "deploymentElementId" : {
-          "type" : "string",
-          "example" : "69-1-0"
-        },
-        "name" : {
-          "type" : "string",
-          "example" : "Accountable Care Organization Management System v.1.0 (COOP DR)"
-        },
-        "id" : {
-          "type" : "string",
-          "example" : "351-1-0"
+          "format" : "date"
         },
         "state" : {
           "type" : "string",
           "enum" : [ "active", "planned", "retired" ]
         },
-        "startDate" : {
-          "type" : "string",
-          "format" : "date"
-        },
         "status" : {
           "type" : "string",
           "enum" : [ "approved", "draft" ]
+        },
+        "systemId" : {
+          "type" : "string",
+          "example" : "326-1-0"
+        },
+        "systemName" : {
+          "type" : "string",
+          "example" : "Health Insurance and Oversight System"
+        },
+        "systemVersion" : {
+          "type" : "string",
+          "example" : "1"
         },
         "wanType" : {
           "type" : "string",
@@ -3220,11 +3189,6 @@
       "type" : "object",
       "required" : [ "ictObjectId" ],
       "properties" : {
-        "ictObjectId" : {
-          "type" : "string",
-          "example" : "408-3-0",
-          "description" : "ICT Object ID for a given system"
-        },
         "Systems" : {
           "type" : "array",
           "items" : {
@@ -3238,6 +3202,11 @@
               }
             }
           }
+        },
+        "ictObjectId" : {
+          "type" : "string",
+          "example" : "408-3-0",
+          "description" : "ICT Object ID for a given system"
         }
       }
     },
@@ -3256,15 +3225,15 @@
     "RoleFindResponse" : {
       "type" : "object",
       "properties" : {
-        "count" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
         "Roles" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/Role"
           }
+        },
+        "count" : {
+          "type" : "integer",
+          "format" : "int32"
         }
       }
     },
@@ -3272,10 +3241,6 @@
       "type" : "object",
       "required" : [ "id" ],
       "properties" : {
-        "name" : {
-          "type" : "string",
-          "example" : "Food and Drug Administration (FDA)"
-        },
         "description" : {
           "type" : "string"
         },
@@ -3283,17 +3248,21 @@
           "type" : "string",
           "example" : "152-3-0"
         },
+        "name" : {
+          "type" : "string",
+          "example" : "Food and Drug Administration (FDA)"
+        },
         "state" : {
           "type" : "string",
           "enum" : [ "active", "planned", "retired" ]
         },
-        "version" : {
-          "type" : "string",
-          "example" : "1"
-        },
         "status" : {
           "type" : "string",
           "enum" : [ "approved", "draft" ]
+        },
+        "version" : {
+          "type" : "string",
+          "example" : "1"
         }
       }
     },
@@ -3301,15 +3270,15 @@
       "type" : "object",
       "required" : [ "count" ],
       "properties" : {
-        "count" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
         "DomainModelNames" : {
           "type" : "array",
           "items" : {
             "type" : "string"
           }
+        },
+        "count" : {
+          "type" : "integer",
+          "format" : "int32"
         }
       }
     },
@@ -3336,58 +3305,7 @@
     "ComponentAddRequest" : {
       "type" : "object",
       "properties" : {
-        "responsibleUser" : {
-          "type" : "string"
-        },
-        "endDate" : {
-          "type" : "string"
-        },
         "catalog" : {
-          "type" : "string"
-        },
-        "cms_technopedia_edition" : {
-          "type" : "string"
-        },
-        "cms_technopedia_licensable" : {
-          "type" : "string"
-        },
-        "description" : {
-          "type" : "string"
-        },
-        "cms_technopedia_release" : {
-          "type" : "string"
-        },
-        "cms_technopedia_versiongroup" : {
-          "type" : "string"
-        },
-        "version" : {
-          "type" : "string"
-        },
-        "platform" : {
-          "type" : "string"
-        },
-        "cms_technopedia_version" : {
-          "type" : "string"
-        },
-        "vendorProduct" : {
-          "type" : "string"
-        },
-        "cms_technopedia_servicepack" : {
-          "type" : "string"
-        },
-        "vendor" : {
-          "type" : "string"
-        },
-        "cms_technopedia_component" : {
-          "type" : "string"
-        },
-        "cms_technopedia_release_id" : {
-          "type" : "string"
-        },
-        "name" : {
-          "type" : "string"
-        },
-        "cms_technopedia_build_version" : {
           "type" : "string"
         },
         "category" : {
@@ -3396,10 +3314,61 @@
         "cms_end_of_support_date" : {
           "type" : "string"
         },
+        "cms_technopedia_build_version" : {
+          "type" : "string"
+        },
+        "cms_technopedia_component" : {
+          "type" : "string"
+        },
+        "cms_technopedia_edition" : {
+          "type" : "string"
+        },
+        "cms_technopedia_licensable" : {
+          "type" : "string"
+        },
+        "cms_technopedia_release" : {
+          "type" : "string"
+        },
+        "cms_technopedia_release_id" : {
+          "type" : "string"
+        },
+        "cms_technopedia_servicepack" : {
+          "type" : "string"
+        },
+        "cms_technopedia_version" : {
+          "type" : "string"
+        },
+        "cms_technopedia_versiongroup" : {
+          "type" : "string"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "endDate" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "platform" : {
+          "type" : "string"
+        },
+        "responsibleUser" : {
+          "type" : "string"
+        },
         "startDate" : {
           "type" : "string"
         },
         "status" : {
+          "type" : "string"
+        },
+        "vendor" : {
+          "type" : "string"
+        },
+        "vendorProduct" : {
+          "type" : "string"
+        },
+        "version" : {
           "type" : "string"
         }
       }
@@ -3408,15 +3377,15 @@
       "type" : "object",
       "required" : [ "count" ],
       "properties" : {
-        "count" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
         "Enumerations" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/Enumeration"
           }
+        },
+        "count" : {
+          "type" : "integer",
+          "format" : "int32"
         }
       }
     },
@@ -3436,15 +3405,15 @@
       "type" : "object",
       "required" : [ "count" ],
       "properties" : {
-        "count" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
         "UrlList" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/Url"
           }
+        },
+        "count" : {
+          "type" : "integer",
+          "format" : "int32"
         }
       }
     },
@@ -3454,13 +3423,16 @@
         "application" : {
           "type" : "string"
         },
-        "phone" : {
+        "email" : {
+          "type" : "string"
+        },
+        "id" : {
           "type" : "string"
         },
         "name" : {
           "type" : "string"
         },
-        "id" : {
+        "phone" : {
           "type" : "string"
         },
         "title" : {
@@ -3468,25 +3440,22 @@
         },
         "url" : {
           "type" : "string"
-        },
-        "email" : {
-          "type" : "string"
         }
       }
     },
     "BusinessOwnerInformation" : {
       "type" : "object",
       "properties" : {
-        "storesBeneficiaryAddress" : {
-          "type" : "boolean",
-          "example" : true
-        },
         "beneficiaryAddressPurpose" : {
           "type" : "array",
           "items" : {
             "type" : "string",
             "example" : "Customer Service"
           }
+        },
+        "beneficiaryAddressPurposeOther" : {
+          "type" : "string",
+          "example" : "Customer Service"
         },
         "beneficiaryAddressSource" : {
           "type" : "array",
@@ -3499,14 +3468,6 @@
           "type" : "string",
           "example" : "Medicaid Address (State)"
         },
-        "storesBankingData" : {
-          "type" : "boolean",
-          "example" : false
-        },
-        "numberOfContractorFte" : {
-          "type" : "string",
-          "example" : "100"
-        },
         "costPerYear" : {
           "type" : "string",
           "example" : "13759255.66"
@@ -3515,17 +3476,25 @@
           "type" : "boolean",
           "example" : true
         },
+        "numberOfContractorFte" : {
+          "type" : "string",
+          "example" : "100"
+        },
         "numberOfFederalFte" : {
           "type" : "string",
           "example" : "25"
         },
-        "beneficiaryAddressPurposeOther" : {
-          "type" : "string",
-          "example" : "Customer Service"
-        },
         "numberOfSupportedUsersPerMonth" : {
           "type" : "string",
           "example" : "314"
+        },
+        "storesBankingData" : {
+          "type" : "boolean",
+          "example" : false
+        },
+        "storesBeneficiaryAddress" : {
+          "type" : "boolean",
+          "example" : true
         }
       }
     },
@@ -3539,23 +3508,48 @@
             "example" : ""
           }
         },
-        "toOwnerId" : {
-          "type" : "string",
-          "example" : "326-762-0"
-        },
-        "sharedViaApi" : {
+        "containsBankingData" : {
           "type" : "boolean"
         },
-        "exchangeVersion" : {
-          "type" : "string",
-          "example" : "1"
+        "containsBeneficiaryAddress" : {
+          "type" : "boolean"
         },
-        "toOwnerName" : {
-          "type" : "string",
-          "example" : "Account Management"
+        "containsPhi" : {
+          "type" : "boolean"
         },
         "containsPii" : {
           "type" : "boolean"
+        },
+        "dataExchangeAgreement" : {
+          "type" : "string",
+          "example" : ""
+        },
+        "dataFormat" : {
+          "type" : "string",
+          "example" : ""
+        },
+        "dataFormatOther" : {
+          "type" : "string"
+        },
+        "exchangeDescription" : {
+          "type" : "string",
+          "example" : "Reference data on vendors acting on behalf of insurance issuers"
+        },
+        "exchangeEndDate" : {
+          "type" : "string",
+          "format" : "date"
+        },
+        "exchangeId" : {
+          "type" : "string",
+          "example" : "139-1178-0"
+        },
+        "exchangeName" : {
+          "type" : "string",
+          "example" : "Acumen Web Portals 1.0 >> Drug Data Processing System 1.0"
+        },
+        "exchangeRetiredDate" : {
+          "type" : "string",
+          "format" : "date"
         },
         "exchangeStartDate" : {
           "type" : "string",
@@ -3565,63 +3559,41 @@
           "type" : "string",
           "example" : "Active"
         },
-        "exchangeEndDate" : {
+        "exchangeVersion" : {
           "type" : "string",
-          "format" : "date"
+          "example" : "1"
         },
         "fromOwnerId" : {
           "type" : "string",
           "example" : "326-762-0"
         },
-        "dataExchangeAgreement" : {
-          "type" : "string",
-          "example" : ""
-        },
-        "isBeneficiaryMailingFile" : {
-          "type" : "boolean"
-        },
-        "dataFormat" : {
-          "type" : "string",
-          "example" : ""
-        },
-        "dataFormatOther" : {
-          "type" : "string"
-        },
-        "toOwnerType" : {
-          "type" : "string",
-          "enum" : [ "application", "organization" ]
-        },
-        "containsBeneficiaryAddress" : {
-          "type" : "boolean"
-        },
         "fromOwnerName" : {
           "type" : "string",
           "example" : "Account Management"
         },
-        "exchangeId" : {
+        "fromOwnerType" : {
           "type" : "string",
-          "example" : "139-1178-0"
+          "enum" : [ "application", "organization" ]
+        },
+        "isBeneficiaryMailingFile" : {
+          "type" : "boolean"
         },
         "numOfRecords" : {
           "type" : "string",
           "example" : "100,000 – 1 Million"
         },
-        "exchangeRetiredDate" : {
-          "type" : "string",
-          "format" : "date"
-        },
-        "exchangeDescription" : {
-          "type" : "string",
-          "example" : "Reference data on vendors acting on behalf of insurance issuers"
-        },
-        "containsPhi" : {
+        "sharedViaApi" : {
           "type" : "boolean"
         },
-        "exchangeName" : {
+        "toOwnerId" : {
           "type" : "string",
-          "example" : "Acumen Web Portals 1.0 >> Drug Data Processing System 1.0"
+          "example" : "326-762-0"
         },
-        "fromOwnerType" : {
+        "toOwnerName" : {
+          "type" : "string",
+          "example" : "Account Management"
+        },
+        "toOwnerType" : {
           "type" : "string",
           "enum" : [ "application", "organization" ]
         },
@@ -3640,9 +3612,6 @@
               }
             }
           }
-        },
-        "containsBankingData" : {
-          "type" : "boolean"
         }
       }
     },
@@ -3650,67 +3619,67 @@
       "type" : "object",
       "required" : [ "application", "objectId", "roleTypeId" ],
       "properties" : {
-        "assigneePhone" : {
+        "application" : {
+          "type" : "string",
+          "description" : "Application where the role assignment exists"
+        },
+        "assigneeDesc" : {
           "type" : "string"
-        },
-        "roleTypeId" : {
-          "type" : "string",
-          "description" : "ID of the role type"
-        },
-        "roleTypeDesc" : {
-          "type" : "string",
-          "description" : "Description of the role type"
-        },
-        "assigneeOrgId" : {
-          "type" : "string",
-          "description" : "ID of the role assignee, if an organization"
-        },
-        "roleId" : {
-          "type" : "string",
-          "description" : "ID of the role assignment"
-        },
-        "assigneeFirstName" : {
-          "type" : "string"
-        },
-        "assigneeUserName" : {
-          "type" : "string",
-          "description" : "Username of the role assignee, if a person"
         },
         "assigneeEmail" : {
           "type" : "string"
         },
-        "assigneeOrgName" : {
-          "type" : "string"
-        },
-        "assigneeDesc" : {
+        "assigneeFirstName" : {
           "type" : "string"
         },
         "assigneeId" : {
           "type" : "string",
           "description" : "ID of the role assignee, if a person"
         },
-        "objectType" : {
-          "type" : "string",
-          "description" : "The type of object the role is assigned to"
-        },
-        "roleTypeName" : {
-          "type" : "string",
-          "description" : "Name of the role type"
-        },
-        "application" : {
-          "type" : "string",
-          "description" : "Application where the role assignment exists"
-        },
         "assigneeLastName" : {
+          "type" : "string"
+        },
+        "assigneeOrgId" : {
+          "type" : "string",
+          "description" : "ID of the role assignee, if an organization"
+        },
+        "assigneeOrgName" : {
+          "type" : "string"
+        },
+        "assigneePhone" : {
           "type" : "string"
         },
         "assigneeType" : {
           "type" : "string",
           "enum" : [ "organization", "person" ]
         },
+        "assigneeUserName" : {
+          "type" : "string",
+          "description" : "Username of the role assignee, if a person"
+        },
         "objectId" : {
           "type" : "string",
           "description" : "ID of the object the role is assiged to"
+        },
+        "objectType" : {
+          "type" : "string",
+          "description" : "The type of object the role is assigned to"
+        },
+        "roleId" : {
+          "type" : "string",
+          "description" : "ID of the role assignment"
+        },
+        "roleTypeDesc" : {
+          "type" : "string",
+          "description" : "Description of the role type"
+        },
+        "roleTypeId" : {
+          "type" : "string",
+          "description" : "ID of the role type"
+        },
+        "roleTypeName" : {
+          "type" : "string",
+          "description" : "Name of the role type"
         }
       }
     },
@@ -3718,15 +3687,15 @@
       "type" : "object",
       "required" : [ "count" ],
       "properties" : {
-        "count" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
         "Users" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/User"
           }
+        },
+        "count" : {
+          "type" : "integer",
+          "format" : "int32"
         }
       }
     },
@@ -3734,15 +3703,15 @@
       "type" : "object",
       "required" : [ "Users", "application" ],
       "properties" : {
-        "application" : {
-          "type" : "string",
-          "enum" : [ "all", "alfabet" ]
-        },
         "Users" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/User"
           }
+        },
+        "application" : {
+          "type" : "string",
+          "enum" : [ "all", "alfabet" ]
         }
       }
     },
@@ -3750,15 +3719,15 @@
       "type" : "object",
       "required" : [ "count" ],
       "properties" : {
-        "count" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
         "Deployments" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/Deployment"
           }
+        },
+        "count" : {
+          "type" : "integer",
+          "format" : "int32"
         }
       }
     },
@@ -3782,15 +3751,15 @@
       "type" : "object",
       "required" : [ "count" ],
       "properties" : {
-        "count" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
         "Contracts" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/Contract"
           }
+        },
+        "count" : {
+          "type" : "integer",
+          "format" : "int32"
         }
       }
     },
@@ -3822,20 +3791,6 @@
         }
       }
     },
-    "DataCenterHosting" : {
-      "type" : "object",
-      "properties" : {
-        "movingToCloudDate" : {
-          "type" : "string",
-          "format" : "date",
-          "example" : "2021-10-13T00:00:00.000Z"
-        },
-        "movingToCloud" : {
-          "type" : "string",
-          "example" : "Yes"
-        }
-      }
-    },
     "AuthorityToOperateFindResponse" : {
       "type" : "object",
       "required" : [ "count" ],
@@ -3856,16 +3811,34 @@
       "type" : "object",
       "required" : [ "awardId", "id", "parentAwardId" ],
       "properties" : {
+        "awardId" : {
+          "type" : "string",
+          "example" : "HHSM500201600052I",
+          "description" : "Contract number"
+        },
         "budgetIds" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/BudgetIds"
           }
         },
-        "awardId" : {
+        "contractDeliverableId" : {
+          "type" : "string",
+          "example" : "11-22-333"
+        },
+        "description" : {
+          "type" : "string",
+          "example" : "Strategic partners acquisition readiness",
+          "description" : "Contract description"
+        },
+        "id" : {
+          "type" : "string",
+          "example" : "18-3-0"
+        },
+        "parentAwardId" : {
           "type" : "string",
           "example" : "HHSM500201600052I",
-          "description" : "Contract number"
+          "description" : "Parent contract number"
         },
         "systemId" : {
           "type" : "string",
@@ -3888,29 +3861,6 @@
             }
           }
         },
-        "contractDeliverableId" : {
-          "type" : "string",
-          "example" : "11-22-333"
-        },
-        "contractADO" : {
-          "type" : "string",
-          "example" : "yes",
-          "description" : "Is ADO Parent Contract, Yes/No"
-        },
-        "description" : {
-          "type" : "string",
-          "example" : "Strategic partners acquisition readiness",
-          "description" : "Contract description"
-        },
-        "id" : {
-          "type" : "string",
-          "example" : "18-3-0"
-        },
-        "parentAwardId" : {
-          "type" : "string",
-          "example" : "HHSM500201600052I",
-          "description" : "Parent contract number"
-        },
         "tbmItTowerCategory" : {
           "type" : "array",
           "items" : {
@@ -3932,7 +3882,13 @@
     "Person" : {
       "type" : "object",
       "properties" : {
+        "email" : {
+          "type" : "string"
+        },
         "firstName" : {
+          "type" : "string"
+        },
+        "id" : {
           "type" : "string"
         },
         "lastName" : {
@@ -3941,13 +3897,7 @@
         "phone" : {
           "type" : "string"
         },
-        "id" : {
-          "type" : "string"
-        },
         "userName" : {
-          "type" : "string"
-        },
-        "email" : {
           "type" : "string"
         }
       }
@@ -3955,15 +3905,15 @@
     "SystemVersionResponse" : {
       "type" : "object",
       "properties" : {
+        "count" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
         "ictObjects" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/IctObject"
           }
-        },
-        "count" : {
-          "type" : "integer",
-          "format" : "int32"
         }
       }
     },
@@ -3983,19 +3933,34 @@
       "type" : "object",
       "required" : [ "id", "name" ],
       "properties" : {
-        "fullPath" : {
-          "type" : "string",
-          "example" : "CMS/OA/OFM/Accounting Management Group"
-        },
-        "component" : {
-          "type" : "string",
-          "example" : "OFM"
-        },
         "Organization" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/Organization"
           }
+        },
+        "acronymn" : {
+          "type" : "string",
+          "example" : "CMS"
+        },
+        "component" : {
+          "type" : "string",
+          "example" : "OFM"
+        },
+        "description" : {
+          "type" : "string",
+          "example" : "Formerly - Business Applications Management Group"
+        },
+        "fullPath" : {
+          "type" : "string",
+          "example" : "CMS/OA/OFM/Accounting Management Group"
+        },
+        "id" : {
+          "type" : "string",
+          "example" : "261-631-0"
+        },
+        "isComponent" : {
+          "type" : "boolean"
         },
         "level" : {
           "type" : "integer",
@@ -4005,24 +3970,9 @@
           "type" : "string",
           "example" : "Centers for Medicare and Medicaid Services"
         },
-        "acronymn" : {
-          "type" : "string",
-          "example" : "CMS"
-        },
-        "description" : {
-          "type" : "string",
-          "example" : "Formerly - Business Applications Management Group"
-        },
-        "id" : {
-          "type" : "string",
-          "example" : "261-631-0"
-        },
         "parentId" : {
           "type" : "string",
           "example" : "261-631-0"
-        },
-        "isComponent" : {
-          "type" : "boolean"
         }
       }
     },
@@ -4030,25 +3980,25 @@
       "type" : "object",
       "required" : [ "application", "id" ],
       "properties" : {
-        "firstName" : {
-          "type" : "string"
-        },
-        "lastName" : {
-          "type" : "string"
-        },
         "application" : {
           "type" : "string"
         },
-        "phone" : {
+        "email" : {
+          "type" : "string"
+        },
+        "firstName" : {
           "type" : "string"
         },
         "id" : {
           "type" : "string"
         },
-        "userName" : {
+        "lastName" : {
           "type" : "string"
         },
-        "email" : {
+        "phone" : {
+          "type" : "string"
+        },
+        "userName" : {
           "type" : "string"
         }
       }
@@ -4056,14 +4006,6 @@
     "CostTypeFindResponse" : {
       "type" : "object",
       "properties" : {
-        "name" : {
-          "type" : "string",
-          "example" : "TBM Towers"
-        },
-        "id" : {
-          "type" : "string",
-          "example" : "143-16-0"
-        },
         "CostTypes" : {
           "type" : "array",
           "items" : {
@@ -4079,106 +4021,76 @@
               }
             }
           }
+        },
+        "id" : {
+          "type" : "string",
+          "example" : "143-16-0"
+        },
+        "name" : {
+          "type" : "string",
+          "example" : "TBM Towers"
         }
       }
     },
     "ComponentFindResponse" : {
       "type" : "object",
       "properties" : {
-        "responsibleUser" : {
-          "type" : "string"
-        },
         "catalog" : {
-          "type" : "string"
-        },
-        "cms_technopedia_edition" : {
-          "type" : "string"
-        },
-        "ictObject" : {
-          "type" : "string"
-        },
-        "cms_technopedia_licensable" : {
-          "type" : "string"
-        },
-        "description" : {
-          "type" : "string"
-        },
-        "cms_technopedia_release" : {
-          "type" : "string"
-        },
-        "cms_technopedia_versiongroup" : {
-          "type" : "string"
-        },
-        "platform" : {
-          "type" : "string"
-        },
-        "cms_technopedia_version" : {
-          "type" : "string"
-        },
-        "vendorProduct" : {
-          "type" : "string"
-        },
-        "cms_technopedia_servicepack" : {
-          "type" : "string"
-        },
-        "vendor" : {
-          "type" : "string"
-        },
-        "cms_technopedia_component" : {
-          "type" : "string"
-        },
-        "cms_technopedia_release_id" : {
-          "type" : "string"
-        },
-        "name" : {
-          "type" : "string"
-        },
-        "cms_technopedia_build_version" : {
           "type" : "string"
         },
         "cms_end_of_support_date" : {
           "type" : "string"
         },
+        "cms_technopedia_build_version" : {
+          "type" : "string"
+        },
+        "cms_technopedia_component" : {
+          "type" : "string"
+        },
+        "cms_technopedia_edition" : {
+          "type" : "string"
+        },
+        "cms_technopedia_licensable" : {
+          "type" : "string"
+        },
+        "cms_technopedia_release" : {
+          "type" : "string"
+        },
+        "cms_technopedia_release_id" : {
+          "type" : "string"
+        },
+        "cms_technopedia_servicepack" : {
+          "type" : "string"
+        },
+        "cms_technopedia_version" : {
+          "type" : "string"
+        },
+        "cms_technopedia_versiongroup" : {
+          "type" : "string"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "ictObject" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "platform" : {
+          "type" : "string"
+        },
+        "responsibleUser" : {
+          "type" : "string"
+        },
         "status" : {
           "type" : "string"
-        }
-      }
-    },
-    "SoftwareProductDetails" : {
-      "type" : "object",
-      "properties" : {
-        "aiPlan" : {
+        },
+        "vendor" : {
           "type" : "string"
         },
-        "systemAiTypeOther" : {
+        "vendorProduct" : {
           "type" : "string"
-        },
-        "apisDeveloped" : {
-          "type" : "string"
-        },
-        "apiFHIRUseOther" : {
-          "type" : "string"
-        },
-        "systemHasApiGateway" : {
-          "type" : "boolean"
-        },
-        "apisAccessibility" : {
-          "type" : "string"
-        },
-        "apiDataArea" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        },
-        "apiFHIRUse" : {
-          "type" : "string"
-        },
-        "systemAiType" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
         }
       }
     },
@@ -4186,31 +4098,31 @@
       "type" : "object",
       "required" : [ "urlId" ],
       "properties" : {
-        "isVersionCodeRepository" : {
-          "type" : "boolean",
-          "description" : "A boolean flag to indicate if this URL provides access to a versioned code repository?"
-        },
         "address" : {
           "type" : "string",
           "description" : "A valid and full URL"
+        },
+        "isApiEndpoint" : {
+          "type" : "boolean",
+          "description" : "A boolean flag to indicate whether URL is an API Endpoint"
+        },
+        "isBehindWebApplicationFirewall" : {
+          "type" : "boolean",
+          "description" : "A boolean flag to indicate whether the application is behind a Web Application Firewall (WAF)"
+        },
+        "isVersionCodeRepository" : {
+          "type" : "boolean",
+          "description" : "A boolean flag to indicate if this URL provides access to a versioned code repository?"
         },
         "urlHostingEnv" : {
           "type" : "string",
           "example" : "Production",
           "description" : "The hosting environment associated with a specific URL"
         },
-        "isApiEndpoint" : {
-          "type" : "boolean",
-          "description" : "A boolean flag to indicate whether URL is an API Endpoint"
-        },
         "urlId" : {
           "type" : "string",
           "example" : "218-10-0",
           "description" : "Unique key that uniquely identified the URL in database"
-        },
-        "isBehindWebApplicationFirewall" : {
-          "type" : "boolean",
-          "description" : "A boolean flag to indicate whether the application is behind a Web Application Firewall (WAF)"
         }
       }
     },
@@ -4242,11 +4154,6 @@
       "type" : "object",
       "required" : [ "projectId" ],
       "properties" : {
-        "systemId" : {
-          "type" : "string",
-          "example" : "123-45-678",
-          "description" : "System which this budget funds"
-        },
         "funding" : {
           "type" : "string",
           "example" : "Most of this funding is directly and only for this system (over 80%)",
@@ -4271,6 +4178,11 @@
           "type" : "string",
           "example" : "CMS Accountable Care Organizations",
           "description" : "Title of this project"
+        },
+        "systemId" : {
+          "type" : "string",
+          "example" : "123-45-678",
+          "description" : "System which this budget funds"
         }
       }
     },
@@ -4278,38 +4190,43 @@
       "type" : "object",
       "required" : [ "ictObjectId", "id", "name", "version" ],
       "properties" : {
+        "BusinessOwnerInformation" : {
+          "$ref" : "#/definitions/BusinessOwnerInformation"
+        },
         "SystemMaintainerInformation" : {
           "$ref" : "#/definitions/SystemMaintainerInformation"
-        },
-        "ictObjectId" : {
-          "type" : "string",
-          "example" : "326-3-0"
         },
         "acronym" : {
           "type" : "string",
           "example" : "CMSS"
         },
-        "systemMaintainerOrg" : {
+        "belongsTo" : {
           "type" : "string",
-          "example" : "OIT"
+          "example" : "326-10-0"
+        },
+        "businessOwnerOrg" : {
+          "type" : "string",
+          "example" : "Center for Medicare Management"
+        },
+        "businessOwnerOrgComp" : {
+          "type" : "string",
+          "example" : "CM-(FFS)"
         },
         "description" : {
           "type" : "string",
           "example" : "This is a CMS System decription"
         },
-        "SoftwareProductDetails" : {
-          "$ref" : "#/definitions/SoftwareProductDetails"
-        },
-        "uuid" : {
+        "ictObjectId" : {
           "type" : "string",
-          "example" : "12FFF52E-195B-4E48-9A38-669A8BD71234"
+          "example" : "326-3-0"
         },
-        "version" : {
+        "id" : {
           "type" : "string",
-          "example" : "1.0"
+          "example" : "326-2-0"
         },
-        "BusinessOwnerInformation" : {
-          "$ref" : "#/definitions/BusinessOwnerInformation"
+        "name" : {
+          "type" : "string",
+          "example" : "CMS System"
         },
         "nextVersionId" : {
           "type" : "string",
@@ -4319,40 +4236,29 @@
           "type" : "string",
           "example" : "326-3-0"
         },
-        "businessOwnerOrg" : {
-          "type" : "string",
-          "example" : "Center for Medicare Management"
-        },
-        "name" : {
-          "type" : "string",
-          "example" : "CMS System"
-        },
-        "businessOwnerOrgComp" : {
-          "type" : "string",
-          "example" : "CM-(FFS)"
-        },
-        "DataCenterHosting" : {
-          "$ref" : "#/definitions/DataCenterHosting"
-        },
-        "id" : {
-          "type" : "string",
-          "example" : "326-2-0"
-        },
         "state" : {
           "type" : "string",
           "example" : "Active"
+        },
+        "status" : {
+          "type" : "string",
+          "example" : "Approved"
+        },
+        "systemMaintainerOrg" : {
+          "type" : "string",
+          "example" : "OIT"
         },
         "systemMaintainerOrgComp" : {
           "type" : "string",
           "example" : "Enterprise Architecture and Data Group"
         },
-        "belongsTo" : {
+        "uuid" : {
           "type" : "string",
-          "example" : "326-10-0"
+          "example" : "12FFF52E-195B-4E48-9A38-669A8BD71234"
         },
-        "status" : {
+        "version" : {
           "type" : "string",
-          "example" : "Approved"
+          "example" : "1.0"
         }
       }
     },
@@ -4360,15 +4266,15 @@
       "type" : "object",
       "required" : [ "Users", "application" ],
       "properties" : {
-        "application" : {
-          "type" : "string",
-          "enum" : [ "all", "alfabet" ]
-        },
         "Users" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/User"
           }
+        },
+        "application" : {
+          "type" : "string",
+          "enum" : [ "all", "alfabet" ]
         }
       }
     },
@@ -4391,31 +4297,7 @@
     "SystemMaintainerInformation" : {
       "type" : "object",
       "properties" : {
-        "majorRefreshDate" : {
-          "type" : "string",
-          "format" : "date"
-        },
-        "yearToRetireReplace" : {
-          "type" : "string",
-          "example" : "2023"
-        },
-        "systemProductionDate" : {
-          "type" : "string",
-          "format" : "date"
-        },
-        "sourceCodeOnDemand" : {
-          "type" : "boolean",
-          "example" : true
-        },
-        "hardCodedIpAddress" : {
-          "type" : "boolean",
-          "example" : true
-        },
-        "ecapParticipation" : {
-          "type" : "boolean",
-          "example" : true
-        },
-        "systemRequirementsOnDemand" : {
+        "agileUsed" : {
           "type" : "boolean",
           "example" : true
         },
@@ -4423,7 +4305,19 @@
           "type" : "boolean",
           "example" : true
         },
-        "testScriptsOnDemand" : {
+        "deploymentFrequency" : {
+          "type" : "string",
+          "example" : "Monthly"
+        },
+        "devCompletionPercent" : {
+          "type" : "string",
+          "example" : "10-14%"
+        },
+        "devWorkDescription" : {
+          "type" : "string",
+          "example" : "The type of development work underway..."
+        },
+        "ecapParticipation" : {
           "type" : "boolean",
           "example" : true
         },
@@ -4431,27 +4325,32 @@
           "type" : "string",
           "example" : "IPv4 and IPv6"
         },
-        "devCompletionPercent" : {
+        "hardCodedIpAddress" : {
+          "type" : "boolean",
+          "example" : true
+        },
+        "ip6EnabledAssetPercent" : {
           "type" : "string",
-          "example" : "10-14%"
+          "example" : "Between 20% and 49%"
+        },
+        "ip6TransitionPlan" : {
+          "type" : "string",
+          "example" : "Yes, transition to IPv6"
+        },
+        "ipEnabledAssetCount" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 1
+        },
+        "majorRefreshDate" : {
+          "type" : "string",
+          "format" : "date"
         },
         "netAccessibility" : {
           "type" : "string",
           "example" : "Accessible to a CMS-internal network only"
         },
-        "testPlanOnDemand" : {
-          "type" : "boolean",
-          "example" : true
-        },
-        "quarterToRetireReplace" : {
-          "type" : "string",
-          "example" : "3"
-        },
-        "agileUsed" : {
-          "type" : "boolean",
-          "example" : true
-        },
-        "systemDesignOnDemand" : {
+        "omDocumentationOnDemand" : {
           "type" : "boolean",
           "example" : true
         },
@@ -4459,30 +4358,9 @@
           "type" : "string",
           "example" : "Yes - Retire and Replace"
         },
-        "ipEnabledAssetCount" : {
-          "type" : "integer",
-          "format" : "int32",
-          "example" : 1
-        },
-        "devWorkDescription" : {
+        "quarterToRetireReplace" : {
           "type" : "string",
-          "example" : "The type of development work underway..."
-        },
-        "testReportsOnDemand" : {
-          "type" : "boolean",
-          "example" : true
-        },
-        "ip6TransitionPlan" : {
-          "type" : "string",
-          "example" : "Yes, transition to IPv6"
-        },
-        "ip6EnabledAssetPercent" : {
-          "type" : "string",
-          "example" : "Between 20% and 49%"
-        },
-        "deploymentFrequency" : {
-          "type" : "string",
-          "example" : "Monthly"
+          "example" : "3"
         },
         "recordsManagementBucket" : {
           "type" : "array",
@@ -4491,13 +4369,41 @@
             "example" : "Administrative Management"
           }
         },
-        "omDocumentationOnDemand" : {
+        "sourceCodeOnDemand" : {
           "type" : "boolean",
           "example" : true
         },
         "systemCustomization" : {
           "type" : "string",
           "example" : "Less Than 20% Customization"
+        },
+        "systemDesignOnDemand" : {
+          "type" : "boolean",
+          "example" : true
+        },
+        "systemProductionDate" : {
+          "type" : "string",
+          "format" : "date"
+        },
+        "systemRequirementsOnDemand" : {
+          "type" : "boolean",
+          "example" : true
+        },
+        "testPlanOnDemand" : {
+          "type" : "boolean",
+          "example" : true
+        },
+        "testReportsOnDemand" : {
+          "type" : "boolean",
+          "example" : true
+        },
+        "testScriptsOnDemand" : {
+          "type" : "boolean",
+          "example" : true
+        },
+        "yearToRetireReplace" : {
+          "type" : "string",
+          "example" : "2023"
         }
       }
     },
@@ -4521,15 +4427,15 @@
       "type" : "object",
       "required" : [ "count" ],
       "properties" : {
-        "count" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
         "Exchanges" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/Exchange"
           }
+        },
+        "count" : {
+          "type" : "integer",
+          "format" : "int32"
         }
       }
     },
@@ -4539,6 +4445,15 @@
     "Enumeration" : {
       "type" : "object",
       "properties" : {
+        "caption" : {
+          "type" : "string"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
         "values" : {
           "type" : "array",
           "items" : {
@@ -4552,15 +4467,6 @@
               }
             }
           }
-        },
-        "name" : {
-          "type" : "string"
-        },
-        "caption" : {
-          "type" : "string"
-        },
-        "description" : {
-          "type" : "string"
         }
       }
     },
@@ -4591,23 +4497,6 @@
         }
       }
     },
-    "SoftwareProducts" : {
-      "type" : "object",
-      "properties" : {
-        "Products" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/Products"
-          }
-        },
-        "deleted" : {
-          "type" : "boolean"
-        },
-        "updated" : {
-          "type" : "boolean"
-        }
-      }
-    },
     "SupportContactAddRequest" : {
       "type" : "object",
       "required" : [ "SupportContacts" ],
@@ -4631,70 +4520,70 @@
     "Response" : {
       "type" : "object",
       "properties" : {
-        "result" : {
-          "type" : "string"
-        },
         "message" : {
           "type" : "array",
           "items" : {
             "type" : "string"
           }
+        },
+        "result" : {
+          "type" : "string"
         }
       }
     },
     "DataCenter" : {
       "type" : "object",
       "properties" : {
-        "zip" : {
+        "address1" : {
           "type" : "string",
-          "example" : "10002"
-        },
-        "endDate" : {
-          "type" : "string",
-          "format" : "date"
+          "example" : "123 main street"
         },
         "address2" : {
           "type" : "string",
           "example" : "suite 100"
         },
-        "city" : {
-          "type" : "string",
-          "example" : "New York"
-        },
-        "address1" : {
-          "type" : "string",
-          "example" : "123 main street"
-        },
-        "description" : {
-          "type" : "string"
-        },
         "addressState" : {
           "type" : "string",
           "example" : "NY"
         },
-        "version" : {
+        "city" : {
           "type" : "string",
-          "example" : "1"
+          "example" : "New York"
         },
-        "name" : {
+        "description" : {
+          "type" : "string"
+        },
+        "endDate" : {
           "type" : "string",
-          "example" : "CMS Baltimore Data Center - EDC4"
+          "format" : "date"
         },
         "id" : {
           "type" : "string",
           "example" : "55-1-0"
         },
-        "state" : {
+        "name" : {
           "type" : "string",
-          "enum" : [ "active", "planned", "retired" ]
+          "example" : "CMS Baltimore Data Center - EDC4"
         },
         "startDate" : {
           "type" : "string",
           "format" : "date"
         },
+        "state" : {
+          "type" : "string",
+          "enum" : [ "active", "planned", "retired" ]
+        },
         "status" : {
           "type" : "string",
           "enum" : [ "approved", "draft" ]
+        },
+        "version" : {
+          "type" : "string",
+          "example" : "1"
+        },
+        "zip" : {
+          "type" : "string",
+          "example" : "10002"
         }
       }
     },
@@ -4742,30 +4631,19 @@
         }
       }
     },
-    "SoftwareProductsFindResponse" : {
-      "type" : "object",
-      "properties" : {
-        "SoftwareProducts" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/SoftwareProducts"
-          }
-        }
-      }
-    },
     "StakeholderFindResponse" : {
       "type" : "object",
       "required" : [ "count" ],
       "properties" : {
-        "count" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
         "Stakeholders" : {
           "type" : "array",
           "items" : {
             "$ref" : "#/definitions/Stakeholder"
           }
+        },
+        "count" : {
+          "type" : "integer",
+          "format" : "int32"
         }
       }
     },
@@ -4776,26 +4654,26 @@
           "type" : "string",
           "description" : "ID assigned by a source system. For example, POA&M ID from CFACTS"
         },
-        "daysOpen" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
         "controlFamily" : {
           "type" : "string"
         },
-        "weaknessRiskLevel" : {
-          "type" : "string"
+        "daysOpen" : {
+          "type" : "integer",
+          "format" : "int32"
         },
         "id" : {
           "type" : "string",
           "description" : "ID assigned by CEDAR"
         },
-        "type" : {
-          "type" : "string"
-        },
         "parentId" : {
           "type" : "string",
           "description" : "ID of the object the threat is assigned to"
+        },
+        "type" : {
+          "type" : "string"
+        },
+        "weaknessRiskLevel" : {
+          "type" : "string"
         }
       }
     }

--- a/pkg/cedar/core/gen/client/budget/budget_add_parameters.go
+++ b/pkg/cedar/core/gen/client/budget/budget_add_parameters.go
@@ -61,10 +61,7 @@ func NewBudgetAddParamsWithHTTPClient(client *http.Client) *BudgetAddParams {
 */
 type BudgetAddParams struct {
 
-	/* Body.
-
-	   Budget(s) to be added to CEDAR.  This required input in a list of Budget documents.
-	*/
+	// Body.
 	Body *models.BudgetAddRequest
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/budget/budget_update_parameters.go
+++ b/pkg/cedar/core/gen/client/budget/budget_update_parameters.go
@@ -61,10 +61,7 @@ func NewBudgetUpdateParamsWithHTTPClient(client *http.Client) *BudgetUpdateParam
 */
 type BudgetUpdateParams struct {
 
-	/* Body.
-
-	   Budgets to be updated in CEDAR. This required input in a list of Budget documents (id, projectId, systemId, fundingId and funding).
-	*/
+	// Body.
 	Body *models.BudgetUpdateRequest
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/c_e_d_a_r_core_api_client.go
+++ b/pkg/cedar/core/gen/client/c_e_d_a_r_core_api_client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/organization"
 	"github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/person"
 	"github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/role"
-	"github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/software_products"
 	"github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/stakeholder"
 	"github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/support_contact"
 	"github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/system"
@@ -87,7 +86,6 @@ func New(transport runtime.ClientTransport, formats strfmt.Registry) *CEDARCoreA
 	cli.Organization = organization.New(transport, formats)
 	cli.Person = person.New(transport, formats)
 	cli.Role = role.New(transport, formats)
-	cli.SoftwareProducts = software_products.New(transport, formats)
 	cli.Stakeholder = stakeholder.New(transport, formats)
 	cli.SupportContact = support_contact.New(transport, formats)
 	cli.System = system.New(transport, formats)
@@ -164,8 +162,6 @@ type CEDARCoreAPI struct {
 
 	Role role.ClientService
 
-	SoftwareProducts software_products.ClientService
-
 	Stakeholder stakeholder.ClientService
 
 	SupportContact support_contact.ClientService
@@ -197,7 +193,6 @@ func (c *CEDARCoreAPI) SetTransport(transport runtime.ClientTransport) {
 	c.Organization.SetTransport(transport)
 	c.Person.SetTransport(transport)
 	c.Role.SetTransport(transport)
-	c.SoftwareProducts.SetTransport(transport)
 	c.Stakeholder.SetTransport(transport)
 	c.SupportContact.SetTransport(transport)
 	c.System.SetTransport(transport)

--- a/pkg/cedar/core/gen/client/component/component_add_parameters.go
+++ b/pkg/cedar/core/gen/client/component/component_add_parameters.go
@@ -61,10 +61,7 @@ func NewComponentAddParamsWithHTTPClient(client *http.Client) *ComponentAddParam
 */
 type ComponentAddParams struct {
 
-	/* Body.
-
-	   Component record to be added to Alfabet.
-	*/
+	// Body.
 	Body *models.ComponentAddRequest
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/contract/contract_add_parameters.go
+++ b/pkg/cedar/core/gen/client/contract/contract_add_parameters.go
@@ -61,10 +61,7 @@ func NewContractAddParamsWithHTTPClient(client *http.Client) *ContractAddParams 
 */
 type ContractAddParams struct {
 
-	/* Body.
-
-	   An array of Contracts to be added to CEDAR Alfabet.
-	*/
+	// Body.
 	Body *models.ContractAddRequest
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/contract/contract_update_parameters.go
+++ b/pkg/cedar/core/gen/client/contract/contract_update_parameters.go
@@ -62,10 +62,7 @@ func NewContractUpdateParamsWithHTTPClient(client *http.Client) *ContractUpdateP
 */
 type ContractUpdateParams struct {
 
-	/* Body.
-
-	   An array of contracts to be updated in Alfabet.
-	*/
+	// Body.
 	Body *models.ContractUpdateRequest
 
 	/* BudgetsOnly.

--- a/pkg/cedar/core/gen/client/deployment/deployment_add_parameters.go
+++ b/pkg/cedar/core/gen/client/deployment/deployment_add_parameters.go
@@ -61,10 +61,7 @@ func NewDeploymentAddParamsWithHTTPClient(client *http.Client) *DeploymentAddPar
 */
 type DeploymentAddParams struct {
 
-	/* Body.
-
-	   Deployment list to be added to CEDAR
-	*/
+	// Body.
 	Body *models.DeploymentAddRequest
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/deployment/deployment_update_parameters.go
+++ b/pkg/cedar/core/gen/client/deployment/deployment_update_parameters.go
@@ -61,10 +61,7 @@ func NewDeploymentUpdateParamsWithHTTPClient(client *http.Client) *DeploymentUpd
 */
 type DeploymentUpdateParams struct {
 
-	/* Body.
-
-	   Deployment list to be updated in Alfabet.
-	*/
+	// Body.
 	Body *models.DeploymentUpdateRequest
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/exchange/exchange_add_parameters.go
+++ b/pkg/cedar/core/gen/client/exchange/exchange_add_parameters.go
@@ -61,10 +61,7 @@ func NewExchangeAddParamsWithHTTPClient(client *http.Client) *ExchangeAddParams 
 */
 type ExchangeAddParams struct {
 
-	/* Body.
-
-	   Data exchange array to be added to Alfabet.
-	*/
+	// Body.
 	Body *models.ExchangeAddRequest
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/exchange/exchange_update_parameters.go
+++ b/pkg/cedar/core/gen/client/exchange/exchange_update_parameters.go
@@ -61,10 +61,7 @@ func NewExchangeUpdateParamsWithHTTPClient(client *http.Client) *ExchangeUpdateP
 */
 type ExchangeUpdateParams struct {
 
-	/* Body.
-
-	   Data exchange array to be updated in Alfabet.
-	*/
+	// Body.
 	Body *models.ExchangeUpdateRequest
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/person/person_add_parameters.go
+++ b/pkg/cedar/core/gen/client/person/person_add_parameters.go
@@ -61,10 +61,7 @@ func NewPersonAddParamsWithHTTPClient(client *http.Client) *PersonAddParams {
 */
 type PersonAddParams struct {
 
-	/* Body.
-
-	   Person information to be added to Alfabet.
-	*/
+	// Body.
 	Body *models.Person
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/person/person_update_parameters.go
+++ b/pkg/cedar/core/gen/client/person/person_update_parameters.go
@@ -61,10 +61,7 @@ func NewPersonUpdateParamsWithHTTPClient(client *http.Client) *PersonUpdateParam
 */
 type PersonUpdateParams struct {
 
-	/* Body.
-
-	   Person information to be updated in Alfabet.
-	*/
+	// Body.
 	Body *models.Person
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/role/role_add_parameters.go
+++ b/pkg/cedar/core/gen/client/role/role_add_parameters.go
@@ -61,10 +61,7 @@ func NewRoleAddParamsWithHTTPClient(client *http.Client) *RoleAddParams {
 */
 type RoleAddParams struct {
 
-	/* Body.
-
-	   Role assignment information to be added to a CEDAR application.
-	*/
+	// Body.
 	Body *models.RoleAddRequest
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/support_contact/support_contact_add_parameters.go
+++ b/pkg/cedar/core/gen/client/support_contact/support_contact_add_parameters.go
@@ -61,10 +61,7 @@ func NewSupportContactAddParamsWithHTTPClient(client *http.Client) *SupportConta
 */
 type SupportContactAddParams struct {
 
-	/* Body.
-
-	   supportContact information to be added to Alfabet.
-	*/
+	// Body.
 	Body *models.SupportContactAddRequest
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/system/system_summary_find_list_parameters.go
+++ b/pkg/cedar/core/gen/client/system/system_summary_find_list_parameters.go
@@ -82,17 +82,17 @@ type SystemSummaryFindListParams struct {
 
 	   Limits the number of systems returned. If no value is provided, the default is 1000
 
-	   Format: int32
+	   Format: int64
 	*/
-	Limit *int32
+	Limit *int64
 
 	/* Offset.
 
 	   Defines the starting position of the first record returned. If no value is provided, the default is 0
 
-	   Format: int32
+	   Format: int64
 	*/
-	Offset *int32
+	Offset *int64
 
 	/* State.
 
@@ -199,24 +199,24 @@ func (o *SystemSummaryFindListParams) SetIncludeInSurvey(includeInSurvey *bool) 
 }
 
 // WithLimit adds the limit to the system summary find list params
-func (o *SystemSummaryFindListParams) WithLimit(limit *int32) *SystemSummaryFindListParams {
+func (o *SystemSummaryFindListParams) WithLimit(limit *int64) *SystemSummaryFindListParams {
 	o.SetLimit(limit)
 	return o
 }
 
 // SetLimit adds the limit to the system summary find list params
-func (o *SystemSummaryFindListParams) SetLimit(limit *int32) {
+func (o *SystemSummaryFindListParams) SetLimit(limit *int64) {
 	o.Limit = limit
 }
 
 // WithOffset adds the offset to the system summary find list params
-func (o *SystemSummaryFindListParams) WithOffset(offset *int32) *SystemSummaryFindListParams {
+func (o *SystemSummaryFindListParams) WithOffset(offset *int64) *SystemSummaryFindListParams {
 	o.SetOffset(offset)
 	return o
 }
 
 // SetOffset adds the offset to the system summary find list params
-func (o *SystemSummaryFindListParams) SetOffset(offset *int32) {
+func (o *SystemSummaryFindListParams) SetOffset(offset *int64) {
 	o.Offset = offset
 }
 
@@ -315,12 +315,12 @@ func (o *SystemSummaryFindListParams) WriteToRequest(r runtime.ClientRequest, re
 	if o.Limit != nil {
 
 		// query param limit
-		var qrLimit int32
+		var qrLimit int64
 
 		if o.Limit != nil {
 			qrLimit = *o.Limit
 		}
-		qLimit := swag.FormatInt32(qrLimit)
+		qLimit := swag.FormatInt64(qrLimit)
 		if qLimit != "" {
 
 			if err := r.SetQueryParam("limit", qLimit); err != nil {
@@ -332,12 +332,12 @@ func (o *SystemSummaryFindListParams) WriteToRequest(r runtime.ClientRequest, re
 	if o.Offset != nil {
 
 		// query param offset
-		var qrOffset int32
+		var qrOffset int64
 
 		if o.Offset != nil {
 			qrOffset = *o.Offset
 		}
-		qOffset := swag.FormatInt32(qrOffset)
+		qOffset := swag.FormatInt64(qrOffset)
 		if qOffset != "" {
 
 			if err := r.SetQueryParam("offset", qOffset); err != nil {

--- a/pkg/cedar/core/gen/client/user/user_add_parameters.go
+++ b/pkg/cedar/core/gen/client/user/user_add_parameters.go
@@ -61,10 +61,7 @@ func NewUserAddParamsWithHTTPClient(client *http.Client) *UserAddParams {
 */
 type UserAddParams struct {
 
-	/* Body.
-
-	   User information to be added to a CEDAR application.
-	*/
+	// Body.
 	Body *models.UserAddRequest
 
 	timeout    time.Duration

--- a/pkg/cedar/core/gen/client/user/user_id_update_parameters.go
+++ b/pkg/cedar/core/gen/client/user/user_id_update_parameters.go
@@ -61,10 +61,7 @@ func NewUserIDUpdateParamsWithHTTPClient(client *http.Client) *UserIDUpdateParam
 */
 type UserIDUpdateParams struct {
 
-	/* Body.
-
-	   User information to be updated in CEDAR.
-	*/
+	// Body.
 	Body *models.UserUpdateRequest
 
 	/* ID.

--- a/pkg/cedar/core/gen/client/user/user_name_update_parameters.go
+++ b/pkg/cedar/core/gen/client/user/user_name_update_parameters.go
@@ -61,10 +61,7 @@ func NewUserNameUpdateParamsWithHTTPClient(client *http.Client) *UserNameUpdateP
 */
 type UserNameUpdateParams struct {
 
-	/* Body.
-
-	   User information to be updated in CEDAR.
-	*/
+	// Body.
 	Body *models.UserUpdateRequest
 
 	/* Username.

--- a/pkg/cedar/core/gen/models/contract.go
+++ b/pkg/cedar/core/gen/models/contract.go
@@ -28,10 +28,6 @@ type Contract struct {
 	// budget ids
 	BudgetIds []*BudgetIds `json:"budgetIds"`
 
-	// Is ADO Parent Contract, Yes/No
-	// Example: yes
-	ContractADO string `json:"contractADO,omitempty"`
-
 	// contract deliverable Id
 	// Example: 11-22-333
 	ContractDeliverableID string `json:"contractDeliverableId,omitempty"`

--- a/pkg/cedar/core/gen/models/software_product_details.go
+++ b/pkg/cedar/core/gen/models/software_product_details.go
@@ -21,7 +21,7 @@ type SoftwareProductDetails struct {
 	AiPlan string `json:"aiPlan,omitempty"`
 
 	// api data area
-	APIDataArea []string `json:"apiDataArea"`
+	APIDataArea string `json:"apiDataArea,omitempty"`
 
 	// api f h i r use
 	APIFHIRUse string `json:"apiFHIRUse,omitempty"`
@@ -36,7 +36,7 @@ type SoftwareProductDetails struct {
 	ApisDeveloped string `json:"apisDeveloped,omitempty"`
 
 	// system ai type
-	SystemAiType []string `json:"systemAiType"`
+	SystemAiType string `json:"systemAiType,omitempty"`
 
 	// system ai type other
 	SystemAiTypeOther string `json:"systemAiTypeOther,omitempty"`

--- a/pkg/cedar/core/gen/models/system_detail.go
+++ b/pkg/cedar/core/gen/models/system_detail.go
@@ -22,12 +22,6 @@ type SystemDetail struct {
 	// business owner information
 	BusinessOwnerInformation *BusinessOwnerInformation `json:"BusinessOwnerInformation,omitempty"`
 
-	// data center hosting
-	DataCenterHosting *DataCenterHosting `json:"DataCenterHosting,omitempty"`
-
-	// software product details
-	SoftwareProductDetails *SoftwareProductDetails `json:"SoftwareProductDetails,omitempty"`
-
 	// system maintainer information
 	SystemMaintainerInformation *SystemMaintainerInformation `json:"SystemMaintainerInformation,omitempty"`
 
@@ -108,14 +102,6 @@ func (m *SystemDetail) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateDataCenterHosting(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSoftwareProductDetails(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateSystemMaintainerInformation(formats); err != nil {
 		res = append(res, err)
 	}
@@ -153,44 +139,6 @@ func (m *SystemDetail) validateBusinessOwnerInformation(formats strfmt.Registry)
 				return ve.ValidateName("BusinessOwnerInformation")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("BusinessOwnerInformation")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *SystemDetail) validateDataCenterHosting(formats strfmt.Registry) error {
-	if swag.IsZero(m.DataCenterHosting) { // not required
-		return nil
-	}
-
-	if m.DataCenterHosting != nil {
-		if err := m.DataCenterHosting.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("DataCenterHosting")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("DataCenterHosting")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *SystemDetail) validateSoftwareProductDetails(formats strfmt.Registry) error {
-	if swag.IsZero(m.SoftwareProductDetails) { // not required
-		return nil
-	}
-
-	if m.SoftwareProductDetails != nil {
-		if err := m.SoftwareProductDetails.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("SoftwareProductDetails")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("SoftwareProductDetails")
 			}
 			return err
 		}
@@ -262,14 +210,6 @@ func (m *SystemDetail) ContextValidate(ctx context.Context, formats strfmt.Regis
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateDataCenterHosting(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateSoftwareProductDetails(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateSystemMaintainerInformation(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -288,38 +228,6 @@ func (m *SystemDetail) contextValidateBusinessOwnerInformation(ctx context.Conte
 				return ve.ValidateName("BusinessOwnerInformation")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("BusinessOwnerInformation")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *SystemDetail) contextValidateDataCenterHosting(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.DataCenterHosting != nil {
-		if err := m.DataCenterHosting.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("DataCenterHosting")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("DataCenterHosting")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *SystemDetail) contextValidateSoftwareProductDetails(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.SoftwareProductDetails != nil {
-		if err := m.SoftwareProductDetails.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("SoftwareProductDetails")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("SoftwareProductDetails")
 			}
 			return err
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -71,6 +71,7 @@ func Serve(config *viper.Viper) {
 		if err != nil {
 			s.logger.Fatal("Failed to parse key pair", zap.Error(err))
 		}
+		/* #nosec */
 		srv := http.Server{
 			Addr:    ":8443",
 			Handler: s,
@@ -85,6 +86,7 @@ func Serve(config *viper.Viper) {
 			s.logger.Fatal("Failed to start server on port 8443")
 		}
 	} else {
+		/* #nosec */
 		srv := http.Server{
 			Addr:    ":8080",
 			Handler: s,


### PR DESCRIPTION
New Swagger introduced in https://github.com/CMSgov/easi-app/pull/1708 has incorrect details for properties on the `SoftwareProductDetails` object; this PR reverts the Swagger file change, the old Swagger should have everything needed for using the CEDAR `/exchange` API for EASI-2167.