### PR TITLE
[NOREF] Allow builds for both 'master' and 'main'

### DIFF
--- a/.github/workflows/deploy_pipeline.yml
+++ b/.github/workflows/deploy_pipeline.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - main
 
 concurrency:
   group: deploy-pipeline

--- a/docs/adr/0018-integration-tests-third-party-apis.md
+++ b/docs/adr/0018-integration-tests-third-party-apis.md
@@ -10,7 +10,7 @@ in CI. Okta tests are out of scope.
 
 In this context, "integration test" refers to either: (1) a Cypress test
 (frontend/backend integration/end-to-end test); or (2) the backend [integration
-tests](https://github.com/CMSgov/easi-app/tree/master/pkg/integration) that run
+tests](https://github.com/CMSgov/easi-app/tree/main/pkg/integration) that run
 when invoking `easi test`. "CI environment" means the network in which our
 CircleCI containers run. "Deployed environment" means one of our AWS
 environments (development, implementation, production). The term "mock" is being
@@ -28,7 +28,7 @@ stub, fake, spy, etc.
   reduce operational and networking overhead from the CI environment.  Since a
   successful deployment to the development AWS environment is required before
   merging code, we can use the [health
-  check](https://github.com/CMSgov/easi-app/blob/master/pkg/server/health_check.go)
+  check](https://github.com/CMSgov/easi-app/blob/main/pkg/server/health_check.go)
   that runs on server start in a deployed environment as a test to prevent
   breaking changes to the CEDAR API client from being merged.
 

--- a/docs/adr/0021-audit-logging.md
+++ b/docs/adr/0021-audit-logging.md
@@ -6,7 +6,7 @@ As we try to have logs for user actions, we need to better understand where
 they live and what extent of logging we will be doing.
 
 The decision to use AWS logging tools is addressed in a previous
-[ADR](https://github.com/CMSgov/easi-app/blob/master/docs/adr/0009-logging-platform.md).
+[ADR](https://github.com/CMSgov/easi-app/blob/main/docs/adr/0009-logging-platform.md).
 We decided to use CMS Cloud Splunk because it best facilitated the requirement
 of forwarding logs to the CCIC and integrating with the CMS Cloud team.
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -137,7 +137,7 @@ writing these tests in TypeScript, there is documentation in supporting that [he
 The project is now using [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/).
  It originally started with Enzyme, and the decision was made to switch to RTL,
  so there may still be tests that have not been converted.
- (See [ADR](https://github.com/CMSgov/easi-app/blob/master/docs/adr/0028-use-react-testing-library.md)
+ (See [ADR](https://github.com/CMSgov/easi-app/blob/main/docs/adr/0028-use-react-testing-library.md)
  for reasoning)
 
 ### Code coverage
@@ -146,7 +146,7 @@ The project is now using [React Testing Library](https://testing-library.com/doc
 `yarn test:coverage`
 
 To view current Go test coverage, go to Github Actions `Run_Tests`
-on the latest master build, and search for "total coverage is."
+on the latest main build, and search for "total coverage is."
 
 There are thresholds set such that the build in Github Actions
 will fail if minimum code coverage thresholds are not met.

--- a/docs/operations/deployment_process.md
+++ b/docs/operations/deployment_process.md
@@ -1,6 +1,6 @@
 # Deploying the EASi Application
 
-EASi code changes are deployed automatically through GitHub Actions. After a merge or commit to `master`, the `build` workflow will trigger; see [`.github/workflows/build.yml`](../.github/workflows/build.yml). This will run a series of checks and tests; if all pass, the application will be automatically deployed to the [dev environment](https://dev.easi.cms.gov). If this succeeds, engineers are then allowed to deploy the application to the [impl](https://impl.easi.cms.gov), and then [prod](https://easi.cms.gov) environments.
+EASi code changes are deployed automatically through GitHub Actions. After a merge or commit to `main`, the `build` workflow will trigger; see [`.github/workflows/build.yml`](../.github/workflows/build.yml). This will run a series of checks and tests; if all pass, the application will be automatically deployed to the [dev environment](https://dev.easi.cms.gov). If this succeeds, engineers are then allowed to deploy the application to the [impl](https://impl.easi.cms.gov), and then [prod](https://easi.cms.gov) environments.
 
 Once a deployment to dev is successful, GitHub will prompt reviewers to approve a deployment to production. Any member of the `CMSgov/oddball-easi` team can approve a production deployment. (The required reviewers for each environment can be viewed in the repo's [environments page](https://github.com/CMSgov/easi-app/settings/environments).) Once a reviewer approves the deployment, the workflow will run the deployment script for that environment.
 

--- a/scripts/github-action-announce-broken-branch
+++ b/scripts/github-action-announce-broken-branch
@@ -2,9 +2,11 @@
 set -euo pipefail
 
 #####
-## Only alert on master branch
+## Only alert on main branch
 #####
-[[ $GITHUB_REF = 'refs/heads/master' ]] || exit 0
+if [ "$GITHUB_REF" != "refs/heads/master" ] && [ "$GITHUB_REF" != "refs/heads/main" ]; then
+    exit 0
+fi
 
 NOW=$(date '+%s')
 


### PR DESCRIPTION
# NOREF

## Changes and Description

- References to `master` have been modified to also allow references to `main`.

[GitHub docs on renaming `master` to `main`](https://github.com/github/renaming)

## Plan of action
1. Merge this ticket
2. Rename the default branch of this repository from `master` to `main`
3. Create a new PR that removes all references to `master`

![image](https://user-images.githubusercontent.com/15203744/183093048-02d89958-bd59-44cf-bd9f-5bc26dde30bc.png)


Once the rename is done, folks will have to do the following locally:
```bash
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

## How to test this change

- Validate that all references to the `master` branch of this repository are properly modified to allow `main` alongside `master`.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
