### PR TITLE
[EASI-2149] fixed bug causing requester obj to be overwritten for csv export

### DIFF
--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -109,7 +109,7 @@ const RequestRepository = () => {
 
   const requesterNameAndComponentColumn = {
     Header: t('intake:contactDetails.requester'),
-    accessor: 'requester',
+    accessor: 'requesterDesc',
     Cell: ({ value }: any) => {
       return value;
     }
@@ -333,7 +333,11 @@ const RequestRepository = () => {
   const csvHeaders = csvHeaderMap(t);
 
   const convertIntakesToCSV = (intakes: any[]) => {
-    return intakes.map(intake => convertIntakeToCSV(intake));
+    const csv = intakes.map(intake => convertIntakeToCSV(intake));
+    console.log('pickles');
+    console.log(csv);
+    console.log('^');
+    return csv;
   };
 
   return (

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -109,7 +109,7 @@ const RequestRepository = () => {
 
   const requesterNameAndComponentColumn = {
     Header: t('intake:contactDetails.requester'),
-    accessor: 'requesterDesc',
+    accessor: 'requesterNameAndComponent',
     Cell: ({ value }: any) => {
       return value;
     }
@@ -333,11 +333,7 @@ const RequestRepository = () => {
   const csvHeaders = csvHeaderMap(t);
 
   const convertIntakesToCSV = (intakes: any[]) => {
-    const csv = intakes.map(intake => convertIntakeToCSV(intake));
-    console.log('pickles');
-    console.log(csv);
-    console.log('^');
-    return csv;
+    return intakes.map(intake => convertIntakeToCSV(intake));
   };
 
   return (

--- a/src/components/RequestRepository/tableMap.ts
+++ b/src/components/RequestRepository/tableMap.ts
@@ -27,14 +27,14 @@ const tableMap = (tableData: SystemIntakeForm[], t: TFunction) => {
 
     // Display both the requester name and the acronym of their component
     // TODO: might be better to just save the component's acronym in the intake?
-    const requesterDesc = `${intake.requester.name}, ${getAcronymForComponent(
-      intake.requester.component
-    )}`;
+    const requesterNameAndComponent = `${
+      intake.requester.name
+    }, ${getAcronymForComponent(intake.requester.component)}`;
 
     // Override all applicable fields in intake to use i18n translations
     return {
       ...intake,
-      requesterDesc,
+      requesterNameAndComponent,
       status: statusTranslation,
       requestType: translateRequestType(intake.requestType)
     };

--- a/src/components/RequestRepository/tableMap.ts
+++ b/src/components/RequestRepository/tableMap.ts
@@ -27,14 +27,14 @@ const tableMap = (tableData: SystemIntakeForm[], t: TFunction) => {
 
     // Display both the requester name and the acronym of their component
     // TODO: might be better to just save the component's acronym in the intake?
-    const requester = `${intake.requester.name}, ${getAcronymForComponent(
+    const requesterDesc = `${intake.requester.name}, ${getAcronymForComponent(
       intake.requester.component
     )}`;
 
     // Override all applicable fields in intake to use i18n translations
     return {
       ...intake,
-      requester,
+      requesterDesc,
       status: statusTranslation,
       requestType: translateRequestType(intake.requestType)
     };

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -270,7 +270,7 @@ export const prepareSystemIntakeForApp = (
 export const convertIntakeToCSV = (intake: any) => {
   const collaboratorTeams: any = {};
   if (intake.governanceTeams.isPresent) {
-    intake.governanceTeams.teams.forEach(team => {
+    intake.governanceTeams.teams.forEach((team: any) => {
       switch (team.name) {
         case 'Technical Review Board':
           collaboratorTeams.trbCollaborator = team.collaborator;
@@ -287,8 +287,6 @@ export const convertIntakeToCSV = (intake: any) => {
     });
   }
 
-  console.log('convertIntakeToCSV');
-  console.log(intake);
   return {
     ...intake,
     ...collaboratorTeams,

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -267,7 +267,7 @@ export const prepareSystemIntakeForApp = (
   };
 };
 
-export const convertIntakeToCSV = (intake: SystemIntakeForm) => {
+export const convertIntakeToCSV = (intake: any) => {
   const collaboratorTeams: any = {};
   if (intake.governanceTeams.isPresent) {
     intake.governanceTeams.teams.forEach(team => {
@@ -287,6 +287,8 @@ export const convertIntakeToCSV = (intake: SystemIntakeForm) => {
     });
   }
 
+  console.log('convertIntakeToCSV');
+  console.log(intake);
   return {
     ...intake,
     ...collaboratorTeams,

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -267,7 +267,9 @@ export const prepareSystemIntakeForApp = (
   };
 };
 
-export const convertIntakeToCSV = (intake: any) => {
+export const convertIntakeToCSV = (
+  intake: SystemIntakeForm & { requesterNameAndComponent: string }
+) => {
   const collaboratorTeams: any = {};
   if (intake.governanceTeams.isPresent) {
     intake.governanceTeams.teams.forEach((team: any) => {


### PR DESCRIPTION
# EASI-2149

## Changes and Description

- Fixed an issue causing the system intake request object on the frontend from being overwritten by a string when rendering the requests table. This made the CSV export have missing values for requester and component, since the object containing that data was replaced by a string
- Renamed string that the frontend table uses to requesterNameAndComponent, so that no existing properties would be overwritten

<!-- Put a description here! -->

## How to test this change

Navigate to the requests page on the frontend, confirm that the requester column on the table is the same as it was before (a string, concatenating requester and component). Then click the "Download all requests as excel file" button, and confirm that the CSV file has correct values for the Requester and Component columns.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
