### PR TITLE
[NOREF] Populate System Intake Requester Email with CEDAR

### DIFF
--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -2468,16 +2468,29 @@ func (r *systemIntakeResolver) RequestName(ctx context.Context, obj *models.Syst
 
 // Requester is the resolver for the requester field.
 func (r *systemIntakeResolver) Requester(ctx context.Context, obj *models.SystemIntake) (*model.SystemIntakeRequester, error) {
-	// Only make a call to CEDAR LDAP if the EUA exists, otherwise return an empty string for the email field
-	var email string
-	if obj.EUAUserID.Valid {
-		user, err := r.service.FetchUserInfo(ctx, obj.EUAUserID.ValueOrZero())
-		if err != nil {
-			return nil, err
-		}
-		email = user.Email.String()
+	requesterWithoutEmail := &model.SystemIntakeRequester{
+		Component: obj.Component.Ptr(),
+		Email:     nil,
+		Name:      obj.Requester,
 	}
 
+	// if the EUA doesn't exist (Sharepoint imports), don't bother calling CEDAR LDAP
+	if !obj.EUAUserID.Valid {
+		return requesterWithoutEmail, nil
+	}
+
+	user, err := r.service.FetchUserInfo(ctx, obj.EUAUserID.ValueOrZero())
+	if err != nil {
+		// check if the EUA ID is just invalid in CEDAR LDAP (i.e. the requester no longer has an active EUA account)
+		if _, ok := err.(*apperrors.InvalidEUAIDError); ok {
+			return requesterWithoutEmail, nil
+		}
+
+		// error we can't handle, like being unable to communicate with CEDAR
+		return nil, err
+	}
+
+	email := user.Email.String()
 	return &model.SystemIntakeRequester{
 		Component: obj.Component.Ptr(),
 		Email:     &email,

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -2468,9 +2468,16 @@ func (r *systemIntakeResolver) RequestName(ctx context.Context, obj *models.Syst
 
 // Requester is the resolver for the requester field.
 func (r *systemIntakeResolver) Requester(ctx context.Context, obj *models.SystemIntake) (*model.SystemIntakeRequester, error) {
+	user, err := r.service.FetchUserInfo(ctx, obj.EUAUserID.ValueOrZero())
+	if err != nil {
+		return nil, err
+	}
+
+	emailAsString := user.Email.String()
+
 	return &model.SystemIntakeRequester{
 		Component: obj.Component.Ptr(),
-		Email:     obj.RequesterEmailAddress.Ptr(),
+		Email:     &emailAsString,
 		Name:      obj.Requester,
 	}, nil
 }

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -2468,16 +2468,19 @@ func (r *systemIntakeResolver) RequestName(ctx context.Context, obj *models.Syst
 
 // Requester is the resolver for the requester field.
 func (r *systemIntakeResolver) Requester(ctx context.Context, obj *models.SystemIntake) (*model.SystemIntakeRequester, error) {
-	user, err := r.service.FetchUserInfo(ctx, obj.EUAUserID.ValueOrZero())
-	if err != nil {
-		return nil, err
+	// Only make a call to CEDAR LDAP if the EUA exists, otherwise return an empty string for the email field
+	var email string
+	if obj.EUAUserID.Valid {
+		user, err := r.service.FetchUserInfo(ctx, obj.EUAUserID.ValueOrZero())
+		if err != nil {
+			return nil, err
+		}
+		email = user.Email.String()
 	}
-
-	emailAsString := user.Email.String()
 
 	return &model.SystemIntakeRequester{
 		Component: obj.Component.Ptr(),
-		Email:     &emailAsString,
+		Email:     &email,
 		Name:      obj.Requester,
 	}, nil
 }

--- a/pkg/graph/schema.resolvers_system_intake_test.go
+++ b/pkg/graph/schema.resolvers_system_intake_test.go
@@ -684,6 +684,7 @@ func (s GraphQLTestSuite) TestUpdateContactDetails() {
 				Requester struct {
 					Name      string
 					Component string
+					Email     string
 				}
 				Isso struct {
 					IsPresent bool
@@ -737,6 +738,7 @@ func (s GraphQLTestSuite) TestUpdateContactDetails() {
 					requester {
 						name
 						component
+						email
 					}
 					isso {
 						name
@@ -763,6 +765,7 @@ func (s GraphQLTestSuite) TestUpdateContactDetails() {
 
 	s.Equal(respIntake.Requester.Name, "Iama Requester")
 	s.Equal(respIntake.Requester.Component, "CMS Office 3")
+	s.Equal(respIntake.Requester.Email, "TEST@local.fake")
 
 	s.Nil(respIntake.Isso.Name.Ptr())
 	s.False(respIntake.Isso.IsPresent)

--- a/pkg/graph/schema.resolvers_system_intake_test.go
+++ b/pkg/graph/schema.resolvers_system_intake_test.go
@@ -56,6 +56,7 @@ func (s GraphQLTestSuite) TestFetchSystemIntakeQuery() {
 	businessOwnerComponent := "OIT"
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:              null.StringFrom("TEST"),
 		ProjectName:            null.StringFrom(projectName),
 		Status:                 models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType:            models.SystemIntakeRequestTypeNEW,
@@ -114,6 +115,7 @@ func (s GraphQLTestSuite) TestFetchSystemIntakeWithNotesQuery() {
 	businessOwnerComponent := "OIT"
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:              null.StringFrom("TEST"),
 		ProjectName:            null.StringFrom(projectName),
 		Status:                 models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType:            models.SystemIntakeRequestTypeNEW,
@@ -201,6 +203,7 @@ func (s GraphQLTestSuite) TestFetchSystemIntakeWithContractMonthAndYearQuery() {
 	projectName := "My cool project"
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:          null.StringFrom("TEST"),
 		ProjectName:        null.StringFrom(projectName),
 		Status:             models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType:        models.SystemIntakeRequestTypeNEW,
@@ -270,6 +273,7 @@ func (s GraphQLTestSuite) TestFetchSystemIntakeWithContractDatesQuery() {
 	contractEndDate, _ := time.Parse("2006-1-2", "2020-10-31")
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:         null.StringFrom("TEST"),
 		ProjectName:       null.StringFrom(projectName),
 		Status:            models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType:       models.SystemIntakeRequestTypeNEW,
@@ -335,6 +339,7 @@ func (s GraphQLTestSuite) TestFetchSystemIntakeWithNoCollaboratorsQuery() {
 	projectName := "My cool project"
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:                   null.StringFrom("TEST"),
 		ProjectName:                 null.StringFrom(projectName),
 		Status:                      models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType:                 models.SystemIntakeRequestTypeNEW,
@@ -392,6 +397,7 @@ func (s GraphQLTestSuite) TestFetchSystemIntakeWithCollaboratorsQuery() {
 	trbName := "My TRB Rep"
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:                   null.StringFrom("TEST"),
 		ProjectName:                 null.StringFrom(projectName),
 		Status:                      models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType:                 models.SystemIntakeRequestTypeNEW,
@@ -447,6 +453,7 @@ func (s GraphQLTestSuite) TestFetchSystemIntakeWithActionsQuery() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		ProjectName: null.StringFrom("Test Project"),
 		Status:      models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType: models.SystemIntakeRequestTypeNEW,
@@ -533,6 +540,7 @@ func (s GraphQLTestSuite) TestIssueLifecycleIDWithPassedLCID() {
 	projectName := "My cool project"
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		ProjectName: null.StringFrom(projectName),
 		Status:      models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType: models.SystemIntakeRequestTypeNEW,
@@ -591,6 +599,7 @@ func (s GraphQLTestSuite) TestIssueLifecycleIDSetNewLCID() {
 	projectName := "My cool project"
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		ProjectName: null.StringFrom(projectName),
 		Status:      models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType: models.SystemIntakeRequestTypeNEW,
@@ -654,6 +663,7 @@ func (s GraphQLTestSuite) TestUpdateContactDetails() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		Status:      models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType: models.SystemIntakeRequestTypeNEW,
 	})
@@ -761,10 +771,107 @@ func (s GraphQLTestSuite) TestUpdateContactDetails() {
 	s.False(respIntake.GovernanceTeams.IsPresent)
 }
 
+func (s GraphQLTestSuite) TestUpdateContactDetailsEmptyEUA() {
+	ctx := context.Background()
+
+	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		// EUAUserID:   null.StringFrom("TEST"),
+		Status:      models.SystemIntakeStatusINTAKESUBMITTED,
+		RequestType: models.SystemIntakeRequestTypeNEW,
+	})
+	s.NoError(intakeErr)
+
+	var resp struct {
+		UpdateSystemIntakeContactDetails struct {
+			SystemIntake struct {
+				ID            string
+				BusinessOwner struct {
+					Name      string
+					Component string
+				}
+				ProductManager struct {
+					Name      string
+					Component string
+				}
+				Requester struct {
+					Name      string
+					Component string
+				}
+				Isso struct {
+					IsPresent bool
+					Name      null.String
+				}
+				GovernanceTeams struct {
+					IsPresent bool
+					Teams     null.String
+				}
+			}
+		}
+	}
+
+	// TODO we're supposed to be able to pass variables as additional arguments using client.Var()
+	// but it wasn't working for me.
+	err := s.client.Post(fmt.Sprintf(
+		`mutation {
+			updateSystemIntakeContactDetails(input: {
+				id: "%s",
+				businessOwner: {
+					name: "Iama Businessowner",
+					component: "CMS Office 1"
+				},
+				productManager: {
+					name: "Iama Productmanager",
+					component: "CMS Office 2"
+				},
+				requester: {
+					name: "Iama Requester",
+					component: "CMS Office 3"
+				},
+				isso: {
+					isPresent: false
+					name: null
+				},
+				governanceTeams: {
+					isPresent: false
+					teams: []
+				}
+			}) {
+				systemIntake {
+					id,
+					businessOwner {
+						name
+						component
+					}
+					productManager {
+						name
+						component
+					}
+					requester {
+						name
+						component
+					}
+					isso {
+						name
+						isPresent
+					}
+					governanceTeams {
+						teams {
+							name
+						}
+						isPresent
+					}
+				}
+			}
+		}`, intake.ID), &resp)
+
+	s.Error(err)
+}
+
 func (s GraphQLTestSuite) TestUpdateContactDetailsWithISSOAndTeams() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		Status:      models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType: models.SystemIntakeRequestTypeNEW,
 	})
@@ -884,6 +991,7 @@ func (s GraphQLTestSuite) TestUpdateContactDetailsWillClearISSOAndTeams() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		Status:      models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType: models.SystemIntakeRequestTypeNEW,
 	})
@@ -994,6 +1102,7 @@ func (s GraphQLTestSuite) TestUpdateContactDetailsWillClearOneTeam() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		Status:      models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType: models.SystemIntakeRequestTypeNEW,
 	})
@@ -1114,6 +1223,7 @@ func (s GraphQLTestSuite) TestUpdateRequestDetails() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		Status:      models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType: models.SystemIntakeRequestTypeNEW,
 	})
@@ -1169,6 +1279,7 @@ func (s GraphQLTestSuite) TestUpdateContractDetails() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		Status:      models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType: models.SystemIntakeRequestTypeNEW,
 	})
@@ -1290,6 +1401,7 @@ func (s GraphQLTestSuite) TestUpdateContractDetailsRemoveFundingSource() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:       null.StringFrom("TEST"),
 		Status:          models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType:     models.SystemIntakeRequestTypeNEW,
 		ExistingFunding: null.BoolFrom(true),
@@ -1345,6 +1457,7 @@ func (s GraphQLTestSuite) TestUpdateContractDetailsRemoveCosts() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:          null.StringFrom("TEST"),
 		Status:             models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType:        models.SystemIntakeRequestTypeNEW,
 		CostIncreaseAmount: null.StringFrom("Just a little"),
@@ -1398,6 +1511,7 @@ func (s GraphQLTestSuite) TestUpdateContractDetailsRemoveContract() {
 	contractEndDate, _ := time.Parse("2006-1-2", "2020-10-31")
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:         null.StringFrom("TEST"),
 		Status:            models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType:       models.SystemIntakeRequestTypeNEW,
 		ExistingContract:  null.StringFrom("HAVE_CONTRACT"),
@@ -1488,9 +1602,9 @@ func (s GraphQLTestSuite) TestSubmitIntake() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		Status:      models.SystemIntakeStatusINTAKEDRAFT,
 		RequestType: models.SystemIntakeRequestTypeNEW,
-		EUAUserID:   null.StringFrom("TEST"),
 	})
 	s.NoError(intakeErr)
 
@@ -1524,9 +1638,9 @@ func (s GraphQLTestSuite) TestExtendLifecycleId() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		Status:      models.SystemIntakeStatusLCIDISSUED,
 		RequestType: models.SystemIntakeRequestTypeNEW,
-		EUAUserID:   null.StringFrom("TEST"),
 	})
 	s.NoError(intakeErr)
 
@@ -1651,9 +1765,9 @@ func (s GraphQLTestSuite) TestExtendLifecycleIdRequiresExpirationDate() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		Status:      models.SystemIntakeStatusLCIDISSUED,
 		RequestType: models.SystemIntakeRequestTypeNEW,
-		EUAUserID:   null.StringFrom("TEST"),
 	})
 	s.NoError(intakeErr)
 
@@ -1706,9 +1820,9 @@ func (s GraphQLTestSuite) TestExtendLifecycleIdRequiresScope() {
 	ctx := context.Background()
 
 	intake, intakeErr := s.store.CreateSystemIntake(ctx, &models.SystemIntake{
+		EUAUserID:   null.StringFrom("TEST"),
 		Status:      models.SystemIntakeStatusLCIDISSUED,
 		RequestType: models.SystemIntakeRequestTypeNEW,
-		EUAUserID:   null.StringFrom("TEST"),
 	})
 	s.NoError(intakeErr)
 

--- a/pkg/graph/schema.resolvers_system_intake_test.go
+++ b/pkg/graph/schema.resolvers_system_intake_test.go
@@ -799,6 +799,7 @@ func (s GraphQLTestSuite) TestUpdateContactDetailsEmptyEUA() {
 				Requester struct {
 					Name      string
 					Component string
+					Email     string
 				}
 				Isso struct {
 					IsPresent bool
@@ -814,7 +815,7 @@ func (s GraphQLTestSuite) TestUpdateContactDetailsEmptyEUA() {
 
 	// TODO we're supposed to be able to pass variables as additional arguments using client.Var()
 	// but it wasn't working for me.
-	err := s.client.Post(fmt.Sprintf(
+	s.client.MustPost(fmt.Sprintf(
 		`mutation {
 			updateSystemIntakeContactDetails(input: {
 				id: "%s",
@@ -852,6 +853,7 @@ func (s GraphQLTestSuite) TestUpdateContactDetailsEmptyEUA() {
 					requester {
 						name
 						component
+						email
 					}
 					isso {
 						name
@@ -867,7 +869,24 @@ func (s GraphQLTestSuite) TestUpdateContactDetailsEmptyEUA() {
 			}
 		}`, intake.ID), &resp)
 
-	s.Error(err)
+	s.Equal(intake.ID.String(), resp.UpdateSystemIntakeContactDetails.SystemIntake.ID)
+
+	respIntake := resp.UpdateSystemIntakeContactDetails.SystemIntake
+	s.Equal(respIntake.BusinessOwner.Name, "Iama Businessowner")
+	s.Equal(respIntake.BusinessOwner.Component, "CMS Office 1")
+
+	s.Equal(respIntake.ProductManager.Name, "Iama Productmanager")
+	s.Equal(respIntake.ProductManager.Component, "CMS Office 2")
+
+	s.Equal(respIntake.Requester.Name, "Iama Requester")
+	s.Equal(respIntake.Requester.Component, "CMS Office 3")
+	s.Equal(respIntake.Requester.Email, "")
+
+	s.Nil(respIntake.Isso.Name.Ptr())
+	s.False(respIntake.Isso.IsPresent)
+
+	s.Nil(respIntake.GovernanceTeams.Teams.Ptr())
+	s.False(respIntake.GovernanceTeams.IsPresent)
 }
 
 func (s GraphQLTestSuite) TestUpdateContactDetailsWithISSOAndTeams() {


### PR DESCRIPTION
# NOREF

## Changes and Description

- Modify resolver code to pull from CEDAR instead of the DB when getting a System Intake's requester' email

## How to test this change

- A test was modified for validating this behavior
- A new test was written for validating behavior when an intake with no EUAUserID is requested (should error out)

Otherwise:
- Use `scripts/dev up:backend` to start up the app's backend
- Use `scripts/dev db:seed` to seed the data
- Make the following GQL request:
```graphql
query test {
  systemIntake(id: "<SOME ID>") {
    id,
    requester {
      name
      component
      email
    }
  }
}
```

and validate that the `email` field looks correct.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
