### PR TITLE
Add newer tables to scripts/dev db:clean task

### DIFF
--- a/scripts/dev
+++ b/scripts/dev
@@ -353,6 +353,7 @@ namespace :db do
   desc "Deletes all rows from all tables"
   task :clean do
     tables = %w{
+      cedar_system_bookmarks
       accessibility_request_status_records
       accessibility_request_notes
       accessibility_request_documents

--- a/scripts/dev
+++ b/scripts/dev
@@ -363,6 +363,7 @@ namespace :db do
       estimated_lifecycle_costs
       business_cases
       grt_feedback
+      system_intake_contacts
       system_intake_funding_sources
       system_intakes
     }


### PR DESCRIPTION
No ticket, just a couple of tables that aren't currently caught by the `db:clean` task in `scripts/dev`. `system_intake_contacts` is the one that caught my eye; not deleting it causes errors if there are rows in it when we try to delete `system_intakes`, due to the foreign key relationship.