### PR TITLE
Storybook attempts

### DIFF
--- a/src/views/Help/SendFeedback/index.stories.tsx
+++ b/src/views/Help/SendFeedback/index.stories.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { ComponentMeta } from '@storybook/react';
+import { Form, Formik, FormikValues } from 'formik';
+
+import { RadioOptionGroupWithAdditionalText } from '.';
+
+export default {
+  title: 'RadioOptionGroupWithAdditionalText',
+  component: RadioOptionGroupWithAdditionalText,
+  decorators: [
+    Story => (
+      <Formik
+        initialValues={{ pet: 'BeardedDragon', petAdditionalText: '' }}
+        onSubmit={(values: FormikValues) => {}}
+      >
+        {({ values }) => (
+          <>
+            <Form>
+              <Story />
+            </Form>
+            <div className="margin-y-4 border-top">
+              <pre>{JSON.stringify(values, null, 2)}</pre>
+            </div>
+          </>
+        )}
+      </Formik>
+    )
+  ]
+} as ComponentMeta<typeof RadioOptionGroupWithAdditionalText>;
+
+export const Default = () => (
+  <RadioOptionGroupWithAdditionalText
+    name="pet"
+    fieldsetLegend="Types of exotic pets"
+    options={[
+      { key: 'bearded-dragon', value: 'BeardedDragon', text: 'Bearded Dragon' },
+      {
+        key: 'red-knee-tarantula',
+        value: 'RedKneeTarantula',
+        text: 'Red Knee Tarantula'
+      },
+      {
+        key: 'other',
+        value: 'Other',
+        text: 'Other exotic pet'
+      }
+    ]}
+    optionKeyForTextInput="other"
+    textInputLabel="What exotic pet is this?"
+  />
+);

--- a/src/views/SystemProfile/RequestCardTestScore/index.stories.tsx
+++ b/src/views/SystemProfile/RequestCardTestScore/index.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import RequestStatusTag from '.';
+
+export default {
+  title: 'RequestStatusTag',
+  component: RequestStatusTag
+} as ComponentMeta<typeof RequestStatusTag>;
+
+const Template: ComponentStory<typeof RequestStatusTag> = (args: any) => (
+  <RequestStatusTag {...args} />
+);
+
+const date = '01/01/2022';
+
+export const HundredPct = Template.bind({});
+HundredPct.storyName = 'Score = 100%';
+HundredPct.args = {
+  scorePct: 100,
+  date
+};
+
+export const LessThanHundredPct = Template.bind({});
+LessThanHundredPct.storyName = 'Score < 100%';
+LessThanHundredPct.args = {
+  scorePct: 85,
+  date
+};

--- a/src/views/SystemProfile/RequestCardTestScore/index.tsx
+++ b/src/views/SystemProfile/RequestCardTestScore/index.tsx
@@ -5,7 +5,13 @@ import {
   IconErrorOutline
 } from '@trussworks/react-uswds';
 
-export default ({ scorePct, date }: { scorePct: number; date: string }) => {
+const RequestCardTestScore = ({
+  scorePct,
+  date
+}: {
+  scorePct: number;
+  date: string;
+}) => {
   const { t } = useTranslation('systemProfile');
 
   let colorClass;
@@ -35,3 +41,5 @@ export default ({ scorePct, date }: { scorePct: number; date: string }) => {
     </div>
   );
 };
+
+export default RequestCardTestScore;


### PR DESCRIPTION
NOREF

This is an attempt to get more visibility on ui components and to get familiar with storybook features.

Components are put in to get a sense of how they can be better suited for reuse, documentation, general reference, etc.

- RequestCardTestScore
  Template args
- RadioOptionGroupWithAdditionalText
  Story decorator with formik context

These components are not necessarily the candidates to actually end up in the storybook.

# Run
`yarn storybook`

# Notes
- React component files need to export with named vars, eg
  `const Foo = () => <div/>; export default Foo`
  instead of
  `export default () => <div/>`
  so that storybook can do its magic to properly wire things up, such as component property type descriptions