### PR TITLE
Help footer behind authenticated

### DIFF
--- a/src/components/Footer/index.test.tsx
+++ b/src/components/Footer/index.test.tsx
@@ -1,10 +1,25 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+import { render } from '@testing-library/react';
 
 import Footer from './index';
 
+jest.mock('@okta/okta-react', () => ({
+  useOktaAuth: () => {
+    return {
+      authState: {
+        isAuthenticated: true
+      }
+    };
+  }
+}));
+
 describe('The Footer component', () => {
   it('renders without crashing', () => {
-    shallow(<Footer />);
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>
+    );
   });
 });

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useOktaAuth } from '@okta/okta-react';
 import { Footer as UswdsFooter, FooterNav } from '@trussworks/react-uswds';
 
 import HelpFooter from 'components/HelpFooter';
@@ -11,6 +12,7 @@ import './index.scss';
 
 const Footer = () => {
   const { t } = useTranslation('footer');
+  const { authState } = useOktaAuth();
   const footerNavLinks = [
     {
       label: t('labels.privacy'),
@@ -34,7 +36,7 @@ const Footer = () => {
       size="slim"
       primary={
         <>
-          <HelpFooter />
+          {authState?.isAuthenticated && <HelpFooter />}
           <div className="usa-footer__primary-container grid-row">
             <div className="mobile-lg:grid-col-8">
               <FooterNav


### PR DESCRIPTION
Patch to put the HelpFooter component behind okta's isAuthenticated.

The help footer is visible after signing in.

Also updates the test to use rtl instead of enzyme.