### PR TITLE
EASI-2154 Incorrect Date Validation - Contract Start/End

### DIFF
--- a/src/validations/systemIntakeSchema.test.ts
+++ b/src/validations/systemIntakeSchema.test.ts
@@ -1,0 +1,53 @@
+import SystemIntakeValidationSchema from './systemIntakeSchema';
+
+describe('System intake validation', () => {
+  it.each([
+    { month: '01', day: '20', year: '1999' },
+    { month: '12', day: '9', year: '2000' }
+  ])('accepts valid start and end dates: %j', async date => {
+    await Promise.all(
+      ['HAVE_CONTRACT', 'IN_PROGRESS'].map(async hasContract => {
+        await expect(
+          SystemIntakeValidationSchema.contractDetails.validateAt(
+            'contract.startDate',
+            { contract: { hasContract, startDate: date } }
+          )
+        ).resolves.toBeDefined();
+        await expect(
+          SystemIntakeValidationSchema.contractDetails.validateAt(
+            'contract.endDate',
+            { contract: { hasContract, endDate: date } }
+          )
+        ).resolves.toBeDefined();
+      })
+    );
+  });
+
+  it.each([
+    { month: '1', day: '20', year: '99' },
+    { month: '', day: '', year: '' },
+    { month: '12', year: '2000' },
+    { day: '20', year: '99' },
+    { month: '1', day: '20' },
+    { month: '12', day: '99', year: '2000' },
+    { month: '99', day: '20', year: '2000' },
+    { month: 'f', day: 'o', year: 'o' }
+  ])('catches invalid start and end dates: %j', async date => {
+    await Promise.all(
+      ['HAVE_CONTRACT', 'IN_PROGRESS'].map(async hasContract => {
+        await expect(
+          SystemIntakeValidationSchema.contractDetails.validateAt(
+            'contract.startDate',
+            { contract: { hasContract, startDate: date } }
+          )
+        ).rejects.toThrow();
+        await expect(
+          SystemIntakeValidationSchema.contractDetails.validateAt(
+            'contract.endDate',
+            { contract: { hasContract, endDate: date } }
+          )
+        ).rejects.toThrow();
+      })
+    );
+  });
+});

--- a/src/validations/systemIntakeSchema.ts
+++ b/src/validations/systemIntakeSchema.ts
@@ -122,9 +122,16 @@ const SystemIntakeValidationSchema: any = {
         then: Yup.object().shape({
           month: Yup.string()
             .trim()
+            .matches(/\d{1,2}/, 'Please enter a valid start month')
             .required('Tell us the contract start month'),
-          day: Yup.string().trim().required('Tell us the contract start day'),
-          year: Yup.string().trim().required('Tell us the contract start year'),
+          day: Yup.string()
+            .trim()
+            .matches(/\d{1,2}/, 'Please enter a valid start day')
+            .required('Tell us the contract start day'),
+          year: Yup.string()
+            .trim()
+            .matches(/\d{4}/, 'Please enter a valid start year')
+            .required('Tell us the contract start year'),
           validDate: Yup.string().when(['month', 'day', 'year'], {
             is: (month: string, day: string, year: string) => {
               if (
@@ -149,9 +156,18 @@ const SystemIntakeValidationSchema: any = {
       endDate: Yup.mixed().when('hasContract', {
         is: (val: string) => ['HAVE_CONTRACT', 'IN_PROGRESS'].includes(val),
         then: Yup.object().shape({
-          month: Yup.string().trim().required('Tell us the contract end month'),
-          day: Yup.string().trim().required('Tell us the contract end day'),
-          year: Yup.string().trim().required('Tell us the contract end year'),
+          month: Yup.string()
+            .trim()
+            .matches(/\d{1,2}/, 'Please enter a valid end month')
+            .required('Tell us the contract end month'),
+          day: Yup.string()
+            .trim()
+            .matches(/\d{1,2}/, 'Please enter a valid end day')
+            .required('Tell us the contract end day'),
+          year: Yup.string()
+            .trim()
+            .matches(/\d{4}/, 'Please enter a valid end year')
+            .required('Tell us the contract end year'),
           validDate: Yup.string().when(['month', 'day', 'year'], {
             is: (month: string, day: string, year: string) => {
               if (


### PR DESCRIPTION
# EASI-2154

## Changes and Description

Proper date validation for contract start & end fields

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
- Jest run `systemIntakeSchema`
- Qa the form field for dates [seen here](https://jiraent.cms.gov/secure/attachment/536240/Screen%20Shot%202022-06-30%20at%2010.28.00%20AM.png)
  - Single digit years used to pass validation. It shouldn't anymore.
