### PR TITLE
EASI-2311 Handle nans in `formatContractDetailsPayload`

### DIFF
--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -104,16 +104,16 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
 
   const formatContractDetailsPayload = (values: ContractDetailsForm) => {
     const startDate = DateTime.fromObject({
-      day: Number(values.contract.startDate.day),
-      month: Number(values.contract.startDate.month),
-      year: Number(values.contract.startDate.year),
+      day: Number(values.contract.startDate.day) || 0,
+      month: Number(values.contract.startDate.month) || 0,
+      year: Number(values.contract.startDate.year) || 0,
       zone: 'UTC'
     }).toISO();
 
     const endDate = DateTime.fromObject({
-      day: Number(values.contract.endDate.day),
-      month: Number(values.contract.endDate.month),
-      year: Number(values.contract.endDate.year),
+      day: Number(values.contract.endDate.day) || 0,
+      month: Number(values.contract.endDate.month) || 0,
+      year: Number(values.contract.endDate.year) || 0,
       zone: 'UTC'
     }).toISO();
 


### PR DESCRIPTION
# EASI-2311

## Changes and Description

Fix some date fields in system intake contract detail form step so that word characters don't crash the render.

Originally thought to do this with intersecting an onChange handle to only return numbers from a string, but since input elements are tied up with formik, it ended up easier to handle nans in the formatting function that gets called on auto-saves.

<!-- Put a description here! -->

## How to test this change

Detail of reproduction steps to qa and test in [ticket](https://jiraent.cms.gov/browse/EASI-2311).
