### PR TITLE
Easi 2323/trb request table and gql (#1760)

### DIFF
--- a/cmd/devdata/main.go
+++ b/cmd/devdata/main.go
@@ -171,6 +171,22 @@ func main() {
 	makeBusinessCase("With LCID Issued", logger, store, intake, func(c *models.BusinessCase) {
 		c.Status = models.BusinessCaseStatusCLOSED
 	})
+
+	makeTRBRequest(models.TRBTNeedHelp, logger, store, func(t *models.TRBRequest) {
+		t.ID = uuid.MustParse("1afc9242-f244-47a3-9f91-4d6fedd8eb91")
+		t.Name = "My excellent question"
+	})
+
+	makeTRBRequest(models.TRBTFormalReview, logger, store, func(t *models.TRBRequest) {
+		t.ID = uuid.MustParse("9841c768-bdcd-4856-bae2-62cfdaffacf6")
+		t.Name = "TACO Review"
+		t.CreatedBy = "TACO"
+	})
+	makeTRBRequest(models.TRBTFormalReview, logger, store, func(t *models.TRBRequest) {
+		t.ID = uuid.MustParse("21f175b9-bcbe-41c1-9c07-9844869bc1ce")
+		t.Name = "Archived Request"
+		t.Archived = true
+	})
 }
 
 func makeSystemIntake(name string, logger *zap.Logger, store *storage.Store, callbacks ...func(*models.SystemIntake)) *models.SystemIntake {
@@ -373,4 +389,15 @@ func must(_ interface{}, err error) {
 func date(year, month, day int) *time.Time {
 	date := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
 	return &date
+}
+
+func makeTRBRequest(rType models.TRBRequestType, logger *zap.Logger, store *storage.Store, callbacks ...func(*models.TRBRequest)) *models.TRBRequest {
+	trb := models.NewTRBRequest("EASI")
+	trb.Type = rType
+	trb.Status = models.TRBSOpen
+	for _, cb := range callbacks {
+		cb(trb)
+	}
+	ret, _ := store.TRBRequestCreate(logger, trb)
+	return ret
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible
 	github.com/lib/pq v1.10.3
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/okta/okta-jwt-verifier-golang v1.3.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pquerna/otp v1.3.0
@@ -71,7 +72,6 @@ require (
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matryer/moq v0.2.7 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect

--- a/migrations/V116__Add_TRB_Request.sql
+++ b/migrations/V116__Add_TRB_Request.sql
@@ -1,0 +1,23 @@
+CREATE TYPE TRB_REQUEST_TYPE AS ENUM (
+    'NEED_HELP',
+    'BRAINSTORM',
+    'FOLLOWUP',
+    'FORMAL_REVIEW'
+);
+
+CREATE TYPE TRB_REQUEST_STATUS AS ENUM (
+    'OPEN',
+    'CLOSED'
+);
+
+CREATE TABLE trb_request (
+    id UUID PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    archived BOOL NOT NULL DEFAULT FALSE,
+    type TRB_REQUEST_TYPE NOT NULL, 
+    status TRB_REQUEST_STATUS NOT NULL DEFAULT 'OPEN',
+    created_by TEXT NOT NULL CHECK (created_by ~ '^[A-Z0-9]{4}$'),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_by TEXT CHECK (modified_by ~ '^[A-Z0-9]{4}$'),
+    modified_at TIMESTAMP WITH TIME ZONE
+);

--- a/pkg/applychanges/apply_changes.go
+++ b/pkg/applychanges/apply_changes.go
@@ -1,0 +1,78 @@
+package applychanges
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/mitchellh/mapstructure"
+)
+
+// sanitizeChanges performs some pre-processing of the changes map for "known" cases that we'd like to handle.
+// Currently, these include:
+// - Empty strings are converted to nil
+// - Empty slices are converted to nil
+func sanitizeChanges(changes map[string]interface{}) {
+	for key, value := range changes {
+		// Get the reflect value for type comparisons
+		reflectValue := reflect.ValueOf(value)
+
+		// String operations
+		if reflectValue.Kind() == reflect.String {
+			valAsString, ok := reflectValue.Interface().(string)
+
+			// Convert empty strings to `nil`
+			if ok && len(valAsString) == 0 {
+				changes[key] = nil
+				continue
+			}
+		}
+
+		// Empty slices don't play well with mapstructure, as they enter as []interface{}
+		// which promptly gets ignored by mapstructure.
+		// In order to get around this, we'll convert empty slices to a real "nil" value
+		if reflectValue.Kind() == reflect.Slice && reflectValue.IsNil() {
+			changes[key] = nil
+		}
+	}
+}
+
+// ApplyChanges applies arbitrary changes from a map to a struct. Any field not mentioned in the changes object will remain the same
+// Code largely copied from GQLGen's docs on changesets
+// https://gqlgen.com/reference/changesets/
+func ApplyChanges(changes map[string]interface{}, to interface{}) error {
+	sanitizeChanges(changes)
+
+	// Set up the decoder. This is almost exactly ripped from https://gqlgen.com/reference/changesets/
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		ErrorUnused: true,
+		TagName:     "json",
+		Result:      to,
+		ZeroFields:  true,
+		Squash:      true,
+		// This is needed to get mapstructure to call the gqlgen unmarshaler func for custom scalars (eg Date)
+		DecodeHook: func(a reflect.Type, b reflect.Type, v interface{}) (interface{}, error) {
+			// If the destination is a time.Time and we need to parse it from a string
+			if b == reflect.TypeOf(time.Time{}) && a == reflect.TypeOf("") {
+				t, err := time.Parse(time.RFC3339Nano, v.(string))
+				return t, err
+			}
+
+			// If the desination implements graphql.Unmarshaler
+			if reflect.PtrTo(b).Implements(reflect.TypeOf((*graphql.Unmarshaler)(nil)).Elem()) {
+				resultType := reflect.New(b)
+				result := resultType.MethodByName("UnmarshalGQL").Call([]reflect.Value{reflect.ValueOf(v)})
+				err, _ := result[0].Interface().(error)
+				return resultType.Elem().Interface(), err
+			}
+
+			return v, nil
+		},
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return dec.Decode(changes)
+}

--- a/pkg/applychanges/apply_changes_test.go
+++ b/pkg/applychanges/apply_changes_test.go
@@ -1,0 +1,136 @@
+package applychanges
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+type Person struct {
+	Name      string   `json:"name"`
+	Age       int      `json:"age"`
+	Nicknames []string `json:"nicknames"`
+}
+
+func TestApplyChanges(t *testing.T) {
+	clay := Person{"Clay", 27, []string{"Clayboy", "Claysadilla"}}
+
+	clayChanges := map[string]interface{}{
+		"age": 28,
+	}
+	err := ApplyChanges(clayChanges, &clay)
+	if err != nil {
+		t.Errorf("ApplyChanges failed: %s", err)
+	}
+	assert.Equal(t, "Clay", clay.Name)
+	assert.Equal(t, 28, clay.Age)
+	assert.Equal(t, []string{"Clayboy", "Claysadilla"}, clay.Nicknames)
+
+	clayChanges = map[string]interface{}{
+		"nicknames": []string{},
+	}
+	err = ApplyChanges(clayChanges, &clay)
+	if err != nil {
+		t.Errorf("ApplyChanges failed: %s", err)
+	}
+	assert.Equal(t, "Clay", clay.Name)
+	assert.Equal(t, 28, clay.Age)
+	assert.Equal(t, []string{}, clay.Nicknames)
+
+	clayChanges = map[string]interface{}{
+		"nicknames": []string{"Clayson the Wise"},
+		"age":       50,
+	}
+	err = ApplyChanges(clayChanges, &clay)
+	if err != nil {
+		t.Errorf("ApplyChanges failed: %s", err)
+	}
+	assert.Equal(t, "Clay", clay.Name)
+	assert.Equal(t, 50, clay.Age)
+	assert.Equal(t, []string{"Clayson the Wise"}, clay.Nicknames)
+}
+
+type PersonWithPointer struct {
+	Name   string  `json:"name"`
+	Parent *string `json:"parent"`
+}
+
+func TestApplyChangesEmptyString(t *testing.T) {
+	mom := "Mom"
+	son := PersonWithPointer{Name: "Son", Parent: &mom}
+
+	sonChanges := map[string]interface{}{
+		"parent": "",
+	}
+	err := ApplyChanges(sonChanges, &son)
+	if err != nil {
+		t.Errorf("ApplyChanges failed: %s", err)
+	}
+	assert.Equal(t, "Son", son.Name)
+	assert.Nil(t, son.Parent) // should set to nil
+}
+
+type AwkwardFirstDate struct {
+	WhenStarted time.Time `json:"whenStarted"`
+	WhenEnded   time.Time `json:"whenEnded"`
+	DidHaveFun  bool      `json:"didHaveFun"`
+}
+
+func TestApplyChangesWithTime(t *testing.T) {
+	fd := AwkwardFirstDate{
+		WhenStarted: time.Now(),
+		WhenEnded:   time.Now(),
+		DidHaveFun:  false,
+	}
+
+	fdChanges := map[string]interface{}{
+		"whenStarted": time.Date(2022, 5, 8, 18, 0, 0, 0, time.UTC), // should work with 'time.Time's
+		"whenEnded":   "2022-05-08T21:00:00Z",                       // and should work with strings in time.RFC3339Nano format
+	}
+	err := ApplyChanges(fdChanges, &fd)
+	if err != nil {
+		t.Errorf("ApplyChanges failed: %s", err)
+	}
+	assert.Equal(t, time.Date(2022, 5, 8, 18, 0, 0, 0, time.UTC), fd.WhenStarted)
+	assert.Equal(t, time.Date(2022, 5, 8, 21, 0, 0, 0, time.UTC), fd.WhenEnded)
+	assert.Equal(t, false, fd.DidHaveFun)
+
+	fdChanges = map[string]interface{}{
+		"didHaveFun": true,
+	}
+	err = ApplyChanges(fdChanges, &fd)
+	if err != nil {
+		t.Errorf("ApplyChanges failed: %s", err)
+	}
+	assert.Equal(t, time.Date(2022, 5, 8, 18, 0, 0, 0, time.UTC), fd.WhenStarted)
+	assert.Equal(t, time.Date(2022, 5, 8, 21, 0, 0, 0, time.UTC), fd.WhenEnded)
+	assert.Equal(t, true, fd.DidHaveFun)
+}
+
+type PersonWithUUID struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
+// TestApplyChangesUUID tests that ApplyChanges works with UUIDs
+// Note that this isn't how GQL passes UUIDs to resolvers, but is something we hackily use
+// in tests to modify the ID of an entity.
+func TestApplyChangesUUID(t *testing.T) {
+	clay := PersonWithUUID{uuid.MustParse("cfe0965f-aa95-4ade-af54-838a85cc6644"), "Clay"}
+
+	// decodeData, decodeErr := hex.DecodeString("02a9920eb0154de38e32fb965ac4653c")
+	// if decodeErr != nil {
+	// 	t.Errorf("Failed to decode UUID: %s", decodeErr)
+	// }
+	clayChanges := map[string]interface{}{
+		"id": []byte{0x2, 0xa9, 0x92, 0xe, 0xb0, 0x15, 0x4d, 0xe3, 0x8e, 0x32, 0xfb, 0x96, 0x5a, 0xc4, 0x65, 0x3c},
+	}
+	err := ApplyChanges(clayChanges, &clay)
+	if err != nil {
+		t.Errorf("ApplyChanges failed: %s", err)
+	}
+	assert.Equal(t, "02a9920e-b015-4de3-8e32-fb965ac4653c", clay.ID.String())
+	assert.Equal(t, "Clay", clay.Name)
+}

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -502,6 +502,7 @@ type ComplexityRoot struct {
 		CreateSystemIntakeActionSendEmail                func(childComplexity int, input model.BasicActionInput) int
 		CreateSystemIntakeContact                        func(childComplexity int, input model.CreateSystemIntakeContactInput) int
 		CreateSystemIntakeNote                           func(childComplexity int, input model.CreateSystemIntakeNoteInput) int
+		CreateTRBRequest                                 func(childComplexity int, requestType models.TRBRequestType) int
 		CreateTestDate                                   func(childComplexity int, input model.CreateTestDateInput) int
 		DeleteAccessibilityRequest                       func(childComplexity int, input model.DeleteAccessibilityRequestInput) int
 		DeleteAccessibilityRequestDocument               func(childComplexity int, input model.DeleteAccessibilityRequestDocumentInput) int
@@ -526,6 +527,7 @@ type ComplexityRoot struct {
 		UpdateSystemIntakeLinkedContract                 func(childComplexity int, input model.UpdateSystemIntakeLinkedContractInput) int
 		UpdateSystemIntakeRequestDetails                 func(childComplexity int, input model.UpdateSystemIntakeRequestDetailsInput) int
 		UpdateSystemIntakeReviewDates                    func(childComplexity int, input model.UpdateSystemIntakeReviewDatesInput) int
+		UpdateTRBRequest                                 func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
 		UpdateTestDate                                   func(childComplexity int, input model.UpdateTestDateInput) int
 	}
 
@@ -547,6 +549,8 @@ type ComplexityRoot struct {
 		SystemIntake             func(childComplexity int, id uuid.UUID) int
 		SystemIntakeContacts     func(childComplexity int, id uuid.UUID) int
 		Systems                  func(childComplexity int, after *string, first int) int
+		TrbRequest               func(childComplexity int, id uuid.UUID) int
+		TrbRequestCollection     func(childComplexity int, archived bool) int
 		Urls                     func(childComplexity int, cedarSystemID string) int
 	}
 
@@ -737,6 +741,18 @@ type ComplexityRoot struct {
 		Component func(childComplexity int) int
 		Email     func(childComplexity int) int
 		Name      func(childComplexity int) int
+	}
+
+	TRBRequest struct {
+		Archived   func(childComplexity int) int
+		CreatedAt  func(childComplexity int) int
+		CreatedBy  func(childComplexity int) int
+		ID         func(childComplexity int) int
+		ModifiedAt func(childComplexity int) int
+		ModifiedBy func(childComplexity int) int
+		Name       func(childComplexity int) int
+		Status     func(childComplexity int) int
+		Type       func(childComplexity int) int
 	}
 
 	TestDate struct {
@@ -962,6 +978,8 @@ type MutationResolver interface {
 	SendFeedbackEmail(ctx context.Context, input model.SendFeedbackEmailInput) (*string, error)
 	SendCantFindSomethingEmail(ctx context.Context, input model.SendCantFindSomethingEmailInput) (*string, error)
 	SendReportAProblemEmail(ctx context.Context, input model.SendReportAProblemEmailInput) (*string, error)
+	CreateTRBRequest(ctx context.Context, requestType models.TRBRequestType) (*models.TRBRequest, error)
+	UpdateTRBRequest(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.TRBRequest, error)
 }
 type QueryResolver interface {
 	AccessibilityRequest(ctx context.Context, id uuid.UUID) (*models.AccessibilityRequest, error)
@@ -982,6 +1000,8 @@ type QueryResolver interface {
 	Urls(ctx context.Context, cedarSystemID string) ([]*models.CedarURL, error)
 	CedarSystemDetails(ctx context.Context, cedarSystemID string) (*models.CedarSystemDetails, error)
 	SystemIntakeContacts(ctx context.Context, id uuid.UUID) (*model.SystemIntakeContactsPayload, error)
+	TrbRequest(ctx context.Context, id uuid.UUID) (*models.TRBRequest, error)
+	TrbRequestCollection(ctx context.Context, archived bool) ([]*models.TRBRequest, error)
 }
 type SystemIntakeResolver interface {
 	Actions(ctx context.Context, obj *models.SystemIntake) ([]*model.SystemIntakeAction, error)
@@ -3289,6 +3309,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.CreateSystemIntakeNote(childComplexity, args["input"].(model.CreateSystemIntakeNoteInput)), true
 
+	case "Mutation.createTRBRequest":
+		if e.complexity.Mutation.CreateTRBRequest == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createTRBRequest_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateTRBRequest(childComplexity, args["requestType"].(models.TRBRequestType)), true
+
 	case "Mutation.createTestDate":
 		if e.complexity.Mutation.CreateTestDate == nil {
 			break
@@ -3577,6 +3609,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.UpdateSystemIntakeReviewDates(childComplexity, args["input"].(model.UpdateSystemIntakeReviewDatesInput)), true
 
+	case "Mutation.updateTRBRequest":
+		if e.complexity.Mutation.UpdateTRBRequest == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateTRBRequest_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateTRBRequest(childComplexity, args["id"].(uuid.UUID), args["changes"].(map[string]interface{})), true
+
 	case "Mutation.updateTestDate":
 		if e.complexity.Mutation.UpdateTestDate == nil {
 			break
@@ -3777,6 +3821,30 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Systems(childComplexity, args["after"].(*string), args["first"].(int)), true
+
+	case "Query.trbRequest":
+		if e.complexity.Query.TrbRequest == nil {
+			break
+		}
+
+		args, err := ec.field_Query_trbRequest_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.TrbRequest(childComplexity, args["id"].(uuid.UUID)), true
+
+	case "Query.trbRequestCollection":
+		if e.complexity.Query.TrbRequestCollection == nil {
+			break
+		}
+
+		args, err := ec.field_Query_trbRequestCollection_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.TrbRequestCollection(childComplexity, args["archived"].(bool)), true
 
 	case "Query.urls":
 		if e.complexity.Query.Urls == nil {
@@ -4629,6 +4697,69 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.SystemIntakeRequester.Name(childComplexity), true
+
+	case "TRBRequest.archived":
+		if e.complexity.TRBRequest.Archived == nil {
+			break
+		}
+
+		return e.complexity.TRBRequest.Archived(childComplexity), true
+
+	case "TRBRequest.createdAt":
+		if e.complexity.TRBRequest.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.TRBRequest.CreatedAt(childComplexity), true
+
+	case "TRBRequest.createdBy":
+		if e.complexity.TRBRequest.CreatedBy == nil {
+			break
+		}
+
+		return e.complexity.TRBRequest.CreatedBy(childComplexity), true
+
+	case "TRBRequest.id":
+		if e.complexity.TRBRequest.ID == nil {
+			break
+		}
+
+		return e.complexity.TRBRequest.ID(childComplexity), true
+
+	case "TRBRequest.modifiedAt":
+		if e.complexity.TRBRequest.ModifiedAt == nil {
+			break
+		}
+
+		return e.complexity.TRBRequest.ModifiedAt(childComplexity), true
+
+	case "TRBRequest.modifiedBy":
+		if e.complexity.TRBRequest.ModifiedBy == nil {
+			break
+		}
+
+		return e.complexity.TRBRequest.ModifiedBy(childComplexity), true
+
+	case "TRBRequest.name":
+		if e.complexity.TRBRequest.Name == nil {
+			break
+		}
+
+		return e.complexity.TRBRequest.Name(childComplexity), true
+
+	case "TRBRequest.status":
+		if e.complexity.TRBRequest.Status == nil {
+			break
+		}
+
+		return e.complexity.TRBRequest.Status(childComplexity), true
+
+	case "TRBRequest.type":
+		if e.complexity.TRBRequest.Type == nil {
+			break
+		}
+
+		return e.complexity.TRBRequest.Type(childComplexity), true
 
 	case "TestDate.date":
 		if e.complexity.TestDate.Date == nil {
@@ -6359,6 +6490,31 @@ input SendReportAProblemEmailInput {
   howSevereWasTheProblem: String!
 }
 
+type TRBRequest {
+    id: UUID!
+    name: String!
+    archived: Boolean!
+    type: TRBRequestType!
+    status: TRBRequestStatus!
+
+    createdBy: String!
+    createdAt: Time!
+    modifiedBy: String
+    modifiedAt: Time
+}
+
+"""
+TRBRequestChanges represents the possible changes you can make to a trb request when updating it.
+Fields explicitly set with NULL will be unset, and omitted fields will be left unchanged.
+https://gqlgen.com/reference/changesets/
+"""
+input TRBRequestChanges @goModel(model: "map[string]interface{}") {
+    name: String
+    archived: Boolean
+    type: TRBRequestType
+    status: TRBRequestStatus 
+}
+
 """
 Defines the mutations for the schema
 """
@@ -6466,6 +6622,10 @@ type Mutation {
   sendFeedbackEmail(input: SendFeedbackEmailInput!): String
   sendCantFindSomethingEmail(input: SendCantFindSomethingEmailInput!): String
   sendReportAProblemEmail(input: SendReportAProblemEmailInput!): String
+  
+  createTRBRequest(requestType: TRBRequestType!): TRBRequest!
+  
+  updateTRBRequest(id: UUID!, changes: TRBRequestChanges): TRBRequest!
 }
 
 """
@@ -6493,8 +6653,20 @@ type Query {
   urls(cedarSystemId: String!): [CedarURL!]!
   cedarSystemDetails(cedarSystemId: String!): CedarSystemDetails
   systemIntakeContacts(id: UUID!): SystemIntakeContactsPayload!
+  trbRequest(id: UUID!): TRBRequest!
+  trbRequestCollection(archived: Boolean! = false): [TRBRequest!]!
+}
+enum TRBRequestType {
+  NEED_HELP
+  BRAINSTORM
+  FOLLOWUP
+  FORMAL_REVIEW
 }
 
+enum TRBRequestStatus {
+  OPEN
+  CLOSED
+}
 """
 UUIDs are represented using 36 ASCII characters, for example B0511859-ADE6-4A67-8969-16EC280C0E1A
 """
@@ -6511,6 +6683,13 @@ Email addresses are represented as strings
 scalar EmailAddress
 
 directive @hasRole(role: Role!) on FIELD_DEFINITION
+
+# https://gqlgen.com/config/#inline-config-with-directives
+directive @goModel(
+  model: String
+  models: [String!]
+) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
+
 
 """
 A user role associated with a job code
@@ -6846,6 +7025,21 @@ func (ec *executionContext) field_Mutation_createSystemIntake_args(ctx context.C
 		}
 	}
 	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_createTRBRequest_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 models.TRBRequestType
+	if tmp, ok := rawArgs["requestType"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requestType"))
+		arg0, err = ec.unmarshalNTRBRequestType2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestType(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["requestType"] = arg0
 	return args, nil
 }
 
@@ -7209,6 +7403,30 @@ func (ec *executionContext) field_Mutation_updateSystemIntakeReviewDates_args(ct
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_updateTRBRequest_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 uuid.UUID
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
+	var arg1 map[string]interface{}
+	if tmp, ok := rawArgs["changes"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("changes"))
+		arg1, err = ec.unmarshalOTRBRequestChanges2map(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["changes"] = arg1
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_updateTestDate_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -7509,6 +7727,36 @@ func (ec *executionContext) field_Query_systems_args(ctx context.Context, rawArg
 		}
 	}
 	args["first"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_trbRequestCollection_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 bool
+	if tmp, ok := rawArgs["archived"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("archived"))
+		arg0, err = ec.unmarshalNBoolean2bool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["archived"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_trbRequest_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 uuid.UUID
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
 	return args, nil
 }
 
@@ -23577,6 +23825,156 @@ func (ec *executionContext) fieldContext_Mutation_sendReportAProblemEmail(ctx co
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_createTRBRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createTRBRequest(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateTRBRequest(rctx, fc.Args["requestType"].(models.TRBRequestType))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.TRBRequest)
+	fc.Result = res
+	return ec.marshalNTRBRequest2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequest(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createTRBRequest(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TRBRequest_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TRBRequest_name(ctx, field)
+			case "archived":
+				return ec.fieldContext_TRBRequest_archived(ctx, field)
+			case "type":
+				return ec.fieldContext_TRBRequest_type(ctx, field)
+			case "status":
+				return ec.fieldContext_TRBRequest_status(ctx, field)
+			case "createdBy":
+				return ec.fieldContext_TRBRequest_createdBy(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TRBRequest_createdAt(ctx, field)
+			case "modifiedBy":
+				return ec.fieldContext_TRBRequest_modifiedBy(ctx, field)
+			case "modifiedAt":
+				return ec.fieldContext_TRBRequest_modifiedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TRBRequest", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createTRBRequest_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateTRBRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateTRBRequest(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateTRBRequest(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.TRBRequest)
+	fc.Result = res
+	return ec.marshalNTRBRequest2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequest(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateTRBRequest(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TRBRequest_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TRBRequest_name(ctx, field)
+			case "archived":
+				return ec.fieldContext_TRBRequest_archived(ctx, field)
+			case "type":
+				return ec.fieldContext_TRBRequest_type(ctx, field)
+			case "status":
+				return ec.fieldContext_TRBRequest_status(ctx, field)
+			case "createdBy":
+				return ec.fieldContext_TRBRequest_createdBy(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TRBRequest_createdAt(ctx, field)
+			case "modifiedBy":
+				return ec.fieldContext_TRBRequest_modifiedBy(ctx, field)
+			case "modifiedAt":
+				return ec.fieldContext_TRBRequest_modifiedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TRBRequest", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateTRBRequest_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_accessibilityRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_accessibilityRequest(ctx, field)
 	if err != nil {
@@ -24933,6 +25331,156 @@ func (ec *executionContext) fieldContext_Query_systemIntakeContacts(ctx context.
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_systemIntakeContacts_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_trbRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_trbRequest(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().TrbRequest(rctx, fc.Args["id"].(uuid.UUID))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.TRBRequest)
+	fc.Result = res
+	return ec.marshalNTRBRequest2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequest(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_trbRequest(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TRBRequest_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TRBRequest_name(ctx, field)
+			case "archived":
+				return ec.fieldContext_TRBRequest_archived(ctx, field)
+			case "type":
+				return ec.fieldContext_TRBRequest_type(ctx, field)
+			case "status":
+				return ec.fieldContext_TRBRequest_status(ctx, field)
+			case "createdBy":
+				return ec.fieldContext_TRBRequest_createdBy(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TRBRequest_createdAt(ctx, field)
+			case "modifiedBy":
+				return ec.fieldContext_TRBRequest_modifiedBy(ctx, field)
+			case "modifiedAt":
+				return ec.fieldContext_TRBRequest_modifiedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TRBRequest", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_trbRequest_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_trbRequestCollection(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_trbRequestCollection(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().TrbRequestCollection(rctx, fc.Args["archived"].(bool))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*models.TRBRequest)
+	fc.Result = res
+	return ec.marshalNTRBRequest2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_trbRequestCollection(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TRBRequest_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TRBRequest_name(ctx, field)
+			case "archived":
+				return ec.fieldContext_TRBRequest_archived(ctx, field)
+			case "type":
+				return ec.fieldContext_TRBRequest_type(ctx, field)
+			case "status":
+				return ec.fieldContext_TRBRequest_status(ctx, field)
+			case "createdBy":
+				return ec.fieldContext_TRBRequest_createdBy(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TRBRequest_createdAt(ctx, field)
+			case "modifiedBy":
+				return ec.fieldContext_TRBRequest_modifiedBy(ctx, field)
+			case "modifiedAt":
+				return ec.fieldContext_TRBRequest_modifiedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TRBRequest", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_trbRequestCollection_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -30514,6 +31062,396 @@ func (ec *executionContext) fieldContext_SystemIntakeRequester_name(ctx context.
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TRBRequest_id(ctx context.Context, field graphql.CollectedField, obj *models.TRBRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TRBRequest_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uuid.UUID)
+	fc.Result = res
+	return ec.marshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TRBRequest_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TRBRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type UUID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TRBRequest_name(ctx context.Context, field graphql.CollectedField, obj *models.TRBRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TRBRequest_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TRBRequest_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TRBRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TRBRequest_archived(ctx context.Context, field graphql.CollectedField, obj *models.TRBRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TRBRequest_archived(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Archived, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TRBRequest_archived(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TRBRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TRBRequest_type(ctx context.Context, field graphql.CollectedField, obj *models.TRBRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TRBRequest_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Type, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(models.TRBRequestType)
+	fc.Result = res
+	return ec.marshalNTRBRequestType2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestType(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TRBRequest_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TRBRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type TRBRequestType does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TRBRequest_status(ctx context.Context, field graphql.CollectedField, obj *models.TRBRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TRBRequest_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(models.TRBRequestStatus)
+	fc.Result = res
+	return ec.marshalNTRBRequestStatus2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TRBRequest_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TRBRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type TRBRequestStatus does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TRBRequest_createdBy(ctx context.Context, field graphql.CollectedField, obj *models.TRBRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TRBRequest_createdBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TRBRequest_createdBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TRBRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TRBRequest_createdAt(ctx context.Context, field graphql.CollectedField, obj *models.TRBRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TRBRequest_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TRBRequest_createdAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TRBRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TRBRequest_modifiedBy(ctx context.Context, field graphql.CollectedField, obj *models.TRBRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TRBRequest_modifiedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ModifiedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TRBRequest_modifiedBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TRBRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TRBRequest_modifiedAt(ctx context.Context, field graphql.CollectedField, obj *models.TRBRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TRBRequest_modifiedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ModifiedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TRBRequest_modifiedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TRBRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -39346,6 +40284,24 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 				return ec._Mutation_sendReportAProblemEmail(ctx, field)
 			})
 
+		case "createTRBRequest":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createTRBRequest(ctx, field)
+			})
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "updateTRBRequest":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateTRBRequest(ctx, field)
+			})
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -39750,6 +40706,52 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_systemIntakeContacts(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "trbRequest":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_trbRequest(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "trbRequestCollection":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_trbRequestCollection(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}
@@ -41383,6 +42385,84 @@ func (ec *executionContext) _SystemIntakeRequester(ctx context.Context, sel ast.
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var tRBRequestImplementors = []string{"TRBRequest"}
+
+func (ec *executionContext) _TRBRequest(ctx context.Context, sel ast.SelectionSet, obj *models.TRBRequest) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tRBRequestImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TRBRequest")
+		case "id":
+
+			out.Values[i] = ec._TRBRequest_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "name":
+
+			out.Values[i] = ec._TRBRequest_name(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "archived":
+
+			out.Values[i] = ec._TRBRequest_archived(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "type":
+
+			out.Values[i] = ec._TRBRequest_type(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "status":
+
+			out.Values[i] = ec._TRBRequest_status(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createdBy":
+
+			out.Values[i] = ec._TRBRequest_createdBy(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createdAt":
+
+			out.Values[i] = ec._TRBRequest_createdAt(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "modifiedBy":
+
+			out.Values[i] = ec._TRBRequest_modifiedBy(ctx, field, obj)
+
+		case "modifiedAt":
+
+			out.Values[i] = ec._TRBRequest_modifiedAt(ctx, field, obj)
+
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -43686,6 +44766,96 @@ func (ec *executionContext) marshalNSystemIntakeStatus2githubᚗcomᚋcmsgovᚋe
 	return res
 }
 
+func (ec *executionContext) marshalNTRBRequest2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequest(ctx context.Context, sel ast.SelectionSet, v models.TRBRequest) graphql.Marshaler {
+	return ec._TRBRequest(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTRBRequest2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.TRBRequest) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTRBRequest2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequest(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTRBRequest2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequest(ctx context.Context, sel ast.SelectionSet, v *models.TRBRequest) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TRBRequest(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNTRBRequestStatus2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestStatus(ctx context.Context, v interface{}) (models.TRBRequestStatus, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := models.TRBRequestStatus(tmp)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNTRBRequestStatus2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestStatus(ctx context.Context, sel ast.SelectionSet, v models.TRBRequestStatus) graphql.Marshaler {
+	res := graphql.MarshalString(string(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNTRBRequestType2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestType(ctx context.Context, v interface{}) (models.TRBRequestType, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := models.TRBRequestType(tmp)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNTRBRequestType2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestType(ctx context.Context, sel ast.SelectionSet, v models.TRBRequestType) graphql.Marshaler {
+	res := graphql.MarshalString(string(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) marshalNTestDate2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTestDateᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.TestDate) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -44586,6 +45756,44 @@ func (ec *executionContext) marshalOString2string(ctx context.Context, sel ast.S
 	return res
 }
 
+func (ec *executionContext) unmarshalOString2ᚕstringᚄ(ctx context.Context, v interface{}) ([]string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNString2string(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOString2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNString2string(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v interface{}) (*string, error) {
 	if v == nil {
 		return nil, nil
@@ -44741,6 +45949,47 @@ func (ec *executionContext) marshalOSystemIntakeNote2ᚖgithubᚗcomᚋcmsgovᚋ
 		return graphql.Null
 	}
 	return ec._SystemIntakeNote(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOTRBRequestChanges2map(ctx context.Context, v interface{}) (map[string]interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return v.(map[string]interface{}), nil
+}
+
+func (ec *executionContext) unmarshalOTRBRequestStatus2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestStatus(ctx context.Context, v interface{}) (*models.TRBRequestStatus, error) {
+	if v == nil {
+		return nil, nil
+	}
+	tmp, err := graphql.UnmarshalString(v)
+	res := models.TRBRequestStatus(tmp)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTRBRequestStatus2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestStatus(ctx context.Context, sel ast.SelectionSet, v *models.TRBRequestStatus) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalString(string(*v))
+	return res
+}
+
+func (ec *executionContext) unmarshalOTRBRequestType2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestType(ctx context.Context, v interface{}) (*models.TRBRequestType, error) {
+	if v == nil {
+		return nil, nil
+	}
+	tmp, err := graphql.UnmarshalString(v)
+	res := models.TRBRequestType(tmp)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTRBRequestType2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestType(ctx context.Context, sel ast.SelectionSet, v *models.TRBRequestType) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalString(string(*v))
+	return res
 }
 
 func (ec *executionContext) marshalOTestDate2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTestDate(ctx context.Context, sel ast.SelectionSet, v *models.TestDate) graphql.Marshaler {

--- a/pkg/graph/resolvers/base_struct.go
+++ b/pkg/graph/resolvers/base_struct.go
@@ -1,18 +1,15 @@
 package resolvers
 
 import (
-	"go.uber.org/zap"
-
 	"github.com/cmsgov/easi-app/pkg/applychanges"
 	"github.com/cmsgov/easi-app/pkg/authentication"
 	"github.com/cmsgov/easi-app/pkg/models"
-	"github.com/cmsgov/easi-app/pkg/storage"
 )
 
 // ApplyChangesAndMetaData is a hook to call before updating a baseStruct object in the database it will
 // 1. Update the base struct meta data
 // 2. Apply changes from the changes object to the provided IBaseStruct
-func ApplyChangesAndMetaData(logger *zap.Logger, bs models.IBaseStruct, changes map[string]interface{}, principal authentication.Principal, store *storage.Store) error {
+func ApplyChangesAndMetaData(changes map[string]interface{}, bs models.IBaseStruct, principal authentication.Principal) error {
 	section := bs.GetBaseStruct()
 
 	modified := principal.ID()

--- a/pkg/graph/resolvers/base_struct.go
+++ b/pkg/graph/resolvers/base_struct.go
@@ -1,0 +1,29 @@
+package resolvers
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/applychanges"
+	"github.com/cmsgov/easi-app/pkg/authentication"
+	"github.com/cmsgov/easi-app/pkg/models"
+	"github.com/cmsgov/easi-app/pkg/storage"
+)
+
+// ApplyChangesAndMetaData is a hook to call before updating a baseStruct object in the database it will
+// 1. Update the base struct meta data
+// 2. Apply changes from the changes object to the provided IBaseStruct
+func ApplyChangesAndMetaData(logger *zap.Logger, bs models.IBaseStruct, changes map[string]interface{}, principal authentication.Principal, store *storage.Store) error {
+	section := bs.GetBaseStruct()
+
+	modified := principal.ID()
+
+	section.ModifiedBy = &modified
+
+	err := applychanges.ApplyChanges(changes, bs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}

--- a/pkg/graph/resolvers/resolver_test.go
+++ b/pkg/graph/resolvers/resolver_test.go
@@ -1,0 +1,111 @@
+package resolvers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/appconfig"
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/authentication"
+	"github.com/cmsgov/easi-app/pkg/models"
+	"github.com/cmsgov/easi-app/pkg/storage"
+	"github.com/cmsgov/easi-app/pkg/testhelpers"
+
+	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
+)
+
+// ResolverSuite is the testify suite for the resolver package
+type ResolverSuite struct {
+	suite.Suite
+	testConfigs *TestConfigs
+}
+
+// SetupTest clears the database between each test
+func (suite *ResolverSuite) SetupTest() {
+	err := suite.testConfigs.Store.TruncateAllTablesDANGEROUS(suite.testConfigs.Logger)
+	assert.NoError(suite.T(), err)
+}
+
+// TestResolverSuite runs the resolver test suite
+func TestResolverSuite(t *testing.T) {
+	rs := new(ResolverSuite)
+	rs.testConfigs = GetDefaultTestConfigs()
+	suite.Run(t, rs)
+}
+
+// TestConfigs is a struct that contains all the dependencies needed to run a test
+type TestConfigs struct {
+	DBConfig  storage.DBConfig
+	LDClient  *ld.LDClient
+	Logger    *zap.Logger
+	UserInfo  *models.UserInfo
+	Store     *storage.Store
+	Principal *authentication.EUAPrincipal
+	Context   context.Context
+}
+
+// GetDefaultTestConfigs returns a TestConfigs struct with all the dependencies needed to run a test
+func GetDefaultTestConfigs() *TestConfigs {
+	tc := TestConfigs{}
+	tc.GetDefaults()
+	return &tc
+}
+
+// GetDefaults sets the dependencies for the TestConfigs struct
+func (tc *TestConfigs) GetDefaults() {
+	config, ldClient, logger, userInfo, princ := getTestDependencies()
+	store, _ := storage.NewStore(logger, config, ldClient)
+
+	tc.DBConfig = config
+	tc.LDClient = ldClient
+	tc.Logger = logger
+	tc.UserInfo = userInfo
+	tc.Store = store
+
+	tc.Principal = princ
+	ctx := appcontext.WithLogger(context.Background(), logger)
+	ctx = appcontext.WithPrincipal(ctx, tc.Principal)
+	tc.Context = ctx
+
+}
+
+// NewDBConfig returns a DBConfig struct with values from appconfig
+func NewDBConfig() storage.DBConfig {
+	config := testhelpers.NewConfig()
+
+	return storage.DBConfig{
+		Host:           config.GetString(appconfig.DBHostConfigKey),
+		Port:           config.GetString(appconfig.DBPortConfigKey),
+		Database:       config.GetString(appconfig.DBNameConfigKey),
+		Username:       config.GetString(appconfig.DBUsernameConfigKey),
+		Password:       config.GetString(appconfig.DBPasswordConfigKey),
+		SSLMode:        config.GetString(appconfig.DBSSLModeConfigKey),
+		MaxConnections: config.GetInt(appconfig.DBMaxConnections),
+	}
+}
+
+func getTestDependencies() (storage.DBConfig, *ld.LDClient, *zap.Logger, *models.UserInfo, *authentication.EUAPrincipal) {
+	config := NewDBConfig()
+	ldClient, _ := ld.MakeCustomClient("fake", ld.Config{Offline: true}, 0)
+	logger := zap.NewNop()
+	userInfo := &models.UserInfo{
+		CommonName: "Test User",
+		Email:      "testuser@test.com",
+		EuaUserID:  "TEST",
+	}
+
+	princ := &authentication.EUAPrincipal{
+		EUAID:            userInfo.EuaUserID,
+		JobCodeEASi:      true,
+		JobCodeGRT:       true,
+		JobCode508User:   true,
+		JobCode508Tester: true,
+	}
+
+	return config, ldClient, logger, userInfo, princ
+
+}

--- a/pkg/graph/resolvers/trb_request.go
+++ b/pkg/graph/resolvers/trb_request.go
@@ -36,11 +36,11 @@ func TRBRequestUpdate(ctx context.Context, id uuid.UUID, changes map[string]inte
 	if err != nil {
 		return nil, err
 	}
-	logger := appcontext.ZLogger(ctx)
+
 	princ := appcontext.Principal(ctx)
 
 	//apply changes here
-	err = ApplyChangesAndMetaData(logger, existing, changes, princ, store)
+	err = ApplyChangesAndMetaData(changes, existing, princ)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/graph/resolvers/trb_request.go
+++ b/pkg/graph/resolvers/trb_request.go
@@ -1,0 +1,76 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/models"
+	"github.com/cmsgov/easi-app/pkg/storage"
+)
+
+//TRBRequestCreate makes a new TRB request
+func TRBRequestCreate(ctx context.Context, requestType models.TRBRequestType, store *storage.Store) (*models.TRBRequest, error) {
+	princ := appcontext.Principal(ctx)
+	trb := models.NewTRBRequest(princ.ID())
+	trb.Type = requestType
+	trb.Status = models.TRBSOpen
+	//TODO make sure this is wired up appropriately
+
+	createdTRB, err := store.TRBRequestCreate(appcontext.ZLogger(ctx), trb)
+	if err != nil {
+		return nil, err
+	}
+
+	//TODO create place holders for the rest of the related sections with calls to their stores
+
+	return createdTRB, err
+
+}
+
+//TRBRequestUpdate updates a TRB request
+func TRBRequestUpdate(ctx context.Context, id uuid.UUID, changes map[string]interface{}, store *storage.Store) (*models.TRBRequest, error) {
+
+	existing, err := store.TRBRequestGetByID(appcontext.ZLogger(ctx), id)
+	if err != nil {
+		return nil, err
+	}
+	logger := appcontext.ZLogger(ctx)
+	princ := appcontext.Principal(ctx)
+
+	//apply changes here
+	err = ApplyChangesAndMetaData(logger, existing, changes, princ, store)
+	if err != nil {
+		return nil, err
+	}
+
+	retTRB, err := store.TRBRequestUpdate(appcontext.ZLogger(ctx), existing)
+	if err != nil {
+		return nil, err
+	}
+
+	return retTRB, err
+
+}
+
+//TRBRequestGetByID returns a TRB request by it's ID
+func TRBRequestGetByID(ctx context.Context, id uuid.UUID, store *storage.Store) (*models.TRBRequest, error) {
+
+	trb, err := store.TRBRequestGetByID(appcontext.ZLogger(ctx), id)
+	if err != nil {
+		return nil, err
+	}
+	return trb, err
+}
+
+//TRBRequestCollectionGet returns all TRB Requests
+func TRBRequestCollectionGet(ctx context.Context, archived bool, store *storage.Store) ([]*models.TRBRequest, error) {
+
+	TRBRequests, err := store.TRBRequestCollectionGet(appcontext.ZLogger(ctx), archived)
+	if err != nil {
+		return nil, err
+	}
+	return TRBRequests, err
+
+}

--- a/pkg/graph/resolvers/trb_request_test.go
+++ b/pkg/graph/resolvers/trb_request_test.go
@@ -1,0 +1,98 @@
+package resolvers
+
+import (
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+//TRBRequestCreate makes a new TRB request
+func (suite *ResolverSuite) TestTRBRequestCreate() {
+
+	//TODO get the context in the test configs
+	trb, err := TRBRequestCreate(suite.testConfigs.Context, models.TRBTBrainstorm, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.NotNil(trb)
+
+	suite.EqualValues(trb.Archived, false)
+	suite.EqualValues(trb.Name, "Draft")
+	suite.EqualValues(trb.Status, models.TRBSOpen)
+	suite.EqualValues(trb.CreatedBy, suite.testConfigs.Principal.EUAID)
+	suite.NotNil(trb.ID)
+	suite.NotNil(trb.CreatedAt)
+	suite.Nil(trb.ModifiedBy)
+	suite.Nil(trb.ModifiedAt)
+
+}
+
+//TRBRequestUpdate updates a TRB request
+func (suite *ResolverSuite) TestTRBRequestUpdate() {
+
+	trb, err := TRBRequestCreate(suite.testConfigs.Context, models.TRBTBrainstorm, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.NotNil(trb)
+
+	changes := map[string]interface{}{
+		"Name":     "Testing",
+		"status":   models.TRBSClosed,
+		"archived": false,
+	}
+	princ := suite.testConfigs.Principal.ID()
+
+	updated, err := TRBRequestUpdate(suite.testConfigs.Context, trb.ID, changes, suite.testConfigs.Store)
+	suite.NotNil(updated)
+	suite.NoError(err)
+	suite.EqualValues(updated.Name, "Testing")
+	suite.EqualValues(updated.Status, models.TRBSClosed)
+	suite.EqualValues(updated.Archived, false)
+	suite.EqualValues(updated.ModifiedBy, &princ)
+	suite.NotNil(updated.ModifiedAt)
+
+}
+
+//TRBRequestGetByID returns a TRB request by it's ID
+func (suite *ResolverSuite) TestTRBRequestGetByID() {
+	trb, err := TRBRequestCreate(suite.testConfigs.Context, models.TRBTBrainstorm, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.NotNil(trb)
+
+	ret, err := TRBRequestGetByID(suite.testConfigs.Context, trb.ID, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.NotNil(ret)
+
+}
+
+//TRBRequestCollectionGet returns all TRB Requests
+func (suite *ResolverSuite) TestTRBRequestCollectionGet() {
+
+	trb, err := TRBRequestCreate(suite.testConfigs.Context, models.TRBTBrainstorm, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.NotNil(trb)
+	//Check we return 1 value
+	col, err := TRBRequestCollectionGet(suite.testConfigs.Context, false, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.Len(col, 1)
+	suite.EqualValues(trb, col[0])
+
+	trb2, err := TRBRequestCreate(suite.testConfigs.Context, models.TRBTBrainstorm, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.NotNil(trb2)
+	//Check for 2 request
+	col, err = TRBRequestCollectionGet(suite.testConfigs.Context, false, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.Len(col, 2)
+
+	changes := map[string]interface{}{
+		"status":   models.TRBSClosed,
+		"archived": true,
+	}
+
+	//archive
+	trbUpdate, err := TRBRequestUpdate(suite.testConfigs.Context, trb2.ID, changes, suite.testConfigs.Store)
+	suite.NoError(err)
+
+	//GET archived collection
+	col, err = TRBRequestCollectionGet(suite.testConfigs.Context, true, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.Len(col, 1)
+	suite.EqualValues(trbUpdate, col[0])
+
+}

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -1474,6 +1474,31 @@ input SendReportAProblemEmailInput {
   howSevereWasTheProblem: String!
 }
 
+type TRBRequest {
+    id: UUID!
+    name: String!
+    archived: Boolean!
+    type: TRBRequestType!
+    status: TRBRequestStatus!
+
+    createdBy: String!
+    createdAt: Time!
+    modifiedBy: String
+    modifiedAt: Time
+}
+
+"""
+TRBRequestChanges represents the possible changes you can make to a trb request when updating it.
+Fields explicitly set with NULL will be unset, and omitted fields will be left unchanged.
+https://gqlgen.com/reference/changesets/
+"""
+input TRBRequestChanges @goModel(model: "map[string]interface{}") {
+    name: String
+    archived: Boolean
+    type: TRBRequestType
+    status: TRBRequestStatus 
+}
+
 """
 Defines the mutations for the schema
 """
@@ -1581,6 +1606,10 @@ type Mutation {
   sendFeedbackEmail(input: SendFeedbackEmailInput!): String
   sendCantFindSomethingEmail(input: SendCantFindSomethingEmailInput!): String
   sendReportAProblemEmail(input: SendReportAProblemEmailInput!): String
+  
+  createTRBRequest(requestType: TRBRequestType!): TRBRequest!
+  
+  updateTRBRequest(id: UUID!, changes: TRBRequestChanges): TRBRequest!
 }
 
 """
@@ -1608,8 +1637,20 @@ type Query {
   urls(cedarSystemId: String!): [CedarURL!]!
   cedarSystemDetails(cedarSystemId: String!): CedarSystemDetails
   systemIntakeContacts(id: UUID!): SystemIntakeContactsPayload!
+  trbRequest(id: UUID!): TRBRequest!
+  trbRequestCollection(archived: Boolean! = false): [TRBRequest!]!
+}
+enum TRBRequestType {
+  NEED_HELP
+  BRAINSTORM
+  FOLLOWUP
+  FORMAL_REVIEW
 }
 
+enum TRBRequestStatus {
+  OPEN
+  CLOSED
+}
 """
 UUIDs are represented using 36 ASCII characters, for example B0511859-ADE6-4A67-8969-16EC280C0E1A
 """
@@ -1626,6 +1667,13 @@ Email addresses are represented as strings
 scalar EmailAddress
 
 directive @hasRole(role: Role!) on FIELD_DEFINITION
+
+# https://gqlgen.com/config/#inline-config-with-directives
+directive @goModel(
+  model: String
+  models: [String!]
+) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
+
 
 """
 A user role associated with a job code

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cmsgov/easi-app/pkg/flags"
 	"github.com/cmsgov/easi-app/pkg/graph/generated"
 	"github.com/cmsgov/easi-app/pkg/graph/model"
+	"github.com/cmsgov/easi-app/pkg/graph/resolvers"
 	"github.com/cmsgov/easi-app/pkg/models"
 	"github.com/cmsgov/easi-app/pkg/services"
 )
@@ -1872,6 +1873,16 @@ func (r *mutationResolver) SendReportAProblemEmail(ctx context.Context, input mo
 	return &msg, nil
 }
 
+// CreateTRBRequest is the resolver for the createTRBRequest field.
+func (r *mutationResolver) CreateTRBRequest(ctx context.Context, requestType models.TRBRequestType) (*models.TRBRequest, error) {
+	return resolvers.TRBRequestCreate(ctx, requestType, r.store)
+}
+
+// UpdateTRBRequest is the resolver for the updateTRBRequest field.
+func (r *mutationResolver) UpdateTRBRequest(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.TRBRequest, error) {
+	return resolvers.TRBRequestUpdate(ctx, id, changes, r.store)
+}
+
 // AccessibilityRequest is the resolver for the accessibilityRequest field.
 func (r *queryResolver) AccessibilityRequest(ctx context.Context, id uuid.UUID) (*models.AccessibilityRequest, error) {
 	// deleted requests need to be returned to be able to show a deleted request view
@@ -2204,6 +2215,16 @@ func (r *queryResolver) SystemIntakeContacts(ctx context.Context, id uuid.UUID) 
 		SystemIntakeContacts: augmentedContacts,
 		InvalidEUAIDs:        invalidEUAIDs,
 	}, nil
+}
+
+// TrbRequest is the resolver for the trbRequest field.
+func (r *queryResolver) TrbRequest(ctx context.Context, id uuid.UUID) (*models.TRBRequest, error) {
+	return resolvers.TRBRequestGetByID(ctx, id, r.store)
+}
+
+// TrbRequestCollection is the resolver for the trbRequestCollection field.
+func (r *queryResolver) TrbRequestCollection(ctx context.Context, archived bool) ([]*models.TRBRequest, error) {
+	return resolvers.TRBRequestCollectionGet(ctx, archived, r.store)
 }
 
 // Actions is the resolver for the actions field.

--- a/pkg/models/base_struct.go
+++ b/pkg/models/base_struct.go
@@ -1,0 +1,51 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// IBaseStruct is an interface that all models must implement
+type IBaseStruct interface {
+	GetBaseStruct() *baseStruct
+	GetID() uuid.UUID
+	GetCreatedBy() string
+	GetModifiedBy() *string
+}
+
+// baseStruct represents the shared data in common betwen all models
+type baseStruct struct {
+	ID         uuid.UUID  `json:"id" db:"id"`
+	CreatedBy  string     `json:"createdBy" db:"created_by"`
+	CreatedAt  time.Time  `json:"createdAt" db:"created_at"`
+	ModifiedBy *string    `json:"modifiedBy" db:"modified_by"`
+	ModifiedAt *time.Time `json:"modifiedAt" db:"modified_at"`
+}
+
+// NewBaseStruct returns a base struct object
+func NewBaseStruct(createdBy string) baseStruct {
+	return baseStruct{
+		CreatedBy: createdBy,
+	}
+}
+
+// GetBaseStruct returns the Base Struct
+func (b *baseStruct) GetBaseStruct() *baseStruct {
+	return b
+}
+
+// GetID returns the ID property for a PlanBasics struct
+func (b baseStruct) GetID() uuid.UUID {
+	return b.ID
+}
+
+// GetModifiedBy returns the ModifiedBy property for a PlanBasics struct
+func (b baseStruct) GetModifiedBy() *string {
+	return b.ModifiedBy
+}
+
+// GetCreatedBy implements the CreatedBy property
+func (b baseStruct) GetCreatedBy() string {
+	return b.CreatedBy
+}

--- a/pkg/models/trb_request.go
+++ b/pkg/models/trb_request.go
@@ -1,0 +1,39 @@
+package models
+
+//TRBRequest represents a TRB request object
+type TRBRequest struct {
+	baseStruct
+	Name     string           `json:"name" db:"name"`
+	Archived bool             `json:"archived" db:"archived"`
+	Type     TRBRequestType   `json:"type" db:"type"`     //TODO should this be a type?
+	Status   TRBRequestStatus `json:"status" db:"status"` //TODO should this be a type?
+}
+
+//NewTRBRequest returns a new trb request object
+func NewTRBRequest(createdBy string) *TRBRequest {
+	return &TRBRequest{
+		Name:       "Draft",
+		baseStruct: NewBaseStruct(createdBy),
+	}
+
+}
+
+// TRBRequestType represents the types of TRBRequestType types.
+type TRBRequestType string
+
+//These are the options for TRBRequestType
+const (
+	TRBTNeedHelp     TRBRequestType = "NEED_HELP"
+	TRBTBrainstorm   TRBRequestType = "BRAINSTORM"
+	TRBTFollowup     TRBRequestType = "FOLLOWUP"
+	TRBTFormalReview TRBRequestType = "FORMAL_REVIEW"
+)
+
+// TRBRequestStatus represents the types of TRBRequestStatus types.
+type TRBRequestStatus string
+
+//These are the options for TRBRequestStatus
+const (
+	TRBSOpen   TRBRequestStatus = "OPEN"
+	TRBSClosed TRBRequestStatus = "CLOSED"
+)

--- a/pkg/storage/SQL/trb_request_collection_get.sql
+++ b/pkg/storage/SQL/trb_request_collection_get.sql
@@ -1,0 +1,11 @@
+SELECT id,
+    name,
+    archived,
+    type,
+    status,
+    created_by,
+    created_at,
+    modified_by,
+    modified_at
+    FROM trb_request
+    WHERE archived = :archived

--- a/pkg/storage/SQL/trb_request_create.sql
+++ b/pkg/storage/SQL/trb_request_create.sql
@@ -1,0 +1,28 @@
+INSERT INTO trb_request(
+        id,
+        name,
+        archived,
+        type,
+        status,
+        created_by,
+        modified_by
+    )
+VALUES (
+        :id,
+        :name,
+        :archived,
+        :type,
+        :status,
+        :created_by,
+        :modified_by
+    )
+RETURNING
+    id,
+    name,
+    archived,
+    type,
+    status,
+    created_by,
+    created_at,
+    modified_by,
+    modified_at;

--- a/pkg/storage/SQL/trb_request_get_by_id.sql
+++ b/pkg/storage/SQL/trb_request_get_by_id.sql
@@ -1,0 +1,11 @@
+SELECT id,
+    name,
+    archived,
+    type,
+    status,
+    created_by,
+    created_at,
+    modified_by,
+    modified_at
+    FROM trb_request
+WHERE trb_request.id = :id

--- a/pkg/storage/SQL/trb_request_update.sql
+++ b/pkg/storage/SQL/trb_request_update.sql
@@ -1,0 +1,19 @@
+UPDATE trb_request
+SET id = :id,
+    name = :name,
+    archived = :archived,
+    type = :type,
+    status = :status,
+    modified_by = :modified_by,
+    modified_at = CURRENT_TIMESTAMP
+WHERE trb_request.id = :id
+RETURNING
+    id,
+    name,
+    archived,
+    type,
+    status,
+    created_by,
+    created_at,
+    modified_by,
+    modified_at;

--- a/pkg/storage/trb_requestStore.go
+++ b/pkg/storage/trb_requestStore.go
@@ -1,0 +1,136 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+
+	_ "embed"
+)
+
+//go:embed SQL/trb_request_collection_get.sql
+var trbRequestCollectionGetSQL string
+
+//go:embed SQL/trb_request_create.sql
+var trbRequestCreateSQL string
+
+//go:embed SQL/trb_request_get_by_id.sql
+var trbRequestGetByIDSQL string
+
+//go:embed SQL/trb_request_update.sql
+var trbRequestUpdateSQL string
+
+//TRBRequestCreate creates a new TRBRequest record
+func (s *Store) TRBRequestCreate(logger *zap.Logger, trb *models.TRBRequest) (*models.TRBRequest, error) {
+
+	if trb.ID == uuid.Nil {
+		trb.ID = uuid.New()
+	}
+
+	stmt, err := s.db.PrepareNamed(trbRequestCreateSQL)
+	if err != nil {
+		logger.Error(
+			fmt.Sprintf("Failed to trb request with error %s", err),
+			zap.String("user", trb.CreatedBy),
+		)
+		return nil, err
+	}
+	retTRB := models.TRBRequest{}
+
+	err = stmt.Get(&retTRB, trb)
+	if err != nil {
+		logger.Error(
+			fmt.Sprintf("Failed to create trb request with error %s", err),
+			zap.String("user", trb.CreatedBy),
+		)
+		return nil, err
+
+	}
+
+	return &retTRB, nil
+}
+
+//TRBRequestGetByID returns an TRBRequest from the db  for a given id
+func (s *Store) TRBRequestGetByID(logger *zap.Logger, id uuid.UUID) (*models.TRBRequest, error) {
+
+	trb := models.TRBRequest{}
+	stmt, err := s.db.PrepareNamed(trbRequestGetByIDSQL)
+	if err != nil {
+		return nil, err
+	}
+	arg := map[string]interface{}{"id": id}
+	err = stmt.Get(&trb, arg)
+
+	if err != nil {
+		logger.Error(
+			"Failed to fetch trb request",
+			zap.Error(err),
+			zap.String("id", id.String()),
+		)
+		return nil, &apperrors.QueryError{
+			Err:       err,
+			Model:     trb,
+			Operation: apperrors.QueryFetch,
+		}
+	}
+	return &trb, err
+}
+
+//TRBRequestUpdate returns an TRBRequest from the db  for a given id
+func (s *Store) TRBRequestUpdate(logger *zap.Logger, trb *models.TRBRequest) (*models.TRBRequest, error) {
+	stmt, err := s.db.PrepareNamed(trbRequestUpdateSQL)
+	if err != nil {
+		logger.Error(
+			fmt.Sprintf("Failed to update trb request %s", err),
+			zap.String("id", trb.ID.String()),
+		)
+		return nil, err
+	}
+	retTRB := models.TRBRequest{}
+
+	err = stmt.Get(&retTRB, trb)
+	if err != nil {
+		logger.Error(
+			fmt.Sprintf("Failed to update trb request %s", err),
+			zap.String("id", trb.ID.String()),
+		)
+		return nil, &apperrors.QueryError{
+			Err:       err,
+			Model:     trb,
+			Operation: apperrors.QueryUpdate,
+		}
+	}
+
+	return &retTRB, err
+}
+
+//TRBRequestCollectionGet returns the collection of models
+func (s *Store) TRBRequestCollectionGet(logger *zap.Logger, archived bool) ([]*models.TRBRequest, error) {
+	trbRequests := []*models.TRBRequest{}
+
+	stmt, err := s.db.PrepareNamed(trbRequestCollectionGetSQL)
+	if err != nil {
+		return nil, err
+	}
+	arg := map[string]interface{}{
+		"archived": archived,
+	}
+	err = stmt.Select(&trbRequests, arg)
+	if err != nil {
+		logger.Error(
+			"Failed to fetch trb requests",
+			zap.Error(err),
+		)
+		return nil, &apperrors.QueryError{
+			Err:       err,
+			Model:     models.TRBRequest{},
+			Operation: apperrors.QueryFetch,
+		}
+	}
+	return trbRequests, err
+
+}

--- a/pkg/storage/truncate.go
+++ b/pkg/storage/truncate.go
@@ -1,0 +1,33 @@
+package storage
+
+import (
+	"go.uber.org/zap"
+)
+
+// TruncateAllTablesDANGEROUS is a function to reset all tables in the DB. It should only be called within test code.
+func (s *Store) TruncateAllTablesDANGEROUS(logger *zap.Logger) error {
+	tables := `
+	cedar_system_bookmarks,
+	accessibility_request_status_records,
+	accessibility_request_notes,
+	accessibility_request_documents,
+	test_dates,
+	accessibility_requests,
+	notes,
+	actions,
+	estimated_lifecycle_costs,
+	business_cases,
+	grt_feedback,
+	system_intake_contacts,
+	system_intake_funding_sources,
+	system_intakes,
+	trb_request
+	`
+
+	_, err := s.db.Exec("TRUNCATE " + tables)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/scripts/dev
+++ b/scripts/dev
@@ -367,6 +367,7 @@ namespace :db do
       system_intake_contacts
       system_intake_funding_sources
       system_intakes
+      trb_request
     }
     sql = tables.map { |table| "DELETE FROM #{table};" }.join
     puts "Cleaning database..."


### PR DESCRIPTION
* trb request migration, sql and model

* introduce apply changes

* Add types for status and type. placeholder store methods. placeholder resolver

* store implemented, GQL implemented.Seed data added

* introducing unit tests

* add unit test for TRB_Request

* introduce base_struct pre-commit

* renamed time fields to use at instead of dts for consistency

* Update BaseStructPreuUpdate comment to be more descriptive

* Add additional clarification to the ApplyChanges method

* move apply changes to separate package, and rename baseStruct pre-update, remove optional apply changes

# EASI-2323

## Changes and Description

-- See pull for the initial [TRB work](https://github.com/CMSgov/easi-app/pull/1760)


## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
