### PR TITLE
[EASI-2318] Updated CEDAR Intake API schema to include contract number of system intake

### DIFF
--- a/cmd/test_cedar_intake/main.go
+++ b/cmd/test_cedar_intake/main.go
@@ -104,6 +104,7 @@ func makeTestSystemIntake(times usefulTimes, projectName string) *models.SystemI
 		ContractStartDate:  date(2021, 1, 1),
 		ContractEndDate:    date(2023, 12, 31),
 		ContractVehicle:    null.StringFrom("Sole source"),
+		ContractNumber:     null.StringFrom("22288144"),
 		Contractor:         null.StringFrom("ACME Co."),
 		AdminLead:          null.StringFrom("Valerie Hartz"),
 		GRTDate:            &times.oneHourInTheFuture,

--- a/docs/cedar.md
+++ b/docs/cedar.md
@@ -56,7 +56,7 @@ CEDAR LDAP is similar, just in the `pkg/cedar/cedarldap` directory:
 swagger generate client -f swagger-impl.json -c ./gen/client -m ./gen/models
 ```
 
-The CEDAR Intake Swagger file requires a bit of preprocessing before code generation. When the Swagger file is updated, put it in `pkg/cedar/intake/cedar_intake.json`, then run `scripts/generate_cedar_intake_client` to preprocess it and regenerate code. See [the intake folder's README](/pkg/cedar/intake/README.md) for more information.
+The CEDAR Intake Swagger file requires a bit of preprocessing before code generation. When the Swagger file is updated, put it in `pkg/cedar/intake/cedar_intake.json`, then run `scripts/generate_cedar_clients` to preprocess it and regenerate code. See [the intake folder's README](/pkg/cedar/intake/README.md) for more information.
 
 ### Connecting to CEDAR when running locally
 

--- a/pkg/cedar/intake/README.md
+++ b/pkg/cedar/intake/README.md
@@ -7,7 +7,7 @@ The Intake API is designed to take a JSON string in its `Body` field, as well as
 
 The Swagger file for the Intake API is saved as `cedar_intake.json` in this folder. The Swagger we get from CEDAR needs preprocessing to add the `"x-nullable": true` property to the definition of the `clientLastUpdatedDate` field on the `IntakeInput` object. This is an optional field, but without the `"x-nullable": true` property, go-swagger will generate the corresponding Go code with a `strfmt.DateTime` field. If this type is used and `.ClientLastUpdatedDate` is not set in our Go code, the zero value of `0001-01-01T00:00:00.000Z` will get sent to CEDAR Intake, which causes an error. With `"x-nullable": true` set, go-swagger generates Go code with a `*strfmt.DateTime` pointer field, and a `nil` pointer will prevent this field from being sent to CEDAR.
 
-To run the preprocessing and regenerate code from an updated Swagger file, run `scripts/generate_cedar_intake_client`. This uses [jq](https://stedolan.github.io/jq/) to add the `"x-nullable": true` field, then calls go-swagger to regenerate code.
+To run the preprocessing and regenerate code from an updated Swagger file, run `scripts/generate_cedar_clients`. This uses [jq](https://stedolan.github.io/jq/) to add the `"x-nullable": true` field, then calls go-swagger to regenerate code.
 
 See [our general CEDAR documentation](/docs/cedar.md) for info on accessing CEDAR and installing `go-swagger` for code generation.
 

--- a/pkg/cedar/intake/client_test.go
+++ b/pkg/cedar/intake/client_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/guregu/null"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
@@ -82,14 +81,11 @@ func (s *ClientTestSuite) TestTranslation() {
 	})
 
 	s.Run("system intake", func() {
-		newIntake := testhelpers.NewSystemIntake()
-		newIntake.ContractNumber = null.StringFrom("44554489")
-		si := translation.TranslatableSystemIntake(newIntake)
+		si := translation.TranslatableSystemIntake(testhelpers.NewSystemIntake())
 		si.CreatedAt = si.ContractStartDate
 		si.UpdatedAt = si.ContractStartDate
 
 		ii, err := si.CreateIntakeModel()
-		// s.True(null.StringFromPtr(ii.ContractNumber) == newIntake.ContractNumber)
 		s.NoError(err)
 		s.NotNil(ii)
 	})

--- a/pkg/cedar/intake/client_test.go
+++ b/pkg/cedar/intake/client_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/guregu/null"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
@@ -81,11 +82,14 @@ func (s *ClientTestSuite) TestTranslation() {
 	})
 
 	s.Run("system intake", func() {
-		si := translation.TranslatableSystemIntake(testhelpers.NewSystemIntake())
+		newIntake := testhelpers.NewSystemIntake()
+		newIntake.ContractNumber = null.StringFrom("44554489")
+		si := translation.TranslatableSystemIntake(newIntake)
 		si.CreatedAt = si.ContractStartDate
 		si.UpdatedAt = si.ContractStartDate
 
 		ii, err := si.CreateIntakeModel()
+		// s.True(null.StringFromPtr(ii.ContractNumber) == newIntake.ContractNumber)
 		s.NoError(err)
 		s.NotNil(ii)
 	})

--- a/pkg/cedar/intake/models/easi_intake.go
+++ b/pkg/cedar/intake/models/easi_intake.go
@@ -17,6 +17,7 @@ type EASIIntake struct {
 	ContractEndDate             *string              `json:"contractEndDate,omitempty" jsonschema:"description=The contract's end date,example=2026-10-20"`
 	ContractStartDate           *string              `json:"contractStartDate,omitempty" jsonschema:"description=The contract's start date,example=2022-10-20"`
 	ContractVehicle             *string              `json:"contractVehicle,omitempty" jsonschema:"description=Contract vehicle for this effort,example=8(a)"`
+	ContractNumber              *string              `json:"contractNumber,omitempty" jsonschema:"description=Contract number for this effort,example=8(a)"`
 	Contractor                  *string              `json:"contractor,omitempty" jsonschema:"description=Contractor who will perform the work detailed in this request,example=Oddball"`
 	CostIncrease                string               `json:"costIncrease" jsonschema:"description=Is there a cost increase associated with this request,example=YES,example=NOT_SURE"`
 	CostIncreaseAmount          *string              `json:"costIncreaseAmount,omitempty" jsonschema:"description=How much is the cost increase,example=Over two million dollars"`

--- a/pkg/cedar/intake/schemas/easi_system_intake.json
+++ b/pkg/cedar/intake/schemas/easi_system_intake.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "$ref": "#/definitions/EASIIntake",
-  "title": "EASIIntakeV05",
+  "title": "EASIIntakeV06",
   "definitions": {
     "EASIFundingSource": {
       "required": [
@@ -120,6 +120,13 @@
         "contractVehicle": {
           "type": "string",
           "description": "Contract vehicle for this effort",
+          "examples": [
+            "8(a)"
+          ]
+        },
+        "contractNumber": {
+          "type": "string",
+          "description": "Contract number for this effort",
           "examples": [
             "8(a)"
           ]

--- a/pkg/cedar/intake/translation/constants.go
+++ b/pkg/cedar/intake/translation/constants.go
@@ -42,7 +42,7 @@ const (
 	IntakeInputSchemaEASIGrtFeedbackVersion SchemaVersion = "EASIGrtFeedbackV02"
 
 	// IntakeInputSchemaEASIIntakeVersion captures the current schema version for System Intakes
-	IntakeInputSchemaEASIIntakeVersion SchemaVersion = "EASIIntakeV05"
+	IntakeInputSchemaEASIIntakeVersion SchemaVersion = "EASIIntakeV06"
 
 	// IntakeInputSchemaEASINoteVersion captures the current schema version for Notes
 	IntakeInputSchemaEASINoteVersion SchemaVersion = "EASINoteV01"

--- a/pkg/cedar/intake/translation/system_intake.go
+++ b/pkg/cedar/intake/translation/system_intake.go
@@ -60,6 +60,7 @@ func (si *TranslatableSystemIntake) CreateIntakeModel() (*wire.IntakeInput, erro
 		CostIncreaseAmount:          si.CostIncreaseAmount.Ptr(),
 		Contractor:                  si.Contractor.Ptr(),
 		ContractVehicle:             si.ContractVehicle.Ptr(),
+		ContractNumber:              si.ContractNumber.Ptr(),
 		RequesterEmailAddress:       si.RequesterEmailAddress.Ptr(),
 		LifecycleID:                 si.LifecycleID.Ptr(),
 		LifecycleScope:              si.LifecycleScope.Ptr(),

--- a/pkg/testhelpers/system_intake.go
+++ b/pkg/testhelpers/system_intake.go
@@ -47,6 +47,7 @@ func NewSystemIntake() models.SystemIntake {
 		CostIncreaseAmount: null.StringFrom(""),
 		Contractor:         null.StringFrom(""),
 		ContractVehicle:    null.StringFrom(""),
+		ContractNumber:     null.StringFrom(""),
 		LifecycleID:        null.StringFrom("123456"),
 		ContractStartDate:  &now,
 		ContractEndDate:    &now,


### PR DESCRIPTION
# EASI-2318

## Changes and Description

- Added ContractNumber to the EASIIntake schema, updated logic to set this property when publishing an intake
- Updated IntakeInputSchemaEASIIntakeVersion to EASIIntakeV06
- Ran generation scripts, included updated Swagger file
- Updated outdated doc that was pointing to an old generation script that doesn't exist anymore (generate_cedar_intake_client was replaced by generate_cedar_clients)

## How to test this change

Open to feedback here...

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
