### PR TITLE
[NOREF] Use dedicated 'local' environment in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -67,7 +67,7 @@ export OKTA_TEST_SECRET=
 
 # Launch Darkly configuration
 export FLAG_SOURCE=LOCAL # LAUNCH_DARKLY, LOCAL, or FILE
-export LD_SDK_KEY=GO_CHECK_1PASSWORD
+export LD_SDK_KEY=<check 1Password to find this value>
 export REACT_APP_LD_CLIENT_ID=63231d448bd05a111f06195b # Points to our "local" environment
 export LD_TIMEOUT_SECONDS=30
 export FLAGDATA_FILE="./cypress/fixtures/flagdata.json" # File to load LD flag data from when FLAG_SOURCE=FILE

--- a/.envrc
+++ b/.envrc
@@ -66,13 +66,10 @@ export OKTA_TEST_PASSWORD=
 export OKTA_TEST_SECRET=
 
 # Launch Darkly configuration
-export LD_SDK_KEY=fakekey
-export LD_TIMEOUT_SECONDS=30
-export LD_ENV_USER=6dec0457-d4f0-490b-83ed-4502aa44a95e
-export REACT_APP_LD_ENV_USER=$LD_ENV_USER
-export REACT_APP_LD_USER_HASH=
 export FLAG_SOURCE=LOCAL # LAUNCH_DARKLY, LOCAL, or FILE
-export REACT_APP_LD_CLIENT_ID=5f51549c031fe609e6df43d8
+export LD_SDK_KEY=GO_CHECK_1PASSWORD
+export REACT_APP_LD_CLIENT_ID=63231d448bd05a111f06195b # Points to our "local" environment
+export LD_TIMEOUT_SECONDS=30
 export FLAGDATA_FILE="./cypress/fixtures/flagdata.json" # File to load LD flag data from when FLAG_SOURCE=FILE
 
 # Default minio credentials for local use


### PR DESCRIPTION
# NOREF

## Changes and Description

- Created a new [local environment in LaunchDarkly](https://app.launchdarkly.com/default/local/features)
- Renamed our old dev/local account to just be for dev

## How to test this change

- Modify your `.envrc.local` LaunchDarkly configs to match [what's in 1Password](https://start.1password.com/open/i?a=RYAMO7WYSJHNNCGOFE3Q2TVVUE&v=j3plnuuwh2alqm5hw3pp65afza&i=w72jgnsgx5atveahlt2egu3j4y&h=cmseasi.1password.com)
- `scripts/dev up` to start the service
- Tinker with targeted rules like `Sandbox` and ensure that they only affect your local environment, and only for the user you're signed in as (should work with local auth or Okta auth)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
