### PR TITLE
Correct syntax in .envrc file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -67,7 +67,7 @@ export OKTA_TEST_SECRET=
 
 # Launch Darkly configuration
 export FLAG_SOURCE=LOCAL # LAUNCH_DARKLY, LOCAL, or FILE
-export LD_SDK_KEY=<check 1Password to find this value>
+export LD_SDK_KEY="check 1Password to find this value"
 export REACT_APP_LD_CLIENT_ID=63231d448bd05a111f06195b # Points to our "local" environment
 export LD_TIMEOUT_SECONDS=30
 export FLAGDATA_FILE="./cypress/fixtures/flagdata.json" # File to load LD flag data from when FLAG_SOURCE=FILE


### PR DESCRIPTION
Small fix to the syntax in `.envrc`, correcting a bug from [this PR earlier](https://github.com/CMSgov/easi-app/pull/1776). The line
```sh
export LD_SDK_KEY=<check 1Password to find this value>
```
caused a syntax error when `direnv` tried to evaluate it (at least using `bash`):
```
direnv: loading ~/source/repos/easi-app/.envrc
./.envrc:70: syntax error near unexpected token `newline'
./.envrc:70: `export LD_SDK_KEY=<check 1Password to find this value>'
```

This PR changes the value to just a regular quoted string, which works fine.