### PR TITLE
[NOREF] Fixing null recipient email when CEDAR LDAP returns null for an email

### DIFF
--- a/src/views/GovernanceReviewTeam/Actions/ExtendLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ExtendLifecycleId.tsx
@@ -86,7 +86,7 @@ const ExtendLifecycleId = ({
     newCostBaseline: '',
     feedback: '',
     notificationRecipients: {
-      regularRecipientEmails: [systemIntake?.requester?.email!],
+      regularRecipientEmails: [systemIntake?.requester?.email!].filter(e => e),
       shouldNotifyITGovernance: true,
       shouldNotifyITInvestment: true
     }

--- a/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
@@ -67,7 +67,7 @@ const IssueLifecycleId = () => {
     newLifecycleId: undefined,
     feedback: '',
     notificationRecipients: {
-      regularRecipientEmails: [systemIntake?.requester?.email!],
+      regularRecipientEmails: [systemIntake?.requester?.email!].filter(e => e),
       shouldNotifyITGovernance: true,
       shouldNotifyITInvestment: true
     }

--- a/src/views/GovernanceReviewTeam/Actions/ProvideGRTFeedbackToBusinessOwner.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ProvideGRTFeedbackToBusinessOwner.tsx
@@ -51,7 +51,7 @@ const ProvideGRTFeedbackToBusinessOwner = ({
     grtFeedback: '',
     emailBody: '',
     notificationRecipients: {
-      regularRecipientEmails: [systemIntake?.requester?.email!],
+      regularRecipientEmails: [systemIntake?.requester?.email!].filter(e => e),
       shouldNotifyITGovernance: true,
       shouldNotifyITInvestment: false
     }

--- a/src/views/GovernanceReviewTeam/Actions/ProvideGRTRecommendationsToGRB.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ProvideGRTRecommendationsToGRB.tsx
@@ -46,7 +46,7 @@ const ProvideGRTRecommendationsToGRB = () => {
     grtFeedback: '',
     emailBody: '',
     notificationRecipients: {
-      regularRecipientEmails: [systemIntake?.requester?.email!],
+      regularRecipientEmails: [systemIntake?.requester?.email!].filter(e => e),
       shouldNotifyITGovernance: true,
       shouldNotifyITInvestment: false
     }

--- a/src/views/GovernanceReviewTeam/Actions/RejectIntake.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/RejectIntake.tsx
@@ -52,7 +52,7 @@ const RejectIntake = () => {
     nextSteps: '',
     reason: '',
     notificationRecipients: {
-      regularRecipientEmails: [systemIntake?.requester?.email!],
+      regularRecipientEmails: [systemIntake?.requester?.email!].filter(e => e),
       shouldNotifyITGovernance: true,
       shouldNotifyITInvestment: false
     }

--- a/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
@@ -67,7 +67,7 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
   const initialValues: ActionForm = {
     feedback: '',
     notificationRecipients: {
-      regularRecipientEmails: [systemIntake?.requester?.email!],
+      regularRecipientEmails: [systemIntake?.requester?.email!].filter(e => e),
       shouldNotifyITGovernance: true,
       shouldNotifyITInvestment:
         pathname.endsWith('no-governance') ||


### PR DESCRIPTION
# NOREF

## Changes and Description

- Hacky fix for when the `systemIntake.requester.email` field is `null` (should send empty array, rather than `[null]`)

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
