### PR TITLE
[NOREF] Fix funding source ID cedar intake

### DIFF
--- a/pkg/cedar/intake/client_test.go
+++ b/pkg/cedar/intake/client_test.go
@@ -2,6 +2,7 @@ package intake
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/google/uuid"
@@ -10,6 +11,7 @@ import (
 	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
+	intakemodels "github.com/cmsgov/easi-app/pkg/cedar/intake/models"
 	"github.com/cmsgov/easi-app/pkg/cedar/intake/translation"
 	"github.com/cmsgov/easi-app/pkg/testhelpers"
 )
@@ -86,6 +88,16 @@ func (s *ClientTestSuite) TestTranslation() {
 		si.UpdatedAt = si.ContractStartDate
 
 		ii, err := si.CreateIntakeModel()
+		s.NoError(err)
+
+		intakeBody := &intakemodels.EASIIntake{}
+		err = json.Unmarshal([]byte(*ii.Body), intakeBody)
+		s.NoError(err)
+
+		// Test that passes that matches what happens now
+		s.EqualValues(si.ID.String(), intakeBody.FundingSources[0].FundingSourceID)
+		// s.EqualValues(si.FundingSources[0].ID.String(), intakeBody.FundingSources[0].FundingSourceID)
+
 		s.NoError(err)
 		s.NotNil(ii)
 	})

--- a/pkg/cedar/intake/client_test.go
+++ b/pkg/cedar/intake/client_test.go
@@ -89,17 +89,19 @@ func (s *ClientTestSuite) TestTranslation() {
 
 		ii, err := si.CreateIntakeModel()
 		s.NoError(err)
+		s.NotNil(ii)
 
+		// Unmarshal the body so we can check that fields are being set properly
 		intakeBody := &intakemodels.EASIIntake{}
 		err = json.Unmarshal([]byte(*ii.Body), intakeBody)
 		s.NoError(err)
 
-		// Test that passes that matches what happens now
-		s.EqualValues(si.ID.String(), intakeBody.FundingSources[0].FundingSourceID)
-		// s.EqualValues(si.FundingSources[0].ID.String(), intakeBody.FundingSources[0].FundingSourceID)
+		// Check that the ID of the Intake is Correct
+		s.EqualValues(si.ID.String(), intakeBody.IntakeID)
 
-		s.NoError(err)
-		s.NotNil(ii)
+		// Check that the Funding Source ID is being pulled from the FundingSources array of the Intake
+		s.EqualValues(si.FundingSources[0].ID.String(), intakeBody.FundingSources[0].FundingSourceID)
+
 	})
 
 	s.Run("note", func() {

--- a/pkg/cedar/intake/translation/system_intake.go
+++ b/pkg/cedar/intake/translation/system_intake.go
@@ -26,7 +26,7 @@ func (si *TranslatableSystemIntake) CreateIntakeModel() (*wire.IntakeInput, erro
 	fundingSources := make([]*intakemodels.EASIFundingSource, 0, len(si.FundingSources))
 	for _, fundingSource := range si.FundingSources {
 		fundingSources = append(fundingSources, &intakemodels.EASIFundingSource{
-			FundingSourceID: si.ID.String(),
+			FundingSourceID: fundingSource.ID.String(),
 			Source:          fundingSource.Source.Ptr(),
 			FundingNumber:   fundingSource.FundingNumber.Ptr(),
 		})


### PR DESCRIPTION
# NOREF

## Changes and Description

- Modified the logic that translates our system intake into a payload for the CEDAR Intake API to use the funding source ID for `fundingSourceID` instead of the System Intake ID

Stemmed from [this conversation](https://cmsgov.slack.com/archives/C02KTCN3ADD/p1663960022481519) and [this conversation](https://cmsgov.slack.com/archives/CNU2B59UH/p1664200443443389)

## How to test this change

1. Start the app with `scripts/dev up:backend`
2. Run `scripts/dev test:go:only github.com/cmsgov/easi-app/pkg/cedar/intake` to run the new tests that were added to test this change

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
