### PR TITLE
Rework draft business case submission to CEDAR Intake

### DIFF
--- a/cmd/test_cedar_intake/main.go
+++ b/cmd/test_cedar_intake/main.go
@@ -250,22 +250,26 @@ func makeTestBusinessCase(times usefulTimes, systemIntake models.SystemIntake) *
 		models.LifecycleCostPhaseOTHER,
 	}
 
-	costAmount := 1
+	increasingCost := 1
 
 	for _, solution := range possibleSolutions {
 		for _, year := range possibleYears {
 			for _, phase := range possiblePhases {
 				phase := phase
+
+				// make a copy, so when we increment costAmount, previously created lifecycleCost.Cost's don't point to the updated value
+				cost := increasingCost
+
 				lifecycleCost := models.EstimatedLifecycleCost{
 					ID:             uuid.New(),
 					BusinessCaseID: businessCase.ID,
 					Solution:       solution,
 					Year:           year,
 					Phase:          &phase,
-					Cost:           &costAmount,
+					Cost:           &cost,
 				}
 				businessCase.LifecycleCostLines = append(businessCase.LifecycleCostLines, lifecycleCost)
-				costAmount++
+				increasingCost++
 			}
 		}
 	}

--- a/cmd/test_cedar_intake/main.go
+++ b/cmd/test_cedar_intake/main.go
@@ -399,9 +399,19 @@ func dumpPayload() {
 	testData := makeTestData()
 
 	fmt.Println("Dumping business case data")
-	intakeObject := translation.TranslatableBusinessCase(*testData.businessCase)
-	dumpIntakeObject(&intakeObject, execDir)
+	businessCaseIntakeObject := translation.TranslatableBusinessCase(*testData.businessCase)
+	dumpIntakeObject(&businessCaseIntakeObject, execDir)
 	fmt.Println("Business case data dumped inside " + execDir + string(filepath.Separator))
+
+	fmt.Println("Dumping GRT feedback data")
+	feedbackIntakeObject := translation.TranslatableFeedback(*testData.feedback)
+	dumpIntakeObject(&feedbackIntakeObject, execDir)
+	fmt.Println("GRT feedback data dumped inside " + execDir + string(filepath.Separator))
+
+	fmt.Println("Dumping system intake data")
+	systemIntakeIntakeObject := translation.TranslatableSystemIntake(*testData.systemIntake)
+	dumpIntakeObject(&systemIntakeIntakeObject, execDir)
+	fmt.Println("System intake data dumped inside " + execDir + string(filepath.Separator))
 }
 
 var submitCmd = &cobra.Command{

--- a/go.sum
+++ b/go.sum
@@ -239,7 +239,6 @@ github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439Z
 github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/pkg/cedar/intake/README.md
+++ b/pkg/cedar/intake/README.md
@@ -27,4 +27,7 @@ The CEDAR team needs a schema of the data we send them in order to decode it for
 
 ## Manual Testing
 
-[`cmd/test_cedar_intake/main.go`](/cmd/test_cedar_intake/main.go) is a script for testing pushing data over to CEDAR Intake. It uses test data (based on the seed data used in `cmd/devdata/main.go`) and calls our Intake client to send data to CEDAR. It requires the `CEDAR_API_URL` and `CEDAR_API_KEY` environment variables to be set; these should be set in your .envrc.local, pointing to the CEDAR dev environment. Run the script with `go run cmd/test_cedar_intake/main.go`; any errors will be reported in the command line.
+[`cmd/test_cedar_intake/main.go`](/cmd/test_cedar_intake/main.go) is a script that creates test data (based on the seed data used in `cmd/devdata/main.go`), which can be used either for examining our translation of data locally or for testing pushing data over to CEDAR Intake, depending on whether the `dump` or `submit` subcommand is used.
+
+- `go run cmd/test_cedar_intake/main.go dump` will create JSON files for test business case, GRT feedback, and system intake data inside the `cmd/test_cedar_intake/` directory. These are examples of the payloads that will be marshaled and sent to CEDAR.
+- `go run cmd/test_cedar_intake/main.go submit` will call our Intake client to send data to CEDAR. It requires the `CEDAR_API_URL` and `CEDAR_API_KEY` environment variables to be set; these should be set in your .envrc.local, pointing to the CEDAR dev environment.

--- a/pkg/cedar/intake/models/easi_biz_case.go
+++ b/pkg/cedar/intake/models/easi_biz_case.go
@@ -47,7 +47,6 @@ type EASIBusinessSolution struct {
 // EASILifecycleCost represents a lifecycle cost item submitted through EASi as part of a business case
 type EASILifecycleCost struct {
 	Cost     *string `json:"cost,omitempty" jsonschema:"description=Fiscal year cost,example=10000"`
-	ID       string  `json:"id" jsonschema:"description=Unique ID of this cost line created by concatenating business case ID + solution + phase + year,example=c7f3495e-f990-4483-a227-2bd9850f36ee_Preferred_Development_1"`
 	Phase    *string `json:"phase,omitempty" jsonschema:"description=Type of work to be performed (can be more then one),example=Development,example=Operations and Maintenance"`
 	Solution string  `json:"solution" jsonschema:"description=Which solution is this (preferred or alternatives),example=Preferred"`
 	Year     string  `json:"year" jsonschema:"description=Which fiscal year does this line pertain to,example=3"`

--- a/pkg/cedar/intake/models/easi_biz_case.go
+++ b/pkg/cedar/intake/models/easi_biz_case.go
@@ -12,43 +12,42 @@ type EASIBizCase struct {
 	ArchivedAt             *string                 `json:"archivedAt,omitempty" jsonschema:"description=Timestamp of when request was archived,example=2023-02-27T14:34:43Z"`
 	BusinessCaseID         string                  `json:"businessCaseId" jsonschema:"description=Unique ID of this business case,example=91e5c1f3-11fb-4124-805c-adbdd02c5395"`
 	BusinessNeed           *string                 `json:"businessNeed,omitempty" jsonschema:"description=Business Need for this effort,example=Process takes too long and holds up key stakeholders"`
-	BusinessOwner          string                  `json:"businessOwner" jsonschema:"description=Business owner of this request,example=John Doe"`
+	BusinessOwner          *string                 `json:"businessOwner,omitempty" jsonschema:"description=Business owner of this request,example=John Doe"`
 	BusinessSolutions      []*EASIBusinessSolution `json:"businessSolutions,omitempty" jsonschema:"description=Array Business Solutions (preferred and alternatives),example=N/A"`
 	CmsBenefit             *string                 `json:"cmsBenefit,omitempty" jsonschema:"description=How CMS will benefit from this effort,example=Reduce FTE hours and generate better end products"`
 	CurrentSolutionSummary *string                 `json:"currentSolutionSummary,omitempty" jsonschema:"description=Summary of the current solution,example=Managed through spreadsheets and email"`
 	IntakeID               *string                 `json:"intakeId,omitempty" jsonschema:"description=Unique ID of the intake associated with this business case,example=36b85781-169a-4539-aa66-916663d8118c"`
 	PriorityAlignment      *string                 `json:"priorityAlignment,omitempty" jsonschema:"description=The ways this effort align with organizational priorities,example=Aligns with CMS' automation push"`
-	ProjectName            string                  `json:"projectName" jsonschema:"description=Name of the project,example=Easy Access to System"`
-	Requester              string                  `json:"requester" jsonschema:"description=Name of the requester,example=John Doe"`
+	ProjectName            *string                 `json:"projectName,omitempty" jsonschema:"description=Name of the project,example=Easy Access to System"`
+	Requester              *string                 `json:"requester,omitempty" jsonschema:"description=Name of the requester,example=John Doe"`
 	RequesterPhoneNumber   *string                 `json:"requesterPhoneNumber,omitempty" jsonschema:"description=Phone number of requester,example=410-123-4567,example=4431234567"`
-	Status                 string                  `json:"status" jsonschema:"Current status of the business case within EASi,example=OPEN"`
 	SuccessIndicators      *string                 `json:"successIndicators,omitempty" jsonschema:"description=How this effort will be determined as successful,example=Workflows are streamlined"`
 	UserEUA                string                  `json:"userEUA" jsonschema:"description=EUA id of the requester,example=J8YN"`
 }
 
 // EASIBusinessSolution represents a business solution submitted through EASi as part of a business case
 type EASIBusinessSolution struct {
-	AcquisitionApproach     *string             `json:"acquisitionApproach,omitempty" jsonschema:"description=Approach to acquiring the products and services required to deliver the system,example=COTS"`
-	Cons                    *string             `json:"cons,omitempty" jsonschema:"description=Cons of this solution,example=A lot of money and time required"`
-	CostSavings             *string             `json:"costSavings,omitempty" jsonschema:"description=Cost savings of this solution,example=over ten million dollars"`
-	HasUI                   *string             `json:"hasUI,omitempty" jsonschema:"description=Does this solution have/need a UI,example=Yes"`
-	HostingCloudServiceType *string             `json:"hostingCloudServiceType,omitempty" jsonschema:"description=What type of cloud service will be used,example=PaaS"`
-	HostingLocation         *string             `json:"hostingLocation,omitempty" jsonschema:"description=Where will this solution be hosted,example=AWS"`
-	HostingType             *string             `json:"hostingType,omitempty" jsonschema:"description=What type of hosting will this solution use,example=cloud"`
-	LifecycleCostLines      []EASILifecycleCost `json:"lifecycleCostLines,omitempty" jsonschema:"description=Array of LifecycleCostLines (costs associated with upcoming Fiscal Years) for this business solution,example=N/A"`
-	Pros                    *string             `json:"pros,omitempty" jsonschema:"description=Pros of this solution,example=Will reduce FTE hours needed"`
-	SecurityIsApproved      *bool               `json:"securityIsApproved,omitempty" jsonschema:"description=Is this solution FedRAMP/FISMA approved,example=True"`
-	SecurityIsBeingReviewed *string             `json:"securityIsBeingReviewed,omitempty" jsonschema:"description=Is this solution in the process of getting FedRAMP/FISMA approval,example=Yes"`
-	SolutionType            string              `json:"solutionType" jsonschema:"enum=preferred,enum=alternativeA,enum=alternativeB,description=Which solution is this (preferred or alternatives),example=preferred"`
-	Summary                 *string             `json:"summary,omitempty" jsonschema:"description=Summary of this solution,example=Building a new application in ServiceNow"`
-	Title                   *string             `json:"title,omitempty" jsonschema:"description=Name of this solution,example=ServiceNow"`
+	AcquisitionApproach     *string              `json:"acquisitionApproach,omitempty" jsonschema:"description=Approach to acquiring the products and services required to deliver the system,example=COTS"`
+	Cons                    *string              `json:"cons,omitempty" jsonschema:"description=Cons of this solution,example=A lot of money and time required"`
+	CostSavings             *string              `json:"costSavings,omitempty" jsonschema:"description=Cost savings of this solution,example=over ten million dollars"`
+	HasUI                   *string              `json:"hasUI,omitempty" jsonschema:"description=Does this solution have/need a UI,example=Yes"`
+	HostingCloudServiceType *string              `json:"hostingCloudServiceType,omitempty" jsonschema:"description=What type of cloud service will be used,example=PaaS"`
+	HostingLocation         *string              `json:"hostingLocation,omitempty" jsonschema:"description=Where will this solution be hosted,example=AWS"`
+	HostingType             *string              `json:"hostingType,omitempty" jsonschema:"description=What type of hosting will this solution use,example=cloud"`
+	LifecycleCostLines      []*EASILifecycleCost `json:"lifecycleCostLines,omitempty" jsonschema:"description=Array of LifecycleCostLines (costs associated with upcoming Fiscal Years) for this business solution,example=N/A"`
+	Pros                    *string              `json:"pros,omitempty" jsonschema:"description=Pros of this solution,example=Will reduce FTE hours needed"`
+	SecurityIsApproved      *bool                `json:"securityIsApproved,omitempty" jsonschema:"description=Is this solution FedRAMP/FISMA approved,example=True"`
+	SecurityIsBeingReviewed *string              `json:"securityIsBeingReviewed,omitempty" jsonschema:"description=Is this solution in the process of getting FedRAMP/FISMA approval,example=Yes"`
+	SolutionType            string               `json:"solutionType" jsonschema:"enum=preferred,enum=alternativeA,enum=alternativeB,description=Which solution is this (preferred or alternatives),example=preferred"`
+	Summary                 *string              `json:"summary,omitempty" jsonschema:"description=Summary of this solution,example=Building a new application in ServiceNow"`
+	Title                   *string              `json:"title,omitempty" jsonschema:"description=Name of this solution,example=ServiceNow"`
 }
 
 // EASILifecycleCost represents a lifecycle cost item submitted through EASi as part of a business case
 type EASILifecycleCost struct {
 	Cost     *string `json:"cost,omitempty" jsonschema:"description=Fiscal year cost,example=10000"`
-	ID       string  `json:"id" jsonschema:"description=Unique ID of this cost line,example=17f51e0f-c9ab-4d8a-8d6f-03aef2d3404d"`
+	ID       *string `json:"id,omitempty" jsonschema:"description=Unique ID of this cost line,example=17f51e0f-c9ab-4d8a-8d6f-03aef2d3404d"`
 	Phase    *string `json:"phase,omitempty" jsonschema:"description=Type of work to be performed (can be more then one),example=Development,example=Operations and Maintenance"`
-	Solution string  `json:"solution" jsonschema:"description=Which solution is this (preferred or alternatives),example=Preferred"`
-	Year     string  `json:"year" jsonschema:"description=Which fiscal year does this line pertain to,example=3"`
+	Solution *string `json:"solution,omitempty" jsonschema:"description=Which solution is this (preferred or alternatives),example=Preferred"`
+	Year     *string `json:"year,omitempty" jsonschema:"description=Which fiscal year does this line pertain to,example=3"`
 }

--- a/pkg/cedar/intake/models/easi_biz_case.go
+++ b/pkg/cedar/intake/models/easi_biz_case.go
@@ -12,42 +12,43 @@ type EASIBizCase struct {
 	ArchivedAt             *string                 `json:"archivedAt,omitempty" jsonschema:"description=Timestamp of when request was archived,example=2023-02-27T14:34:43Z"`
 	BusinessCaseID         string                  `json:"businessCaseId" jsonschema:"description=Unique ID of this business case,example=91e5c1f3-11fb-4124-805c-adbdd02c5395"`
 	BusinessNeed           *string                 `json:"businessNeed,omitempty" jsonschema:"description=Business Need for this effort,example=Process takes too long and holds up key stakeholders"`
-	BusinessOwner          *string                 `json:"businessOwner,omitempty" jsonschema:"description=Business owner of this request,example=John Doe"`
+	BusinessOwner          string                  `json:"businessOwner" jsonschema:"description=Business owner of this request,example=John Doe"`
 	BusinessSolutions      []*EASIBusinessSolution `json:"businessSolutions,omitempty" jsonschema:"description=Array Business Solutions (preferred and alternatives),example=N/A"`
 	CmsBenefit             *string                 `json:"cmsBenefit,omitempty" jsonschema:"description=How CMS will benefit from this effort,example=Reduce FTE hours and generate better end products"`
 	CurrentSolutionSummary *string                 `json:"currentSolutionSummary,omitempty" jsonschema:"description=Summary of the current solution,example=Managed through spreadsheets and email"`
 	IntakeID               *string                 `json:"intakeId,omitempty" jsonschema:"description=Unique ID of the intake associated with this business case,example=36b85781-169a-4539-aa66-916663d8118c"`
 	PriorityAlignment      *string                 `json:"priorityAlignment,omitempty" jsonschema:"description=The ways this effort align with organizational priorities,example=Aligns with CMS' automation push"`
-	ProjectName            *string                 `json:"projectName,omitempty" jsonschema:"description=Name of the project,example=Easy Access to System"`
-	Requester              *string                 `json:"requester,omitempty" jsonschema:"description=Name of the requester,example=John Doe"`
+	ProjectName            string                  `json:"projectName" jsonschema:"description=Name of the project,example=Easy Access to System"`
+	Requester              string                  `json:"requester" jsonschema:"description=Name of the requester,example=John Doe"`
 	RequesterPhoneNumber   *string                 `json:"requesterPhoneNumber,omitempty" jsonschema:"description=Phone number of requester,example=410-123-4567,example=4431234567"`
+	Status                 string                  `json:"status" jsonschema:"Current status of the business case within EASi,example=OPEN"`
 	SuccessIndicators      *string                 `json:"successIndicators,omitempty" jsonschema:"description=How this effort will be determined as successful,example=Workflows are streamlined"`
 	UserEUA                string                  `json:"userEUA" jsonschema:"description=EUA id of the requester,example=J8YN"`
 }
 
 // EASIBusinessSolution represents a business solution submitted through EASi as part of a business case
 type EASIBusinessSolution struct {
-	AcquisitionApproach     *string              `json:"acquisitionApproach,omitempty" jsonschema:"description=Approach to acquiring the products and services required to deliver the system,example=COTS"`
-	Cons                    *string              `json:"cons,omitempty" jsonschema:"description=Cons of this solution,example=A lot of money and time required"`
-	CostSavings             *string              `json:"costSavings,omitempty" jsonschema:"description=Cost savings of this solution,example=over ten million dollars"`
-	HasUI                   *string              `json:"hasUI,omitempty" jsonschema:"description=Does this solution have/need a UI,example=Yes"`
-	HostingCloudServiceType *string              `json:"hostingCloudServiceType,omitempty" jsonschema:"description=What type of cloud service will be used,example=PaaS"`
-	HostingLocation         *string              `json:"hostingLocation,omitempty" jsonschema:"description=Where will this solution be hosted,example=AWS"`
-	HostingType             *string              `json:"hostingType,omitempty" jsonschema:"description=What type of hosting will this solution use,example=cloud"`
-	LifecycleCostLines      []*EASILifecycleCost `json:"lifecycleCostLines,omitempty" jsonschema:"description=Array of LifecycleCostLines (costs associated with upcoming Fiscal Years) for this business solution,example=N/A"`
-	Pros                    *string              `json:"pros,omitempty" jsonschema:"description=Pros of this solution,example=Will reduce FTE hours needed"`
-	SecurityIsApproved      *bool                `json:"securityIsApproved,omitempty" jsonschema:"description=Is this solution FedRAMP/FISMA approved,example=True"`
-	SecurityIsBeingReviewed *string              `json:"securityIsBeingReviewed,omitempty" jsonschema:"description=Is this solution in the process of getting FedRAMP/FISMA approval,example=Yes"`
-	SolutionType            string               `json:"solutionType" jsonschema:"enum=preferred,enum=alternativeA,enum=alternativeB,description=Which solution is this (preferred or alternatives),example=preferred"`
-	Summary                 *string              `json:"summary,omitempty" jsonschema:"description=Summary of this solution,example=Building a new application in ServiceNow"`
-	Title                   *string              `json:"title,omitempty" jsonschema:"description=Name of this solution,example=ServiceNow"`
+	AcquisitionApproach     *string             `json:"acquisitionApproach,omitempty" jsonschema:"description=Approach to acquiring the products and services required to deliver the system,example=COTS"`
+	Cons                    *string             `json:"cons,omitempty" jsonschema:"description=Cons of this solution,example=A lot of money and time required"`
+	CostSavings             *string             `json:"costSavings,omitempty" jsonschema:"description=Cost savings of this solution,example=over ten million dollars"`
+	HasUI                   *string             `json:"hasUI,omitempty" jsonschema:"description=Does this solution have/need a UI,example=Yes"`
+	HostingCloudServiceType *string             `json:"hostingCloudServiceType,omitempty" jsonschema:"description=What type of cloud service will be used,example=PaaS"`
+	HostingLocation         *string             `json:"hostingLocation,omitempty" jsonschema:"description=Where will this solution be hosted,example=AWS"`
+	HostingType             *string             `json:"hostingType,omitempty" jsonschema:"description=What type of hosting will this solution use,example=cloud"`
+	LifecycleCostLines      []EASILifecycleCost `json:"lifecycleCostLines,omitempty" jsonschema:"description=Array of LifecycleCostLines (costs associated with upcoming Fiscal Years) for this business solution,example=N/A"`
+	Pros                    *string             `json:"pros,omitempty" jsonschema:"description=Pros of this solution,example=Will reduce FTE hours needed"`
+	SecurityIsApproved      *bool               `json:"securityIsApproved,omitempty" jsonschema:"description=Is this solution FedRAMP/FISMA approved,example=True"`
+	SecurityIsBeingReviewed *string             `json:"securityIsBeingReviewed,omitempty" jsonschema:"description=Is this solution in the process of getting FedRAMP/FISMA approval,example=Yes"`
+	SolutionType            string              `json:"solutionType" jsonschema:"enum=preferred,enum=alternativeA,enum=alternativeB,description=Which solution is this (preferred or alternatives),example=preferred"`
+	Summary                 *string             `json:"summary,omitempty" jsonschema:"description=Summary of this solution,example=Building a new application in ServiceNow"`
+	Title                   *string             `json:"title,omitempty" jsonschema:"description=Name of this solution,example=ServiceNow"`
 }
 
 // EASILifecycleCost represents a lifecycle cost item submitted through EASi as part of a business case
 type EASILifecycleCost struct {
 	Cost     *string `json:"cost,omitempty" jsonschema:"description=Fiscal year cost,example=10000"`
-	ID       *string `json:"id,omitempty" jsonschema:"description=Unique ID of this cost line,example=17f51e0f-c9ab-4d8a-8d6f-03aef2d3404d"`
+	ID       string  `json:"id" jsonschema:"description=Unique ID of this cost line,example=17f51e0f-c9ab-4d8a-8d6f-03aef2d3404d"`
 	Phase    *string `json:"phase,omitempty" jsonschema:"description=Type of work to be performed (can be more then one),example=Development,example=Operations and Maintenance"`
-	Solution *string `json:"solution,omitempty" jsonschema:"description=Which solution is this (preferred or alternatives),example=Preferred"`
-	Year     *string `json:"year,omitempty" jsonschema:"description=Which fiscal year does this line pertain to,example=3"`
+	Solution string  `json:"solution" jsonschema:"description=Which solution is this (preferred or alternatives),example=Preferred"`
+	Year     string  `json:"year" jsonschema:"description=Which fiscal year does this line pertain to,example=3"`
 }

--- a/pkg/cedar/intake/models/easi_biz_case.go
+++ b/pkg/cedar/intake/models/easi_biz_case.go
@@ -47,7 +47,7 @@ type EASIBusinessSolution struct {
 // EASILifecycleCost represents a lifecycle cost item submitted through EASi as part of a business case
 type EASILifecycleCost struct {
 	Cost     *string `json:"cost,omitempty" jsonschema:"description=Fiscal year cost,example=10000"`
-	ID       string  `json:"id" jsonschema:"description=Unique ID of this cost line,example=17f51e0f-c9ab-4d8a-8d6f-03aef2d3404d"`
+	ID       string  `json:"id" jsonschema:"description=Unique ID of this cost line created by concatenating business case ID + solution + phase + year,example=c7f3495e-f990-4483-a227-2bd9850f36ee_Preferred_Development_1"`
 	Phase    *string `json:"phase,omitempty" jsonschema:"description=Type of work to be performed (can be more then one),example=Development,example=Operations and Maintenance"`
 	Solution string  `json:"solution" jsonschema:"description=Which solution is this (preferred or alternatives),example=Preferred"`
 	Year     string  `json:"year" jsonschema:"description=Which fiscal year does this line pertain to,example=3"`

--- a/pkg/cedar/intake/schemas/easi_business_case.json
+++ b/pkg/cedar/intake/schemas/easi_business_case.json
@@ -235,7 +235,6 @@
     },
     "EASILifecycleCost": {
       "required": [
-        "id",
         "solution",
         "year"
       ],
@@ -245,13 +244,6 @@
           "description": "Fiscal year cost",
           "examples": [
             "10000"
-          ]
-        },
-        "id": {
-          "type": "string",
-          "description": "Unique ID of this cost line created by concatenating business case ID + solution + phase + year",
-          "examples": [
-            "c7f3495e-f990-4483-a227-2bd9850f36ee_Preferred_Development_1"
           ]
         },
         "phase": {

--- a/pkg/cedar/intake/schemas/easi_business_case.json
+++ b/pkg/cedar/intake/schemas/easi_business_case.json
@@ -1,15 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "$ref": "#/definitions/EASIBizCase",
-  "title": "EASIBizCaseV04",
+  "title": "EASIBizCaseV03",
   "definitions": {
     "EASIBizCase": {
       "required": [
         "businessCaseId",
-        "businessOwner",
-        "projectName",
-        "requester",
-        "status",
         "userEUA"
       ],
       "properties": {
@@ -97,12 +93,6 @@
           "examples": [
             "410-123-4567",
             "4431234567"
-          ]
-        },
-        "status": {
-          "type": "string",
-          "examples": [
-            "OPEN"
           ]
         },
         "successIndicators": {
@@ -234,11 +224,6 @@
       "type": "object"
     },
     "EASILifecycleCost": {
-      "required": [
-        "id",
-        "solution",
-        "year"
-      ],
       "properties": {
         "cost": {
           "type": "string",

--- a/pkg/cedar/intake/schemas/easi_business_case.json
+++ b/pkg/cedar/intake/schemas/easi_business_case.json
@@ -1,11 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "$ref": "#/definitions/EASIBizCase",
-  "title": "EASIBizCaseV03",
+  "title": "EASIBizCaseV04",
   "definitions": {
     "EASIBizCase": {
       "required": [
         "businessCaseId",
+        "businessOwner",
+        "projectName",
+        "requester",
+        "status",
         "userEUA"
       ],
       "properties": {
@@ -93,6 +97,12 @@
           "examples": [
             "410-123-4567",
             "4431234567"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "examples": [
+            "OPEN"
           ]
         },
         "successIndicators": {
@@ -224,6 +234,11 @@
       "type": "object"
     },
     "EASILifecycleCost": {
+      "required": [
+        "id",
+        "solution",
+        "year"
+      ],
       "properties": {
         "cost": {
           "type": "string",

--- a/pkg/cedar/intake/schemas/easi_business_case.json
+++ b/pkg/cedar/intake/schemas/easi_business_case.json
@@ -249,9 +249,9 @@
         },
         "id": {
           "type": "string",
-          "description": "Unique ID of this cost line",
+          "description": "Unique ID of this cost line created by concatenating business case ID + solution + phase + year",
           "examples": [
-            "17f51e0f-c9ab-4d8a-8d6f-03aef2d3404d"
+            "c7f3495e-f990-4483-a227-2bd9850f36ee_Preferred_Development_1"
           ]
         },
         "phase": {

--- a/pkg/cedar/intake/translation/biz.go
+++ b/pkg/cedar/intake/translation/biz.go
@@ -28,15 +28,16 @@ func (bc *TranslatableBusinessCase) CreateIntakeModel() (*wire.IntakeInput, erro
 		UserEUA:                bc.EUAUserID,
 		BusinessCaseID:         bc.ID.String(),
 		IntakeID:               pStr(bc.SystemIntakeID.String()),
-		ProjectName:            bc.ProjectName.Ptr(),
-		Requester:              bc.Requester.Ptr(),
+		ProjectName:            bc.ProjectName.ValueOrZero(), // will always have a value by the time a draft business case is submitted
+		Requester:              bc.Requester.ValueOrZero(),   // will always have a value by the time a draft business case is submitted
 		RequesterPhoneNumber:   bc.RequesterPhoneNumber.Ptr(),
-		BusinessOwner:          bc.BusinessOwner.Ptr(),
+		BusinessOwner:          bc.BusinessOwner.ValueOrZero(), // will always have a value by the time a draft business case is submitted
 		BusinessNeed:           bc.BusinessNeed.Ptr(),
 		CurrentSolutionSummary: bc.CurrentSolutionSummary.Ptr(),
 		CmsBenefit:             bc.CMSBenefit.Ptr(),
 		PriorityAlignment:      bc.PriorityAlignment.Ptr(),
 		SuccessIndicators:      bc.SuccessIndicators.Ptr(),
+		Status:                 string(bc.Status),
 
 		ArchivedAt: pStr(strDateTime(bc.ArchivedAt)),
 
@@ -61,7 +62,7 @@ func (bc *TranslatableBusinessCase) CreateIntakeModel() (*wire.IntakeInput, erro
 		Pros:                    bc.PreferredPros.Ptr(),
 		Cons:                    bc.PreferredCons.Ptr(),
 		CostSavings:             bc.PreferredCostSavings.Ptr(),
-		LifecycleCostLines:      []*intakemodels.EASILifecycleCost{},
+		LifecycleCostLines:      []intakemodels.EASILifecycleCost{},
 	}
 
 	// TODO: do we need to check if alternative a and b are filled out?
@@ -82,7 +83,7 @@ func (bc *TranslatableBusinessCase) CreateIntakeModel() (*wire.IntakeInput, erro
 		Pros:                    bc.AlternativeAPros.Ptr(),
 		Cons:                    bc.AlternativeACons.Ptr(),
 		CostSavings:             bc.AlternativeACostSavings.Ptr(),
-		LifecycleCostLines:      []*intakemodels.EASILifecycleCost{},
+		LifecycleCostLines:      []intakemodels.EASILifecycleCost{},
 	}
 
 	// Alternative b (optional)
@@ -100,17 +101,17 @@ func (bc *TranslatableBusinessCase) CreateIntakeModel() (*wire.IntakeInput, erro
 		Pros:                    bc.AlternativeBPros.Ptr(),
 		Cons:                    bc.AlternativeBCons.Ptr(),
 		CostSavings:             bc.AlternativeBCostSavings.Ptr(),
-		LifecycleCostLines:      []*intakemodels.EASILifecycleCost{},
+		LifecycleCostLines:      []intakemodels.EASILifecycleCost{},
 	}
 
 	// Add lifecycle cost lines to business solutions
 	bcID := bc.ID.String()
 
 	for _, line := range bc.LifecycleCostLines {
-		lc := &intakemodels.EASILifecycleCost{
-			ID:       pStr(bcID),
-			Solution: pStr(string(line.Solution)),
-			Year:     pStr(string(line.Year)),
+		lc := intakemodels.EASILifecycleCost{
+			ID:       bcID,
+			Solution: string(line.Solution),
+			Year:     string(line.Year),
 		}
 
 		phase := ""

--- a/pkg/cedar/intake/translation/biz.go
+++ b/pkg/cedar/intake/translation/biz.go
@@ -28,16 +28,15 @@ func (bc *TranslatableBusinessCase) CreateIntakeModel() (*wire.IntakeInput, erro
 		UserEUA:                bc.EUAUserID,
 		BusinessCaseID:         bc.ID.String(),
 		IntakeID:               pStr(bc.SystemIntakeID.String()),
-		ProjectName:            bc.ProjectName.ValueOrZero(), // will always have a value by the time a draft business case is submitted
-		Requester:              bc.Requester.ValueOrZero(),   // will always have a value by the time a draft business case is submitted
+		ProjectName:            bc.ProjectName.Ptr(),
+		Requester:              bc.Requester.Ptr(),
 		RequesterPhoneNumber:   bc.RequesterPhoneNumber.Ptr(),
-		BusinessOwner:          bc.BusinessOwner.ValueOrZero(), // will always have a value by the time a draft business case is submitted
+		BusinessOwner:          bc.BusinessOwner.Ptr(),
 		BusinessNeed:           bc.BusinessNeed.Ptr(),
 		CurrentSolutionSummary: bc.CurrentSolutionSummary.Ptr(),
 		CmsBenefit:             bc.CMSBenefit.Ptr(),
 		PriorityAlignment:      bc.PriorityAlignment.Ptr(),
 		SuccessIndicators:      bc.SuccessIndicators.Ptr(),
-		Status:                 string(bc.Status),
 
 		ArchivedAt: pStr(strDateTime(bc.ArchivedAt)),
 
@@ -62,7 +61,7 @@ func (bc *TranslatableBusinessCase) CreateIntakeModel() (*wire.IntakeInput, erro
 		Pros:                    bc.PreferredPros.Ptr(),
 		Cons:                    bc.PreferredCons.Ptr(),
 		CostSavings:             bc.PreferredCostSavings.Ptr(),
-		LifecycleCostLines:      []intakemodels.EASILifecycleCost{},
+		LifecycleCostLines:      []*intakemodels.EASILifecycleCost{},
 	}
 
 	// TODO: do we need to check if alternative a and b are filled out?
@@ -83,7 +82,7 @@ func (bc *TranslatableBusinessCase) CreateIntakeModel() (*wire.IntakeInput, erro
 		Pros:                    bc.AlternativeAPros.Ptr(),
 		Cons:                    bc.AlternativeACons.Ptr(),
 		CostSavings:             bc.AlternativeACostSavings.Ptr(),
-		LifecycleCostLines:      []intakemodels.EASILifecycleCost{},
+		LifecycleCostLines:      []*intakemodels.EASILifecycleCost{},
 	}
 
 	// Alternative b (optional)
@@ -101,17 +100,17 @@ func (bc *TranslatableBusinessCase) CreateIntakeModel() (*wire.IntakeInput, erro
 		Pros:                    bc.AlternativeBPros.Ptr(),
 		Cons:                    bc.AlternativeBCons.Ptr(),
 		CostSavings:             bc.AlternativeBCostSavings.Ptr(),
-		LifecycleCostLines:      []intakemodels.EASILifecycleCost{},
+		LifecycleCostLines:      []*intakemodels.EASILifecycleCost{},
 	}
 
 	// Add lifecycle cost lines to business solutions
 	bcID := bc.ID.String()
 
 	for _, line := range bc.LifecycleCostLines {
-		lc := intakemodels.EASILifecycleCost{
-			ID:       bcID,
-			Solution: string(line.Solution),
-			Year:     string(line.Year),
+		lc := &intakemodels.EASILifecycleCost{
+			ID:       pStr(bcID),
+			Solution: pStr(string(line.Solution)),
+			Year:     pStr(string(line.Year)),
 		}
 
 		phase := ""

--- a/pkg/cedar/intake/translation/biz.go
+++ b/pkg/cedar/intake/translation/biz.go
@@ -3,7 +3,6 @@ package translation
 import (
 	"encoding/json"
 	"strconv"
-	"strings"
 
 	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
 	intakemodels "github.com/cmsgov/easi-app/pkg/cedar/intake/models"
@@ -109,19 +108,7 @@ func (bc *TranslatableBusinessCase) CreateIntakeModel() (*wire.IntakeInput, erro
 	bcID := bc.ID.String()
 
 	for _, line := range bc.LifecycleCostLines {
-		// we can't use line.ID as a stable ID over time; those UUIDs get regenerated every time a business case is updated,
-		// pkg/storage/business_case.go UpdateBusinessCase() drops all lifecycle cost lines, then recreates them based on the updated business case
-		// instead, use a concatenation of (business case ID, solution, phase, year), which will always be unique and stable over time
-
-		phaseID := "UnknownPhase"
-		if line.Phase != nil {
-			phaseID = string(*line.Phase)
-		}
-
-		lcID := strings.Join([]string{bcID, string(line.Solution), phaseID, string(line.Year)}, "_")
-
 		lc := intakemodels.EASILifecycleCost{
-			ID:       lcID,
 			Solution: string(line.Solution),
 			Year:     string(line.Year),
 		}

--- a/pkg/cedar/intake/translation/biz.go
+++ b/pkg/cedar/intake/translation/biz.go
@@ -3,6 +3,7 @@ package translation
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 
 	wire "github.com/cmsgov/easi-app/pkg/cedar/intake/gen/models"
 	intakemodels "github.com/cmsgov/easi-app/pkg/cedar/intake/models"
@@ -108,8 +109,19 @@ func (bc *TranslatableBusinessCase) CreateIntakeModel() (*wire.IntakeInput, erro
 	bcID := bc.ID.String()
 
 	for _, line := range bc.LifecycleCostLines {
+		// we can't use line.ID as a stable ID over time; those UUIDs get regenerated every time a business case is updated,
+		// pkg/storage/business_case.go UpdateBusinessCase() drops all lifecycle cost lines, then recreates them based on the updated business case
+		// instead, use a concatenation of (business case ID, solution, phase, year), which will always be unique and stable over time
+
+		phaseID := "UnknownPhase"
+		if line.Phase != nil {
+			phaseID = string(*line.Phase)
+		}
+
+		lcID := strings.Join([]string{bcID, string(line.Solution), phaseID, string(line.Year)}, "_")
+
 		lc := intakemodels.EASILifecycleCost{
-			ID:       bcID,
+			ID:       lcID,
 			Solution: string(line.Solution),
 			Year:     string(line.Year),
 		}

--- a/pkg/cedar/intake/translation/constants.go
+++ b/pkg/cedar/intake/translation/constants.go
@@ -36,7 +36,7 @@ const (
 	IntakeInputSchemaEASIActionVersion SchemaVersion = "EASIActionV01"
 
 	// IntakeInputSchemaEASIBizCaseVersion captures the current schema version for Business Cases
-	IntakeInputSchemaEASIBizCaseVersion SchemaVersion = "EASIBizCaseV03"
+	IntakeInputSchemaEASIBizCaseVersion SchemaVersion = "EASIBizCaseV04"
 
 	// IntakeInputSchemaEASIGrtFeedbackVersion captures the current schema version for GRT Feedback
 	IntakeInputSchemaEASIGrtFeedbackVersion SchemaVersion = "EASIGrtFeedbackV02"

--- a/pkg/cedar/intake/translation/constants.go
+++ b/pkg/cedar/intake/translation/constants.go
@@ -36,7 +36,7 @@ const (
 	IntakeInputSchemaEASIActionVersion SchemaVersion = "EASIActionV01"
 
 	// IntakeInputSchemaEASIBizCaseVersion captures the current schema version for Business Cases
-	IntakeInputSchemaEASIBizCaseVersion SchemaVersion = "EASIBizCaseV04"
+	IntakeInputSchemaEASIBizCaseVersion SchemaVersion = "EASIBizCaseV03"
 
 	// IntakeInputSchemaEASIGrtFeedbackVersion captures the current schema version for GRT Feedback
 	IntakeInputSchemaEASIGrtFeedbackVersion SchemaVersion = "EASIGrtFeedbackV02"

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -394,6 +394,7 @@ func (s *Server) routes(
 					store.UpdateSystemIntake,
 					store.UpdateBusinessCase,
 					emailClient.SendBusinessCaseSubmissionEmail,
+					publisher.PublishBusinessCase,
 					models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED,
 				),
 				models.ActionTypeSUBMITFINALBIZCASE: services.NewSubmitBusinessCase(
@@ -405,6 +406,7 @@ func (s *Server) routes(
 					store.UpdateSystemIntake,
 					store.UpdateBusinessCase,
 					emailClient.SendBusinessCaseSubmissionEmail,
+					publisher.PublishBusinessCase,
 					models.SystemIntakeStatusBIZCASEFINALSUBMITTED,
 				), models.ActionTypeSUBMITINTAKE: services.NewSubmitSystemIntake(
 					serviceConfig,

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -394,7 +394,6 @@ func (s *Server) routes(
 					store.UpdateSystemIntake,
 					store.UpdateBusinessCase,
 					emailClient.SendBusinessCaseSubmissionEmail,
-					publisher.PublishBusinessCase,
 					models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED,
 				),
 				models.ActionTypeSUBMITFINALBIZCASE: services.NewSubmitBusinessCase(
@@ -406,7 +405,6 @@ func (s *Server) routes(
 					store.UpdateSystemIntake,
 					store.UpdateBusinessCase,
 					emailClient.SendBusinessCaseSubmissionEmail,
-					publisher.PublishBusinessCase,
 					models.SystemIntakeStatusBIZCASEFINALSUBMITTED,
 				), models.ActionTypeSUBMITINTAKE: services.NewSubmitSystemIntake(
 					serviceConfig,

--- a/pkg/services/action.go
+++ b/pkg/services/action.go
@@ -165,7 +165,6 @@ func NewSubmitBusinessCase(
 	updateIntake func(context.Context, *models.SystemIntake) (*models.SystemIntake, error),
 	updateBusinessCase func(context.Context, *models.BusinessCase) (*models.BusinessCase, error),
 	sendEmail func(ctx context.Context, requestName string, intakeID uuid.UUID) error,
-	submitToCEDAR func(ctx context.Context, bc models.BusinessCase) error,
 	newIntakeStatus models.SystemIntakeStatus,
 ) ActionExecuter {
 	return func(ctx context.Context, intake *models.SystemIntake, action *models.Action) error {
@@ -232,15 +231,6 @@ func NewSubmitBusinessCase(
 		err = sendEmail(ctx, businessCase.ProjectName.String, businessCase.SystemIntakeID)
 		if err != nil {
 			appcontext.ZLogger(ctx).Error("Submit Business Case email failed to send: ", zap.Error(err))
-		}
-
-		// TODO - EASI-2363 - rework conditional to also trigger on publishing finalized system intakes
-		// need to check intake.Status, *not* businessCase.SystemIntakeStatus - intake is what gets returned from calling updateIntake()
-		if intake.Status == models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED {
-			err = submitToCEDAR(ctx, *businessCase)
-			if err != nil {
-				appcontext.ZLogger(ctx).Error("Submission to CEDAR failed", zap.Error(err))
-			}
 		}
 
 		return nil

--- a/pkg/services/action.go
+++ b/pkg/services/action.go
@@ -165,6 +165,7 @@ func NewSubmitBusinessCase(
 	updateIntake func(context.Context, *models.SystemIntake) (*models.SystemIntake, error),
 	updateBusinessCase func(context.Context, *models.BusinessCase) (*models.BusinessCase, error),
 	sendEmail func(ctx context.Context, requestName string, intakeID uuid.UUID) error,
+	submitToCEDAR func(ctx context.Context, bc models.BusinessCase) error,
 	newIntakeStatus models.SystemIntakeStatus,
 ) ActionExecuter {
 	return func(ctx context.Context, intake *models.SystemIntake, action *models.Action) error {
@@ -231,6 +232,15 @@ func NewSubmitBusinessCase(
 		err = sendEmail(ctx, businessCase.ProjectName.String, businessCase.SystemIntakeID)
 		if err != nil {
 			appcontext.ZLogger(ctx).Error("Submit Business Case email failed to send: ", zap.Error(err))
+		}
+
+		// TODO - EASI-2363 - rework conditional to also trigger on publishing finalized system intakes
+		// need to check intake.Status, *not* businessCase.SystemIntakeStatus - intake is what gets returned from calling updateIntake()
+		if intake.Status == models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED {
+			err = submitToCEDAR(ctx, *businessCase)
+			if err != nil {
+				appcontext.ZLogger(ctx).Error("Submission to CEDAR failed", zap.Error(err))
+			}
 		}
 
 		return nil

--- a/pkg/services/action_test.go
+++ b/pkg/services/action_test.go
@@ -207,32 +207,67 @@ func (s *ServicesTestSuite) TestNewSubmitBizCase() {
 	saveAction := func(ctx context.Context, action *models.Action) error {
 		return nil
 	}
-	submitEmailCount := 0
-	sendSubmitEmail := func(ctx context.Context, requester string, intakeID uuid.UUID) error {
-		submitEmailCount++
-		return nil
-	}
 
 	s.Run("golden path submit Biz Case", func() {
+		submitEmailCount := 0
+		sendSubmitEmailMock := func(ctx context.Context, requester string, intakeID uuid.UUID) error {
+			submitEmailCount++
+			return nil
+		}
+
+		submitToCEDARStub := func(ctx context.Context, bc models.BusinessCase) error {
+			return nil
+		}
+
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		action := models.Action{ActionType: models.ActionTypeSUBMITBIZCASE}
 		status := models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED
-		submitBusinessCase := NewSubmitBusinessCase(serviceConfig, authorize, fetchOpenBusinessCase, validateForSubmit, saveAction, updateIntake, updateBusinessCase, sendSubmitEmail, status)
+		submitBusinessCase := NewSubmitBusinessCase(
+			serviceConfig,
+			authorize,
+			fetchOpenBusinessCase,
+			validateForSubmit,
+			saveAction,
+			updateIntake,
+			updateBusinessCase,
+			sendSubmitEmailMock,
+			submitToCEDARStub,
+			status,
+		)
 		s.Equal(0, submitEmailCount)
 
 		err := submitBusinessCase(ctx, &intake, &action)
 
 		s.NoError(err)
 		s.Equal(1, submitEmailCount)
-
-		submitEmailCount = 0
 	})
 
 	s.Run("submit Biz Case sets the intake status to the value passed", func() {
+		submitEmailCount := 0
+		sendSubmitEmailMock := func(ctx context.Context, requester string, intakeID uuid.UUID) error {
+			submitEmailCount++
+			return nil
+		}
+
+		submitToCEDARStub := func(ctx context.Context, bc models.BusinessCase) error {
+			return nil
+		}
+
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		action := models.Action{ActionType: models.ActionTypeSUBMITBIZCASE}
 		status := models.SystemIntakeStatusBIZCASEFINALSUBMITTED
-		submitBusinessCase := NewSubmitBusinessCase(serviceConfig, authorize, fetchOpenBusinessCase, validateForSubmit, saveAction, updateIntake, updateBusinessCase, sendSubmitEmail, status)
+		submitBusinessCase := NewSubmitBusinessCase(
+			serviceConfig,
+			authorize,
+			fetchOpenBusinessCase,
+			validateForSubmit,
+			saveAction,
+			updateIntake,
+			updateBusinessCase,
+			sendSubmitEmailMock,
+			submitToCEDARStub,
+			status,
+		)
 		s.Equal(0, submitEmailCount)
 
 		err := submitBusinessCase(ctx, &intake, &action)
@@ -240,11 +275,17 @@ func (s *ServicesTestSuite) TestNewSubmitBizCase() {
 		s.NoError(err)
 		s.Equal(1, submitEmailCount)
 		s.Equal(intake.Status, status)
-
-		submitEmailCount = 0
 	})
 
 	s.Run("returns error from authorization if authorization fails", func() {
+		sendSubmitEmailStub := func(ctx context.Context, requester string, intakeID uuid.UUID) error {
+			return nil
+		}
+
+		submitToCEDARStub := func(ctx context.Context, bc models.BusinessCase) error {
+			return nil
+		}
+
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		action := models.Action{ActionType: models.ActionTypeSUBMITBIZCASE}
 		status := models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED
@@ -252,39 +293,98 @@ func (s *ServicesTestSuite) TestNewSubmitBizCase() {
 		failAuthorize := func(ctx context.Context, intake *models.SystemIntake) (bool, error) {
 			return false, authorizationError
 		}
-		submitBusinessCase := NewSubmitBusinessCase(serviceConfig, failAuthorize, fetchOpenBusinessCase, validateForSubmit, saveAction, updateIntake, updateBusinessCase, sendSubmitEmail, status)
+		submitBusinessCase := NewSubmitBusinessCase(
+			serviceConfig,
+			failAuthorize,
+			fetchOpenBusinessCase,
+			validateForSubmit,
+			saveAction,
+			updateIntake,
+			updateBusinessCase,
+			sendSubmitEmailStub,
+			submitToCEDARStub,
+			status,
+		)
 		err := submitBusinessCase(ctx, &intake, &action)
 
 		s.Equal(authorizationError, err)
 	})
 
 	s.Run("returns unauthorized error if authorization denied", func() {
+		sendSubmitEmailStub := func(ctx context.Context, requester string, intakeID uuid.UUID) error {
+			return nil
+		}
+
+		submitToCEDARStub := func(ctx context.Context, bc models.BusinessCase) error {
+			return nil
+		}
+
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		action := models.Action{ActionType: models.ActionTypeSUBMITBIZCASE}
 		status := models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED
 		unauthorize := func(ctx context.Context, intake *models.SystemIntake) (bool, error) {
 			return false, nil
 		}
-		submitBusinessCase := NewSubmitBusinessCase(serviceConfig, unauthorize, fetchOpenBusinessCase, validateForSubmit, saveAction, updateIntake, updateBusinessCase, sendSubmitEmail, status)
+		submitBusinessCase := NewSubmitBusinessCase(
+			serviceConfig,
+			unauthorize,
+			fetchOpenBusinessCase,
+			validateForSubmit,
+			saveAction,
+			updateIntake,
+			updateBusinessCase,
+			sendSubmitEmailStub,
+			submitToCEDARStub,
+			status,
+		)
 		err := submitBusinessCase(ctx, &intake, &action)
 
 		s.IsType(&apperrors.UnauthorizedError{}, err)
 	})
 
 	s.Run("returns error if fails to save action", func() {
+		sendSubmitEmailStub := func(ctx context.Context, requester string, intakeID uuid.UUID) error {
+			return nil
+		}
+
+		submitToCEDARStub := func(ctx context.Context, bc models.BusinessCase) error {
+			return nil
+		}
+
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		action := models.Action{ActionType: models.ActionTypeSUBMITBIZCASE}
 		status := models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED
 		failCreateAction := func(ctx context.Context, action *models.Action) error {
 			return errors.New("error")
 		}
-		submitBusinessCase := NewSubmitBusinessCase(serviceConfig, authorize, fetchOpenBusinessCase, validateForSubmit, failCreateAction, updateIntake, updateBusinessCase, sendSubmitEmail, status)
+		submitBusinessCase := NewSubmitBusinessCase(
+			serviceConfig,
+			authorize,
+			fetchOpenBusinessCase,
+			validateForSubmit,
+			failCreateAction,
+			updateIntake,
+			updateBusinessCase,
+			sendSubmitEmailStub,
+			submitToCEDARStub,
+			status,
+		)
 		err := submitBusinessCase(ctx, &intake, &action)
 
 		s.IsType(&apperrors.QueryError{}, err)
 	})
 
 	s.Run("does not return error for validation if status is not biz case final", func() {
+		submitEmailCount := 0
+		sendSubmitEmailMock := func(ctx context.Context, requester string, intakeID uuid.UUID) error {
+			submitEmailCount++
+			return nil
+		}
+
+		submitToCEDARStub := func(ctx context.Context, bc models.BusinessCase) error {
+			return nil
+		}
+
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusBIZCASEDRAFT}
 		action := models.Action{ActionType: models.ActionTypeSUBMITBIZCASE}
 		status := models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED
@@ -295,16 +395,35 @@ func (s *ServicesTestSuite) TestNewSubmitBizCase() {
 				Model:   businessCase,
 			}
 		}
-		submitBusinessCase := NewSubmitBusinessCase(serviceConfig, authorize, fetchOpenBusinessCase, failValidation, saveAction, updateIntake, updateBusinessCase, sendSubmitEmail, status)
+		submitBusinessCase := NewSubmitBusinessCase(
+			serviceConfig,
+			authorize,
+			fetchOpenBusinessCase,
+			failValidation,
+			saveAction,
+			updateIntake,
+			updateBusinessCase,
+			sendSubmitEmailMock,
+			submitToCEDARStub,
+			status,
+		)
 		err := submitBusinessCase(ctx, &intake, &action)
 
 		s.NoError(err)
 		s.Equal(1, submitEmailCount)
-
-		submitEmailCount = 0
 	})
 
 	s.Run("returns error when status is biz case final and validation fails", func() {
+		submitEmailCount := 0
+		sendSubmitEmailMock := func(ctx context.Context, requester string, intakeID uuid.UUID) error {
+			submitEmailCount++
+			return nil
+		}
+
+		submitToCEDARStub := func(ctx context.Context, bc models.BusinessCase) error {
+			return nil
+		}
+
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusBIZCASEFINALNEEDED}
 		action := models.Action{ActionType: models.ActionTypeSUBMITBIZCASE}
 		status := models.SystemIntakeStatusBIZCASEFINALSUBMITTED
@@ -318,7 +437,18 @@ func (s *ServicesTestSuite) TestNewSubmitBizCase() {
 		fetchOpenBusinessCase = func(ctx context.Context, id uuid.UUID) (*models.BusinessCase, error) {
 			return &models.BusinessCase{SystemIntakeStatus: intake.Status}, nil
 		}
-		submitBusinessCase := NewSubmitBusinessCase(serviceConfig, authorize, fetchOpenBusinessCase, failValidation, saveAction, updateIntake, updateBusinessCase, sendSubmitEmail, status)
+		submitBusinessCase := NewSubmitBusinessCase(
+			serviceConfig,
+			authorize,
+			fetchOpenBusinessCase,
+			failValidation,
+			saveAction,
+			updateIntake,
+			updateBusinessCase,
+			sendSubmitEmailMock,
+			submitToCEDARStub,
+			status,
+		)
 		err := submitBusinessCase(ctx, &intake, &action)
 
 		s.IsType(&apperrors.ValidationError{}, err)
@@ -326,29 +456,133 @@ func (s *ServicesTestSuite) TestNewSubmitBizCase() {
 	})
 
 	s.Run("returns query error if update intake fails", func() {
+		sendSubmitEmailStub := func(ctx context.Context, requester string, intakeID uuid.UUID) error {
+			return nil
+		}
+
+		submitToCEDARStub := func(ctx context.Context, bc models.BusinessCase) error {
+			return nil
+		}
+
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		action := models.Action{ActionType: models.ActionTypeSUBMITBIZCASE}
 		status := models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED
 		failUpdateIntake := func(ctx context.Context, intake *models.SystemIntake) (*models.SystemIntake, error) {
 			return &models.SystemIntake{}, errors.New("update error")
 		}
-		submitBusinessCase := NewSubmitBusinessCase(serviceConfig, authorize, fetchOpenBusinessCase, validateForSubmit, saveAction, failUpdateIntake, updateBusinessCase, sendSubmitEmail, status)
+		submitBusinessCase := NewSubmitBusinessCase(
+			serviceConfig,
+			authorize,
+			fetchOpenBusinessCase,
+			validateForSubmit,
+			saveAction,
+			failUpdateIntake,
+			updateBusinessCase,
+			sendSubmitEmailStub,
+			submitToCEDARStub,
+			status,
+		)
 		err := submitBusinessCase(ctx, &intake, &action)
 
 		s.IsType(&apperrors.QueryError{}, err)
 	})
 
 	s.Run("returns query error if update biz case fails", func() {
+		sendSubmitEmailStub := func(ctx context.Context, requester string, intakeID uuid.UUID) error {
+			return nil
+		}
+
+		submitToCEDARStub := func(ctx context.Context, bc models.BusinessCase) error {
+			return nil
+		}
+
 		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
 		action := models.Action{ActionType: models.ActionTypeSUBMITBIZCASE}
 		status := models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED
 		failUpdateBizCase := func(ctx context.Context, businessCase *models.BusinessCase) (*models.BusinessCase, error) {
 			return &models.BusinessCase{}, errors.New("update error")
 		}
-		submitBusinessCase := NewSubmitBusinessCase(serviceConfig, authorize, fetchOpenBusinessCase, validateForSubmit, saveAction, updateIntake, failUpdateBizCase, sendSubmitEmail, status)
+		submitBusinessCase := NewSubmitBusinessCase(
+			serviceConfig,
+			authorize,
+			fetchOpenBusinessCase,
+			validateForSubmit,
+			saveAction,
+			updateIntake,
+			failUpdateBizCase,
+			sendSubmitEmailStub,
+			submitToCEDARStub,
+			status,
+		)
 		err := submitBusinessCase(ctx, &intake, &action)
 
 		s.IsType(&apperrors.QueryError{}, err)
+	})
+
+	s.Run("Submits business case data to CEDAR when submitting draft business case", func() {
+		sendSubmitEmailStub := func(ctx context.Context, requester string, intakeID uuid.UUID) error {
+			return nil
+		}
+
+		submitToCEDARCount := 0
+		submitToCEDARMock := func(ctx context.Context, bc models.BusinessCase) error {
+			submitToCEDARCount++
+			return nil
+		}
+
+		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
+		action := models.Action{ActionType: models.ActionTypeSUBMITBIZCASE}
+		status := models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED
+
+		submitBusinessCase := NewSubmitBusinessCase(
+			serviceConfig,
+			authorize,
+			fetchOpenBusinessCase,
+			validateForSubmit,
+			saveAction,
+			updateIntake,
+			updateBusinessCase,
+			sendSubmitEmailStub,
+			submitToCEDARMock,
+			status,
+		)
+		s.Equal(0, submitToCEDARCount)
+
+		err := submitBusinessCase(ctx, &intake, &action)
+
+		s.NoError(err)
+		s.Equal(1, submitToCEDARCount)
+	})
+
+	s.Run("Error submitting business case data to CEDAR when submitting draft business case does not return overall error", func() {
+		sendSubmitEmailStub := func(ctx context.Context, requester string, intakeID uuid.UUID) error {
+			return nil
+		}
+
+		failSubmitToCEDAR := func(ctx context.Context, bc models.BusinessCase) error {
+			return errors.New("Could not submit business case to CEDAR")
+		}
+
+		intake := models.SystemIntake{Status: models.SystemIntakeStatusINTAKEDRAFT}
+		action := models.Action{ActionType: models.ActionTypeSUBMITBIZCASE}
+		status := models.SystemIntakeStatusBIZCASEDRAFTSUBMITTED
+
+		submitBusinessCase := NewSubmitBusinessCase(
+			serviceConfig,
+			authorize,
+			fetchOpenBusinessCase,
+			validateForSubmit,
+			saveAction,
+			updateIntake,
+			updateBusinessCase,
+			sendSubmitEmailStub,
+			failSubmitToCEDAR,
+			status,
+		)
+
+		err := submitBusinessCase(ctx, &intake, &action)
+
+		s.NoError(err)
 	})
 }
 


### PR DESCRIPTION
# EASI-1538

## Changes and Description

- Re-applies changes from https://github.com/CMSgov/easi-app/pull/1785 to submit draft business case data to the CEDAR Intake API.
- Add subcommands to `cmd/test_cedar_intake/main.go` - the `submit` subcommand runs the previous functionality of submitting to CEDAR from your local machine, while the `dump` subcommand creates JSON files locally as examples of the payloads that will be sent to CEDAR.
- ID field removed from lifecycle cost lines - from discussion with the CEDAR team, we decided to remove IDs from sub-entities; CEDAR will delete and regenerate sub-entities on their end when a top-level entity is updated.

## How to test this change

First, enable the `emit-to-cedar` feature flag for your EUA ID in the local environment in LaunchDarkly.

The easiest way to test this is to put a log/print statement in `pkg/cedar/intake/client.go`'s `publishIntakeObject()` method that logs when it's called. Run the full app locally, create an intake, request a draft business case (as an admin), and submit a draft business case (every field can be left empty); you should see the output from the log/print statement you added in the `easi` container logs.

For a more thorough test, connect to the VPN, make sure you have the `CEDAR_API_URL` and `CEDAR_API_KEY` environment variables set to valid values for CEDAR IMPL. Go through the same process of submitting a draft business case locally, then ask the CEDAR team in #oit-easi-cedar on Slack whether they received the payload.