### PR TITLE
Upgrade Cypress dependencies, remove direct md5 dependency

### DIFF
--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -32,4 +32,4 @@ COPY scripts/seed_database /scripts/seed_database
 COPY --from=build /easi/bin/seed /build/seed
 
 ENTRYPOINT ["/node_modules/.bin/cypress"]
-CMD ["run"]
+CMD ["run", "--spec=/cypress/e2e/businessCase.cy.js"]

--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -32,4 +32,4 @@ COPY scripts/seed_database /scripts/seed_database
 COPY --from=build /easi/bin/seed /build/seed
 
 ENTRYPOINT ["/node_modules/.bin/cypress"]
-CMD ["run", "--spec=/cypress/e2e/businessCase.cy.js"]
+CMD ["run"]

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -11,6 +11,7 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 const cypressOTP = require('cypress-otp');
+const cypressCodeCovTask = require('@cypress/code-coverage/task');
 const wp = require('@cypress/webpack-preprocessor');
 
 module.exports = (on, config) => {
@@ -19,6 +20,7 @@ module.exports = (on, config) => {
   on('task', {
     generateOTP: cypressOTP
   });
+  cypressCodeCovTask(on, config);
 
   const options = {
     webpackOptions: {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@types/uuid": "^8.3.4",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.2",
     "babel-loader": "8.1.0",
-    "cypress": "^10.7.0",
+    "cypress": "10.9.0",
     "cypress-otp": "^1.0.2",
     "enzyme": "^3.10.0",
     "eslint": "^7.11.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "jest-canvas-mock": "^2.2.0",
     "jest-launchdarkly-mock": "^0.1.1",
     "markdown-spellcheck": "^1.3.1",
-    "md5": "^2.3.0",
     "prettier": "^2.0.0",
     "react-test-renderer": "^16.12.0",
     "redux-mock-store": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "yup": "^0.32.8"
   },
   "scripts": {
-    "start": "craco start",
+    "start": "craco -r @cypress/instrument-cra start",
     "build": "CI=true craco build",
     "build:ts": "tsc",
     "test": "craco test",
@@ -111,6 +111,7 @@
     ]
   },
   "devDependencies": {
+    "@cypress/instrument-cra": "^1.4.0",
     "@cypress/webpack-preprocessor": "^5.4.1",
     "@storybook/addon-actions": "^6.3.1",
     "@storybook/addon-controls": "^6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7204,10 +7204,10 @@ cypress-otp@^1.0.2:
   dependencies:
     otplib "12.0.1"
 
-cypress@^10.7.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.7.0.tgz#2d37f8b9751c6de33ee48639cb7e67a2ce593231"
-  integrity sha512-gTFvjrUoBnqPPOu9Vl5SBHuFlzx/Wxg/ZXIz2H4lzoOLFelKeF7mbwYUOzgzgF0oieU2WhJAestQdkgwJMMTvQ==
+cypress@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.9.0.tgz#273a61a6304766f9d6423e5ac8d4a9a11ed8b485"
+  integrity sha512-MjIWrRpc+bQM9U4kSSdATZWZ2hUqHGFEQTF7dfeZRa4MnalMtc88FIE49USWP2ZVtfy5WPBcgfBX+YorFqGElA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -7228,7 +7228,7 @@ cypress@^10.7.0:
     dayjs "^1.10.4"
     debug "^4.3.2"
     enquirer "^2.3.6"
-    eventemitter2 "^6.4.3"
+    eventemitter2 "6.4.7"
     execa "4.1.0"
     executable "^4.1.1"
     extract-zip "2.0.1"
@@ -8486,10 +8486,10 @@ event-stream@=3.3.4:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
-eventemitter2@^6.4.3:
-  version "6.4.4"
-  resolved "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz"
-  integrity sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==
+eventemitter2@6.4.7:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
+  integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
 eventemitter3@^4.0.0:
   version "4.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6060,11 +6060,6 @@ character-reference-invalid@^1.0.0:
   resolved "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz"
   integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
-charenc@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-  integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
-
 check-more-types@2.24.0, check-more-types@^2.24.0:
   version "2.24.0"
   resolved "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz"
@@ -6894,11 +6889,6 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-crypt@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
-  integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -10514,7 +10504,7 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.2"
 
-is-buffer@^1.1.5, is-buffer@~1.1.6:
+is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -12357,15 +12347,6 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
-
-md5@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
-  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
-  dependencies:
-    charenc "0.0.2"
-    crypt "0.0.2"
-    is-buffer "~1.1.6"
 
 mdast-squeeze-paragraphs@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1555,6 +1555,15 @@
     js-yaml "3.14.1"
     nyc "15.1.0"
 
+"@cypress/instrument-cra@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@cypress/instrument-cra/-/instrument-cra-1.4.0.tgz#c62427b9890e67544e86fd5b927cfdca3ad003d2"
+  integrity sha512-gXf540xL0jcUXkWyrA2Ug9rzs+jRkc9EPhnRi8XfbnRjdF4lvnn108N6x0lgTApMTbbpCDbVuskHGXDmIuD3CQ==
+  dependencies:
+    babel-plugin-istanbul "6.0.0"
+    debug "4.2.0"
+    find-yarn-workspace-root "^2.0.0"
+
 "@cypress/request@^2.88.10":
   version "2.88.10"
   resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.10.tgz#b66d76b07f860d3a4b8d7a0604d020c662752cce"
@@ -5263,7 +5272,7 @@ babel-plugin-extract-import-names@1.6.22:
   dependencies:
     "@babel/helper-plugin-utils" "7.10.4"
 
-babel-plugin-istanbul@^6.0.0:
+babel-plugin-istanbul@6.0.0, babel-plugin-istanbul@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz"
   integrity sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==
@@ -7318,6 +7327,13 @@ debug@4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
+
 debug@4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -8962,6 +8978,13 @@ find-up@^5.0.0:
   dependencies:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
+
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
 
 flat-cache@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
# Verifying Bug

- Re-enabled code-coverage, removed `md5` dependency - https://github.com/CMSgov/easi-app/actions/runs/3230496766. (Should fail on e2e test due to missing `md5`)

# The Plan
- Upgrade Cypress to >= 10.10.0
- Upgrade direct dependency on `@cypress/webpack-preprocessor` to >= 5.13.1 (see https://github.com/cypress-io/cypress/issues/24051)
- Run tests with code coverage enabled - they _should_ pass. (Save link to successful run)
- Assuming they pass, remove code coverage again, make sure everything still passes.
- Change `Dockerfile.cypress` to use `yarn install --frozen-lockfile` instead of `npm install --dev --silent`.
- Make this a proper NOREF PR. Link to: 
    - https://github.com/CMSgov/easi-app/pull/1791 (where I added `md5` dependency)
    - failing run on this PR with code coverage but w/o md5
    - successful run on this PR after upgrade, with coverage, w/o md5

# Previous Work
- https://github.com/CMSgov/easi-app/actions/runs/3158710993/jobs/5141096573 - past workflow run that failed due to missing md5 dependency