### PR TITLE
[NOREF] Email notification and recipient fixes

### DIFF
--- a/src/components/AdditionalContacts/index.tsx
+++ b/src/components/AdditionalContacts/index.tsx
@@ -6,29 +6,38 @@ import classNames from 'classnames';
 import CedarContactSelect from 'components/CedarContactSelect';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
+import Spinner from 'components/Spinner';
 import contactRoles from 'constants/enums/contactRoles';
 import { initialContactDetails } from 'constants/systemIntake';
 import useSystemIntakeContacts from 'hooks/useSystemIntakeContacts';
+import { GetSystemIntakeContacts_systemIntakeContacts_systemIntakeContacts as AugmentedSystemIntakeContact } from 'queries/types/GetSystemIntakeContacts';
 import {
-  CreateContactType,
   DeleteContactType,
-  SystemIntakeContactProps,
-  UpdateContactType
+  SystemIntakeContactProps
 } from 'types/systemIntake';
 
 import cmsDivisionsAndOfficesOptions from './cmsDivisionsAndOfficesOptions';
 
+type ContactProps = {
+  /** Contact object for display */
+  contact: SystemIntakeContactProps;
+  /** Delete contact from database */
+  deleteContact: DeleteContactType;
+  /** Set active contact when editing */
+  setActiveContact: (activeContact: SystemIntakeContactProps | null) => void;
+  /** Type of display */
+  type: 'contact' | 'recipient';
+};
+
+/**
+ * Component to display additional contact
+ */
 const Contact = ({
   contact,
   deleteContact,
   setActiveContact,
   type
-}: {
-  contact: SystemIntakeContactProps;
-  deleteContact: DeleteContactType;
-  setActiveContact: (activeContact: SystemIntakeContactProps | null) => void;
-  type: 'contact' | 'recipient';
-}) => {
+}: ContactProps) => {
   const { commonName, component, role, id } = contact;
   const { t } = useTranslation('intake');
 
@@ -60,17 +69,26 @@ const Contact = ({
   );
 };
 
+type ContactFormProps = {
+  /** Contact being created or edited */
+  activeContact: SystemIntakeContactProps;
+  /** Set active contact */
+  setActiveContact: (contact: SystemIntakeContactProps | null) => void;
+  /** Create or update contact on form submission */
+  onSubmit: (contact: SystemIntakeContactProps) => any;
+  /** Type of form */
+  type: 'contact' | 'recipient';
+};
+
+/**
+ * Form to create or update additional contacts
+ */
 const ContactForm = ({
   activeContact,
   setActiveContact,
   onSubmit,
   type
-}: {
-  activeContact: SystemIntakeContactProps;
-  setActiveContact: (contact: SystemIntakeContactProps | null) => void;
-  onSubmit: CreateContactType | UpdateContactType;
-  type: 'contact' | 'recipient';
-}) => {
+}: ContactFormProps) => {
   const { t } = useTranslation('intake');
 
   const [errors, setErrors] = useState({
@@ -183,7 +201,7 @@ const ContactForm = ({
       {/* Action Buttons */}
       <div className="margin-top-2">
         <Button type="button" outline onClick={() => setActiveContact(null)}>
-          Cancel
+          {t('Cancel')}
         </Button>
         <Button type="button" onClick={() => handleSubmit()}>
           {t(
@@ -199,14 +217,23 @@ const ContactForm = ({
 };
 
 type AdditionalContactsProps = {
+  /** System intake ID */
   systemIntakeId: string;
+  /** Contact being created or edited */
   activeContact: SystemIntakeContactProps | null;
+  /** Set active contact */
   setActiveContact: (contact: SystemIntakeContactProps | null) => void;
-  onCreateContact?: (contact: SystemIntakeContactProps) => any;
+  /** Function called after contact is created */
+  onCreateContact?: (contact: AugmentedSystemIntakeContact) => any;
+  /** Type of form - Recipient type does not display contacts */
   type?: 'recipient' | 'contact';
+  /** Outer div class */
   className?: string;
 };
 
+/**
+ * Additional contacts/recipients component for system intakes
+ */
 export default function AdditionalContacts({
   systemIntakeId,
   activeContact,
@@ -217,21 +244,21 @@ export default function AdditionalContacts({
 }: AdditionalContactsProps) {
   const { t } = useTranslation('intake');
   const {
-    contacts: {
-      data: { additionalContacts },
-      loading
-    },
+    contacts,
     createContact,
     updateContact,
     deleteContact
   } = useSystemIntakeContacts(systemIntakeId);
+  const { additionalContacts } = contacts.data;
 
-  // Wait for contacts to load
-  if (loading) return null;
+  const [loading, setIsLoading] = useState(contacts.loading);
+
+  if (contacts.loading) return null;
 
   return (
     <div className={classNames('system-intake-contacts', className)}>
       {type === 'contact' && (
+        // Only display list of additional contacts if type is set to 'contact'
         <>
           <h4>
             {t(
@@ -286,24 +313,46 @@ export default function AdditionalContacts({
         </>
       )}
 
-      {activeContact && !activeContact.id && !activeContact.systemIntakeId && (
-        <ContactForm
-          activeContact={activeContact}
-          setActiveContact={setActiveContact}
-          onSubmit={onCreateContact || createContact}
-          type={type}
-        />
-      )}
+      {loading ? (
+        // Display spinner if contact is loading
+        <Spinner />
+      ) : (
+        // Additional contacts form
+        <>
+          {activeContact && !activeContact.id && !activeContact.systemIntakeId && (
+            <ContactForm
+              activeContact={activeContact}
+              setActiveContact={setActiveContact}
+              onSubmit={contact => {
+                // Handle loading state when contact is created
+                setIsLoading(true);
+                createContact(contact).then(response => {
+                  if (response) {
+                    // Set loading as false after mutation is completed
+                    setIsLoading(false);
+                    // Handle response after contact is created
+                    if (onCreateContact) {
+                      onCreateContact(response);
+                    }
+                  }
+                });
+              }}
+              type={type}
+            />
+          )}
 
-      {(!activeContact || activeContact?.systemIntakeId) && (
-        <Button
-          type="button"
-          outline
-          onClick={() => setActiveContact(initialContactDetails)}
-          disabled={!!activeContact?.id}
-        >
-          {t('contactDetails.additionalContacts.add', { type })}
-        </Button>
+          {(!activeContact || activeContact?.systemIntakeId) && (
+            // Button to add additional contact
+            <Button
+              type="button"
+              outline
+              onClick={() => setActiveContact(initialContactDetails)}
+              disabled={!!activeContact?.id}
+            >
+              {t('contactDetails.additionalContacts.add', { type })}
+            </Button>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/AdditionalContacts/index.tsx
+++ b/src/components/AdditionalContacts/index.tsx
@@ -202,6 +202,7 @@ type AdditionalContactsProps = {
   systemIntakeId: string;
   activeContact: SystemIntakeContactProps | null;
   setActiveContact: (contact: SystemIntakeContactProps | null) => void;
+  onCreateContact?: (contact: SystemIntakeContactProps) => any;
   type?: 'recipient' | 'contact';
   className?: string;
 };
@@ -210,6 +211,7 @@ export default function AdditionalContacts({
   systemIntakeId,
   activeContact,
   setActiveContact,
+  onCreateContact,
   type = 'contact',
   className
 }: AdditionalContactsProps) {
@@ -288,7 +290,7 @@ export default function AdditionalContacts({
         <ContactForm
           activeContact={activeContact}
           setActiveContact={setActiveContact}
-          onSubmit={createContact}
+          onSubmit={onCreateContact || createContact}
           type={type}
         />
       )}

--- a/src/types/action.ts
+++ b/src/types/action.ts
@@ -60,7 +60,7 @@ export type ActionForm = {
   shouldSendEmail: boolean;
 };
 
-export type SubmitLifecycleIdForm = {
+export interface SubmitLifecycleIdForm extends ActionForm {
   newLifecycleId?: boolean;
   lifecycleId?: string;
   expirationDateMonth?: string;
@@ -69,9 +69,7 @@ export type SubmitLifecycleIdForm = {
   scope?: string;
   nextSteps?: string;
   costBaseline?: string;
-  feedback: string;
-  notificationRecipients: EmailNotificationRecipients;
-};
+}
 
 // TODO: look into combining the submit and extend LCID?
 export type ExtendLifecycleIdForm = {
@@ -84,17 +82,16 @@ export type ExtendLifecycleIdForm = {
   feedback: string;
 };
 
-export type RejectIntakeForm = {
-  feedback: string;
+export interface RejectIntakeForm extends ActionForm {
   nextSteps: string;
   reason: string;
-  notificationRecipients: EmailNotificationRecipients;
-};
+}
 
 export type ProvideGRTFeedbackForm = {
   grtFeedback: string;
   emailBody: string;
   notificationRecipients: EmailNotificationRecipients;
+  shouldSendEmail: boolean;
 };
 
 export type EmailRecipientsFieldsProps = {

--- a/src/types/action.ts
+++ b/src/types/action.ts
@@ -57,6 +57,7 @@ export type ActionState = {
 export type ActionForm = {
   feedback: string;
   notificationRecipients: EmailNotificationRecipients;
+  shouldSendEmail: boolean;
 };
 
 export type SubmitLifecycleIdForm = {

--- a/src/validations/actionSchema.ts
+++ b/src/validations/actionSchema.ts
@@ -1,8 +1,8 @@
 import { DateTime } from 'luxon';
 import * as Yup from 'yup';
 
-const skippableEmail = Yup.string().when('skipEmail', {
-  is: true,
+const skippableEmail = Yup.string().when('shouldSendEmail', {
+  is: false,
   then: schema => schema.optional(),
   otherwise: schema => schema.required('Please fill out email')
 });
@@ -11,15 +11,17 @@ const notificationRecipients = Yup.object().shape({
   shouldNotifyITGovernance: Yup.boolean(),
   shouldNotifyITInvestment: Yup.boolean(),
   regularRecipientEmails: Yup.array().when(
-    ['shouldNotifyITGovernance', 'shouldNotifyITInvestment', 'skipEmail'],
+    ['shouldNotifyITGovernance', 'shouldNotifyITInvestment', 'shouldSendEmail'],
     {
       is: (
         shouldNotifyITGovernance: boolean,
         shouldNotifyITInvestment: boolean,
-        skipEmail: boolean
+        shouldSendEmail: boolean
       ) => {
         return (
-          !shouldNotifyITGovernance && !shouldNotifyITInvestment && !skipEmail
+          !shouldNotifyITGovernance &&
+          !shouldNotifyITInvestment &&
+          shouldSendEmail
         );
       },
       then: schema => schema.min(1, 'Please select a recipient'),

--- a/src/views/GovernanceReviewTeam/Actions/CompleteWithoutEmailButton.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/CompleteWithoutEmailButton.tsx
@@ -2,12 +2,24 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, IconArrowForward } from '@trussworks/react-uswds';
 import classnames from 'classnames';
+import { FormikErrors } from 'formik';
+
+import { ActionForm } from 'types/action';
+
+interface CompleteWithoutEmailButtonProps
+  extends React.HTMLProps<HTMLButtonElement> {
+  setFieldValue: (field: string, value: any) => void;
+  submitForm: () => Promise<any>;
+  setErrors?: (errors: FormikErrors<ActionForm>) => void;
+}
 
 export default ({
   disabled,
-  onClick,
-  className
-}: React.HTMLProps<HTMLButtonElement>) => {
+  setFieldValue,
+  submitForm,
+  className,
+  setErrors
+}: CompleteWithoutEmailButtonProps) => {
   const { t } = useTranslation('action');
 
   return (
@@ -23,7 +35,11 @@ export default ({
         className
       )}
       disabled={disabled}
-      onClick={onClick}
+      onClick={() => {
+        if (setErrors) setErrors({});
+        setFieldValue('shouldSendEmail', false);
+        setTimeout(submitForm);
+      }}
     >
       {t('submitAction.completeWithoutEmail')}
       <IconArrowForward className="margin-left-05 margin-bottom-2px text-tbottom" />

--- a/src/views/GovernanceReviewTeam/Actions/EmailRecipientsFields.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/EmailRecipientsFields.tsx
@@ -18,6 +18,7 @@ import FieldGroup from 'components/shared/FieldGroup';
 import HelpText from 'components/shared/HelpText';
 import TruncatedContent from 'components/shared/TruncatedContent';
 import useSystemIntakeContacts from 'hooks/useSystemIntakeContacts';
+import { GetSystemIntakeContacts_systemIntakeContacts_systemIntakeContacts as AugmentedSystemIntakeContact } from 'queries/types/GetSystemIntakeContacts';
 import { EmailRecipientsFieldsProps } from 'types/action';
 import {
   CreateContactType,
@@ -416,6 +417,32 @@ export default ({
                 systemIntakeId={systemIntakeId}
                 activeContact={activeContact}
                 setActiveContact={setActiveContact}
+                onCreateContact={(contact: SystemIntakeContactProps) => {
+                  // Create contact
+                  createContact(contact).then(
+                    (response: AugmentedSystemIntakeContact | undefined) => {
+                      if (
+                        // Check for CEDAR response
+                        response &&
+                        // Check if response from CEDAR includes email
+                        response.email &&
+                        // Check if recipient is already selected
+                        !recipients.regularRecipientEmails.includes(
+                          response.email
+                        )
+                      ) {
+                        // If recipient is not already selected, add email to recipients array
+                        setRecipients({
+                          ...recipients,
+                          regularRecipientEmails: [
+                            ...recipients.regularRecipientEmails,
+                            response.email
+                          ]
+                        });
+                      }
+                    }
+                  );
+                }}
                 type="recipient"
                 className="margin-top-3"
               />

--- a/src/views/GovernanceReviewTeam/Actions/EmailRecipientsFields.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/EmailRecipientsFields.tsx
@@ -417,31 +417,22 @@ export default ({
                 systemIntakeId={systemIntakeId}
                 activeContact={activeContact}
                 setActiveContact={setActiveContact}
-                onCreateContact={(contact: SystemIntakeContactProps) => {
-                  // Create contact
-                  createContact(contact).then(
-                    (response: AugmentedSystemIntakeContact | undefined) => {
-                      if (
-                        // Check for CEDAR response
-                        response &&
-                        // Check if response from CEDAR includes email
-                        response.email &&
-                        // Check if recipient is already selected
-                        !recipients.regularRecipientEmails.includes(
-                          response.email
-                        )
-                      ) {
-                        // If recipient is not already selected, add email to recipients array
-                        setRecipients({
-                          ...recipients,
-                          regularRecipientEmails: [
-                            ...recipients.regularRecipientEmails,
-                            response.email
-                          ]
-                        });
-                      }
-                    }
-                  );
+                onCreateContact={(contact: AugmentedSystemIntakeContact) => {
+                  if (
+                    // Check if response from CEDAR includes email
+                    contact.email &&
+                    // Check if recipient is already selected
+                    !recipients.regularRecipientEmails.includes(contact.email)
+                  ) {
+                    // If recipient is not already selected, add email to recipients array
+                    setRecipients({
+                      ...recipients,
+                      regularRecipientEmails: [
+                        ...recipients.regularRecipientEmails,
+                        contact.email
+                      ]
+                    });
+                  }
                 }}
                 type="recipient"
                 className="margin-top-3"

--- a/src/views/GovernanceReviewTeam/Actions/SubmitAction.test.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/SubmitAction.test.tsx
@@ -257,11 +257,6 @@ describe('Submit Action', () => {
           query: CreateSystemIntakeActionNotItRequest,
           variables: {
             input: {
-              notificationRecipients: {
-                regularRecipientEmails: [],
-                shouldNotifyITGovernance: true,
-                shouldNotifyITInvestment: true
-              },
               feedback: '',
               intakeId: systemIntakeId,
               shouldSendEmail: false

--- a/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
@@ -94,7 +94,7 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
         pathname.endsWith('no-governance') ||
         pathname.endsWith('not-it-request')
     },
-    shouldSendEmail: false
+    shouldSendEmail: true
   };
 
   const backLink = `/governance-review-team/${systemId}/actions`;
@@ -211,11 +211,9 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
                 </div>
                 <div>
                   <CompleteWithoutEmailButton
-                    onClick={() => {
-                      setErrors({});
-                      setFieldValue('shouldSendEmail', false);
-                      submitForm();
-                    }}
+                    setErrors={setErrors}
+                    setFieldValue={setFieldValue}
+                    submitForm={submitForm}
                     disabled={!!activeContact}
                   />
                 </div>

--- a/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/SubmitAction.tsx
@@ -35,8 +35,6 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
   const { t } = useTranslation('action');
   const history = useHistory();
 
-  const [shouldSendEmail, setShouldSendEmail] = useState<boolean>(true);
-
   // Requester object and loading state
   const {
     contacts: {
@@ -59,18 +57,23 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
     values: ActionForm,
     { setFieldError }: FormikHelpers<ActionForm>
   ) => {
-    const { feedback, notificationRecipients } = values;
+    const { feedback, notificationRecipients, shouldSendEmail } = values;
+
+    const variables: ActionInput = {
+      input: {
+        intakeId: systemId,
+        feedback,
+        shouldSendEmail
+      }
+    };
+
+    if (shouldSendEmail) {
+      variables.input.notificationRecipients = notificationRecipients;
+    }
 
     // GQL mutation to submit action
     mutate({
-      variables: {
-        input: {
-          intakeId: systemId,
-          feedback,
-          shouldSendEmail,
-          notificationRecipients
-        }
-      }
+      variables
     })
       .then(({ errors }) => {
         if (!errors) {
@@ -90,7 +93,8 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
       shouldNotifyITInvestment:
         pathname.endsWith('no-governance') ||
         pathname.endsWith('not-it-request')
-    }
+    },
+    shouldSendEmail: false
   };
 
   const backLink = `/governance-review-team/${systemId}/actions`;
@@ -198,8 +202,7 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
                     type="submit"
                     onClick={() => {
                       setErrors({});
-                      setShouldSendEmail(true);
-                      setFieldValue('skipEmail', false);
+                      setFieldValue('shouldSendEmail', true);
                     }}
                     disabled={!!activeContact}
                   >
@@ -210,10 +213,8 @@ const SubmitAction = ({ actionName, query }: SubmitActionProps) => {
                   <CompleteWithoutEmailButton
                     onClick={() => {
                       setErrors({});
-                      setShouldSendEmail(false);
-                      setFieldValue('skipEmail', true);
-                      // todo hack timeout to propagate skipEmail value to the validator before submission
-                      setTimeout(submitForm);
+                      setFieldValue('shouldSendEmail', false);
+                      submitForm();
                     }}
                     disabled={!!activeContact}
                   />


### PR DESCRIPTION
# NOREF

## Changes and Description

**Changes to system intake notifications / recipients work:**
- Fixes "complete action without sending an email" button functionality
- Automatically selects additional recipients after being added
- Adds spinner loading state when additional contact is added
  - This affects both action notification recipients and additional contacts on system intake form

<!-- Put a description here! -->

## How to test this change
- Test additional recipients
  - Add new recipient to system intake request action
  - Spinner should appear after button click until recipient info is added to list
  - Recipient should automatically be selected 
- Test Email notifications
  - Open http://127.0.0.1:1080/ in browser to test MailTrack emails
  - Complete action with and without sending email
- Test additional contacts form on system intake request to make sure changes didn't break anything there

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
