### PR TITLE
[NOREF] Normalize EUA to uppercase when creating a principal object

### DIFF
--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -58,7 +58,7 @@ func authenticateMiddleware(logger *zap.Logger, next http.Handler) http.Handler 
 
 		logger.Info("Using local authorization middleware and populating EUA ID and job codes")
 		ctx := appcontext.WithPrincipal(r.Context(), &authentication.EUAPrincipal{
-			EUAID:            config.EUA,
+			EUAID:            strings.ToUpper(config.EUA),
 			JobCodeEASi:      true,
 			JobCodeGRT:       swag.ContainsStrings(config.JobCodes, "EASI_D_GOVTEAM"),
 			JobCode508User:   swag.ContainsStrings(config.JobCodes, "EASI_D_508_USER"),

--- a/pkg/okta/authentication_middleware.go
+++ b/pkg/okta/authentication_middleware.go
@@ -76,7 +76,7 @@ func (f oktaMiddlewareFactory) newPrincipal(jwt *jwtverifier.Jwt) (*authenticati
 	jc508User := jwtGroupsContainsJobCode(jwt, f.code508User)
 
 	return &authentication.EUAPrincipal{
-			EUAID:            euaID,
+			EUAID:            strings.ToUpper(euaID),
 			JobCodeEASi:      jcEASi,
 			JobCodeGRT:       jcGRT,
 			JobCode508Tester: jc508Tester,


### PR DESCRIPTION
# NOREF

## Changes and Description

- When creating EUA Principal objects, uppercase the ID before storing it in the struct so that any references to it (like when storing it in the DB) are properly cased.

## How to test this change



## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
