### PR TITLE
[NOREF] Split MINIO_ADDRESS env variables

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -76,14 +76,10 @@ export FLAGDATA_FILE="./cypress/fixtures/flagdata.json" # File to load LD flag d
 export MINIO_ACCESS_KEY='minioadmin'
 export MINIO_SECRET_KEY='minioadmin'
 
+# localhost:9000 needs to be used here because these environment variables are what are used by running `go test`.
 # These will be overridden to minio:9000 in docker-compose files to allow the backend container to contact the MinIO container
-# We set them to localhost:9000 here so tests running locally (on the host, outside containers) can reach MinIO
-export MINIO_HOST=localhost:9000
-
-# host.docker.internal is accessible by both the backend container (within the Docker network) and by the host;
-# so we can use it both to allow the backend container to connect to MinIO and to run tests locally outside the containers
-# If the MinIO container exposes a different port number than 9000, use the exposed port number here
-export MINIO_ADDRESS="http://host.docker.internal:9000"
+# using docker-compose network names
+export MINIO_ADDRESS="http://localhost:9000"
 
 # For connecting to a local postgres instance
 export PGHOST=localhost

--- a/docker-compose.cypress_ci.yml
+++ b/docker-compose.cypress_ci.yml
@@ -47,7 +47,6 @@ services:
       - REACT_APP_API_ADDRESS=http://easi:8080/api/v1
       - MINIO_ACCESS_KEY=minioadmin
       - MINIO_SECRET_KEY=minioadmin
-      - MINIO_HOST=minio:9000
       - PGHOST=db
       - PGPORT=5432
       - PGDATABASE=postgres

--- a/docker-compose.cypress_local.yml
+++ b/docker-compose.cypress_local.yml
@@ -67,7 +67,6 @@ services:
       - REACT_APP_API_ADDRESS=http://easi:8080/api/v1
       - MINIO_ACCESS_KEY
       - MINIO_SECRET_KEY
-      - MINIO_HOST=minio:9000
       - PGHOST=db
       - PGPORT=5432
       - PGDATABASE=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - LAMBDA_ENDPOINT=http://prince:9001
       - MINIO_ACCESS_KEY=minioadmin
       - MINIO_SECRET_KEY=minioadmin
-      - MINIO_ADDRESS
+      - MINIO_ADDRESS=http://minio:9000 # Use the docker-compose network name for the container
       - SERVER_CERT
       - SERVER_KEY
       - USE_TLS


### PR DESCRIPTION
# NOREF

## Changes and Description

- Reverts some changes from https://github.com/CMSgov/easi-app/pull/1819 that turned out to be Docker for windows specific (i.e. the existence of `host.docker.internal` seems to be tied to Docker for Windows / WSL)

## How to test this change

- Ensure all env vars are set: `direnv allow`
- Start the application: `scripts/dev up`
- Run tests: `scripts/dev test:go`
- Ensure you can upload files from the Web UI locally!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
