### PR TITLE
Notify requester and TRB admins when TRB request form is submitted

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -36,6 +36,7 @@ export EMAIL_TEMPLATE_DIR=$APP_DIR/pkg/email/templates
 export GRT_EMAIL=success@simulator.amazonses.com
 export IT_INVESTMENT_EMAIL=it_investment_email@cms.gov
 export ACCESSIBILITY_TEAM_EMAIL=success@simulator.amazonses.com
+export TRB_EMAIL=success@simulator.amazonses.com
 export EASI_HELP_EMAIL=success@simulator.amazonses.com
 
 # AWS variables

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -80,6 +80,7 @@ jobs:
           GRT_EMAIL: success@simulator.amazonses.com
           IT_INVESTMENT_EMAIL: success@simulator.amazonses.com
           ACCESSIBILITY_TEAM_EMAIL: success@simulator.amazonses.com
+          TRB_EMAIL: success@simulator.amazonses.com
           EASI_HELP_EMAIL: success@simulator.amazonses.com
           OKTA_CLIENT_ID: 0oa2e913coDQeG19S297
           OKTA_DOMAIN: https://test.idp.idm.cms.gov

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,8 @@ services:
       - OKTA_ISSUER=https://test.idp.idm.cms.gov/oauth2/aus2e96etlbFPnBHt297
       - GRT_EMAIL=success@simulator.amazonses.com
       - IT_INVESTMENT_EMAIL=success@simulator.amazonses.com
-      - ACCESSIBILITY_TEAM_EMAIL=success@simluator.amazonses.com
-      - TRB_EMAIL=success@simluator.amazonses.com
+      - ACCESSIBILITY_TEAM_EMAIL=success@simulator.amazonses.com
+      - TRB_EMAIL=success@simulator.amazonses.com
       - EASI_HELP_EMAIL=success@simulator.amazonses.com
       - EMAIL_TEMPLATE_DIR=./pkg/email/templates
       - AWS_REGION=us-west-2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - GRT_EMAIL=success@simulator.amazonses.com
       - IT_INVESTMENT_EMAIL=success@simulator.amazonses.com
       - ACCESSIBILITY_TEAM_EMAIL=success@simluator.amazonses.com
+      - TRB_EMAIL=success@simluator.amazonses.com
       - EASI_HELP_EMAIL=success@simulator.amazonses.com
       - EMAIL_TEMPLATE_DIR=./pkg/email/templates
       - AWS_REGION=us-west-2

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -132,6 +132,9 @@ const ITInvestmentEmailKey = "IT_INVESTMENT_EMAIL"
 // AccessibilityTeamEmailKey is the key for the receiving email for the 508 team
 const AccessibilityTeamEmailKey = "ACCESSIBILITY_TEAM_EMAIL"
 
+// TRBEmailKey is the key for the receiving email for the TRB
+const TRBEmailKey = "TRB_EMAIL"
+
 // EASIHelpEmailKey is the key for the receiving email for EASI help requests
 const EASIHelpEmailKey = "EASI_HELP_EMAIL"
 

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -16,6 +16,7 @@ type Config struct {
 	GRTEmail               models.EmailAddress
 	ITInvestmentEmail      models.EmailAddress
 	AccessibilityTeamEmail models.EmailAddress
+	TRBEmail               models.EmailAddress
 	EASIHelpEmail          models.EmailAddress
 	URLHost                string
 	URLScheme              string

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -49,6 +49,8 @@ type templates struct {
 	helpSendFeedback                           templateCaller
 	helpCantFindSomething                      templateCaller
 	helpReportAProblem                         templateCaller
+	trbFormSubmittedAdmin                      templateCaller
+	trbFormSubmittedRequester                  templateCaller
 }
 
 // sender is an interface for swapping out email provider implementations
@@ -208,6 +210,20 @@ func NewClient(config Config, sender sender) (Client, error) {
 		return Client{}, templateError(helpReportAProblemTemplateName)
 	}
 	appTemplates.helpReportAProblem = helpReportAProblemTemplate
+
+	trbFormSubmittedAdminTemplateName := "trb_request_form_submission_admin.gohtml"
+	trbFormSubmittedAdminTemplate := rawTemplates.Lookup(trbFormSubmittedAdminTemplateName)
+	if trbFormSubmittedAdminTemplate == nil {
+		return Client{}, templateError(trbFormSubmittedAdminTemplateName)
+	}
+	appTemplates.trbFormSubmittedAdmin = trbFormSubmittedAdminTemplate
+
+	trbFormSubmittedRequesterTemplateName := "trb_request_form_submission_requester.gohtml"
+	trbFormSubmittedRequesterTemplate := rawTemplates.Lookup(trbFormSubmittedRequesterTemplateName)
+	if trbFormSubmittedRequesterTemplate == nil {
+		return Client{}, templateError(trbFormSubmittedRequesterTemplateName)
+	}
+	appTemplates.trbFormSubmittedRequester = trbFormSubmittedRequesterTemplate
 
 	client := Client{
 		config:    config,

--- a/pkg/email/email_test.go
+++ b/pkg/email/email_test.go
@@ -59,6 +59,7 @@ func TestEmailTestSuite(t *testing.T) {
 	emailConfig := Config{
 		GRTEmail:          models.NewEmailAddress("grt_email@cms.fake"),     // unique email address that can't get confused with ITInvestmentEmail
 		ITInvestmentEmail: models.NewEmailAddress("it_investment@cms.fake"), // unique email address that can't get confused with GRTEmail
+		TRBEmail:          models.NewEmailAddress("trb_email@cms.fake"),
 		URLHost:           config.GetString(appconfig.ClientHostKey),
 		URLScheme:         config.GetString(appconfig.ClientProtocolKey),
 		TemplateDirectory: config.GetString(appconfig.EmailTemplateDirectoryKey),

--- a/pkg/email/templates/trb_request_form_submission_admin.gohtml
+++ b/pkg/email/templates/trb_request_form_submission_admin.gohtml
@@ -1,0 +1,14 @@
+<h1>EASi</h1>
+
+<p>Easy Access to System Information</p>
+
+{{.RequesterName}} has submitted a new TRB Request, {{.RequestName}}, for {{.Component}}. Use the link below to review the request in EASi and assign a TRB lead. A member of the TRB should respond within two business days with feedback about the request.  
+
+<a href="{{.RequestLink}}">View the request in EASi</a>
+
+Next steps:
+<ul>
+<li>Review the request and assign a TRB lead.</li>
+<li>Work with {{.RequesterName}} and the project team to decide on a day and time for the TRB consult session, and add the date in EASi.</li>
+<li>Send a separate calendar invite with a remote video conferencing meeting link.</li>
+</ul>

--- a/pkg/email/templates/trb_request_form_submission_admin.gohtml
+++ b/pkg/email/templates/trb_request_form_submission_admin.gohtml
@@ -1,10 +1,10 @@
-<h1>EASi</h1>
+<h1 style="margin-bottom: 0.5rem;">EASi</h1>
 
-<p>Easy Access to System Information</p>
+<span style="font-size:15px; line-height: 18px; color: #71767A">Easy Access to System Information</span>
 
-{{.RequesterName}} has submitted a new TRB Request, {{.RequestName}}, for {{.Component}}. Use the link below to review the request in EASi and assign a TRB lead. A member of the TRB should respond within two business days with feedback about the request.  
+<p>{{.RequesterName}} has submitted a new TRB Request, {{.RequestName}}, for {{.Component}}. Use the link below to review the request in EASi and assign a TRB lead. A member of the TRB should respond within two business days with feedback about the request.</p>
 
-<a href="{{.RequestLink}}">View the request in EASi</a>
+<p><a href="{{.RequestLink}}" style="font-weight: bold">View the request in EASi</a></p>
 
 Next steps:
 <ul>

--- a/pkg/email/templates/trb_request_form_submission_requester.gohtml
+++ b/pkg/email/templates/trb_request_form_submission_requester.gohtml
@@ -6,6 +6,6 @@
 
 <a href="{{.RequestLink}}">View your request in EASi</a>
 
-If you have questions, please contact the Technical Review Board (TRB) at {{.TRBInboxAddress}}.
+<p>If you have questions, please contact the Technical Review Board (TRB) at {{.TRBInboxAddress}}.</p>
 
 <p>You will continue to receive email notifications about your request until it is closed.</p>

--- a/pkg/email/templates/trb_request_form_submission_requester.gohtml
+++ b/pkg/email/templates/trb_request_form_submission_requester.gohtml
@@ -1,0 +1,11 @@
+<h1>EASi</h1>
+
+<p>Easy Access to System Information</p>
+
+<p>You have completed the initial request form for your TRB Request ({{.RequestName}}). The TRB will review it and get back to you within two business days with feedback about your request. They will then work with you to schedule a time for your TRB consult session.</p>
+
+<a href="{{.RequestLink}}">View your request in EASi</a>
+
+If you have questions, please contact the Technical Review Board (TRB) at {{.TRBInboxAddress}}.
+
+<p>You will continue to receive email notifications about your request until it is closed.</p>

--- a/pkg/email/templates/trb_request_form_submission_requester.gohtml
+++ b/pkg/email/templates/trb_request_form_submission_requester.gohtml
@@ -1,11 +1,11 @@
-<h1>EASi</h1>
+<h1 style="margin-bottom: 0.5rem;">EASi</h1>
 
-<p>Easy Access to System Information</p>
+<span style="font-size:15px; line-height: 18px; color: #71767A">Easy Access to System Information</span>
 
 <p>You have completed the initial request form for your TRB Request ({{.RequestName}}). The TRB will review it and get back to you within two business days with feedback about your request. They will then work with you to schedule a time for your TRB consult session.</p>
 
-<a href="{{.RequestLink}}">View your request in EASi</a>
+<a href="{{.RequestLink}}" style="font-weight: bold">View your request in EASi</a>
 
-<p>If you have questions, please contact the Technical Review Board (TRB) at {{.TRBInboxAddress}}.</p>
+<p>If you have questions, please contact the Technical Review Board (TRB) at <a href="mailto:{{.TRBInboxAddress}}">{{.TRBInboxAddress}}</a>.</p>
 
 <p>You will continue to receive email notifications about your request until it is closed.</p>

--- a/pkg/email/trb_request_form_submission.go
+++ b/pkg/email/trb_request_form_submission.go
@@ -38,8 +38,8 @@ func (c Client) trbRequestFormSubmissionAdminEmailBody(requestName string, reque
 	return b.String(), nil
 }
 
-// SendTRBFormSubmissionTemplateToAdmins notifies the TRB admin mailbox that a TRB Request form has been submitted
-func (c Client) SendTRBFormSubmissionTemplateToAdmins(ctx context.Context, requestName string, requesterName string, component string) error {
+// SendTRBFormSubmissionNotificationToAdmins notifies the TRB admin mailbox that a TRB Request form has been submitted
+func (c Client) SendTRBFormSubmissionNotificationToAdmins(ctx context.Context, requestName string, requesterName string, component string) error {
 	subject := fmt.Sprintf("A new TRB Request has been submitted (%v)", requestName)
 	body, err := c.trbRequestFormSubmissionAdminEmailBody(requestName, requesterName, component)
 	if err != nil {
@@ -86,8 +86,8 @@ func (c Client) trbRequestFormSubmissionRequesterEmailBody(requestName string) (
 	return b.String(), nil
 }
 
-// SendTRBFormSubmissionTemplateToRequester notifies a TRB requester that their TRB Request form has been submitted
-func (c Client) SendTRBFormSubmissionTemplateToRequester(ctx context.Context, requesterEmail models.EmailAddress, requestName string, requesterName string) error {
+// SendTRBFormSubmissionNotificationToRequester notifies a TRB requester that their TRB Request form has been submitted
+func (c Client) SendTRBFormSubmissionNotificationToRequester(ctx context.Context, requesterEmail models.EmailAddress, requestName string, requesterName string) error {
 	subject := fmt.Sprintf("Your TRB Request form has been submitted (%v)", requestName)
 	body, err := c.trbRequestFormSubmissionRequesterEmailBody(requestName)
 	if err != nil {

--- a/pkg/email/trb_request_form_submission.go
+++ b/pkg/email/trb_request_form_submission.go
@@ -1,0 +1,109 @@
+package email
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+type adminEmailParameters struct {
+	RequestName   string
+	RequesterName string
+	Component     string
+	RequestLink   string
+}
+
+func (c Client) trbRequestFormSubmissionAdminEmailBody(requestName string, requesterName string, component string) (string, error) {
+	data := adminEmailParameters{
+		RequestName:   requestName,
+		RequesterName: requesterName,
+		Component:     component,
+		RequestLink:   "", // TODO - populate
+	}
+
+	var b bytes.Buffer
+	if c.templates.trbFormSubmittedAdmin == nil {
+		return "", errors.New("TRB Form Submission Admin template is nil")
+	}
+
+	err := c.templates.trbFormSubmittedAdmin.Execute(&b, data)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}
+
+// SendTRBFormSubmissionTemplateToAdmins notifies the TRB admin mailbox that a TRB Request form has been submitted
+func (c Client) SendTRBFormSubmissionTemplateToAdmins(ctx context.Context, requestName string, requesterName string, component string) error {
+	subject := fmt.Sprintf("A new TRB Request has been submitted (%v)", requestName)
+	body, err := c.trbRequestFormSubmissionAdminEmailBody(requestName, requesterName, component)
+	if err != nil {
+		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}
+	}
+
+	err = c.sender.Send(
+		ctx,
+		[]models.EmailAddress{}, // TODO - add configured TRBInboxEmail
+		[]models.EmailAddress{},
+		subject,
+		body,
+	)
+	if err != nil {
+		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}
+	}
+
+	return nil
+}
+
+type requesterEmailParameters struct {
+	RequestName     string
+	RequestLink     string
+	TRBInboxAddress string
+}
+
+func (c Client) trbRequestFormSubmissionRequesterEmailBody(requestName string) (string, error) {
+	data := requesterEmailParameters{
+		RequestName:     requestName,
+		RequestLink:     "", // TODO - populate
+		TRBInboxAddress: "", // TODO - load from config
+	}
+
+	var b bytes.Buffer
+	if c.templates.trbFormSubmittedRequester == nil {
+		return "", errors.New("TRB Form Submission Requester template is nil")
+	}
+
+	err := c.templates.trbFormSubmittedRequester.Execute(&b, data)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}
+
+// SendTRBFormSubmissionTemplateToRequester notifies a TRB requester that their TRB Request form has been submitted
+func (c Client) SendTRBFormSubmissionTemplateToRequester(ctx context.Context, requesterEmail models.EmailAddress, requestName string, requesterName string) error {
+	subject := fmt.Sprintf("Your TRB Request form has been submitted (%v)", requestName)
+	body, err := c.trbRequestFormSubmissionRequesterEmailBody(requestName)
+	if err != nil {
+		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}
+	}
+
+	err = c.sender.Send(
+		ctx,
+		[]models.EmailAddress{requesterEmail},
+		[]models.EmailAddress{},
+		subject,
+		body,
+	)
+	if err != nil {
+		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}
+	}
+
+	return nil
+}

--- a/pkg/email/trb_request_form_submission.go
+++ b/pkg/email/trb_request_form_submission.go
@@ -48,7 +48,7 @@ func (c Client) SendTRBFormSubmissionTemplateToAdmins(ctx context.Context, reque
 
 	err = c.sender.Send(
 		ctx,
-		[]models.EmailAddress{}, // TODO - add configured TRBInboxEmail
+		[]models.EmailAddress{c.config.TRBEmail},
 		[]models.EmailAddress{},
 		subject,
 		body,
@@ -70,7 +70,7 @@ func (c Client) trbRequestFormSubmissionRequesterEmailBody(requestName string) (
 	data := requesterEmailParameters{
 		RequestName:     requestName,
 		RequestLink:     "", // TODO - populate
-		TRBInboxAddress: "", // TODO - load from config
+		TRBInboxAddress: c.config.TRBEmail.String(),
 	}
 
 	var b bytes.Buffer

--- a/pkg/email/trb_request_form_submission_test.go
+++ b/pkg/email/trb_request_form_submission_test.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 
@@ -14,7 +15,38 @@ func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToAdmins() {
 	ctx := context.Background()
 
 	s.Run("successful call has the right content", func() {
-		// TODO
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+
+		requestName := "TestRequest"
+		requesterName := "Test Requester"
+		component := "TestComponent"
+
+		// TODO - EASI-2488 - put correct path here
+		adminViewOpeningTag := fmt.Sprintf(
+			"<a href=\"%s://%s/TODO/admin-view\" style=\"font-weight: bold\">",
+			s.config.URLScheme,
+			s.config.URLHost,
+		)
+
+		expectedEmail := "<h1 style=\"margin-bottom: 0.5rem;\">EASi</h1>\n\n" +
+			"<span style=\"font-size:15px; line-height: 18px; color: #71767A\">Easy Access to System Information</span>\n\n" +
+			"<p>" + requesterName + " has submitted a new TRB Request, " + requestName + ", for " + component + ". " +
+			"Use the link below to review the request in EASi and assign a TRB lead. " +
+			"A member of the TRB should respond within two business days with feedback about the request.</p>\n\n" +
+			"<p>" + adminViewOpeningTag + "View the request in EASi</a></p>\n\n" +
+			"Next steps:\n<ul>\n" +
+			"<li>Review the request and assign a TRB lead.</li>\n" +
+			"<li>Work with " + requesterName + " and the project team to decide on a day and time for the TRB consult session, and add the date in EASi.</li>\n" +
+			"<li>Send a separate calendar invite with a remote video conferencing meeting link.</li>\n" +
+			"</ul>\n"
+
+		err = client.SendTRBFormSubmissionNotificationToAdmins(ctx, requestName, requesterName, component)
+
+		s.NoError(err)
+		s.ElementsMatch(sender.toAddresses, []models.EmailAddress{s.config.TRBEmail})
+		s.Equal(fmt.Sprintf("A new TRB Request has been submitted (%s)", requestName), sender.subject)
+		s.Equal(expectedEmail, sender.body)
 	})
 
 	s.Run("if the template is nil, we get the error from it", func() {
@@ -66,7 +98,41 @@ func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToRequester() {
 	ctx := context.Background()
 
 	s.Run("successful call has the right content", func() {
-		// TODO
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+
+		requestID := uuid.MustParse("1b53e333-fc2e-4b59-9ba2-7bcd3f32ce55")
+		requestName := "TestRequest"
+		requesterEmail := models.NewEmailAddress("test.requester@test.com")
+		requesterName := "Test Requester"
+
+		requesterViewOpeningTag := fmt.Sprintf(
+			"<a href=\"%s://%s/trb/task-list/%s\" style=\"font-weight: bold\">",
+			s.config.URLScheme,
+			s.config.URLHost,
+			requestID,
+		)
+
+		mailToTRBInboxElement := fmt.Sprintf(
+			"<a href=\"mailto:%s\">%s</a>",
+			s.config.TRBEmail,
+			s.config.TRBEmail,
+		)
+
+		expectedEmail := "<h1 style=\"margin-bottom: 0.5rem;\">EASi</h1>\n\n" +
+			"<span style=\"font-size:15px; line-height: 18px; color: #71767A\">Easy Access to System Information</span>\n\n" +
+			"<p>You have completed the initial request form for your TRB Request (" + requestName + "). " +
+			"The TRB will review it and get back to you within two business days with feedback about your request. They will then work with you to schedule a time for your TRB consult session.</p>\n\n" +
+			requesterViewOpeningTag + "View your request in EASi</a>\n\n" +
+			"<p>If you have questions, please contact the Technical Review Board (TRB) at " + mailToTRBInboxElement + ".</p>\n\n" +
+			"<p>You will continue to receive email notifications about your request until it is closed.</p>\n"
+
+		err = client.SendTRBFormSubmissionNotificationToRequester(ctx, requestID, requestName, requesterEmail, requesterName)
+
+		s.NoError(err)
+		s.ElementsMatch(sender.toAddresses, []models.EmailAddress{requesterEmail})
+		s.Equal(fmt.Sprintf("Your TRB Request form has been submitted (%s)", requestName), sender.subject)
+		s.Equal(expectedEmail, sender.body)
 	})
 
 	s.Run("if the template is nil, we get the error from it", func() {

--- a/pkg/email/trb_request_form_submission_test.go
+++ b/pkg/email/trb_request_form_submission_test.go
@@ -20,7 +20,7 @@ func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToAdmins() {
 		s.NoError(err)
 		client.templates = templates{}
 
-		err = client.SendTRBFormSubmissionTemplateToAdmins(ctx, "testRequest", "testRequester", "testComponent")
+		err = client.SendTRBFormSubmissionNotificationToAdmins(ctx, "testRequest", "testRequester", "testComponent")
 
 		s.Error(err)
 		s.IsType(err, &apperrors.NotificationError{})
@@ -34,7 +34,7 @@ func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToAdmins() {
 		s.NoError(err)
 		client.templates.trbFormSubmittedAdmin = mockFailedTemplateCaller{}
 
-		err = client.SendTRBFormSubmissionTemplateToAdmins(ctx, "testRequest", "testRequester", "testComponent")
+		err = client.SendTRBFormSubmissionNotificationToAdmins(ctx, "testRequest", "testRequester", "testComponent")
 
 		s.Error(err)
 		s.IsType(err, &apperrors.NotificationError{})
@@ -49,7 +49,7 @@ func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToAdmins() {
 		client, err := NewClient(s.config, &sender)
 		s.NoError(err)
 
-		err = client.SendTRBFormSubmissionTemplateToAdmins(ctx, "testRequest", "testRequester", "testComponent")
+		err = client.SendTRBFormSubmissionNotificationToAdmins(ctx, "testRequest", "testRequester", "testComponent")
 
 		s.Error(err)
 		s.IsType(err, &apperrors.NotificationError{})
@@ -72,7 +72,7 @@ func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToRequester() {
 		s.NoError(err)
 		client.templates = templates{}
 
-		err = client.SendTRBFormSubmissionTemplateToRequester(ctx, models.NewEmailAddress("test@fake.email"), "testRequest", "testRequester")
+		err = client.SendTRBFormSubmissionNotificationToRequester(ctx, models.NewEmailAddress("test@fake.email"), "testRequest", "testRequester")
 
 		s.Error(err)
 		s.IsType(err, &apperrors.NotificationError{})
@@ -86,7 +86,7 @@ func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToRequester() {
 		s.NoError(err)
 		client.templates.trbFormSubmittedRequester = mockFailedTemplateCaller{}
 
-		err = client.SendTRBFormSubmissionTemplateToRequester(ctx, models.NewEmailAddress("test@fake.email"), "testRequest", "testRequester")
+		err = client.SendTRBFormSubmissionNotificationToRequester(ctx, models.NewEmailAddress("test@fake.email"), "testRequest", "testRequester")
 
 		s.Error(err)
 		s.IsType(err, &apperrors.NotificationError{})
@@ -101,7 +101,7 @@ func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToRequester() {
 		client, err := NewClient(s.config, &sender)
 		s.NoError(err)
 
-		err = client.SendTRBFormSubmissionTemplateToRequester(ctx, models.NewEmailAddress("test@fake.email"), "testRequest", "testRequester")
+		err = client.SendTRBFormSubmissionNotificationToRequester(ctx, models.NewEmailAddress("test@fake.email"), "testRequest", "testRequester")
 
 		s.Error(err)
 		s.IsType(err, &apperrors.NotificationError{})

--- a/pkg/email/trb_request_form_submission_test.go
+++ b/pkg/email/trb_request_form_submission_test.go
@@ -1,0 +1,112 @@
+package email
+
+import (
+	"context"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToAdmins() {
+	sender := mockSender{}
+	ctx := context.Background()
+
+	s.Run("successful call has the right content", func() {
+		// TODO
+	})
+
+	s.Run("if the template is nil, we get the error from it", func() {
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+		client.templates = templates{}
+
+		err = client.SendTRBFormSubmissionTemplateToAdmins(ctx, "testRequest", "testRequester", "testComponent")
+
+		s.Error(err)
+		s.IsType(err, &apperrors.NotificationError{})
+		e := err.(*apperrors.NotificationError)
+		s.Equal(apperrors.DestinationTypeEmail, e.DestinationType)
+		s.Equal("TRB Form Submission Admin template is nil", e.Err.Error())
+	})
+
+	s.Run("if the template fails to execute, we get the error from it", func() {
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+		client.templates.trbFormSubmittedAdmin = mockFailedTemplateCaller{}
+
+		err = client.SendTRBFormSubmissionTemplateToAdmins(ctx, "testRequest", "testRequester", "testComponent")
+
+		s.Error(err)
+		s.IsType(err, &apperrors.NotificationError{})
+		e := err.(*apperrors.NotificationError)
+		s.Equal(apperrors.DestinationTypeEmail, e.DestinationType)
+		s.Equal("template caller had an error", e.Err.Error())
+	})
+
+	s.Run("if the sender fails, we get the error from it", func() {
+		sender := mockFailedSender{}
+
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+
+		err = client.SendTRBFormSubmissionTemplateToAdmins(ctx, "testRequest", "testRequester", "testComponent")
+
+		s.Error(err)
+		s.IsType(err, &apperrors.NotificationError{})
+		e := err.(*apperrors.NotificationError)
+		s.Equal(apperrors.DestinationTypeEmail, e.DestinationType)
+		s.Equal("sender had an error", e.Err.Error())
+	})
+}
+
+func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToRequester() {
+	sender := mockSender{}
+	ctx := context.Background()
+
+	s.Run("successful call has the right content", func() {
+		// TODO
+	})
+
+	s.Run("if the template is nil, we get the error from it", func() {
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+		client.templates = templates{}
+
+		err = client.SendTRBFormSubmissionTemplateToRequester(ctx, models.NewEmailAddress("test@fake.email"), "testRequest", "testRequester")
+
+		s.Error(err)
+		s.IsType(err, &apperrors.NotificationError{})
+		e := err.(*apperrors.NotificationError)
+		s.Equal(apperrors.DestinationTypeEmail, e.DestinationType)
+		s.Equal("TRB Form Submission Requester template is nil", e.Err.Error())
+	})
+
+	s.Run("if the template fails to execute, we get the error from it", func() {
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+		client.templates.trbFormSubmittedRequester = mockFailedTemplateCaller{}
+
+		err = client.SendTRBFormSubmissionTemplateToRequester(ctx, models.NewEmailAddress("test@fake.email"), "testRequest", "testRequester")
+
+		s.Error(err)
+		s.IsType(err, &apperrors.NotificationError{})
+		e := err.(*apperrors.NotificationError)
+		s.Equal(apperrors.DestinationTypeEmail, e.DestinationType)
+		s.Equal("template caller had an error", e.Err.Error())
+	})
+
+	s.Run("if the sender fails, we get the error from it", func() {
+		sender := mockFailedSender{}
+
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+
+		err = client.SendTRBFormSubmissionTemplateToRequester(ctx, models.NewEmailAddress("test@fake.email"), "testRequest", "testRequester")
+
+		s.Error(err)
+		s.IsType(err, &apperrors.NotificationError{})
+		e := err.(*apperrors.NotificationError)
+		s.Equal(apperrors.DestinationTypeEmail, e.DestinationType)
+		s.Equal("sender had an error", e.Err.Error())
+	})
+}

--- a/pkg/email/trb_request_form_submission_test.go
+++ b/pkg/email/trb_request_form_submission_test.go
@@ -3,6 +3,8 @@ package email
 import (
 	"context"
 
+	"github.com/google/uuid"
+
 	"github.com/cmsgov/easi-app/pkg/apperrors"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
@@ -72,7 +74,13 @@ func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToRequester() {
 		s.NoError(err)
 		client.templates = templates{}
 
-		err = client.SendTRBFormSubmissionNotificationToRequester(ctx, models.NewEmailAddress("test@fake.email"), "testRequest", "testRequester")
+		err = client.SendTRBFormSubmissionNotificationToRequester(
+			ctx,
+			uuid.New(),
+			"testRequest",
+			models.NewEmailAddress("test@fake.email"),
+			"testRequester",
+		)
 
 		s.Error(err)
 		s.IsType(err, &apperrors.NotificationError{})
@@ -86,7 +94,13 @@ func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToRequester() {
 		s.NoError(err)
 		client.templates.trbFormSubmittedRequester = mockFailedTemplateCaller{}
 
-		err = client.SendTRBFormSubmissionNotificationToRequester(ctx, models.NewEmailAddress("test@fake.email"), "testRequest", "testRequester")
+		err = client.SendTRBFormSubmissionNotificationToRequester(
+			ctx,
+			uuid.New(),
+			"testRequest",
+			models.NewEmailAddress("test@fake.email"),
+			"testRequester",
+		)
 
 		s.Error(err)
 		s.IsType(err, &apperrors.NotificationError{})
@@ -101,7 +115,13 @@ func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToRequester() {
 		client, err := NewClient(s.config, &sender)
 		s.NoError(err)
 
-		err = client.SendTRBFormSubmissionNotificationToRequester(ctx, models.NewEmailAddress("test@fake.email"), "testRequest", "testRequester")
+		err = client.SendTRBFormSubmissionNotificationToRequester(
+			ctx,
+			uuid.New(),
+			"testRequest",
+			models.NewEmailAddress("test@fake.email"),
+			"testRequester",
+		)
 
 		s.Error(err)
 		s.IsType(err, &apperrors.NotificationError{})

--- a/pkg/graph/resolvers/trb_request_form.go
+++ b/pkg/graph/resolvers/trb_request_form.go
@@ -54,7 +54,6 @@ func UpdateTRBRequestForm(
 	emailInfoErrGroup := new(errgroup.Group)
 
 	if willSendNotifications {
-
 		emailInfoErrGroup.Go(func() error {
 			// declare new error variable so we don't interfere with calls outside of this goroutine
 			requestPtr, getRequestErr := store.GetTRBRequestByID(appcontext.ZLogger(ctx), id)
@@ -94,6 +93,7 @@ func UpdateTRBRequestForm(
 
 	// send notification emails last; make sure database has been updated first
 
+	// don't need to check willSendNotifications here; emailInfoErrGroup only launches goroutines if willSendNotifications is true above
 	if err = emailInfoErrGroup.Wait(); err != nil {
 		return nil, err
 	}

--- a/pkg/graph/resolvers/trb_request_form.go
+++ b/pkg/graph/resolvers/trb_request_form.go
@@ -113,8 +113,9 @@ func UpdateTRBRequestForm(
 		emailErrGroup.Go(func() error {
 			return emailClient.SendTRBFormSubmissionNotificationToRequester(
 				ctx,
-				requesterInfo.Email,
+				request.ID,
 				request.Name,
+				requesterInfo.Email,
 				requesterInfo.CommonName,
 			)
 		})

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1940,7 +1940,13 @@ func (r *mutationResolver) DeleteTRBRequestDocument(ctx context.Context, id uuid
 
 // UpdateTRBRequestForm is the resolver for the updateTRBRequestForm field.
 func (r *mutationResolver) UpdateTRBRequestForm(ctx context.Context, input map[string]interface{}) (*models.TRBRequestForm, error) {
-	return resolvers.UpdateTRBRequestForm(ctx, r.store, input)
+	return resolvers.UpdateTRBRequestForm(
+		ctx,
+		r.store,
+		r.emailClient,
+		r.service.FetchUserInfo,
+		input,
+	)
 }
 
 // SetRolesForUserOnSystem is the resolver for the setRolesForUserOnSystem field.

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -53,6 +53,7 @@ func (s Server) NewEmailConfig() email.Config {
 	s.checkRequiredConfig(appconfig.GRTEmailKey)
 	s.checkRequiredConfig(appconfig.ITInvestmentEmailKey)
 	s.checkRequiredConfig(appconfig.AccessibilityTeamEmailKey)
+	s.checkRequiredConfig(appconfig.TRBEmailKey)
 	s.checkRequiredConfig(appconfig.EASIHelpEmailKey)
 	s.checkRequiredConfig(appconfig.ClientHostKey)
 	s.checkRequiredConfig(appconfig.ClientProtocolKey)
@@ -62,6 +63,7 @@ func (s Server) NewEmailConfig() email.Config {
 		GRTEmail:               models.NewEmailAddress(s.Config.GetString(appconfig.GRTEmailKey)),
 		ITInvestmentEmail:      models.NewEmailAddress(s.Config.GetString(appconfig.ITInvestmentEmailKey)),
 		AccessibilityTeamEmail: models.NewEmailAddress(s.Config.GetString(appconfig.AccessibilityTeamEmailKey)),
+		TRBEmail:               models.NewEmailAddress(s.Config.GetString(appconfig.TRBEmailKey)),
 		EASIHelpEmail:          models.NewEmailAddress(s.Config.GetString(appconfig.EASIHelpEmailKey)),
 		URLHost:                s.Config.GetString(appconfig.ClientHostKey),
 		URLScheme:              s.Config.GetString(appconfig.ClientProtocolKey),


### PR DESCRIPTION
# EASI-2443

## Changes and Description

- When a TRB request form is submitted, send notification emails to the requester and to the TRB inbox.
- Introduces a new config variable, `TRB_EMAIL`, for the TRB inbox address.

## Email Appearance

These are screenshots of how Mailcatcher renders the emails:
![trb request submission notification - admins](https://user-images.githubusercontent.com/92891039/204862845-e0947831-3b4a-483e-8543-f1777672d030.PNG)
![trb request submission notification - requester](https://user-images.githubusercontent.com/92891039/204862860-c816da71-9540-47bd-8107-e626b72ab841.PNG)

## How to test this change

Run the following GraphQL mutation to create a TRB request:
```gql
mutation {
  createTRBRequest(requestType: NEED_HELP) {
    id
    type
    form {
      id
      status
      trbRequestId
      component
      needsAssistanceWith
      hasSolutionInMind
      proposedSolution
      whereInProcess
      whereInProcessOther
      hasExpectedStartEndDates
      expectedStartDate
      expectedEndDate
      collabGroups
      collabDateSecurity
      collabDateEnterpriseArchitecture
      collabDateCloud
      collabDatePrivacyAdvisor
      collabDateGovernanceReviewBoard
      collabDateOther
      collabGroupOther
      createdBy
      createdAt
      modifiedBy
      modifiedAt
    }
  }
}
```

Note down the returned request ID for use in the following steps.

Run the following GraphQL mutation to create an _unsubmitted_ form, then check Mailcatcher; emails should _not_ have been sent:

```gql
mutation createUnsubmittedForm {
  updateTRBRequestForm(input: {
    isSubmitted: false,
    trbRequestId: "trbRequestIdFromAbove",
    needsAssistanceWith: "Some of the things",
    hasSolutionInMind: true,
    proposedSolution: "It's like Tinder, but for cats",
    whereInProcess: CONTRACTING_WORK_HAS_STARTED,
    whereInProcessOther: "Fixing Wifi",
    hasExpectedStartEndDates: true,
    expectedStartDate:"2022-11-30T03:29:56.901Z",
    expectedEndDate:"2050-11-30T03:29:56.901Z",
    collabGroups: [SECURITY, CLOUD, PRIVACY_ADVISOR],
    collabDateSecurity: "2021-10-20T03:29:56.901Z",
    collabDateEnterpriseArchitecture: "2021-10-21T03:29:56.901Z",
    collabDateCloud: "2021-10-22T03:29:56.901Z",
    collabDatePrivacyAdvisor: "2021-10-23T03:29:56.901Z",
    collabDateGovernanceReviewBoard: "2021-10-24T03:29:56.901Z",
    collabDateOther: "2021-10-25T03:29:56.901Z",
    collabGroupOther: "2021-10-26T03:29:56.901Z",
    subjectAreaTechnicalReferenceArchitecture: [CMS_TRA_BUSINESS_RULES],
    subjectAreaNetworkAndSecurity: [GENERAL_NETWORK_AND_SECURITY_SERVICES_INFORMATION],
    subjectAreaCloudAndInfrastructure: [DISASTER_RECOVERY],
    subjectAreaApplicationDevelopment: [OTHER],
    subjectAreaDataAndDataManagement: [DATA_WAREHOUSING],
    subjectAreaGovernmentProcessesAndPolicies: [OTHER_AVAILABLE_TRB_SERVICES],
    subjectAreaOtherTechnicalTopics: [ASSISTANCE_WITH_SYSTEM_CONCEPT_DEVELOPMENT],
    component: "Taco Truck",
  }) {
    status
    trbRequestId
    component
    needsAssistanceWith
    hasSolutionInMind
    proposedSolution
    whereInProcess
    whereInProcessOther
    hasExpectedStartEndDates
    expectedStartDate
    expectedEndDate
    collabGroups
    collabDateSecurity
    collabDateEnterpriseArchitecture
    collabDateCloud
    collabDatePrivacyAdvisor
    collabDateGovernanceReviewBoard
    collabDateOther
    collabGroupOther
    subjectAreaTechnicalReferenceArchitecture
    subjectAreaNetworkAndSecurity
    subjectAreaCloudAndInfrastructure
    subjectAreaApplicationDevelopment
    subjectAreaDataAndDataManagement
    subjectAreaGovernmentProcessesAndPolicies
    subjectAreaOtherTechnicalTopics
    createdBy
    createdAt
    modifiedBy
    modifiedAt
  }
}
```

Run the following GraphQL mutation to submit the created form, then check MailCatcher - emails should have been sent to the requester and admin:

```gql
mutation submitExistingForm {
  updateTRBRequestForm(input: {
    isSubmitted: true,
    trbRequestId: "trbRequestIdFromAbove",
  }) {
    status
  }
}
```

## Notes
- The styles for the emails are a mix of CSS copied from the Figma mockups (linked from the Jira ticket), [Adam's advice on Slack](https://oddball.slack.com/archives/C037ZNEQ7DH/p1669220502594669), and my own judgment (adjusting margins, not specifying any font in order to stay consistent with the rest of our emails).