### PR TITLE
Notify attendees when they're added to a TRB request

### DIFF
--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -52,6 +52,7 @@ type templates struct {
 	helpReportAProblem                         templateCaller
 	trbFormSubmittedAdmin                      templateCaller
 	trbFormSubmittedRequester                  templateCaller
+	trbAttendeeAdded                           templateCaller
 }
 
 // sender is an interface for swapping out email provider implementations
@@ -225,6 +226,13 @@ func NewClient(config Config, sender sender) (Client, error) {
 		return Client{}, templateError(trbFormSubmittedRequesterTemplateName)
 	}
 	appTemplates.trbFormSubmittedRequester = trbFormSubmittedRequesterTemplate
+
+	trbAttendeeAddedTemplateName := "trb_attendee_added.gohtml"
+	trbAttendeeAddedTemplate := rawTemplates.Lookup(trbAttendeeAddedTemplateName)
+	if trbAttendeeAddedTemplate == nil {
+		return Client{}, templateError(trbAttendeeAddedTemplateName)
+	}
+	appTemplates.trbAttendeeAdded = trbAttendeeAddedTemplate
 
 	client := Client{
 		config:    config,

--- a/pkg/email/templates/trb_attendee_added.gohtml
+++ b/pkg/email/templates/trb_attendee_added.gohtml
@@ -1,0 +1,13 @@
+<h1 style="margin-bottom: 0.5rem;">EASi</h1>
+
+<span style="font-size:15px; line-height: 18px; color: #71767A">Easy Access to System Information</span>
+
+<p>{{.RequesterName}} has added you to the attendee list for the Technical Review Board (TRB) consult session for {{.RequestName}}.</p>
+
+<p>When a date has been set for this consult session, you will receive an email from EASi as well as a calendar invite from the TRB.</p>
+
+<p>If you have questions or you believe this to be an error, please contact {{.RequesterName}} or email the TRB at <a href="mailto:{{.TRBInboxAddress}}">{{.TRBInboxAddress}}</a>.</p>
+
+<hr>
+
+<p>You will continue to receive emails from EASi related to the scheduling and outcome of this consult session.</p>

--- a/pkg/email/templates/trb_request_form_submission_requester.gohtml
+++ b/pkg/email/templates/trb_request_form_submission_requester.gohtml
@@ -8,4 +8,6 @@
 
 <p>If you have questions, please contact the Technical Review Board (TRB) at <a href="mailto:{{.TRBInboxAddress}}">{{.TRBInboxAddress}}</a>.</p>
 
+<hr>
+
 <p>You will continue to receive email notifications about your request until it is closed.</p>

--- a/pkg/email/trb_attendee_added.go
+++ b/pkg/email/trb_attendee_added.go
@@ -1,0 +1,64 @@
+package email
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+type attendeeAddedEmailParameters struct {
+	RequestName     string
+	RequesterName   string
+	TRBInboxAddress string
+}
+
+func (c Client) trbAttendeeAddedEmailBody(requestName string, requesterName string) (string, error) {
+	data := attendeeAddedEmailParameters{
+		RequestName:     requestName,
+		RequesterName:   requesterName,
+		TRBInboxAddress: c.config.TRBEmail.String(),
+	}
+
+	var b bytes.Buffer
+	if c.templates.trbAttendeeAdded == nil {
+		return "", errors.New("TRB Attendee Added template is nil")
+	}
+
+	err := c.templates.trbAttendeeAdded.Execute(&b, data)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}
+
+// SendTRBAttendeeAddedNotification notifies someone that they've been added as an attendee on a TRB request
+func (c Client) SendTRBAttendeeAddedNotification(
+	ctx context.Context,
+	attendeeEmail models.EmailAddress,
+	requestName string,
+	requesterName string,
+) error {
+	subject := fmt.Sprintf("You are invited to the TRB consult for (%v)", requestName)
+	body, err := c.trbAttendeeAddedEmailBody(requestName, requesterName)
+	if err != nil {
+		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}
+	}
+
+	err = c.sender.Send(
+		ctx,
+		[]models.EmailAddress{attendeeEmail},
+		[]models.EmailAddress{},
+		subject,
+		body,
+	)
+	if err != nil {
+		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}
+	}
+
+	return nil
+}

--- a/pkg/email/trb_attendee_added_test.go
+++ b/pkg/email/trb_attendee_added_test.go
@@ -1,0 +1,99 @@
+package email
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+func (s *EmailTestSuite) TestSendTRBAttendeeAddedNotification() {
+	sender := mockSender{}
+	ctx := context.Background()
+
+	s.Run("successful call has the right content", func() {
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+
+		attendeeEmail := models.NewEmailAddress("test.attendee@test.com")
+		requestName := "TestRequest"
+		requesterName := "Test Requester"
+
+		mailToTRBInboxElement := fmt.Sprintf(
+			"<a href=\"mailto:%s\">%s</a>",
+			s.config.TRBEmail,
+			s.config.TRBEmail,
+		)
+
+		expectedEmail := "<h1 style=\"margin-bottom: 0.5rem;\">EASi</h1>\n\n" +
+			"<span style=\"font-size:15px; line-height: 18px; color: #71767A\">Easy Access to System Information</span>\n\n" +
+			"<p>" + requesterName + " has added you to the attendee list for the Technical Review Board (TRB) consult session for " + requestName + ".</p>\n\n" +
+			"<p>When a date has been set for this consult session, you will receive an email from EASi as well as a calendar invite from the TRB.</p>\n\n" +
+			"<p>If you have questions or you believe this to be an error, please contact " + requesterName + " or email the TRB at " + mailToTRBInboxElement + ".</p>\n\n" +
+			"<hr>\n\n" +
+			"<p>You will continue to receive emails from EASi related to the scheduling and outcome of this consult session.</p>\n"
+
+		err = client.SendTRBAttendeeAddedNotification(ctx, attendeeEmail, requestName, requesterName)
+
+		s.NoError(err)
+		s.ElementsMatch(sender.toAddresses, []models.EmailAddress{attendeeEmail})
+		s.Equal(fmt.Sprintf("You are invited to the TRB consult for (%s)", requestName), sender.subject)
+		s.Equal(expectedEmail, sender.body)
+	})
+
+	s.Run("if the template is nil, we get the error from it", func() {
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+		client.templates = templates{}
+
+		attendeeEmail := models.NewEmailAddress("test.attendee@test.com")
+		requestName := "TestRequest"
+		requesterName := "Test Requester"
+
+		err = client.SendTRBAttendeeAddedNotification(ctx, attendeeEmail, requestName, requesterName)
+
+		s.Error(err)
+		s.IsType(err, &apperrors.NotificationError{})
+		e := err.(*apperrors.NotificationError)
+		s.Equal(apperrors.DestinationTypeEmail, e.DestinationType)
+		s.Equal("TRB Attendee Added template is nil", e.Err.Error())
+	})
+
+	s.Run("if the template fails to execute, we get the error from it", func() {
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+		client.templates.trbAttendeeAdded = mockFailedTemplateCaller{}
+
+		attendeeEmail := models.NewEmailAddress("test.attendee@test.com")
+		requestName := "TestRequest"
+		requesterName := "Test Requester"
+
+		err = client.SendTRBAttendeeAddedNotification(ctx, attendeeEmail, requestName, requesterName)
+
+		s.Error(err)
+		s.IsType(err, &apperrors.NotificationError{})
+		e := err.(*apperrors.NotificationError)
+		s.Equal(apperrors.DestinationTypeEmail, e.DestinationType)
+		s.Equal("template caller had an error", e.Err.Error())
+	})
+
+	s.Run("if the sender fails, we get the error from it", func() {
+		sender := mockFailedSender{}
+
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+
+		attendeeEmail := models.NewEmailAddress("test.attendee@test.com")
+		requestName := "TestRequest"
+		requesterName := "Test Requester"
+
+		err = client.SendTRBAttendeeAddedNotification(ctx, attendeeEmail, requestName, requesterName)
+
+		s.Error(err)
+		s.IsType(err, &apperrors.NotificationError{})
+		e := err.(*apperrors.NotificationError)
+		s.Equal(apperrors.DestinationTypeEmail, e.DestinationType)
+		s.Equal("sender had an error", e.Err.Error())
+	})
+}

--- a/pkg/email/trb_request_form_submission_test.go
+++ b/pkg/email/trb_request_form_submission_test.go
@@ -125,6 +125,7 @@ func (s *EmailTestSuite) TestSendTRBFormSubmissionTemplateToRequester() {
 			"The TRB will review it and get back to you within two business days with feedback about your request. They will then work with you to schedule a time for your TRB consult session.</p>\n\n" +
 			requesterViewOpeningTag + "View your request in EASi</a>\n\n" +
 			"<p>If you have questions, please contact the Technical Review Board (TRB) at " + mailToTRBInboxElement + ".</p>\n\n" +
+			"<hr>\n\n" +
 			"<p>You will continue to receive email notifications about your request until it is closed.</p>\n"
 
 		err = client.SendTRBFormSubmissionNotificationToRequester(ctx, requestID, requestName, requesterEmail, requesterName)

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1891,12 +1891,18 @@ func (r *mutationResolver) UpdateTRBRequest(ctx context.Context, id uuid.UUID, c
 
 // CreateTRBRequestAttendee is the resolver for the createTRBRequestAttendee field.
 func (r *mutationResolver) CreateTRBRequestAttendee(ctx context.Context, input model.CreateTRBRequestAttendeeInput) (*models.TRBRequestAttendee, error) {
-	return resolvers.CreateTRBRequestAttendee(ctx, r.store, &models.TRBRequestAttendee{
-		TRBRequestID: input.TrbRequestID,
-		EUAUserID:    input.EuaUserID,
-		Component:    input.Component,
-		Role:         models.PersonRole(input.Role),
-	})
+	return resolvers.CreateTRBRequestAttendee(
+		ctx,
+		r.store,
+		r.emailClient,
+		r.service.FetchUserInfo,
+		&models.TRBRequestAttendee{
+			TRBRequestID: input.TrbRequestID,
+			EUAUserID:    input.EuaUserID,
+			Component:    input.Component,
+			Role:         models.PersonRole(input.Role),
+		},
+	)
 }
 
 // UpdateTRBRequestAttendee is the resolver for the updateTRBRequestAttendee field.


### PR DESCRIPTION
# EASI-2444

## Changes and Description

- When a TRB attendee is added (by calling the `createTRBRequestAttendee` GQL mutation), send them an email notification that they've been added to the attendee list.
- Small change to the email notification for requesters on TRB form submission - add an `<hr>` to match the Figma.

## Email Appearance

Screenshot of the attendee notification, rendered by Mailcatcher:
![trb attendee notification email](https://user-images.githubusercontent.com/92891039/206294624-078be9d3-ca47-435c-a378-abed8f8654b9.PNG)

Screenshot of the requester notification, with the `<hr>` (compare to [Figma](https://www.figma.com/file/iGatgTnlzTuqW9CQFYHDam/TRB-Intake-e2e?node-id=1060%3A88786&t=QG9ReTyUNL5sNR4B-0)):
![trb request submission notification - requester - with horizontal line](https://user-images.githubusercontent.com/92891039/206294870-5a38efe2-7bb9-4be7-9f26-bd30c6a4e132.PNG)


## How to test this change

Run the following GraphQL mutation to create a TRB request, noting down the returned request ID:

```gql
mutation {
  createTRBRequest(requestType: NEED_HELP) {
    id # use this for the following steps
    form {
      status
    }
    taskStatuses {
      formStatus
      feedbackStatus
      consultStatus
    }
  }
}
```

Run the following GraphQL mutation to add an attendee, using the request ID from above:
```gql
mutation {
  createTRBRequestAttendee(input:{
    trbRequestId:"trbRequestIdFromAbove"
    euaUserId:"HYG2"
    component:"The Cool Kids"
    role:CLOUD_NAVIGATOR
  }) {
    id
    euaUserId
  	userInfo {
      commonName
      email
      euaUserId
    }
    trbRequestId
    component
    role
  }
}
```

Open Mailcatcher at localhost:1080; you should see a notification sent to karianne.hickle@local.fake. (The email address comes from `pkg/local/cedar_ldap.go`)

## Notes
* The email styles were borrowed from https://github.com/CMSgov/easi-app/pull/1837, as was some of the resolver logic.
* Because we're going to be adding a fair amount of notification emails, I looked into using reflection to reduce some of the boilerplate loading code in `pkg/email/email.go`, but I didn't find a solution I was satisfied with. See the first comment on EASI-2444 for more details.