### PR TITLE
Ignore minor/patch upgrades to configure-aws-credentials GH action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "aws-actions/configure-aws-credentials"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
Small follow-up to https://github.com/CMSgov/easi-app/pull/1848, preventing the `aws-actions/configure-aws-credentials` github action from receiving dependabot updates that would take us off `v1-node16`, like [this one](https://github.com/CMSgov/easi-app/pull/1855). Per [this issue](https://github.com/aws-actions/configure-aws-credentials/issues/489#issuecomment-1278145876) on the `configure-aws-actions` repository, they're not going to update to Node 16 until v2 (a major version update), so we should keep using `v1-node16`.

Documentation on configuring Dependabot ignore: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore