### PR TITLE
EASI-2388 - TRB Advice Letters

### DIFF
--- a/migrations/V124__Add_TRB_Advice_Letters.sql
+++ b/migrations/V124__Add_TRB_Advice_Letters.sql
@@ -1,0 +1,25 @@
+CREATE TYPE trb_advice_letter_status AS ENUM (
+    'IN_PROGRESS',
+    'READY_FOR_REVIEW',
+    'COMPLETED'
+);
+
+CREATE TABLE trb_advice_letters (
+    -- PK, FK
+    id UUID PRIMARY KEY NOT NULL,
+    trb_request_id uuid NOT NULL REFERENCES trb_request(id),
+
+    -- general metadata
+    created_by TEXT NOT NULL CHECK (created_by ~ '^[A-Z0-9]{4}$'),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_by TEXT CHECK (modified_by ~ '^[A-Z0-9]{4}$'),
+    modified_at TIMESTAMP WITH TIME ZONE,
+
+    -- advice letter-specific fields
+    status trb_advice_letter_status NOT NULL DEFAULT 'IN_PROGRESS',
+    meeting_summary TEXT,
+    next_steps TEXT,
+    is_followup_recommended BOOLEAN,
+    followup_point TEXT, -- not necessarily a firm date; can be something like "In 6 months or when development is complete"
+    date_sent TIMESTAMP WITH TIME ZONE
+);

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -8076,7 +8076,6 @@ input UpdateTRBAdviceLetterInput @goModel(model: "map[string]interface{}") {
   meetingSummary: String
   nextSteps: String
   isFollowupRecommended: Boolean
-  dateSent: Time
   followupPoint: String
 }
 

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -416,6 +416,13 @@ type SendReportAProblemEmailInput struct {
 	HowSevereWasTheProblem string `json:"howSevereWasTheProblem"`
 }
 
+// The data needed to send a TRB advice letter, including who to notify
+type SendTRBAdviceLetterInput struct {
+	ID             uuid.UUID `json:"id"`
+	CopyTrbMailbox bool      `json:"copyTrbMailbox"`
+	NotifyEuaIds   []string  `json:"notifyEuaIds"`
+}
+
 type SetRolesForUserOnSystemInput struct {
 	CedarSystemID      string   `json:"cedarSystemID"`
 	EuaUserID          string   `json:"euaUserId"`

--- a/pkg/graph/resolvers/trb_advice_letter.go
+++ b/pkg/graph/resolvers/trb_advice_letter.go
@@ -1,0 +1,89 @@
+package resolvers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/models"
+	"github.com/cmsgov/easi-app/pkg/storage"
+)
+
+// GetTRBAdviceLetterByTRBRequestID fetches a TRB advice letter record by its associated request's ID.
+func GetTRBAdviceLetterByTRBRequestID(ctx context.Context, store *storage.Store, id uuid.UUID) (*models.TRBAdviceLetter, error) {
+	letter, err := store.GetTRBAdviceLetterByTRBRequestID(appcontext.ZLogger(ctx), id)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return letter, nil
+}
+
+// CreateTRBAdviceLetter creates an advice letter for a TRB request, in the "In Progress" status, when the advice letter is ready to be worked on.
+func CreateTRBAdviceLetter(ctx context.Context, store *storage.Store, trbRequestID uuid.UUID) (*models.TRBAdviceLetter, error) {
+	letter, err := store.CreateTRBAdviceLetter(appcontext.ZLogger(ctx), appcontext.Principal(ctx).ID(), trbRequestID)
+	if err != nil {
+		return nil, err
+	}
+
+	return letter, nil
+}
+
+// UpdateTRBAdviceLetter handles general updates to a TRB advice letter
+func UpdateTRBAdviceLetter(ctx context.Context, store *storage.Store, input map[string]interface{}) (*models.TRBAdviceLetter, error) {
+	logger := appcontext.ZLogger(ctx)
+
+	trbRequestIDStr, idFound := input["trbRequestId"]
+	if !idFound {
+		return nil, errors.New("missing required property trbRequestId")
+	}
+
+	trbRequestID, err := uuid.Parse(trbRequestIDStr.(string))
+	if err != nil {
+		return nil, err
+	}
+
+	letter, err := store.GetTRBAdviceLetterByTRBRequestID(logger, trbRequestID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ApplyChangesAndMetaData(input, letter, appcontext.Principal(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	updatedLetter, err := store.UpdateTRBAdviceLetter(logger, letter)
+	if err != nil {
+		return nil, err
+	}
+
+	return updatedLetter, err
+}
+
+// RequestReviewForTRBAdviceLetter sets a TRB advice letter as ready for review and (TODO) notifies the given recipients.
+func RequestReviewForTRBAdviceLetter(ctx context.Context, store *storage.Store, id uuid.UUID) (*models.TRBAdviceLetter, error) {
+	// TODO - EASI-2514 - send notification email(s)
+
+	letter, err := store.UpdateTRBAdviceLetterStatus(appcontext.ZLogger(ctx), id, models.TRBAdviceLetterStatusReadyForReview)
+	if err != nil {
+		return nil, err
+	}
+
+	return letter, nil
+}
+
+// SendTRBAdviceLetter sends a TRB advice letter, setting its DateSent field, and (TODO) notifies the given recipients.
+func SendTRBAdviceLetter(ctx context.Context, store *storage.Store, id uuid.UUID) (*models.TRBAdviceLetter, error) {
+	// TODO - EASI-2515 - send notification email(s)
+
+	letter, err := store.UpdateTRBAdviceLetterStatus(appcontext.ZLogger(ctx), id, models.TRBAdviceLetterStatusCompleted)
+	if err != nil {
+		return nil, err
+	}
+
+	return letter, nil
+}

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -1994,7 +1994,6 @@ input UpdateTRBAdviceLetterInput @goModel(model: "map[string]interface{}") {
   meetingSummary: String
   nextSteps: String
   isFollowupRecommended: Boolean
-  dateSent: Time
   followupPoint: String
 }
 

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -1518,6 +1518,7 @@ type TRBRequest {
   feedback: [TRBRequestFeedback!]!
   documents: [TRBRequestDocument!]!
   form: TRBRequestForm!
+  adviceLetter: TRBAdviceLetter
   taskStatuses: TRBTaskStatuses!
   consultMeetingTime: Time
   trbLead: String
@@ -1535,6 +1536,7 @@ type TRBTaskStatuses {
   feedbackStatus: TRBFeedbackStatus!
   consultPrepStatus: TRBConsultPrepStatus!
   attendConsultStatus: TRBAttendConsultStatus!
+  adviceLetterStatus: TRBAdviceLetterStatus!
 }
 
 """
@@ -1709,6 +1711,17 @@ enum TRBAttendConsultStatus {
   CANNOT_START_YET
   READY_TO_SCHEDULE
   SCHEDULED
+  COMPLETED
+}
+
+"""
+Represents the status of the TRB advice letter step
+"""
+enum TRBAdviceLetterStatus {
+  CANNOT_START_YET
+  READY_TO_START
+  IN_PROGRESS
+  READY_FOR_REVIEW
   COMPLETED
 }
 
@@ -1957,6 +1970,44 @@ input UpdateTRBRequestTRBLeadInput {
 }
 
 """
+Represents an advice letter for a TRB request
+"""
+type TRBAdviceLetter {
+  id: UUID!
+  trbRequestId: UUID!
+  meetingSummary: String
+  nextSteps: String
+  isFollowupRecommended: Boolean
+  dateSent: Time
+  followupPoint: String
+  createdBy: String!
+  createdAt: Time!
+  modifiedBy: String
+  modifiedAt: Time
+}
+
+"""
+The data needed to update a TRB advice letter
+"""
+input UpdateTRBAdviceLetterInput @goModel(model: "map[string]interface{}") {
+  trbRequestId: UUID!
+  meetingSummary: String
+  nextSteps: String
+  isFollowupRecommended: Boolean
+  dateSent: Time
+  followupPoint: String
+}
+
+"""
+The data needed to send a TRB advice letter, including who to notify
+"""
+input SendTRBAdviceLetterInput {
+  id: UUID!
+  copyTrbMailbox: Boolean!
+  notifyEuaIds: [String!]!
+}
+
+"""
 Defines the mutations for the schema
 """
 type Mutation {
@@ -2077,6 +2128,14 @@ type Mutation {
   updateTRBRequestConsultMeetingTime(input: UpdateTRBRequestConsultMeetingTimeInput!): TRBRequest!
     @hasRole(role: EASI_TRB_ADMIN)
   updateTRBRequestTRBLead(input: UpdateTRBRequestTRBLeadInput!): TRBRequest!
+    @hasRole(role: EASI_TRB_ADMIN)
+  createTRBAdviceLetter(trbRequestId: UUID!): TRBAdviceLetter!
+    @hasRole(role: EASI_TRB_ADMIN)
+  updateTRBAdviceLetter(input: UpdateTRBAdviceLetterInput!): TRBAdviceLetter!
+    @hasRole(role: EASI_TRB_ADMIN)
+  requestReviewForTRBAdviceLetter(id: UUID!): TRBAdviceLetter!
+    @hasRole(role: EASI_TRB_ADMIN)
+  sendTRBAdviceLetter(input: SendTRBAdviceLetterInput!): TRBAdviceLetter!
     @hasRole(role: EASI_TRB_ADMIN)
 }
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -7,6 +7,7 @@ package graph
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"strconv"
 	"time"
@@ -2013,6 +2014,26 @@ func (r *mutationResolver) UpdateTRBRequestTRBLead(ctx context.Context, input mo
 	)
 }
 
+// CreateTRBAdviceLetter is the resolver for the createTRBAdviceLetter field.
+func (r *mutationResolver) CreateTRBAdviceLetter(ctx context.Context, trbRequestID uuid.UUID) (*models.TRBAdviceLetter, error) {
+	panic(fmt.Errorf("not implemented: CreateTRBAdviceLetter - createTRBAdviceLetter"))
+}
+
+// UpdateTRBAdviceLetter is the resolver for the updateTRBAdviceLetter field.
+func (r *mutationResolver) UpdateTRBAdviceLetter(ctx context.Context, input map[string]interface{}) (*models.TRBAdviceLetter, error) {
+	panic(fmt.Errorf("not implemented: UpdateTRBAdviceLetter - updateTRBAdviceLetter"))
+}
+
+// RequestReviewForTRBAdviceLetter is the resolver for the requestReviewForTRBAdviceLetter field.
+func (r *mutationResolver) RequestReviewForTRBAdviceLetter(ctx context.Context, id uuid.UUID) (*models.TRBAdviceLetter, error) {
+	panic(fmt.Errorf("not implemented: RequestReviewForTRBAdviceLetter - requestReviewForTRBAdviceLetter"))
+}
+
+// SendTRBAdviceLetter is the resolver for the sendTRBAdviceLetter field.
+func (r *mutationResolver) SendTRBAdviceLetter(ctx context.Context, input model.SendTRBAdviceLetterInput) (*models.TRBAdviceLetter, error) {
+	panic(fmt.Errorf("not implemented: SendTRBAdviceLetter - sendTRBAdviceLetter"))
+}
+
 // AccessibilityRequest is the resolver for the accessibilityRequest field.
 func (r *queryResolver) AccessibilityRequest(ctx context.Context, id uuid.UUID) (*models.AccessibilityRequest, error) {
 	// deleted requests need to be returned to be able to show a deleted request view
@@ -2773,6 +2794,11 @@ func (r *tRBRequestResolver) Documents(ctx context.Context, obj *models.TRBReque
 // Form is the resolver for the form field.
 func (r *tRBRequestResolver) Form(ctx context.Context, obj *models.TRBRequest) (*models.TRBRequestForm, error) {
 	return resolvers.GetTRBRequestFormByTRBRequestID(ctx, r.store, obj.ID)
+}
+
+// AdviceLetter is the resolver for the adviceLetter field.
+func (r *tRBRequestResolver) AdviceLetter(ctx context.Context, obj *models.TRBRequest) (*models.TRBAdviceLetter, error) {
+	panic(fmt.Errorf("not implemented: AdviceLetter - adviceLetter"))
 }
 
 // TaskStatuses is the resolver for the taskStatuses field.

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -7,7 +7,6 @@ package graph
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/url"
 	"strconv"
 	"time"
@@ -2016,22 +2015,22 @@ func (r *mutationResolver) UpdateTRBRequestTRBLead(ctx context.Context, input mo
 
 // CreateTRBAdviceLetter is the resolver for the createTRBAdviceLetter field.
 func (r *mutationResolver) CreateTRBAdviceLetter(ctx context.Context, trbRequestID uuid.UUID) (*models.TRBAdviceLetter, error) {
-	panic(fmt.Errorf("not implemented: CreateTRBAdviceLetter - createTRBAdviceLetter"))
+	return resolvers.CreateTRBAdviceLetter(ctx, r.store, trbRequestID)
 }
 
 // UpdateTRBAdviceLetter is the resolver for the updateTRBAdviceLetter field.
 func (r *mutationResolver) UpdateTRBAdviceLetter(ctx context.Context, input map[string]interface{}) (*models.TRBAdviceLetter, error) {
-	panic(fmt.Errorf("not implemented: UpdateTRBAdviceLetter - updateTRBAdviceLetter"))
+	return resolvers.UpdateTRBAdviceLetter(ctx, r.store, input)
 }
 
 // RequestReviewForTRBAdviceLetter is the resolver for the requestReviewForTRBAdviceLetter field.
 func (r *mutationResolver) RequestReviewForTRBAdviceLetter(ctx context.Context, id uuid.UUID) (*models.TRBAdviceLetter, error) {
-	panic(fmt.Errorf("not implemented: RequestReviewForTRBAdviceLetter - requestReviewForTRBAdviceLetter"))
+	return resolvers.RequestReviewForTRBAdviceLetter(ctx, r.store, id)
 }
 
 // SendTRBAdviceLetter is the resolver for the sendTRBAdviceLetter field.
 func (r *mutationResolver) SendTRBAdviceLetter(ctx context.Context, input model.SendTRBAdviceLetterInput) (*models.TRBAdviceLetter, error) {
-	panic(fmt.Errorf("not implemented: SendTRBAdviceLetter - sendTRBAdviceLetter"))
+	return resolvers.SendTRBAdviceLetter(ctx, r.store, input.ID)
 }
 
 // AccessibilityRequest is the resolver for the accessibilityRequest field.
@@ -2798,7 +2797,7 @@ func (r *tRBRequestResolver) Form(ctx context.Context, obj *models.TRBRequest) (
 
 // AdviceLetter is the resolver for the adviceLetter field.
 func (r *tRBRequestResolver) AdviceLetter(ctx context.Context, obj *models.TRBRequest) (*models.TRBAdviceLetter, error) {
-	panic(fmt.Errorf("not implemented: AdviceLetter - adviceLetter"))
+	return resolvers.GetTRBAdviceLetterByTRBRequestID(ctx, r.store, obj.ID)
 }
 
 // TaskStatuses is the resolver for the taskStatuses field.

--- a/pkg/models/trb_advice_letter.go
+++ b/pkg/models/trb_advice_letter.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TRBAdviceLetterStatus is an enumeration of the possible statuses of a TRBAdviceLetter
+type TRBAdviceLetterStatus string
+
+// These are the possible statuses for a TRB advice letter
+const (
+	TRBAdviceLetterStatusCannotStartYet TRBAdviceLetterStatus = "CANNOT_START_YET"
+	TRBAdviceLetterStatusReadyToStart   TRBAdviceLetterStatus = "READY_TO_START"
+	TRBAdviceLetterStatusInProgress     TRBAdviceLetterStatus = "IN_PROGRESS"
+	TRBAdviceLetterStatusReadyForReview TRBAdviceLetterStatus = "READY_FOR_REVIEW"
+	TRBAdviceLetterStatusCompleted      TRBAdviceLetterStatus = "COMPLETED"
+)
+
+// TRBAdviceLetter represents the data for a TRB advice letter
+type TRBAdviceLetter struct {
+	baseStruct
+	TRBRequestID          uuid.UUID             `json:"trbRequestId" db:"trb_request_id"`
+	Status                TRBAdviceLetterStatus `json:"status" db:"status"`
+	MeetingSummary        *string               `json:"meetingSummary" db:"meeting_summary"`
+	NextSteps             *string               `json:"nextSteps" db:"next_steps"`
+	IsFollowupRecommended *bool                 `json:"isFollowupRecommended" db:"is_followup_recommended"`
+	DateSent              *time.Time            `json:"dateSent" db:"date_sent"`
+
+	// not necessarily a firm date; can be something like "In 6 months or when development is complete"
+	FollowupPoint *string `json:"followupPoint" db:"followup_point"`
+}

--- a/pkg/models/trb_request.go
+++ b/pkg/models/trb_request.go
@@ -80,4 +80,5 @@ type TRBTaskStatuses struct {
 	FeedbackStatus      TRBFeedbackStatus      `json:"feedbackStatus"`
 	ConsultPrepStatus   TRBConsultPrepStatus   `json:"consultPrepStatus"`
 	AttendConsultStatus TRBAttendConsultStatus `json:"attendConsultStatus"`
+	AdviceLetterStatus  TRBAdviceLetterStatus  `json:"adviceLetterStatus"`
 }

--- a/pkg/storage/trb_advice_letter.go
+++ b/pkg/storage/trb_advice_letter.go
@@ -1,0 +1,213 @@
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+// CreateTRBAdviceLetter creates an advice letter for a TRB request, in the "In Progress" status
+func (s *Store) CreateTRBAdviceLetter(logger *zap.Logger, createdBy string, trbRequestID uuid.UUID) (*models.TRBAdviceLetter, error) {
+	adviceLetter := models.TRBAdviceLetter{
+		TRBRequestID: trbRequestID,
+		Status:       models.TRBAdviceLetterStatusInProgress,
+	}
+	adviceLetter.ID = uuid.New()
+	adviceLetter.CreatedBy = createdBy
+
+	const trbAdviceLetterCreateSQL = `
+		INSERT INTO trb_advice_letters (
+			id,
+			trb_request_id,
+			created_by,
+			status
+		) VALUES (
+			:id,
+			:trb_request_id,
+			:created_by,
+			:status 
+		) RETURNING
+			id,
+			trb_request_id,
+			created_by,
+			created_at,
+			modified_by,
+			modified_at,
+			status,
+			meeting_summary,
+			next_steps,
+			is_followup_recommended,
+			followup_point,
+			date_sent
+	`
+	stmt, err := s.db.PrepareNamed(trbAdviceLetterCreateSQL)
+	if err != nil {
+		logger.Error(
+			fmt.Sprintf("Failed to prepare SQL statement for creating TRB advice letter with error %s", err),
+			zap.Error(err),
+			zap.String("user", createdBy),
+		)
+		return nil, err
+	}
+
+	retLetter := models.TRBAdviceLetter{}
+
+	err = stmt.Get(&retLetter, adviceLetter)
+	if err != nil {
+		logger.Error(
+			fmt.Sprintf("Failed to create TRB advice letter with error %s", err),
+			zap.Error(err),
+			zap.String("user", createdBy),
+		)
+		return nil, err
+	}
+
+	return &retLetter, nil
+}
+
+// UpdateTRBAdviceLetterStatus sets the status of a TRB advice letter, for setting the letter as ready to review or sending the letter.
+// When it sends the letter, it also updates the DateSent field.
+func (s *Store) UpdateTRBAdviceLetterStatus(logger *zap.Logger, id uuid.UUID, status models.TRBAdviceLetterStatus) (*models.TRBAdviceLetter, error) {
+	const trbAdviceLetterStatusUpdateSQL = `
+	UPDATE trb_advice_letters
+	SET
+		status = :status,
+		date_sent = :date_sent
+	WHERE id = :id
+	RETURNING *;
+	`
+
+	stmt, err := s.db.PrepareNamed(trbAdviceLetterStatusUpdateSQL)
+	if err != nil {
+		logger.Error(
+			fmt.Sprintf("Failed to prepare SQL statement for updating TRB advice letter status with error %s", err),
+			zap.Error(err),
+			zap.String("id", id.String()),
+			zap.String("status", string(status)),
+		)
+		return nil, err
+	}
+
+	updated := models.TRBAdviceLetter{}
+	arg := map[string]interface{}{
+		"id":     id,
+		"status": string(status),
+	}
+
+	if status == models.TRBAdviceLetterStatusCompleted {
+		arg["date_sent"] = time.Now()
+	} else {
+		arg["date_sent"] = nil // need this to avoid errors from the ":date_sent" parameter being absent in the SQL statement
+	}
+
+	err = stmt.Get(&updated, arg)
+	if err != nil {
+		logger.Error(
+			fmt.Sprintf("Failed to update TRB advice letter status with error %s", err),
+			zap.String("id", id.String()),
+			zap.String("status", string(status)),
+		)
+		return nil, &apperrors.QueryError{
+			Err:       err,
+			Model:     updated,
+			Operation: apperrors.QueryUpdate,
+		}
+	}
+
+	return &updated, nil
+}
+
+// UpdateTRBAdviceLetter updates all of a TRB advice letter's mutable fields.
+// The letter's status can be set, though UpdateTRBAdviceLetterStatus() should be used when setting a letter ready for review or sending a letter.
+func (s *Store) UpdateTRBAdviceLetter(logger *zap.Logger, letter *models.TRBAdviceLetter) (*models.TRBAdviceLetter, error) {
+	const trbAdviceLetterUpdateSQL = `
+		UPDATE trb_advice_letters
+		SET
+			trb_request_id = :trb_request_id,
+			status = :status,
+			meeting_summary = :meeting_summary,
+			next_steps = :next_steps,
+			is_followup_recommended = :is_followup_recommended,
+			date_sent = :date_sent,
+			followup_point = :followup_point,
+			modified_by = :modified_by,
+			modified_at = :modified_at
+		WHERE id = :id
+		RETURNING *;
+	`
+
+	stmt, err := s.db.PrepareNamed(trbAdviceLetterUpdateSQL)
+	if err != nil {
+		logger.Error(
+			fmt.Sprintf("Failed to prepare SQL statement for updating TRB advice letter with error %s", err),
+			zap.Error(err),
+			zap.String("id", letter.ID.String()),
+		)
+		return nil, err
+	}
+
+	updated := models.TRBAdviceLetter{}
+
+	err = stmt.Get(&updated, letter)
+	if err != nil {
+		logger.Error(
+			fmt.Sprintf("Failed to update TRB advice letter with error %s", err),
+			zap.String("id", letter.ID.String()),
+		)
+		return nil, &apperrors.QueryError{
+			Err:       err,
+			Model:     letter,
+			Operation: apperrors.QueryUpdate,
+		}
+	}
+
+	return &updated, nil
+}
+
+// GetTRBAdviceLetterByTRBRequestID fetches a TRB advice letter record by its associated request's ID
+func (s *Store) GetTRBAdviceLetterByTRBRequestID(logger *zap.Logger, trbRequestID uuid.UUID) (*models.TRBAdviceLetter, error) {
+	letter := models.TRBAdviceLetter{}
+
+	stmt, err := s.db.PrepareNamed(`SELECT * FROM trb_advice_letters WHERE trb_request_id = :trb_request_id`)
+	if err != nil {
+		logger.Error(
+			fmt.Sprintf("Failed to prepare SQL statement for fetching TRB advice letter with error %s", err),
+			zap.Error(err),
+			zap.String("trbRequestID", trbRequestID.String()),
+		)
+		return nil, err
+	}
+
+	arg := map[string]interface{}{"trb_request_id": trbRequestID}
+
+	err = stmt.Get(&letter, arg)
+	if err != nil {
+		logger.Error(
+			"Failed to fetch TRB advice letter",
+			zap.Error(err),
+			zap.String("trbRequestID", trbRequestID.String()),
+		)
+
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, &apperrors.ResourceNotFoundError{
+				Err:      err,
+				Resource: models.TRBAdviceLetter{},
+			}
+		}
+
+		return nil, &apperrors.QueryError{
+			Err:       err,
+			Model:     letter,
+			Operation: apperrors.QueryFetch,
+		}
+	}
+
+	return &letter, nil
+}

--- a/pkg/storage/trb_advice_letter.go
+++ b/pkg/storage/trb_advice_letter.go
@@ -98,7 +98,7 @@ func (s *Store) UpdateTRBAdviceLetterStatus(logger *zap.Logger, id uuid.UUID, st
 	updated := models.TRBAdviceLetter{}
 	arg := map[string]interface{}{
 		"id":     id,
-		"status": string(status),
+		"status": status,
 	}
 
 	if status == models.TRBAdviceLetterStatusCompleted {
@@ -125,7 +125,7 @@ func (s *Store) UpdateTRBAdviceLetterStatus(logger *zap.Logger, id uuid.UUID, st
 }
 
 // UpdateTRBAdviceLetter updates all of a TRB advice letter's mutable fields.
-// The letter's status can be set, though UpdateTRBAdviceLetterStatus() should be used when setting a letter ready for review or sending a letter.
+// The letter's status _can_ be set, though UpdateTRBAdviceLetterStatus() should be used when setting a letter ready for review or sending a letter.
 func (s *Store) UpdateTRBAdviceLetter(logger *zap.Logger, letter *models.TRBAdviceLetter) (*models.TRBAdviceLetter, error) {
 	const trbAdviceLetterUpdateSQL = `
 		UPDATE trb_advice_letters

--- a/pkg/storage/trb_advice_letter_test.go
+++ b/pkg/storage/trb_advice_letter_test.go
@@ -1,0 +1,128 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+func createTRBRequest(s *StoreTestSuite, logger *zap.Logger, createdBy string) uuid.UUID {
+	trbRequest := models.NewTRBRequest(createdBy)
+	trbRequest.Type = models.TRBTNeedHelp
+	trbRequest.Status = models.TRBSOpen
+	createdRequest, err := s.store.CreateTRBRequest(logger, trbRequest)
+	s.NoError(err)
+
+	return createdRequest.ID
+}
+
+func (s *StoreTestSuite) TestTRBAdviceLetterStoreMethods() {
+	ctx := context.Background()
+	logger := appcontext.ZLogger(ctx)
+
+	anonEua := "ANON"
+
+	s.Run("Creating an advice letter returns a blank advice letter in the In Progress status", func() {
+		trbRequestID := createTRBRequest(s, logger, anonEua)
+
+		createdLetter, err := s.store.CreateTRBAdviceLetter(logger, anonEua, trbRequestID)
+		s.NoError(err)
+		s.EqualValues(trbRequestID, createdLetter.TRBRequestID)
+		s.EqualValues(anonEua, createdLetter.CreatedBy)
+		s.EqualValues(models.TRBAdviceLetterStatusInProgress, createdLetter.Status)
+		s.Nil(createdLetter.MeetingSummary)
+		s.Nil(createdLetter.NextSteps)
+		s.Nil(createdLetter.IsFollowupRecommended)
+		s.Nil(createdLetter.DateSent)
+		s.Nil(createdLetter.FollowupPoint)
+	})
+
+	s.Run("Creating, then fetching an advice letter returns a blank advice letter in the In Progress status", func() {
+		trbRequestID := createTRBRequest(s, logger, anonEua)
+
+		_, err := s.store.CreateTRBAdviceLetter(logger, anonEua, trbRequestID)
+		s.NoError(err)
+
+		fetchedLetter, err := s.store.GetTRBAdviceLetterByTRBRequestID(logger, trbRequestID)
+		s.NoError(err)
+
+		s.EqualValues(trbRequestID, fetchedLetter.TRBRequestID)
+		s.EqualValues(anonEua, fetchedLetter.CreatedBy)
+		s.EqualValues(models.TRBAdviceLetterStatusInProgress, fetchedLetter.Status)
+
+		s.Nil(fetchedLetter.MeetingSummary)
+		s.Nil(fetchedLetter.NextSteps)
+		s.Nil(fetchedLetter.IsFollowupRecommended)
+		s.Nil(fetchedLetter.DateSent)
+		s.Nil(fetchedLetter.FollowupPoint)
+	})
+
+	s.Run("Updating an advice letter returns an advice letter with updated data", func() {
+		trbRequestID := createTRBRequest(s, logger, anonEua)
+
+		createdLetter, err := s.store.CreateTRBAdviceLetter(logger, anonEua, trbRequestID)
+		s.NoError(err)
+
+		updatedMeetingSummary := "Meeting went well, no notes"
+		updatedNextSteps := "Move forward with development"
+		updatedIsFollowupRecommended := true
+		updatedFollowupPoint := "In 3 months, check that everything's going well"
+		updatedLetter := models.TRBAdviceLetter{
+			TRBRequestID:          createdLetter.TRBRequestID,
+			Status:                createdLetter.Status,
+			MeetingSummary:        &updatedMeetingSummary,
+			NextSteps:             &updatedNextSteps,
+			IsFollowupRecommended: &updatedIsFollowupRecommended,
+			FollowupPoint:         &updatedFollowupPoint,
+		}
+		updatedLetter.ID = createdLetter.ID
+
+		returnedLetter, err := s.store.UpdateTRBAdviceLetter(logger, &updatedLetter)
+		s.NoError(err)
+
+		// fields that should have remained constant
+		s.EqualValues(createdLetter.ID, returnedLetter.ID)
+		s.EqualValues(createdLetter.TRBRequestID, returnedLetter.TRBRequestID)
+		s.EqualValues(anonEua, returnedLetter.CreatedBy)
+		s.EqualValues(models.TRBAdviceLetterStatusInProgress, returnedLetter.Status)
+		s.Nil(returnedLetter.DateSent)
+
+		// updated fields
+		s.EqualValues(updatedMeetingSummary, *returnedLetter.MeetingSummary)
+		s.EqualValues(updatedNextSteps, *returnedLetter.NextSteps)
+		s.EqualValues(updatedIsFollowupRecommended, *returnedLetter.IsFollowupRecommended)
+		s.EqualValues(updatedFollowupPoint, *returnedLetter.FollowupPoint)
+	})
+
+	s.Run("Updating an advice letter to be ready for review changes the status while leaving DateSent nil", func() {
+		trbRequestID := createTRBRequest(s, logger, anonEua)
+
+		createdLetter, err := s.store.CreateTRBAdviceLetter(logger, anonEua, trbRequestID)
+		s.NoError(err)
+
+		updatedLetter, err := s.store.UpdateTRBAdviceLetterStatus(logger, createdLetter.ID, models.TRBAdviceLetterStatusReadyForReview)
+		s.NoError(err)
+
+		s.EqualValues(models.TRBAdviceLetterStatusReadyForReview, updatedLetter.Status)
+		s.Nil(updatedLetter.DateSent)
+	})
+
+	s.Run("Updating an advice letter to complete it changes the status and sets DateSent", func() {
+		trbRequestID := createTRBRequest(s, logger, anonEua)
+
+		createdLetter, err := s.store.CreateTRBAdviceLetter(logger, anonEua, trbRequestID)
+		s.NoError(err)
+
+		updatedLetter, err := s.store.UpdateTRBAdviceLetterStatus(logger, createdLetter.ID, models.TRBAdviceLetterStatusCompleted)
+		s.NoError(err)
+
+		s.EqualValues(models.TRBAdviceLetterStatusCompleted, updatedLetter.Status)
+
+		// don't bother stubbing time.Now(), just make sure that DateSent was set to *something* instead of nil
+		s.NotNil(updatedLetter.DateSent)
+	})
+}

--- a/pkg/storage/truncate.go
+++ b/pkg/storage/truncate.go
@@ -25,6 +25,7 @@ func (s *Store) TruncateAllTablesDANGEROUS(logger *zap.Logger) error {
 	trb_request_forms,
 	trb_request_attendees,
 	trb_request_feedback,
+	trb_advice_letters,
 	trb_request
 	`
 


### PR DESCRIPTION
# EASI-2388

## Changes and Description

- Introduce TRB Advice Letters
    - Add SQL migration to create table for them
    - Create store methods for creating/fetching/updating them
    - Add them to GraphQL schema
    - Add resolvers for creating/fetching/updating them

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## Notes
- Technically, advice letters could probably be integrated into the TRB request table - each request can only have 0 or 1 associated letter, not multiple - but putting them in a separate table seems generally cleaner. It also should make setting up FK relationships for recommendations/notes on advice letters easier.
- I didn't add unit tests for the resolver functions because I didn't feel they'd add much; right now, those functions are pretty much just wrappers around the store functions. When we add email notifications in EASI-2514/EASI-2515, it might be worth creating unit tests.
- I didn’t check if the request is in the proper status for an advice letter, even though an advice letter technically shouldn't be able to be created until the consult session has been scheduled and has occurred. I followed the precedent of the feedback resolver, which similarly doesn't check if a request is ready to receive feedback. I'm not sure if we should put restrictions like these in place, but I don't think so; I don't think it's likely that we'll have a bug or a malicious user that would create letters/feedback entries early.
- The `getTRBAdviceLetterStatus()` function I added to `pkg/graph/resolvers/trb_task_status.go` is private - can we make the other functions that fetch individual statuses private as well? They're only used either in that file or in tests, making them private shouldn't cause any issues.
