### PR TITLE
EASI-2388 - correcting spurious errors, making methods private

### DIFF
--- a/pkg/graph/resolvers/trb_request_feedback_test.go
+++ b/pkg/graph/resolvers/trb_request_feedback_test.go
@@ -109,7 +109,7 @@ func (s *ResolverSuite) TestCreateTRBRequestFeedback() {
 		s.EqualValues(toCreate.NotifyEUAIDs[1], created.NotifyEUAIDs[1])
 		s.EqualValues(toCreate.NotifyEUAIDs[2], created.NotifyEUAIDs[2])
 		// Verify that the TRB request feedback status is now "edits requested"
-		updatedFeedbackStatus, err := GetTRBFeedbackStatus(ctx, store, trbRequest.ID)
+		updatedFeedbackStatus, err := getTRBFeedbackStatus(ctx, store, trbRequest.ID)
 		s.NoError(err)
 		s.EqualValues(models.TRBFeedbackStatusEditsRequested, *updatedFeedbackStatus)
 		form, err := GetTRBRequestFormByTRBRequestID(ctx, store, trbRequest.ID)
@@ -152,7 +152,7 @@ func (s *ResolverSuite) TestCreateTRBRequestFeedback() {
 		s.EqualValues(toCreate2.NotifyEUAIDs[2], created2.NotifyEUAIDs[2])
 
 		// Verify that the TRB request feedback status is now "completed"
-		finalFeedbackStatus, err := GetTRBFeedbackStatus(ctx, store, trbRequest.ID)
+		finalFeedbackStatus, err := getTRBFeedbackStatus(ctx, store, trbRequest.ID)
 		s.NoError(err)
 		s.EqualValues(models.TRBFeedbackStatusCompleted, *finalFeedbackStatus)
 	})

--- a/pkg/graph/resolvers/trb_task_status.go
+++ b/pkg/graph/resolvers/trb_task_status.go
@@ -13,8 +13,7 @@ import (
 	"github.com/cmsgov/easi-app/pkg/storage"
 )
 
-// GetTRBFormStatus retrieves the status of the form step of the TRB request task list
-func GetTRBFormStatus(ctx context.Context, store *storage.Store, trbRequestID uuid.UUID) (*models.TRBFormStatus, error) {
+func getTRBFormStatus(ctx context.Context, store *storage.Store, trbRequestID uuid.UUID) (*models.TRBFormStatus, error) {
 	form, err := store.GetTRBRequestFormByTRBRequestID(ctx, trbRequestID)
 	if err != nil {
 		return nil, err
@@ -22,8 +21,7 @@ func GetTRBFormStatus(ctx context.Context, store *storage.Store, trbRequestID uu
 	return &form.Status, nil
 }
 
-// GetTRBFeedbackStatus retrieves the status of the feedback step of the TRB request task list
-func GetTRBFeedbackStatus(ctx context.Context, store *storage.Store, trbRequestID uuid.UUID) (*models.TRBFeedbackStatus, error) {
+func getTRBFeedbackStatus(ctx context.Context, store *storage.Store, trbRequestID uuid.UUID) (*models.TRBFeedbackStatus, error) {
 	status := models.TRBFeedbackStatusCannotStartYet
 	errGroup := new(errgroup.Group)
 
@@ -63,10 +61,9 @@ func GetTRBFeedbackStatus(ctx context.Context, store *storage.Store, trbRequestI
 	return &status, nil
 }
 
-// GetTRBConsultPrepStatus retrieves the status of the consult step of the TRB request task list
-func GetTRBConsultPrepStatus(ctx context.Context, store *storage.Store, trbRequestID uuid.UUID) (*models.TRBConsultPrepStatus, error) {
+func getTRBConsultPrepStatus(ctx context.Context, store *storage.Store, trbRequestID uuid.UUID) (*models.TRBConsultPrepStatus, error) {
 	status := models.TRBConsultPrepStatusCannotStartYet
-	feedbackStatus, err := GetTRBFeedbackStatus(ctx, store, trbRequestID)
+	feedbackStatus, err := getTRBFeedbackStatus(ctx, store, trbRequestID)
 	if err != nil {
 		return nil, err
 	}
@@ -86,10 +83,9 @@ func GetTRBConsultPrepStatus(ctx context.Context, store *storage.Store, trbReque
 	return &status, nil
 }
 
-// GetTRBAttendConsultStatus retrieves the status of the consult step of the TRB request task list
-func GetTRBAttendConsultStatus(ctx context.Context, store *storage.Store, trbRequestID uuid.UUID) (*models.TRBAttendConsultStatus, error) {
+func getTRBAttendConsultStatus(ctx context.Context, store *storage.Store, trbRequestID uuid.UUID) (*models.TRBAttendConsultStatus, error) {
 	status := models.TRBAttendConsultStatusCannotStartYet
-	feedbackStatus, err := GetTRBFeedbackStatus(ctx, store, trbRequestID)
+	feedbackStatus, err := getTRBFeedbackStatus(ctx, store, trbRequestID)
 	if err != nil {
 		return nil, err
 	}
@@ -171,28 +167,28 @@ func GetTRBTaskStatuses(ctx context.Context, store *storage.Store, trbRequestID 
 	var formStatus *models.TRBFormStatus
 	var errForm error
 	errGroup.Go(func() error {
-		formStatus, errForm = GetTRBFormStatus(ctx, store, trbRequestID)
+		formStatus, errForm = getTRBFormStatus(ctx, store, trbRequestID)
 		return errForm
 	})
 
 	var feedbackStatus *models.TRBFeedbackStatus
 	var errFeedback error
 	errGroup.Go(func() error {
-		feedbackStatus, errFeedback = GetTRBFeedbackStatus(ctx, store, trbRequestID)
+		feedbackStatus, errFeedback = getTRBFeedbackStatus(ctx, store, trbRequestID)
 		return errFeedback
 	})
 
 	var consultPrepStatus *models.TRBConsultPrepStatus
 	var errConsultPrep error
 	errGroup.Go(func() error {
-		consultPrepStatus, errConsultPrep = GetTRBConsultPrepStatus(ctx, store, trbRequestID)
+		consultPrepStatus, errConsultPrep = getTRBConsultPrepStatus(ctx, store, trbRequestID)
 		return errConsultPrep
 	})
 
 	var attendConsultStatus *models.TRBAttendConsultStatus
 	var errAttendConsult error
 	errGroup.Go(func() error {
-		attendConsultStatus, errAttendConsult = GetTRBAttendConsultStatus(ctx, store, trbRequestID)
+		attendConsultStatus, errAttendConsult = getTRBAttendConsultStatus(ctx, store, trbRequestID)
 		return errAttendConsult
 	})
 


### PR DESCRIPTION
# EASI-2388

## Changes and Description

- Add a new `Store` method, `GetTRBAdviceLetterStatusByTRBRequestID()`, that only fetches an advice letter's status and _doesn't_ log an error if it doesn't find any matching rows. This allows the TRB Task Status resolver to determine and return an advice letter's status without triggering any errors/alerts.
- Refactor utility methods in `pkg/graph/resolvers/trb_task_status.go` to be private methods; they don't need to be public, they're just used by `GetTRBTaskStatuses()`, which is called from `schema.resolvers.go`.

## How to test this change

To detect the error - check out `main`, spin up the backend and open the GraphQL playground. Create a TRB request and use its ID in the query
```gql
query {
  trbRequest(id: "trbRequestIdFromAbove") {
    taskStatuses {
      adviceLetterStatus
    }
  }
}
```
The query should return without some errors; however, the backend container will log an error, which can be seen by running `docker-compose logs --no-log-prefix easi | jq --raw-input 'fromjson?' | jq 'select(.level == "error")'` on the command line from within the repo.

Switch to this branch and repeat the steps above - an error should _not_ be logged by the container.