### PR TITLE
[EASI-2580] Separate TRB email method parameters from the template parameter structs

### DIFF
--- a/pkg/email/trb_request_trb_lead.go
+++ b/pkg/email/trb_request_trb_lead.go
@@ -17,18 +17,29 @@ type SendTRBRequestTRBLeadEmailInput struct {
 	TRBRequestName string
 	RequesterName  string
 	TRBLeadName    string
-	TRBEmail       models.EmailAddress
+}
+
+// trbLeadEmailTemplateParams contains the data needed for interpolation in the TRB lead email template
+type trbLeadEmailTemplateParams struct {
+	TRBLeadName    string
+	TRBRequestName string
 	TRBRequestLink string
+	RequesterName  string
 }
 
 // SendTRBRequestTRBLeadEmail sends an email to the EASI team containing a user's request for help
 func (c Client) SendTRBRequestTRBLeadEmail(ctx context.Context, input SendTRBRequestTRBLeadEmailInput) error {
 	subject := input.TRBRequestName + " is assigned to " + input.TRBLeadName
-	input.TRBEmail = c.config.TRBEmail
-	input.TRBRequestLink = c.urlFromPath(path.Join("trb", "task-list", input.TRBRequestID.String()))
+
+	templateParams := trbLeadEmailTemplateParams{
+		TRBLeadName:    input.TRBLeadName,
+		TRBRequestName: input.TRBRequestName,
+		TRBRequestLink: c.urlFromPath(path.Join("trb", "task-list", input.TRBRequestID.String())),
+		RequesterName:  input.RequesterName,
+	}
 
 	var b bytes.Buffer
-	err := c.templates.trbRequestTRBLead.Execute(&b, input)
+	err := c.templates.trbRequestTRBLead.Execute(&b, templateParams)
 
 	if err != nil {
 		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}


### PR DESCRIPTION
# EASI-2580

## Changes and Description

- Separated the parameters that are needed for the TRB consult meeting email function from the parameters that are used by the email template
- Separated the parameters that are needed for the TRB lead email function from the parameters that are used by the email template

## How to test this change
```GraphQL
# Create a TRB request, note the ID
mutation {
  createTRBRequest(requestType: NEED_HELP) {
    id # use this for the following steps
    form {
      status
    }
    taskStatuses {
      formStatus
      feedbackStatus
      consultPrepStatus
    }
  }
}

# Submit the TRB request form by setting isSubmitted to true
mutation {
  updateTRBRequestForm(
    input: { isSubmitted: true, trbRequestId: "trbRequestIdFromAbove" }
  ) {
    status
  }
}

# Create TRB request feedback again, now with action "READY_FOR_CONSULT"
mutation {
  createTRBRequestFeedback(
    input: {
      trbRequestId: "trbRequestIdFromAbove"
      feedbackMessage: "This is TRB request is NICE!"
      copyTrbMailbox: true
      notifyEuaIds: ["FAKE", "REAL", "LOLZ"]
      action: READY_FOR_CONSULT
    }
  ) {
    id
    trbRequestId
    feedbackMessage
    copyTrbMailbox
    notifyEuaIds
    action
    createdBy
    createdAt
    modifiedBy
    modifiedAt
  }
}

# Create TRB request feedback again, now with action "READY_FOR_CONSULT"
mutation {
  updateTRBRequestConsultMeetingTime(
    input: {
      trbRequestId: "trbRequestIdFromAbove"
      consultMeetingTime: "2021-07-20T17:30:15+05:30"
      copyTrbMailbox: true
      notifyEuaIds: ["FAKE", "REAL", "LOLZ"]
      notes: "Some cool notes about the consult meeting"
    }
  ) {
    id
    form {
      status
    }
    taskStatuses {
      formStatus
      feedbackStatus
      consultPrepStatus
      attendConsultStatus
    }
    consultMeetingTime
    trbLead
  }
}

# Assign a TRB lead for the request
mutation {
  updateTRBRequestTRBLead(
    input: { trbRequestId: "trbRequestIdFromAbove", trbLead: "ABCD" }
  ) {
    id
    form {
      status
    }
    taskStatuses {
      formStatus
      feedbackStatus
      consultPrepStatus
      attendConsultStatus
    }
    consultMeetingTime
    trbLead
  }
}
```

You can check the formatting of the emails locally with MailCatcher by navigating to http://localhost:1080

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
