### PR TITLE
EASI-2568 Remove Decommission System as an option from IT Gov

### DIFF
--- a/src/i18n/en-US/home.ts
+++ b/src/i18n/en-US/home.ts
@@ -12,8 +12,7 @@ const home = {
     title: 'Governance Services',
     itg: {
       heading: 'IT Governance',
-      body:
-        'Includes applying for a lifecycle ID, recompetes and decommissioning a system'
+      body: 'Includes applying for a lifecycle ID, and recompetes'
     },
     '508': {
       heading: 'Section 508 compliance',

--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -129,8 +129,7 @@ const intake = {
       addNewSystem: 'Add a new system',
       majorChanges: 'Major changes or upgrades to an existing system',
       recompete:
-        'Re-compete a contract without any changes to systems or services',
-      shutdown: 'Decommission a system'
+        'Re-compete a contract without any changes to systems or services'
     },
     helpAndGuidance: {
       majorChanges: {

--- a/src/i18n/en-US/makingARequest.ts
+++ b/src/i18n/en-US/makingARequest.ts
@@ -6,8 +6,7 @@ const makingARequest = {
     options: [
       'add a new system',
       'make major changes or updates',
-      're-compete a contract',
-      'decomission a system'
+      're-compete a contract'
     ]
   },
   forEnterpriseArchitectureHelp: {

--- a/src/views/MakingARequest/__snapshots__/index.test.tsx.snap
+++ b/src/views/MakingARequest/__snapshots__/index.test.tsx.snap
@@ -48,9 +48,6 @@ exports[`The making a request page matches the snapshot 1`] = `
           <li>
             re-compete a contract
           </li>
-          <li>
-            decomission a system
-          </li>
         </ul>
       </div>
     </div>

--- a/src/views/RequestTypeForm/index.test.tsx
+++ b/src/views/RequestTypeForm/index.test.tsx
@@ -277,41 +277,6 @@ describe('The request type form page', () => {
     ).toBeInTheDocument();
   });
 
-  it('creates a shutdown intake', async () => {
-    const intakeMutation = {
-      request: {
-        query: CreateSystemIntake,
-        variables: {
-          input: {
-            requestType: 'SHUTDOWN',
-            requester: {
-              name: 'John Doe'
-            }
-          }
-        }
-      },
-      result: {
-        data: {
-          createSystemIntake: {
-            id: INTAKE_ID,
-            status: 'INTAKE_DRAFT',
-            requestType: 'SHUTDOWN',
-            requester: {
-              name: 'John Doe'
-            }
-          }
-        }
-      }
-    };
-
-    renderPage([intakeMutation, intakeQuery({})]);
-
-    screen.getByRole('radio', { name: /decommission/i }).click();
-    screen.getByRole('button', { name: /continue/i }).click();
-
-    expect(await screen.findByTestId('system-intake')).toBeInTheDocument();
-  });
-
   it('executes request type validations', async () => {
     renderPage([]);
 

--- a/src/views/RequestTypeForm/index.tsx
+++ b/src/views/RequestTypeForm/index.tsx
@@ -60,9 +60,6 @@ const RequestTypeForm = () => {
             case 'RECOMPETE':
               history.push(navigationLink);
               break;
-            case 'SHUTDOWN':
-              history.push(`/system/${id}/contact-details`);
-              break;
             default:
               // console.warn(`Unknown request type: ${systemIntake.requestType}`);
               break;

--- a/src/views/RequestTypeForm/index.tsx
+++ b/src/views/RequestTypeForm/index.tsx
@@ -160,15 +160,6 @@ const RequestTypeForm = () => {
                       value="RECOMPETE"
                       checked={values.requestType === 'RECOMPETE'}
                     />
-                    <Field
-                      as={RadioField}
-                      id="RequestType-ShutdownSystem"
-                      className="margin-bottom-4"
-                      label={t('requestTypeForm.fields.shutdown')}
-                      name="requestType"
-                      value="SHUTDOWN"
-                      checked={values.requestType === 'SHUTDOWN'}
-                    />
                   </fieldset>
                 </FieldGroup>
                 <CollapsableLink


### PR DESCRIPTION
# EASI-2568

## Changes and Description

- Remove request "decommission" text from homepage
- Remove "decommission" text from IT Gov explanation
- Remove "decommission/shutdown" option from the request types
  - Remove test case
- Remove request type case in the form submit function in [src/views/RequestTypeForm/index.tsx](https://github.com/CMSgov/easi-app/blob/08104738907b2d32d8193847347b77b8e4950f49/src/views/RequestTypeForm/index.tsx#L63-L65)
- Remove "Decomission a system" translation text in [src/i18n/en-US/intake.ts](https://github.com/CMSgov/easi-app/blob/08104738907b2d32d8193847347b77b8e4950f49/src/i18n/en-US/intake.ts#L83)
<!-- Put a description here! -->

## How to test this change

QA the IT Gov request flows to make sure there are no regression on the other remaining request types or IT Gov processes.