### PR TITLE
[NOREF] Attempting to fix cypress intercept flake

### DIFF
--- a/cypress/e2e/trbRequest.cy.js
+++ b/cypress/e2e/trbRequest.cy.js
@@ -3,9 +3,6 @@ describe('Technical Assistance', () => {
     cy.localLogin({ name: 'ABCD' });
 
     cy.intercept('POST', '/api/graph/query', req => {
-      if (req.body.operationName === 'GetCedarContacts') {
-        req.alias = 'getCedarContacts';
-      }
       if (req.body.operationName === 'DeleteTRBRequestAttendee') {
         req.alias = 'deleteTRBRequestAttendee';
       }
@@ -94,7 +91,7 @@ describe('Technical Assistance', () => {
       .should('be.visible');
   });
   /** Adds new attendee */
-  it('Adds, edits, and deletes attendee', () => {
+  it.only('Adds, edits, and deletes attendee', () => {
     // Fill out the Basic Details required fields
     cy.trbRequest.basicDetails.fillRequiredFields();
 

--- a/cypress/e2e/trbRequest.cy.js
+++ b/cypress/e2e/trbRequest.cy.js
@@ -91,7 +91,7 @@ describe('Technical Assistance', () => {
       .should('be.visible');
   });
   /** Adds new attendee */
-  it.only('Adds, edits, and deletes attendee', () => {
+  it('Adds, edits, and deletes attendee', () => {
     // Fill out the Basic Details required fields
     cy.trbRequest.basicDetails.fillRequiredFields();
 

--- a/cypress/support/trbRequest.js
+++ b/cypress/support/trbRequest.js
@@ -19,14 +19,12 @@ cy.trbRequest = {
     fillRequiredFields: attendee => {
       if (attendee.userInfo && !attendee.id) {
         const { commonName, euaUserId } = attendee.userInfo;
-        cy.get('#react-select-euaUserId-input').type(
-          `${commonName}, ${euaUserId}`
-        );
 
-        // Wait for cedar contacts query to complete
-        cy.wait('@getCedarContacts')
-          .its('response.statusCode')
-          .should('eq', 200);
+        const nameAndId = `${commonName}, ${euaUserId}`;
+        cy.get('#react-select-euaUserId-input').type(nameAndId);
+
+        // Wait to see if the first option is what we expect it to be
+        cy.contains('#react-select-euaUserId-option-0', nameAndId);
 
         cy.get('#react-select-euaUserId-input')
           .type('{downarrow}{enter}')


### PR DESCRIPTION
# NOREF

## Changes and Description

- Replaces a `cy.wait` paired with `cy.intercept` with a `cy.contains`. This hopefully makes it so that we're able to retry DOM queries instead of hoping a `cy.intercept` fires in the order we expect

<!-- Put a description here! -->

## How to test this change

- Ensure E2E tests pass locally and on CI!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
