### PR TITLE
[NOREF] Create attendee by default

### DIFF
--- a/migrations/V128__Modify_TRB_Attendee_Role_Component_Nullable.sql
+++ b/migrations/V128__Modify_TRB_Attendee_Role_Component_Nullable.sql
@@ -1,0 +1,4 @@
+ALTER TABLE trb_request_attendees
+    ALTER COLUMN component DROP NOT NULL,
+    ALTER COLUMN role DROP NOT NULL,
+    ALTER COLUMN role DROP DEFAULT;

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -7933,8 +7933,8 @@ type TRBRequestAttendee {
   euaUserId: String! # Sort of duplicative, as this is also in UserInfo
   userInfo: UserInfo
   trbRequestId: UUID!
-  component: String!
-  role: PersonRole!
+  component: String
+  role: PersonRole
   createdBy: String!
   createdAt: Time!
   modifiedBy: String
@@ -38506,14 +38506,11 @@ func (ec *executionContext) _TRBRequestAttendee_component(ctx context.Context, f
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_TRBRequestAttendee_component(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -38550,14 +38547,11 @@ func (ec *executionContext) _TRBRequestAttendee_role(ctx context.Context, field 
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(models.PersonRole)
+	res := resTmp.(*models.PersonRole)
 	fc.Result = res
-	return ec.marshalNPersonRole2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐPersonRole(ctx, field.Selections, res)
+	return ec.marshalOPersonRole2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐPersonRole(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_TRBRequestAttendee_role(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -53646,16 +53640,10 @@ func (ec *executionContext) _TRBRequestAttendee(ctx context.Context, sel ast.Sel
 
 			out.Values[i] = ec._TRBRequestAttendee_component(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "role":
 
 			out.Values[i] = ec._TRBRequestAttendee_role(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "createdBy":
 
 			out.Values[i] = ec._TRBRequestAttendee_createdBy(ctx, field, obj)
@@ -58439,6 +58427,23 @@ func (ec *executionContext) unmarshalOLifecycleCostYear2githubᚗcomᚋcmsgovᚋ
 
 func (ec *executionContext) marshalOLifecycleCostYear2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐLifecycleCostYear(ctx context.Context, sel ast.SelectionSet, v models.LifecycleCostYear) graphql.Marshaler {
 	res := graphql.MarshalString(string(v))
+	return res
+}
+
+func (ec *executionContext) unmarshalOPersonRole2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐPersonRole(ctx context.Context, v interface{}) (*models.PersonRole, error) {
+	if v == nil {
+		return nil, nil
+	}
+	tmp, err := graphql.UnmarshalString(v)
+	res := models.PersonRole(tmp)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOPersonRole2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐPersonRole(ctx context.Context, sel ast.SelectionSet, v *models.PersonRole) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalString(string(*v))
 	return res
 }
 

--- a/pkg/graph/resolvers/resolver_test.go
+++ b/pkg/graph/resolvers/resolver_test.go
@@ -22,7 +22,8 @@ import (
 // ResolverSuite is the testify suite for the resolver package
 type ResolverSuite struct {
 	suite.Suite
-	testConfigs *TestConfigs
+	testConfigs       *TestConfigs
+	fetchUserInfoStub func(context.Context, string) (*models.UserInfo, error)
 }
 
 // SetupTest clears the database between each test
@@ -35,6 +36,13 @@ func (suite *ResolverSuite) SetupTest() {
 func TestResolverSuite(t *testing.T) {
 	rs := new(ResolverSuite)
 	rs.testConfigs = GetDefaultTestConfigs()
+	rs.fetchUserInfoStub = func(context.Context, string) (*models.UserInfo, error) {
+		return &models.UserInfo{
+			EuaUserID:  "ANON",
+			CommonName: "Anonymous",
+			Email:      models.NewEmailAddress("anon@local.fake"),
+		}, nil
+	}
 	suite.Run(t, rs)
 }
 

--- a/pkg/graph/resolvers/trb_advice_letter_recommendation_test.go
+++ b/pkg/graph/resolvers/trb_advice_letter_recommendation_test.go
@@ -17,7 +17,7 @@ func (s *ResolverSuite) TestTRBAdviceLetterRecommendationCRUD() {
 	trbRequest := models.NewTRBRequest(anonEua)
 	trbRequest.Type = models.TRBTNeedHelp
 	trbRequest.Status = models.TRBSOpen
-	trbRequest, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, store)
+	trbRequest, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, store)
 	s.NoError(err)
 
 	s.Run("create/update/fetch TRB request feedback", func() {

--- a/pkg/graph/resolvers/trb_request_attendee_test.go
+++ b/pkg/graph/resolvers/trb_request_attendee_test.go
@@ -46,14 +46,22 @@ func (s *ResolverSuite) TestCreateTRBRequestAttendee() {
 	trbRequest := models.NewTRBRequest(anonEua)
 	trbRequest.Type = models.TRBTNeedHelp
 	trbRequest.Status = models.TRBSOpen
-	trbRequest, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
+	trbRequest, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
 	s.NoError(err)
 
+	s.Run("fetches TRB request attendees (default attendee should exist)", func() {
+		fetched, err := GetTRBRequestAttendeesByTRBRequestID(ctx, s.testConfigs.Store, trbRequest.ID)
+		s.NoError(err)
+		s.True(len(fetched) == 1)
+	})
+
 	s.Run("create/update/fetch TRB request attendees", func() {
+		paRole := models.PersonRolePrivacyAdvisor
+		cnRole := models.PersonRoleCloudNavigator
 		attendee := models.TRBRequestAttendee{
-			EUAUserID:    anonEua,
+			EUAUserID:    "ABCD", // not ANON, since that's created by default from s.fetchUserInfoStub
 			TRBRequestID: trbRequest.ID,
-			Role:         models.PersonRolePrivacyAdvisor,
+			Role:         &paRole,
 		}
 		attendee.CreatedBy = anonEua
 		createdAttendee, err := CreateTRBRequestAttendee(
@@ -65,24 +73,25 @@ func (s *ResolverSuite) TestCreateTRBRequestAttendee() {
 		)
 		s.NoError(err)
 
-		createdAttendee.Role = models.PersonRoleCloudNavigator
+		createdAttendee.Role = &cnRole
 		createdAttendee.ModifiedBy = &anonEua
 		updatedAttendee, err := UpdateTRBRequestAttendee(ctx, s.testConfigs.Store, createdAttendee)
 		s.NoError(err)
-		s.EqualValues(updatedAttendee.Role, models.PersonRoleCloudNavigator)
+		s.EqualValues(*updatedAttendee.Role, models.PersonRoleCloudNavigator)
 		s.EqualValues(updatedAttendee.ModifiedBy, &anonEua)
 
-		createdAttendee.Component = "The Citadel of Ricks"
+		component := "The Citadel of Ricks"
+		createdAttendee.Component = &component
 		createdAttendee.ModifiedBy = &anonEua
 		updatedAttendee, err = UpdateTRBRequestAttendee(ctx, s.testConfigs.Store, createdAttendee)
 		s.NoError(err)
-		s.EqualValues(updatedAttendee.Component, "The Citadel of Ricks")
+		s.EqualValues(*updatedAttendee.Component, "The Citadel of Ricks")
 		s.EqualValues(updatedAttendee.ModifiedBy, &anonEua)
 	})
 
 	s.Run("fetches TRB request attendees", func() {
 		fetched, err := GetTRBRequestAttendeesByTRBRequestID(ctx, s.testConfigs.Store, trbRequest.ID)
 		s.NoError(err)
-		s.True(len(fetched) == 1)
+		s.True(len(fetched) == 2) // Default attendee, plus the one we created in the previous test!
 	})
 }

--- a/pkg/graph/resolvers/trb_request_document_test.go
+++ b/pkg/graph/resolvers/trb_request_document_test.go
@@ -12,7 +12,7 @@ import (
 
 func (suite *ResolverSuite) TestTRBRequestDocumentResolvers() {
 	// general setup
-	trbRequest, err := CreateTRBRequest(suite.testConfigs.Context, models.TRBTFormalReview, suite.testConfigs.Store)
+	trbRequest, err := CreateTRBRequest(suite.testConfigs.Context, models.TRBTFormalReview, suite.fetchUserInfoStub, suite.testConfigs.Store)
 	suite.NoError(err)
 	suite.NotNil(trbRequest)
 	trbRequestID := trbRequest.ID

--- a/pkg/graph/resolvers/trb_request_feedback_test.go
+++ b/pkg/graph/resolvers/trb_request_feedback_test.go
@@ -67,7 +67,7 @@ func (s *ResolverSuite) TestCreateTRBRequestFeedback() {
 	trbRequest := models.NewTRBRequest(anonEua)
 	trbRequest.Type = models.TRBTNeedHelp
 	trbRequest.Status = models.TRBSOpen
-	trbRequest, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, store)
+	trbRequest, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, store)
 	s.NoError(err)
 
 	form, err := GetTRBRequestFormByTRBRequestID(ctx, store, trbRequest.ID)

--- a/pkg/graph/resolvers/trb_request_form_test.go
+++ b/pkg/graph/resolvers/trb_request_form_test.go
@@ -47,7 +47,7 @@ func (s *ResolverSuite) TestCreateTRBRequestForm() {
 	trbRequest := models.NewTRBRequest(anonEua)
 	trbRequest.Type = models.TRBTNeedHelp
 	trbRequest.Status = models.TRBSOpen
-	trbRequest, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
+	trbRequest, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
 	s.NoError(err)
 
 	s.Run("create/update/fetch TRB request forms", func() {

--- a/pkg/graph/resolvers/trb_request_test.go
+++ b/pkg/graph/resolvers/trb_request_test.go
@@ -10,7 +10,7 @@ import (
 // TestCreateTRBRequest makes a new TRB request
 func (s *ResolverSuite) TestCreateTRBRequest() {
 	//TODO get the context in the test configs
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 
@@ -26,7 +26,7 @@ func (s *ResolverSuite) TestCreateTRBRequest() {
 
 // TestUpdateTRBRequest updates a TRB request
 func (s *ResolverSuite) TestUpdateTRBRequest() {
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 
@@ -49,7 +49,7 @@ func (s *ResolverSuite) TestUpdateTRBRequest() {
 
 // TestGetTRBRequestByID returns a TRB request by it's ID
 func (s *ResolverSuite) TestGetTRBRequestByID() {
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 
@@ -60,7 +60,7 @@ func (s *ResolverSuite) TestGetTRBRequestByID() {
 
 // TestGetTRBRequests returns all TRB Requests
 func (s *ResolverSuite) TestGetTRBRequests() {
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 	//Check we return 1 value
@@ -69,7 +69,7 @@ func (s *ResolverSuite) TestGetTRBRequests() {
 	s.Len(col, 1)
 	s.EqualValues(trb, col[0])
 
-	trb2, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
+	trb2, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb2)
 	//Check for 2 request
@@ -95,7 +95,7 @@ func (s *ResolverSuite) TestGetTRBRequests() {
 
 // TestUpdateTRBRequestConsultMeetingTime tests the scheduling of consult meeting
 func (s *ResolverSuite) TestUpdateTRBRequestConsultMeetingTime() {
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 
@@ -141,7 +141,7 @@ func (s *ResolverSuite) TestUpdateTRBRequestConsultMeetingTime() {
 
 // TestUpdateTRBRequestTRBLead tests the scheduling of consult meeting
 func (s *ResolverSuite) TestUpdateTRBRequestTRBLead() {
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -1555,8 +1555,8 @@ type TRBRequestAttendee {
   euaUserId: String! # Sort of duplicative, as this is also in UserInfo
   userInfo: UserInfo
   trbRequestId: UUID!
-  component: String!
-  role: PersonRole!
+  component: String
+  role: PersonRole
   createdBy: String!
   createdAt: Time!
   modifiedBy: String

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1867,7 +1867,7 @@ func (r *mutationResolver) SendReportAProblemEmail(ctx context.Context, input mo
 
 // CreateTRBRequest is the resolver for the createTRBRequest field.
 func (r *mutationResolver) CreateTRBRequest(ctx context.Context, requestType models.TRBRequestType) (*models.TRBRequest, error) {
-	return resolvers.CreateTRBRequest(ctx, requestType, r.store)
+	return resolvers.CreateTRBRequest(ctx, requestType, r.service.FetchUserInfo, r.store)
 }
 
 // UpdateTRBRequest is the resolver for the updateTRBRequest field.
@@ -1877,6 +1877,7 @@ func (r *mutationResolver) UpdateTRBRequest(ctx context.Context, id uuid.UUID, c
 
 // CreateTRBRequestAttendee is the resolver for the createTRBRequestAttendee field.
 func (r *mutationResolver) CreateTRBRequestAttendee(ctx context.Context, input model.CreateTRBRequestAttendeeInput) (*models.TRBRequestAttendee, error) {
+	role := models.PersonRole(input.Role)
 	return resolvers.CreateTRBRequestAttendee(
 		ctx,
 		r.store,
@@ -1885,17 +1886,18 @@ func (r *mutationResolver) CreateTRBRequestAttendee(ctx context.Context, input m
 		&models.TRBRequestAttendee{
 			TRBRequestID: input.TrbRequestID,
 			EUAUserID:    input.EuaUserID,
-			Component:    input.Component,
-			Role:         models.PersonRole(input.Role),
+			Component:    &input.Component,
+			Role:         &role,
 		},
 	)
 }
 
 // UpdateTRBRequestAttendee is the resolver for the updateTRBRequestAttendee field.
 func (r *mutationResolver) UpdateTRBRequestAttendee(ctx context.Context, input model.UpdateTRBRequestAttendeeInput) (*models.TRBRequestAttendee, error) {
+	role := models.PersonRole(input.Role)
 	attendee := &models.TRBRequestAttendee{
-		Component: input.Component,
-		Role:      models.PersonRole(input.Role),
+		Component: &input.Component,
+		Role:      &role,
 	}
 	attendee.ID = input.ID
 	return resolvers.UpdateTRBRequestAttendee(ctx, r.store, attendee)

--- a/pkg/models/trb_request_attendee.go
+++ b/pkg/models/trb_request_attendee.go
@@ -32,8 +32,8 @@ const (
 // TRBRequestAttendee represents an EUA user who is included as an attendee for a TRB request
 type TRBRequestAttendee struct {
 	baseStruct
-	EUAUserID    string     `json:"euaUserId" db:"eua_user_id"`
-	TRBRequestID uuid.UUID  `json:"trbRequestId" db:"trb_request_id"`
-	Component    string     `json:"component" db:"component"`
-	Role         PersonRole `json:"role" db:"role"`
+	EUAUserID    string      `json:"euaUserId" db:"eua_user_id"`
+	TRBRequestID uuid.UUID   `json:"trbRequestId" db:"trb_request_id"`
+	Component    *string     `json:"component" db:"component"`
+	Role         *PersonRole `json:"role" db:"role"`
 }

--- a/pkg/storage/trb_request_attendee_test.go
+++ b/pkg/storage/trb_request_attendee_test.go
@@ -16,21 +16,24 @@ func (s *StoreTestSuite) TestCreateTRBRequestAttendee() {
 	s.NoError(err)
 
 	s.Run("create a TRB request attendee", func() {
+		poRole := models.PersonRoleProductOwner
+		cnRole := models.PersonRoleCloudNavigator
 		attendee := models.TRBRequestAttendee{
 			EUAUserID:    anonEua,
 			TRBRequestID: trbRequest.ID,
-			Role:         models.PersonRoleProductOwner,
+			Role:         &poRole,
 		}
 		attendee.CreatedBy = anonEua
 		createdAttendee, err := s.store.CreateTRBRequestAttendee(ctx, &attendee)
 		s.NoError(err)
 
-		createdAttendee.Role = models.PersonRoleCloudNavigator
+		createdAttendee.Role = &cnRole
 		createdAttendee.ModifiedBy = &anonEua
 		_, err = s.store.UpdateTRBRequestAttendee(ctx, createdAttendee)
 		s.NoError(err)
 
-		createdAttendee.Component = "The Citadel of Ricks"
+		component := "The Citadel of Ricks"
+		createdAttendee.Component = &component
 		createdAttendee.ModifiedBy = &anonEua
 		_, err = s.store.UpdateTRBRequestAttendee(ctx, createdAttendee)
 		s.NoError(err)

--- a/src/data/mock/trbRequest.ts
+++ b/src/data/mock/trbRequest.ts
@@ -122,6 +122,7 @@ export const trbRequest: TrbRequest = {
     subjectAreaDataAndDataManagementOther: null,
     subjectAreaGovernmentProcessesAndPoliciesOther: null,
     subjectAreaOtherTechnicalTopicsOther: null,
+    submittedAt: null,
     __typename: 'TRBRequestForm'
   },
   __typename: 'TRBRequest'

--- a/src/hooks/useTRBAttendees.tsx
+++ b/src/hooks/useTRBAttendees.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import {
   FetchResult,
   OperationVariables,
@@ -15,24 +14,19 @@ import {
 } from 'queries/TrbAttendeeQueries';
 import { GetTRBRequestAttendees as RequestResult } from 'queries/types/GetTRBRequestAttendees';
 import { TRBAttendee } from 'queries/types/TRBAttendee';
-import { AppState } from 'reducers/rootReducer';
 import {
   CreateTRBRequestAttendeeInput,
   UpdateTRBRequestAttendeeInput
 } from 'types/graphql-global-types';
-import {
-  FormattedTRBAttendees,
-  TRBAttendeeData
-} from 'types/technicalAssistance';
 
 /** useTRBAttendees hook return type */
 type UseTRBAttendees = {
   /** Data returned from GetTRBRequestAttendees query */
   data: {
     /** Requester object */
-    requester: TRBAttendeeData;
+    requester: TRBAttendee;
     /** Additional attendees array sorted by time created */
-    attendees: TRBAttendeeData[];
+    attendees: TRBAttendee[];
     /** GetTRBRequestAttendees query loading state */
     loading: boolean;
   };
@@ -49,40 +43,8 @@ type UseTRBAttendees = {
  */
 export default function useTRBAttendees(
   /** TRB Request ID */
-  trbRequestId: string,
-  /**
-   * createdBy value from TRB request used for retrieving
-   * requester if different from current user.
-   * Not needed in TRB Request Form.
-   */
-  createdBy?: string
+  trbRequestId: string
 ): UseTRBAttendees {
-  /** Current user info from redux */
-  const currentUser = useSelector((state: AppState) => state.auth);
-
-  /**
-   * Initial requester object
-   */
-  const initialRequester: TRBAttendeeData = useMemo(() => {
-    /** Whether or not current user is the requester */
-    const currentUserIsRequester: boolean = createdBy
-      ? createdBy === currentUser.euaId
-      : true;
-
-    return {
-      trbRequestId,
-      id: '',
-      component: '',
-      role: null,
-      userInfo: {
-        // If requester is same as current user, pre-fill name
-        commonName: currentUserIsRequester ? currentUser.name : '',
-        // If createdBy is not provided, defaults to current user EUA
-        euaUserId: createdBy || currentUser.euaId
-      }
-    };
-  }, [trbRequestId, currentUser, createdBy]);
-
   /**
    * Query to get attendees by TRB request ID
    */
@@ -90,51 +52,16 @@ export default function useTRBAttendees(
     variables: { id: trbRequestId }
   });
 
-  /** Array of attendees sorted by time created */
-  const attendeesArray = useMemo(() => {
-    if (!data?.trbRequest?.attendees) return undefined;
+  /**
+   * Array of attendees sorted by time created, with requester attendee object first
+   */
+  const attendees = useMemo(() => {
+    if (!data?.trbRequest?.attendees) return [];
     // Sort attendees array by time created
     return [...data.trbRequest.attendees].sort((a, b) =>
       a.createdAt < b.createdAt ? 1 : -1
     );
   }, [data?.trbRequest?.attendees]);
-
-  /**
-   * Formatted TRB attendees object
-   *
-   * Separates requester from additional attendees
-   */
-  const formattedAttendees: FormattedTRBAttendees = useMemo(() => {
-    /** Initial attendees object before data is loaded from query */
-    const initialAttendeesObject: FormattedTRBAttendees = {
-      requester: initialRequester,
-      attendees: []
-    };
-
-    // If no attendees, return initial attendees object
-    if (!attendeesArray) return initialAttendeesObject;
-
-    /** Requester object from attendees query */
-    const requesterObject: TRBAttendee | undefined = attendeesArray.find(
-      attendee =>
-        attendee?.userInfo?.euaUserId === initialRequester?.userInfo?.euaUserId
-    );
-
-    return {
-      requester: {
-        // Data from initial requester
-        ...initialRequester,
-        // If requester exists in attendees, add to object
-        ...requesterObject
-      },
-      // Filter requester from attendees array
-      attendees: attendeesArray.filter(
-        attendee =>
-          attendee?.userInfo?.euaUserId !==
-          initialRequester?.userInfo?.euaUserId
-      )
-    };
-  }, [attendeesArray, initialRequester]);
 
   /** Create attendee mutation */
   const [createAttendee] = useMutation<CreateTRBRequestAttendeeInput>(
@@ -161,7 +88,11 @@ export default function useTRBAttendees(
   );
 
   return {
-    data: { ...formattedAttendees, loading },
+    data: {
+      requester: attendees[0],
+      attendees: attendees.slice(1),
+      loading
+    },
     createAttendee,
     updateAttendee,
     deleteAttendee

--- a/src/hooks/useTRBAttendees.tsx
+++ b/src/hooks/useTRBAttendees.tsx
@@ -18,6 +18,7 @@ import {
   CreateTRBRequestAttendeeInput,
   UpdateTRBRequestAttendeeInput
 } from 'types/graphql-global-types';
+import { initialAttendee } from 'views/TechnicalAssistance/RequestForm/Attendees';
 
 /** useTRBAttendees hook return type */
 type UseTRBAttendees = {
@@ -53,15 +54,19 @@ export default function useTRBAttendees(
   });
 
   /**
-   * Array of attendees sorted by time created, with requester attendee object first
+   * Array of attendees sorted by time created, with requester attendee object last
    */
   const attendees = useMemo(() => {
     if (!data?.trbRequest?.attendees) return [];
+
     // Sort attendees array by time created
     return [...data.trbRequest.attendees].sort((a, b) =>
       a.createdAt < b.createdAt ? 1 : -1
     );
   }, [data?.trbRequest?.attendees]);
+
+  /** Requester object - last in attendees array when sorted by createdAt time */
+  const requester: TRBAttendee | undefined = attendees.at(-1);
 
   /** Create attendee mutation */
   const [createAttendee] = useMutation<CreateTRBRequestAttendeeInput>(
@@ -89,8 +94,8 @@ export default function useTRBAttendees(
 
   return {
     data: {
-      requester: attendees[0],
-      attendees: attendees.slice(1),
+      requester: requester || initialAttendee,
+      attendees: loading ? [] : attendees.slice(0, attendees.length - 1),
       loading
     },
     createAttendee,

--- a/src/queries/types/CreateTRBRequestAttendee.ts
+++ b/src/queries/types/CreateTRBRequestAttendee.ts
@@ -21,8 +21,8 @@ export interface CreateTRBRequestAttendee_createTRBRequestAttendee {
   id: UUID;
   trbRequestId: UUID;
   userInfo: CreateTRBRequestAttendee_createTRBRequestAttendee_userInfo | null;
-  component: string;
-  role: PersonRole;
+  component: string | null;
+  role: PersonRole | null;
   createdAt: Time;
 }
 

--- a/src/queries/types/DeleteTRBRequestAttendee.ts
+++ b/src/queries/types/DeleteTRBRequestAttendee.ts
@@ -21,8 +21,8 @@ export interface DeleteTRBRequestAttendee_deleteTRBRequestAttendee {
   id: UUID;
   trbRequestId: UUID;
   userInfo: DeleteTRBRequestAttendee_deleteTRBRequestAttendee_userInfo | null;
-  component: string;
-  role: PersonRole;
+  component: string | null;
+  role: PersonRole | null;
   createdAt: Time;
 }
 

--- a/src/queries/types/GetTRBRequestAttendees.ts
+++ b/src/queries/types/GetTRBRequestAttendees.ts
@@ -21,8 +21,8 @@ export interface GetTRBRequestAttendees_trbRequest_attendees {
   id: UUID;
   trbRequestId: UUID;
   userInfo: GetTRBRequestAttendees_trbRequest_attendees_userInfo | null;
-  component: string;
-  role: PersonRole;
+  component: string | null;
+  role: PersonRole | null;
   createdAt: Time;
 }
 

--- a/src/queries/types/TRBAttendee.ts
+++ b/src/queries/types/TRBAttendee.ts
@@ -21,7 +21,7 @@ export interface TRBAttendee {
   id: UUID;
   trbRequestId: UUID;
   userInfo: TRBAttendee_userInfo | null;
-  component: string;
-  role: PersonRole;
+  component: string | null;
+  role: PersonRole | null;
   createdAt: Time;
 }

--- a/src/queries/types/UpdateTRBRequestAttendee.ts
+++ b/src/queries/types/UpdateTRBRequestAttendee.ts
@@ -21,8 +21,8 @@ export interface UpdateTRBRequestAttendee_updateTRBRequestAttendee {
   id: UUID;
   trbRequestId: UUID;
   userInfo: UpdateTRBRequestAttendee_updateTRBRequestAttendee_userInfo | null;
-  component: string;
-  role: PersonRole;
+  component: string | null;
+  role: PersonRole | null;
   createdAt: Time;
 }
 

--- a/src/types/technicalAssistance.ts
+++ b/src/types/technicalAssistance.ts
@@ -3,14 +3,8 @@ import { PersonRole } from './graphql-global-types';
 /** TRB attendee fields allows null role in form */
 export type TRBAttendeeFields = {
   euaUserId: string;
-  component: string;
+  component: string | null;
   role: PersonRole | null;
-};
-
-/** TRB attendees formatted for form */
-export type TRBAttendeesForm = {
-  requester: TRBAttendeeFields;
-  attendees: TRBAttendeeFields[];
 };
 
 /** Field labels */
@@ -19,28 +13,6 @@ export type AttendeeFieldLabels = {
   component: string;
   role: string;
   submit?: string;
-};
-
-/** TRB Attendee user info */
-export type TRBAttendeeUserInfo = {
-  commonName: string;
-  euaUserId: string;
-  email?: string;
-} | null;
-
-/** TRB Attendee object with user info */
-export type TRBAttendeeData = {
-  id?: string;
-  trbRequestId: string;
-  userInfo: TRBAttendeeUserInfo;
-  component: string;
-  role: PersonRole | null;
-};
-
-/** Formatted attendees for display */
-export type FormattedTRBAttendees = {
-  requester: TRBAttendeeData;
-  attendees: TRBAttendeeData[];
 };
 
 /** TRB Admin page */

--- a/src/validations/trbRequestSchema.ts
+++ b/src/validations/trbRequestSchema.ts
@@ -120,9 +120,13 @@ export const basicSchema: yup.SchemaOf<TrbRequestFormBasic> = inputBasicSchema.c
 
 export const trbRequesterSchema = yup.object({
   euaUserId: yup.string().required('Requester name is a required field'),
-  component: yup.string().required('Requester component is a required field'),
+  component: yup
+    .string()
+    .nullable()
+    .required('Requester component is a required field'),
   role: yup
     .mixed<PersonRole>()
+    .nullable()
     .oneOf(Object.values(PersonRole))
     .required('Requester role is a required field')
 });

--- a/src/views/TechnicalAssistance/AdminHome/Summary/index.test.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/Summary/index.test.tsx
@@ -60,7 +60,6 @@ describe('TRB Admin Home summary', () => {
               name={trbRequest.name}
               requestType={trbRequest.type}
               createdAt={trbRequest.createdAt}
-              createdBy={trbRequest.createdBy}
               status={trbRequest.status}
               taskStatuses={trbRequest.taskStatuses}
               trbLead={trbRequest.trbLead}

--- a/src/views/TechnicalAssistance/AdminHome/Summary/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/Summary/index.tsx
@@ -50,7 +50,7 @@ export default function Summary({
   // Get requester object from request attendees
   const {
     data: { requester, loading }
-  } = useTRBAttendees(trbRequestId, createdBy);
+  } = useTRBAttendees(trbRequestId);
 
   /**
    * Requester info for display in summary box

--- a/src/views/TechnicalAssistance/AdminHome/Summary/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/Summary/index.tsx
@@ -22,7 +22,6 @@ type SummaryProps = {
   name: string;
   requestType: TRBRequestType;
   createdAt: string;
-  createdBy: string;
   status: TRBRequestStatus;
   taskStatuses: TRBRequestTaskStatuses;
   trbLead: string | null;
@@ -33,7 +32,6 @@ export default function Summary({
   name,
   requestType,
   createdAt,
-  createdBy,
   status,
   taskStatuses,
   trbLead

--- a/src/views/TechnicalAssistance/AdminHome/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/AdminHome/__snapshots__/index.test.tsx.snap
@@ -85,12 +85,6 @@ exports[`TRB admin home wrapper matches the snapshot 1`] = `
                 >
                   Requester
                 </h5>
-                <h4
-                  class="margin-y-05"
-                  data-testid="trbSummary-requester_ABCD"
-                >
-                  ABCD
-                </h4>
               </div>
               <div
                 class="margin-top-2 margin-bottom-05"

--- a/src/views/TechnicalAssistance/AdminHome/index.test.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/index.test.tsx
@@ -5,7 +5,6 @@ import { MockedProvider } from '@apollo/client/testing';
 import {
   render,
   screen,
-  waitFor,
   waitForElementToBeRemoved
 } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
@@ -40,7 +39,7 @@ const defaultStore = mockStore({
 
 describe('TRB admin home wrapper', () => {
   it('matches the snapshot', async () => {
-    const { asFragment, getByTestId } = render(
+    const { asFragment } = render(
       <MemoryRouter initialEntries={[`/trb/${trbRequest.id}/request`]}>
         <Provider store={defaultStore}>
           <MockedProvider mocks={[getTrbRequestQuery]} addTypename={false}>
@@ -54,10 +53,6 @@ describe('TRB admin home wrapper', () => {
 
     // Wait for page to load
     await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
-
-    await waitFor(() => {
-      expect(getByTestId('trbSummary-requester_ABCD')).toBeInTheDocument();
-    });
 
     // Snapshot
     expect(asFragment()).toMatchSnapshot();

--- a/src/views/TechnicalAssistance/AdminHome/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/index.tsx
@@ -104,7 +104,6 @@ export default function AdminHome() {
         name={trbRequest.name}
         requestType={trbRequest.type}
         createdAt={trbRequest.createdAt}
-        createdBy={trbRequest.createdBy}
         status={trbRequest.status}
         taskStatuses={trbRequest.taskStatuses}
         trbLead={trbRequest.trbLead}

--- a/src/views/TechnicalAssistance/RequestForm/Attendees.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/Attendees.tsx
@@ -10,10 +10,10 @@ import classNames from 'classnames';
 import UswdsReactLink from 'components/LinkWrapper';
 import Divider from 'components/shared/Divider';
 import useTRBAttendees from 'hooks/useTRBAttendees';
+import { TRBAttendee } from 'queries/types/TRBAttendee';
 import { PersonRole } from 'types/graphql-global-types';
 import {
   AttendeeFieldLabels,
-  TRBAttendeeData,
   TRBAttendeeFields
 } from 'types/technicalAssistance';
 import { trbRequesterSchema } from 'validations/trbRequestSchema';
@@ -24,14 +24,14 @@ import Pager from './Pager';
 import { FormStepComponentProps, StepSubmit } from '.';
 
 /** Initial blank attendee object */
-export const initialAttendee: TRBAttendeeData = {
+export const initialAttendee: TRBAttendee = {
+  __typename: 'TRBRequestAttendee',
   trbRequestId: '',
-  userInfo: {
-    commonName: '',
-    euaUserId: ''
-  },
-  component: '',
-  role: null
+  id: '',
+  userInfo: null,
+  component: null,
+  role: null,
+  createdAt: ''
 };
 
 function Attendees({
@@ -60,7 +60,7 @@ function Attendees({
    *
    * Used to set field values when creating or editing attendee
    */
-  const [activeAttendee, setActiveAttendee] = useState<TRBAttendeeData>({
+  const [activeAttendee, setActiveAttendee] = useState<TRBAttendee>({
     ...initialAttendee,
     trbRequestId: request.id
   });

--- a/src/views/TechnicalAssistance/RequestForm/Attendees.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/Attendees.tsx
@@ -2,16 +2,16 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Route, Switch, useHistory, useRouteMatch } from 'react-router-dom';
-import { ApolloError, FetchResult } from '@apollo/client';
+import { ApolloError } from '@apollo/client';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Form } from '@trussworks/react-uswds';
 import classNames from 'classnames';
 
 import UswdsReactLink from 'components/LinkWrapper';
+import PageLoading from 'components/PageLoading';
 import Divider from 'components/shared/Divider';
 import useTRBAttendees from 'hooks/useTRBAttendees';
 import { TRBAttendee } from 'queries/types/TRBAttendee';
-import { PersonRole } from 'types/graphql-global-types';
 import {
   AttendeeFieldLabels,
   TRBAttendeeFields
@@ -28,7 +28,12 @@ export const initialAttendee: TRBAttendee = {
   __typename: 'TRBRequestAttendee',
   trbRequestId: '',
   id: '',
-  userInfo: null,
+  userInfo: {
+    __typename: 'UserInfo',
+    commonName: '',
+    euaUserId: '',
+    email: ''
+  },
   component: null,
   role: null,
   createdAt: ''
@@ -82,8 +87,7 @@ function Attendees({
    * Get TRB attendees data and mutations
    */
   const {
-    data: { attendees, requester },
-    createAttendee,
+    data: { attendees, requester, loading },
     updateAttendee,
     deleteAttendee
   } = useTRBAttendees(request.id);
@@ -94,46 +98,13 @@ function Attendees({
   useEffect(() => {
     /** Default reqiester values */
     const defaultValues: TRBAttendeeFields = {
-      euaUserId: requester.userInfo?.euaUserId || '',
-      component: requester.component,
-      role: requester.role
+      euaUserId: requester?.userInfo?.euaUserId || '',
+      component: requester?.component,
+      role: requester?.role
     };
     // Reset form
     reset(defaultValues);
   }, [requester, reset]);
-
-  /**
-   * Create or update  attendee
-   */
-  const submitAttendee = useCallback(
-    (formData: TRBAttendeeFields): Promise<FetchResult> => {
-      const { component, role, euaUserId } = formData;
-      // If attendee object has ID, update attendee
-      if (requester.id) {
-        return updateAttendee({
-          variables: {
-            input: {
-              id: requester.id,
-              component,
-              role: role as PersonRole
-            }
-          }
-        });
-      }
-      // If no ID is present, create new attendee
-      return createAttendee({
-        variables: {
-          input: {
-            trbRequestId: request.id,
-            euaUserId,
-            component,
-            role: role as PersonRole
-          }
-        }
-      });
-    },
-    [createAttendee, updateAttendee, request.id, requester.id]
-  );
 
   /** Submit requester as attendee */
   const submitForm = useCallback<StepSubmit>(
@@ -143,9 +114,17 @@ function Attendees({
         // Validation passed
         async formData => {
           // Submit the input only if there are changes
-          if (isDirty) {
-            // Submit requester fields
-            await submitAttendee(formData)
+          if (isDirty && requester.id) {
+            // Update requester
+            await updateAttendee({
+              variables: {
+                input: {
+                  id: requester.id,
+                  component: formData.component,
+                  role: formData.role
+                }
+              }
+            })
               // Refresh the RequestForm parent request query
               // to update things like `stepsCompleted`
               .then(() => refetchRequest())
@@ -176,7 +155,15 @@ function Attendees({
             }
           }
         ),
-    [t, handleSubmit, isDirty, refetchRequest, setFormAlert, submitAttendee]
+    [
+      t,
+      handleSubmit,
+      isDirty,
+      refetchRequest,
+      setFormAlert,
+      requester,
+      updateAttendee
+    ]
   );
 
   useEffect(() => {
@@ -186,6 +173,9 @@ function Attendees({
   useEffect(() => {
     setIsStepSubmitting(isSubmitting);
   }, [setIsStepSubmitting, isSubmitting]);
+
+  // Wait until attendees query has completed to load form
+  if (loading) return <PageLoading />;
 
   return (
     <div className="trb-attendees margin-top-2">

--- a/src/views/TechnicalAssistance/RequestForm/AttendeesForm/components.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/AttendeesForm/components.tsx
@@ -31,10 +31,10 @@ import InitialsIcon from 'components/shared/InitialsIcon';
 import TablePagination from 'components/TablePagination';
 import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
 import contactRoles from 'constants/enums/contactRoles';
+import { TRBAttendee } from 'queries/types/TRBAttendee';
 import { PersonRole } from 'types/graphql-global-types';
 import {
   AttendeeFieldLabels,
-  TRBAttendeeData,
   TRBAttendeeFields
 } from 'types/technicalAssistance';
 
@@ -45,7 +45,7 @@ type AttendeeFieldsProps = {
   /** Fields type */
   type: 'requester' | 'attendee';
   /** Sets the default values for the form */
-  activeAttendee: TRBAttendeeData;
+  activeAttendee: TRBAttendee;
   /** Control from useForm hook */
   control: Control<TRBAttendeeFields>;
   /** Field errors object */
@@ -228,9 +228,9 @@ const AttendeeFields = ({
 /** Single TRB attendee props */
 type AttendeeProps = {
   /** Attendee object */
-  attendee: TRBAttendeeData;
+  attendee: TRBAttendee;
   /** Set active attendee - used to edit attendee */
-  setActiveAttendee?: (activeAttendee: TRBAttendeeData) => void;
+  setActiveAttendee?: (activeAttendee: TRBAttendee) => void;
   /** Delete attendee */
   deleteAttendee?: () => void;
 };
@@ -314,11 +314,11 @@ const Attendee = ({
 /** TRB attendees list props */
 type AttendeesTableProps = {
   /** Array of attendee objects */
-  attendees: TRBAttendeeData[];
+  attendees: TRBAttendee[];
   /** TRB request id */
   trbRequestId: string;
   /** Set active attendee - used to edit attendee */
-  setActiveAttendee?: (activeAttendee: TRBAttendeeData) => void;
+  setActiveAttendee?: (activeAttendee: TRBAttendee) => void;
   /** Delete attendee */
   deleteAttendee?: (id: string) => void;
 };
@@ -335,7 +335,7 @@ const AttendeesTable = ({
   }, [attendees]);
 
   /** Columns for display in table */
-  const columns: Column<{ attendee: TRBAttendeeData }>[] = useMemo(
+  const columns: Column<{ attendee: TRBAttendee }>[] = useMemo(
     () => [
       {
         accessor: 'attendee',
@@ -387,7 +387,7 @@ const AttendeesTable = ({
                 className="tablet:grid-col-6 margin-bottom-1"
               >
                 {row.cells.map(cell => {
-                  const attendee: TRBAttendeeData = cell.value;
+                  const attendee: TRBAttendee = cell.value;
                   return (
                     <td
                       {...cell.getCellProps()}

--- a/src/views/TechnicalAssistance/RequestForm/AttendeesForm/index.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/AttendeesForm/index.tsx
@@ -9,10 +9,10 @@ import { Form, IconArrowBack } from '@trussworks/react-uswds';
 import UswdsReactLink from 'components/LinkWrapper';
 import PageHeading from 'components/PageHeading';
 import useTRBAttendees from 'hooks/useTRBAttendees';
+import { TRBAttendee } from 'queries/types/TRBAttendee';
 import { PersonRole } from 'types/graphql-global-types';
 import {
   AttendeeFieldLabels,
-  TRBAttendeeData,
   TRBAttendeeFields
 } from 'types/technicalAssistance';
 import { trbAttendeeSchema } from 'validations/trbRequestSchema';
@@ -26,9 +26,9 @@ import { AttendeeFields } from './components';
 
 interface AttendeesFormProps {
   backToFormUrl?: string;
-  activeAttendee: TRBAttendeeData;
+  activeAttendee: TRBAttendee;
   /** Set active attendee - used to edit attendee */
-  setActiveAttendee: (activeAttendee: TRBAttendeeData) => void;
+  setActiveAttendee: (activeAttendee: TRBAttendee) => void;
   trbRequestId: string;
   setFormAlert: React.Dispatch<React.SetStateAction<TrbFormAlert>>;
   taskListUrl: string;

--- a/src/views/TechnicalAssistance/RequestForm/SubmittedRequest.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/SubmittedRequest.tsx
@@ -47,7 +47,7 @@ function SubmittedRequest({
 
   const {
     data: { requester, attendees }
-  } = useTRBAttendees(request.id, request.createdBy);
+  } = useTRBAttendees(request.id);
 
   return (
     <>


### PR DESCRIPTION
# NOREF

## Changes and Description

- Make `component` and `role` nullable on TRB Attendees
- Create an Attendee when making a TRB Request with the caller's EUA ID & info
- TODO: (@aterstriep @adamodd?) Frontend changes to remove code that creates a new attendee for the requester on the "Attendees" page of the TRB Initial Request Form
- TODO (@aterstriep @adamodd?) Updates

## How to test this change

- `scripts/dev up`
- Open the TRB UI
- Create a new TRB request
- Ensure that there's an Attendee in the DB already, even though the FE never called to create one!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
