### PR TITLE
[NOREF] Skip sending emails when no toAddressses is provided

### DIFF
--- a/pkg/appses/ses.go
+++ b/pkg/appses/ses.go
@@ -44,6 +44,12 @@ func (s Sender) Send(
 	subject string,
 	body string,
 ) error {
+	// Don't send an email if there's no recipients (even if there are ccAddresses)
+	if len(toAddresses) == 0 {
+		appcontext.ZLogger(ctx).Warn("attempted to send an email with empty toAddresses")
+		return nil
+	}
+
 	input := &ses.SendEmailInput{
 		Destination: &ses.Destination{
 			ToAddresses: models.EmailAddressesToStringPtrs(toAddresses),

--- a/pkg/appses/ses_test.go
+++ b/pkg/appses/ses_test.go
@@ -74,4 +74,15 @@ func (s *SESTestSuite) TestSend() {
 
 		s.NoError(err)
 	})
+	s.Run("Does nothing when passing empty toAddresses", func() {
+		err := s.sender.Send(
+			context.Background(),
+			[]models.EmailAddress{},
+			nil,
+			"Test Subject",
+			"Test Body",
+		)
+
+		s.NoError(err)
+	})
 }

--- a/pkg/local/email.go
+++ b/pkg/local/email.go
@@ -44,6 +44,11 @@ func NewSMTPSender(serverAddress string) SMTPSender {
 
 // Send sends and logs an email
 func (sender SMTPSender) Send(ctx context.Context, toAddresses []models.EmailAddress, ccAddresses []models.EmailAddress, subject string, body string) error {
+	// Don't send an email if there's no recipients (even if there are ccAddresses)
+	if len(toAddresses) == 0 {
+		return nil
+	}
+
 	e := email.Email{
 		From:    "testsender@oddball.dev",
 		To:      models.EmailAddressesToStrings(toAddresses),


### PR DESCRIPTION
# NOREF

## Changes and Description

- Skip sending emails when `toAddresses` is empty

## How to test this change

- Check that the CI tests pass (which run the appses suite, specifically this file)
https://github.com/CMSgov/easi-app/blob/4209f5be9cc6b7f89e547fa5f4bfad9e6c0bcb87/pkg/appses/ses_test.go#L77-L87

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
