### PR TITLE
[NOREF] Add `isRecent` property to TRB Requests

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -843,6 +843,7 @@ type ComplexityRoot struct {
 		Feedback           func(childComplexity int) int
 		Form               func(childComplexity int) int
 		ID                 func(childComplexity int) int
+		IsRecent           func(childComplexity int) int
 		ModifiedAt         func(childComplexity int) int
 		ModifiedBy         func(childComplexity int) int
 		Name               func(childComplexity int) int
@@ -1286,6 +1287,7 @@ type TRBRequestResolver interface {
 	TaskStatuses(ctx context.Context, obj *models.TRBRequest) (*models.TRBTaskStatuses, error)
 
 	AdminNotes(ctx context.Context, obj *models.TRBRequest) ([]*models.TRBAdminNote, error)
+	IsRecent(ctx context.Context, obj *models.TRBRequest) (bool, error)
 }
 type TRBRequestAttendeeResolver interface {
 	UserInfo(ctx context.Context, obj *models.TRBRequestAttendee) (*models.UserInfo, error)
@@ -5588,6 +5590,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TRBRequest.ID(childComplexity), true
 
+	case "TRBRequest.isRecent":
+		if e.complexity.TRBRequest.IsRecent == nil {
+			break
+		}
+
+		return e.complexity.TRBRequest.IsRecent(childComplexity), true
+
 	case "TRBRequest.modifiedAt":
 		if e.complexity.TRBRequest.ModifiedAt == nil {
 			break
@@ -7932,6 +7941,7 @@ type TRBRequest {
   consultMeetingTime: Time
   trbLead: String
   adminNotes: [TRBAdminNote!]! @hasRole(role: EASI_TRB_ADMIN)
+  isRecent: Boolean!
   createdBy: String!
   createdAt: Time! # will be used for UploadedAt in frontend
   modifiedBy: String
@@ -26527,6 +26537,8 @@ func (ec *executionContext) fieldContext_Mutation_createTRBRequest(ctx context.C
 				return ec.fieldContext_TRBRequest_trbLead(ctx, field)
 			case "adminNotes":
 				return ec.fieldContext_TRBRequest_adminNotes(ctx, field)
+			case "isRecent":
+				return ec.fieldContext_TRBRequest_isRecent(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_TRBRequest_createdBy(ctx, field)
 			case "createdAt":
@@ -26619,6 +26631,8 @@ func (ec *executionContext) fieldContext_Mutation_updateTRBRequest(ctx context.C
 				return ec.fieldContext_TRBRequest_trbLead(ctx, field)
 			case "adminNotes":
 				return ec.fieldContext_TRBRequest_adminNotes(ctx, field)
+			case "isRecent":
+				return ec.fieldContext_TRBRequest_isRecent(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_TRBRequest_createdBy(ctx, field)
 			case "createdAt":
@@ -27360,6 +27374,8 @@ func (ec *executionContext) fieldContext_Mutation_updateTRBRequestConsultMeeting
 				return ec.fieldContext_TRBRequest_trbLead(ctx, field)
 			case "adminNotes":
 				return ec.fieldContext_TRBRequest_adminNotes(ctx, field)
+			case "isRecent":
+				return ec.fieldContext_TRBRequest_isRecent(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_TRBRequest_createdBy(ctx, field)
 			case "createdAt":
@@ -27476,6 +27492,8 @@ func (ec *executionContext) fieldContext_Mutation_updateTRBRequestTRBLead(ctx co
 				return ec.fieldContext_TRBRequest_trbLead(ctx, field)
 			case "adminNotes":
 				return ec.fieldContext_TRBRequest_adminNotes(ctx, field)
+			case "isRecent":
+				return ec.fieldContext_TRBRequest_isRecent(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_TRBRequest_createdBy(ctx, field)
 			case "createdAt":
@@ -28616,6 +28634,8 @@ func (ec *executionContext) fieldContext_Mutation_reopenTrbRequest(ctx context.C
 				return ec.fieldContext_TRBRequest_trbLead(ctx, field)
 			case "adminNotes":
 				return ec.fieldContext_TRBRequest_adminNotes(ctx, field)
+			case "isRecent":
+				return ec.fieldContext_TRBRequest_isRecent(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_TRBRequest_createdBy(ctx, field)
 			case "createdAt":
@@ -30255,6 +30275,8 @@ func (ec *executionContext) fieldContext_Query_trbRequest(ctx context.Context, f
 				return ec.fieldContext_TRBRequest_trbLead(ctx, field)
 			case "adminNotes":
 				return ec.fieldContext_TRBRequest_adminNotes(ctx, field)
+			case "isRecent":
+				return ec.fieldContext_TRBRequest_isRecent(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_TRBRequest_createdBy(ctx, field)
 			case "createdAt":
@@ -30347,6 +30369,8 @@ func (ec *executionContext) fieldContext_Query_trbRequests(ctx context.Context, 
 				return ec.fieldContext_TRBRequest_trbLead(ctx, field)
 			case "adminNotes":
 				return ec.fieldContext_TRBRequest_adminNotes(ctx, field)
+			case "isRecent":
+				return ec.fieldContext_TRBRequest_isRecent(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_TRBRequest_createdBy(ctx, field)
 			case "createdAt":
@@ -38344,6 +38368,50 @@ func (ec *executionContext) fieldContext_TRBRequest_adminNotes(ctx context.Conte
 				return ec.fieldContext_TRBAdminNote_modifiedAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TRBAdminNote", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TRBRequest_isRecent(ctx context.Context, field graphql.CollectedField, obj *models.TRBRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TRBRequest_isRecent(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TRBRequest().IsRecent(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TRBRequest_isRecent(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TRBRequest",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -53774,6 +53842,26 @@ func (ec *executionContext) _TRBRequest(ctx context.Context, sel ast.SelectionSe
 					}
 				}()
 				res = ec._TRBRequest_adminNotes(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		case "isRecent":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TRBRequest_isRecent(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}

--- a/pkg/graph/resolvers/trb_request.go
+++ b/pkg/graph/resolvers/trb_request.go
@@ -330,7 +330,7 @@ func ReopenTRBRequest(
 // IsRecentTRBRequest determines if a TRB Request should be determined to be flagged as "recent" or not.
 // TODO: Add more logic in https://jiraent.cms.gov/browse/EASI-2711
 func IsRecentTRBRequest(ctx context.Context, obj *models.TRBRequest, now time.Time) bool {
-	numDaysToConsiderRecent := 7
+	numDaysToConsiderRecent := -7
 	recentIfAfterDate := now.AddDate(0, 0, numDaysToConsiderRecent)
 	return obj.CreatedAt.After(recentIfAfterDate)
 }

--- a/pkg/graph/resolvers/trb_request.go
+++ b/pkg/graph/resolvers/trb_request.go
@@ -326,3 +326,11 @@ func ReopenTRBRequest(
 
 	return updatedTrb, nil
 }
+
+// IsRecentTRBRequest determines if a TRB Request should be determined to be flagged as "recent" or not.
+// TODO: Add more logic in https://jiraent.cms.gov/browse/EASI-2711
+func IsRecentTRBRequest(ctx context.Context, obj *models.TRBRequest, now time.Time) bool {
+	numDaysToConsiderRecent := 7
+	recentIfAfterDate := now.AddDate(0, 0, numDaysToConsiderRecent)
+	return obj.CreatedAt.After(recentIfAfterDate)
+}

--- a/pkg/graph/resolvers/trb_request_test.go
+++ b/pkg/graph/resolvers/trb_request_test.go
@@ -165,3 +165,25 @@ func (s *ResolverSuite) TestUpdateTRBRequestTRBLead() {
 	s.NoError(err)
 	s.EqualValues("MCLV", *updated.TRBLead)
 }
+
+func (s *ResolverSuite) TestIsRecentTRBRequest() {
+	// Set up a date to mock the current time
+	dateOnlyLayout := "2006-01-02"
+	now, err := time.Parse(dateOnlyLayout, "2020-01-10")
+	s.NoError(err)
+
+	// 10 Days old
+	tenDaysOld := models.NewTRBRequest(s.testConfigs.DBConfig.Username)
+	tenDaysOld.CreatedAt = now.AddDate(0, 0, -10)
+	s.False(IsRecentTRBRequest(s.testConfigs.Context, tenDaysOld, now))
+
+	// 6 days old
+	sixDaysOld := models.NewTRBRequest(s.testConfigs.DBConfig.Username)
+	sixDaysOld.CreatedAt = now.AddDate(0, 0, -6)
+	s.True(IsRecentTRBRequest(s.testConfigs.Context, sixDaysOld, now))
+
+	// 0 days old
+	zeroDaysOld := models.NewTRBRequest(s.testConfigs.DBConfig.Username)
+	zeroDaysOld.CreatedAt = now
+	s.True(IsRecentTRBRequest(s.testConfigs.Context, zeroDaysOld, now))
+}

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -1518,6 +1518,7 @@ type TRBRequest {
   consultMeetingTime: Time
   trbLead: String
   adminNotes: [TRBAdminNote!]! @hasRole(role: EASI_TRB_ADMIN)
+  isRecent: Boolean!
   createdBy: String!
   createdAt: Time! # will be used for UploadedAt in frontend
   modifiedBy: String

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -2901,6 +2901,11 @@ func (r *tRBRequestResolver) AdminNotes(ctx context.Context, obj *models.TRBRequ
 	return resolvers.GetTRBAdminNotesByTRBRequestID(ctx, r.store, obj.ID)
 }
 
+// IsRecent is the resolver for the isRecent field.
+func (r *tRBRequestResolver) IsRecent(ctx context.Context, obj *models.TRBRequest) (bool, error) {
+	return resolvers.IsRecentTRBRequest(ctx, obj, time.Now()), nil
+}
+
 // UserInfo is the resolver for the userInfo field.
 func (r *tRBRequestAttendeeResolver) UserInfo(ctx context.Context, obj *models.TRBRequestAttendee) (*models.UserInfo, error) {
 	userInfo, err := r.service.FetchUserInfo(ctx, obj.EUAUserID)


### PR DESCRIPTION
# NOREF

## Changes and Description

- Adds `isRecent` to TRB Request type in GQL
  - Currently only looks to see if a request was created in the past week, and doesn't do anything else.
  - Added unit tests to [trb_request_test.go](./pkg/graph/resolvers/trb_request_test.go)

## How to test this change

- Look at the unit tests and ensure they both pass and make sense
- Create a TRB request locally and use PSQL/Postico/PGAdmin to modify the "created at" date to see if the query comes back as expected.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
