### PR TITLE
[NOREF] Lower some Error logs to Warnings

### DIFF
--- a/pkg/cedar/cedarldap/translated_client.go
+++ b/pkg/cedar/cedarldap/translated_client.go
@@ -52,7 +52,7 @@ func NewTranslatedClient(cedarHost string, cedarAPIKey string) TranslatedClient 
 // this function only supports querying for a _single_ user's info
 func (c TranslatedClient) FetchUserInfo(ctx context.Context, euaID string) (*models2.UserInfo, error) {
 	if euaID == "" {
-		appcontext.ZLogger(ctx).Error("No EUA ID specified; unable to request user info from CEDAR LDAP")
+		appcontext.ZLogger(ctx).Warn("No EUA ID specified; unable to request user info from CEDAR LDAP")
 		return nil, &apperrors.InvalidParametersError{
 			FunctionName: "cedarldap.FetchUserInfo",
 		}
@@ -101,9 +101,9 @@ func (c TranslatedClient) FetchUserInfo(ctx context.Context, euaID string) (*mod
 // FetchUserInfos fetches multiple users' personal details
 func (c TranslatedClient) FetchUserInfos(ctx context.Context, euaIDs []string) ([]*models2.UserInfo, error) {
 	if len(euaIDs) == 0 {
-		appcontext.ZLogger(ctx).Error("No EUA ID specified; unable to request user info from CEDAR LDAP")
+		appcontext.ZLogger(ctx).Warn("No EUA IDs specified; unable to request user info from CEDAR LDAP")
 		return nil, &apperrors.InvalidParametersError{
-			FunctionName: "cedarldap.FetchUserInfo",
+			FunctionName: "cedarldap.FetchUserInfos",
 		}
 	}
 
@@ -149,7 +149,7 @@ func (c TranslatedClient) FetchUserInfos(ctx context.Context, euaIDs []string) (
 // `commonName` parameter in * to make the search match any person whose name contains the commonName param
 func (c TranslatedClient) SearchCommonNameContains(ctx context.Context, commonName string) ([]*models2.UserInfo, error) {
 	if commonName == "" {
-		appcontext.ZLogger(ctx).Error("No commonName specified; skipping request to CEDAR LDAP")
+		appcontext.ZLogger(ctx).Warn("No commonName specified; skipping request to CEDAR LDAP")
 		return nil, nil
 	}
 


### PR DESCRIPTION
# NOREF

## Changes and Description

- Reduce (occasionally) expected cases for CEDAR LDAP client to `logger.Warn` from `logger.Error`
  - Some of these cases were being hit by the LCID alerting code, and were logging as errors when they more likely should be warnings.

<!-- Put a description here! -->

## How to test this change

- Not much to test here, other than checking the translated client code to see if there's other cases that should be modified!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
