### PR TITLE
[EASI-2721] - PDF export intake resolution

### DIFF
--- a/src/components/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/components/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -1065,34 +1065,34 @@ exports[`The Business Case Review Component matches the snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="easi-pdf-export__controls margin-top-6"
+  </div>
+  <div
+    className="easi-pdf-export__controls margin-top-6"
+  >
+    <button
+      className="usa-button usa-button--unstyled easi-no-print display-flex flex-align-center"
+      onClick={[Function]}
+      type="button"
     >
-      <button
-        className="usa-button usa-button--unstyled easi-no-print display-flex flex-align-center"
-        onClick={[Function]}
-        type="button"
+      <svg
+        className="usa-icon margin-right-05"
+        focusable={false}
+        height="1em"
+        role="img"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          className="usa-icon margin-right-05"
-          focusable={false}
-          height="1em"
-          role="img"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M0 0h24v24H0z"
-            fill="none"
-          />
-          <path
-            d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-          />
-        </svg>
-        Download Business Case as PDF
-      </button>
-    </div>
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+        <path
+          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+        />
+      </svg>
+      Download Business Case as PDF
+    </button>
   </div>
 </div>
 `;

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -98,9 +98,15 @@ const PDFExport = ({
 }: PDFExportProps) => {
   const divEl = useRef<HTMLDivElement>(null);
 
-  return (
+  const IntakeContent: JSX.Element = (
     <div className="easi-pdf-export" ref={divEl}>
-      {linkPosition === 'bottom' && children}
+      {children}
+    </div>
+  );
+
+  return (
+    <>
+      {linkPosition === 'bottom' && IntakeContent}
 
       <div
         className={classNames('easi-pdf-export__controls', {
@@ -118,8 +124,8 @@ const PDFExport = ({
         </button>
       </div>
 
-      {linkPosition === 'top' && children}
-    </div>
+      {linkPosition === 'top' && IntakeContent}
+    </>
   );
 };
 

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -442,34 +442,34 @@ exports[`The GRT business case review matches the snapshot 1`] = `
         </dl>
       </div>
     </div>
-    <div
-      className="easi-pdf-export__controls margin-top-6"
+  </div>
+  <div
+    className="easi-pdf-export__controls margin-top-6"
+  >
+    <button
+      className="usa-button usa-button--unstyled easi-no-print display-flex flex-align-center"
+      onClick={[Function]}
+      type="button"
     >
-      <button
-        className="usa-button usa-button--unstyled easi-no-print display-flex flex-align-center"
-        onClick={[Function]}
-        type="button"
+      <svg
+        className="usa-icon margin-right-05"
+        focusable={false}
+        height="1em"
+        role="img"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          className="usa-icon margin-right-05"
-          focusable={false}
-          height="1em"
-          role="img"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M0 0h24v24H0z"
-            fill="none"
-          />
-          <path
-            d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-          />
-        </svg>
-        Download Business Case as PDF
-      </button>
-    </div>
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+        <path
+          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+        />
+      </svg>
+      Download Business Case as PDF
+    </button>
   </div>
   <a
     className="usa-button margin-top-5"

--- a/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
@@ -359,33 +359,33 @@ exports[`The GRT intake review view matches the snapshot 1`] = `
           </div>
         </dl>
       </div>
-      <div
-        class="easi-pdf-export__controls margin-top-6"
+    </div>
+    <div
+      class="easi-pdf-export__controls margin-top-6"
+    >
+      <button
+        class="usa-button usa-button--unstyled easi-no-print display-flex flex-align-center"
+        type="button"
       >
-        <button
-          class="usa-button usa-button--unstyled easi-no-print display-flex flex-align-center"
-          type="button"
+        <svg
+          class="usa-icon margin-right-05"
+          focusable="false"
+          height="1em"
+          role="img"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            class="usa-icon margin-right-05"
-            focusable="false"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 0h24v24H0z"
-              fill="none"
-            />
-            <path
-              d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-            />
-          </svg>
-          Download System Intake as PDF
-        </button>
-      </div>
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+          <path
+            d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+          />
+        </svg>
+        Download System Intake as PDF
+      </button>
     </div>
     <a
       class="usa-button margin-top-5"


### PR DESCRIPTION
# EASI-2721

## Changes and Description

- Moved the download PDF link and icon outside of the scope of PDF generated content

Issue was caused by the `svg` without an `alt` text.  
For future reference in PDF generation, and images will need this attribute


## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
