### PR TITLE
[EASI-2583, 1806] - Basic User TRB request and Systems List integration

### DIFF
--- a/cypress/e2e/accessibility.cy.js
+++ b/cypress/e2e/accessibility.cy.js
@@ -114,7 +114,7 @@ describe.skip('Accessibility Requests', () => {
     cy.visit('/');
     cy.contains('h1', 'Welcome to EASi');
     cy.contains('h2', 'Governance Services');
-    cy.contains('h3', 'My governance requests');
+    cy.contains('h3', 'My requests');
     cy.get('table').within(() => {
       cy.get('thead').within(() => {
         cy.contains('th', 'Request name');

--- a/cypress/e2e/homepage.cy.js
+++ b/cypress/e2e/homepage.cy.js
@@ -8,12 +8,12 @@ import {
 describe('Homepage', () => {
   it('shows the basic homepage for no user roles', () => {
     cy.localLogin({ name: 'USR1' });
-    cy.contains('h3', 'My governance requests');
+    cy.contains('h3', 'My requests');
   });
 
   it('shows the basic homepage for basic easi role', () => {
     cy.localLogin({ name: 'USR2', role: BASIC_USER_PROD });
-    cy.contains('h3', 'My governance requests');
+    cy.contains('h3', 'My requests');
   });
 
   it('shows the 508 table to 508 admins', () => {

--- a/src/components/LinkCard/index.stories.tsx
+++ b/src/components/LinkCard/index.stories.tsx
@@ -8,9 +8,5 @@ export default {
 };
 
 export const Default = () => {
-  return (
-    <LinkCard link="/mylink" heading="Take me to your link">
-      <div>If you click on me I will take you to a really wonderful place</div>
-    </LinkCard>
-  );
+  return <LinkCard type="TRB" />;
 };

--- a/src/components/LinkCard/index.test.tsx
+++ b/src/components/LinkCard/index.test.tsx
@@ -4,22 +4,14 @@ import { shallow } from 'enzyme';
 import LinkCard from './index';
 
 describe('LinkCard', () => {
-  const props = {
-    link: 'https://test/page',
-    heading: 'I am your header'
-  };
-
-  const wrapper = shallow(
-    <LinkCard {...props}>
-      <div>Component, I am your child</div>
-    </LinkCard>
-  );
+  const wrapper = shallow(<LinkCard type="TRB" />);
   it('renders without crashing', () => {
     expect(wrapper.length).toEqual(1);
   });
-
   it('renders heading with link', () => {
-    expect(wrapper.find('h3').children().contains(props.heading)).toEqual(true);
-    expect(wrapper.find('UswdsReactLink').prop('to')).toEqual(props.link);
+    expect(
+      wrapper.find('h3').children().contains('Technical Assistance')
+    ).toEqual(true);
+    expect(wrapper.find('UswdsReactLink').prop('to')).toEqual('/trb');
   });
 });

--- a/src/components/LinkCard/index.tsx
+++ b/src/components/LinkCard/index.tsx
@@ -1,22 +1,22 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
+import { Button, IconArrowForward } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 
 import UswdsReactLink from 'components/LinkWrapper';
 
+export type LinkRequestType = 'ITGov' | 'TRB' | '508';
+
 type LinkCardProps = {
-  children: React.ReactNode;
   className?: string;
-  link: string;
-  heading: React.ReactNode | string;
+  type: LinkRequestType;
 } & JSX.IntrinsicElements['div'];
 
-const LinkCard = ({
-  children,
-  className,
-  link,
-  heading,
-  ...props
-}: LinkCardProps) => {
+const LinkCard = ({ className, type }: LinkCardProps) => {
+  const { t } = useTranslation('home');
+
+  const history = useHistory();
   return (
     <div
       className={classnames(
@@ -26,12 +26,27 @@ const LinkCard = ({
         'bg-base-lightest',
         className
       )}
-      {...props}
     >
       <h3 className="margin-top-0 margin-bottom-1">
-        <UswdsReactLink to={link}>{heading}</UswdsReactLink>
+        {t(`actions.${type}.heading`)}
       </h3>
-      <div className="margin-top-1">{children}</div>
+      <div className="margin-top-1">{t(`actions.${type}.body`)}</div>
+
+      <UswdsReactLink
+        to={t(`actions.${type}.link`)}
+        className="display-flex flex-align-center margin-top-1 margin-bottom-3"
+      >
+        {t(`actions.${type}.learnMore`)}
+        <IconArrowForward className="margin-left-1" />
+      </UswdsReactLink>
+
+      <Button
+        type="button"
+        className="usa-button usa-button--outline"
+        onClick={() => history.push(t(`actions.${type}.buttonLink`))}
+      >
+        {t(`actions.${type}.button`)}
+      </Button>
     </div>
   );
 };

--- a/src/components/shared/Divider/index.scss
+++ b/src/components/shared/Divider/index.scss
@@ -1,3 +1,5 @@
+@use 'uswds-core' as *;
+
 .easi-divider {
     width: 100%;
     height: 0px;

--- a/src/i18n/en-US/home.ts
+++ b/src/i18n/en-US/home.ts
@@ -1,7 +1,7 @@
 const home = {
   title: 'Welcome to EASi',
   subtitle:
-    'The place to find CMS IT governance and Section 508 services as well as comprehensive information about CMS systems.',
+    'The place to find CMS IT Governance, assistance with technical issues, Section 508 services, as well as comprehensive information about CMS systems.',
   startNow: 'Start now',
   signIn: 'Sign in to start',
   accessibility: {

--- a/src/i18n/en-US/home.ts
+++ b/src/i18n/en-US/home.ts
@@ -8,16 +8,34 @@ const home = {
     heading: '508 Requests',
     newRequest: 'Add a new request'
   },
+  actionTitle: 'Available Services',
   actions: {
-    title: 'Governance Services',
-    itg: {
+    ITGov: {
       heading: 'IT Governance',
-      body: 'Includes applying for a lifecycle ID, and recompetes'
+      body:
+        'Includes processes for applying for a Lifecycle ID and decomissioning a system.',
+      learnMore: 'Learn more about IT Governance',
+      link: '/system/making-a-request',
+      button: 'Start an IT Governance request',
+      buttonLink: '/system/request-type'
     },
     '508': {
       heading: 'Section 508',
       body:
-        'Learn about the process and make a request for 508 testing of your application'
+        'Request 508 testing for your application or system and learn about the process.',
+      learnMore: 'Learn more about 508 testing',
+      link: '/508/making-a-request',
+      button: 'Start a 508 testing request',
+      buttonLink: '/508/testing-overview?continue=true'
+    },
+    TRB: {
+      heading: 'Technical Assistance',
+      body:
+        'Get help, feedback, and guidance from the Technical Review Board (TRB).',
+      learnMore: 'Learn more about the TRB',
+      link: '/trb',
+      button: 'Start a TRB request',
+      buttonLink: '/trb/start'
     }
   },
   requestsTable: {
@@ -26,9 +44,9 @@ const home = {
     title: 'Request Table',
     breadcrumb: {
       home: 'Home',
-      table: 'My governance requests'
+      table: 'My requests'
     },
-    heading: 'My governance requests',
+    heading: 'My requests',
     headers: {
       name: 'Request name',
       type: 'Governance',

--- a/src/i18n/en-US/home.ts
+++ b/src/i18n/en-US/home.ts
@@ -38,7 +38,8 @@ const home = {
     },
     types: {
       ACCESSIBILITY_REQUEST: 'Section 508',
-      GOVERNANCE_REQUEST: 'IT Governance'
+      GOVERNANCE_REQUEST: 'IT Governance',
+      TRB: 'TRB'
     },
     defaultName: 'Draft',
     defaultSubmittedAt: 'Not submitted',

--- a/src/i18n/en-US/systemProfile.ts
+++ b/src/i18n/en-US/systemProfile.ts
@@ -235,6 +235,7 @@ const systemProfile = {
   systemTable: {
     title: 'All Systems',
     subtitle: 'Bookmark systems that you want to access more quickly.',
+    noResults: 'No systems found.',
     id: 'system-list',
     search: 'Search Table',
     header: {

--- a/src/i18n/en-US/technicalAssistance.ts
+++ b/src/i18n/en-US/technicalAssistance.ts
@@ -630,6 +630,10 @@ const technicalAssistance = {
     requester: 'Requester',
     submissionDate: 'Submission Date',
     status: 'Status',
+    requestStatuses: {
+      OPEN: 'Open',
+      CLOSED: 'Closed'
+    },
     taskStatuses: {
       formStatus: {
         READY_TO_START: 'Ready to start request form',

--- a/src/queries/GetRequestsQuery.ts
+++ b/src/queries/GetRequestsQuery.ts
@@ -16,5 +16,12 @@ export default gql`
         }
       }
     }
+    trbRequests(archived: false) {
+      id
+      name
+      submittedAt: createdAt
+      status
+      nextMeetingDate: consultMeetingTime
+    }
   }
 `;

--- a/src/queries/types/GetRequests.ts
+++ b/src/queries/types/GetRequests.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { RequestType } from "./../../types/graphql-global-types";
+import { RequestType, TRBRequestStatus } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL query operation: GetRequests
@@ -31,8 +31,18 @@ export interface GetRequests_requests {
   edges: GetRequests_requests_edges[];
 }
 
+export interface GetRequests_trbRequests {
+  __typename: "TRBRequest";
+  id: UUID;
+  name: string;
+  submittedAt: Time;
+  status: TRBRequestStatus;
+  nextMeetingDate: Time | null;
+}
+
 export interface GetRequests {
   requests: GetRequests_requests | null;
+  trbRequests: GetRequests_trbRequests[];
 }
 
 export interface GetRequestsVariables {

--- a/src/views/Home/index.test.tsx
+++ b/src/views/Home/index.test.tsx
@@ -9,6 +9,8 @@ import configureMockStore from 'redux-mock-store';
 
 import { initialSystemIntakeForm } from 'data/systemIntake';
 import { MessageProvider } from 'hooks/useMessage';
+import GetCedarSystemBookmarksQuery from 'queries/GetCedarSystemBookmarksQuery';
+import GetCedarSystemsQuery from 'queries/GetCedarSystemsQuery';
 import GetRequestsQuery from 'queries/GetRequestsQuery';
 import { Flags } from 'types/flags';
 import Table from 'views/MyRequests/Table';
@@ -38,6 +40,43 @@ const defaultFlags: Flags = {
   downgradeGovTeam: false,
   sandbox: true
 } as Flags;
+
+const mocks = [
+  {
+    request: {
+      query: GetRequestsQuery,
+      variables: { first: 20 }
+    },
+    result: {
+      data: {
+        requests: {
+          edges: []
+        },
+        trbRequests: []
+      }
+    }
+  },
+  {
+    request: {
+      query: GetCedarSystemsQuery
+    },
+    result: {
+      data: {
+        cedarSystems: []
+      }
+    }
+  },
+  {
+    request: {
+      query: GetCedarSystemBookmarksQuery
+    },
+    result: {
+      data: {
+        cedarSystemBookmarks: []
+      }
+    }
+  }
+];
 
 describe('The home page', () => {
   beforeEach(() => {
@@ -79,21 +118,7 @@ describe('The home page', () => {
           }
         });
         let component: any;
-        const mocks = [
-          {
-            request: {
-              query: GetRequestsQuery,
-              variables: { first: 20 }
-            },
-            result: {
-              data: {
-                requests: {
-                  edges: []
-                }
-              }
-            }
-          }
-        ];
+
         await act(async () => {
           component = mount(
             <MemoryRouter initialEntries={['/']} initialIndex={0}>
@@ -110,13 +135,17 @@ describe('The home page', () => {
           expect(component.find('a[children="Start now"]').exists()).toEqual(
             false
           );
+
           expect(
-            component.find('a[children="IT Governance"]').exists()
+            component.find('h3[children="IT Governance"]').exists()
           ).toEqual(true);
-          expect(component.find('a[children="Section 508"]').exists()).toEqual(
+
+          expect(component.find('h3[children="Section 508"]').exists()).toEqual(
             true
           );
+
           expect(component.find('hr').exists()).toBeTruthy();
+
           expect(component.find(Table).exists()).toBeTruthy();
         });
       });
@@ -156,11 +185,13 @@ describe('The home page', () => {
       const store = mockStore(mockedStore);
       return mount(
         <MemoryRouter initialEntries={['/']} initialIndex={0}>
-          <Provider store={store}>
-            <MessageProvider>
-              <Home />
-            </MessageProvider>
-          </Provider>
+          <MockedProvider mocks={mocks}>
+            <Provider store={store}>
+              <MessageProvider>
+                <Home />
+              </MessageProvider>
+            </Provider>
+          </MockedProvider>
         </MemoryRouter>
       );
     };

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -100,7 +100,9 @@ const Home = () => {
 
               <hr className="margin-bottom-3" aria-hidden />
 
-              <h2 className="margin-y-2">{t('home:actionTitle')}</h2>
+              <h2 className="margin-top-2 margin-bottom-1">
+                {t('home:actionTitle')}
+              </h2>
 
               <Grid row gap={2}>
                 {[
@@ -110,6 +112,7 @@ const Home = () => {
                 ].map(requestType => (
                   <Grid tablet={{ col: 4 }} key={Object.keys(requestType)[0]}>
                     <LinkCard
+                      className="margin-top-1"
                       type={Object.keys(requestType)[0] as LinkRequestType}
                     />
                   </Grid>

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -2,18 +2,31 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
 import { Alert, Grid } from '@trussworks/react-uswds';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import LinkCard, { LinkRequestType } from 'components/LinkCard';
 import MainContent from 'components/MainContent';
 import PageHeading from 'components/PageHeading';
+import PageLoading from 'components/PageLoading';
 import RequestRepository from 'components/RequestRepository';
 import useMessage from 'hooks/useMessage';
+import GetCedarSystemBookmarksQuery from 'queries/GetCedarSystemBookmarksQuery';
+import GetCedarSystemsQuery from 'queries/GetCedarSystemsQuery';
+import {
+  GetCedarSystemBookmarks,
+  GetCedarSystemBookmarks_cedarSystemBookmarks as CedarSystemBookmark
+} from 'queries/types/GetCedarSystemBookmarks';
+import {
+  GetCedarSystems,
+  GetCedarSystems_cedarSystems as CedarSystem
+} from 'queries/types/GetCedarSystems';
 import { AppState } from 'reducers/rootReducer';
 import user from 'utils/user';
 import List from 'views/Accessibility/AccessibilityRequest/List';
 import Table from 'views/MyRequests/Table';
+import SystemsListTable from 'views/SystemList/Table';
 
 import WelcomeText from './WelcomeText';
 
@@ -28,6 +41,20 @@ const Home = () => {
   const requestTypes: Record<LinkRequestType, any> = t('home:actions', {
     returnObjects: true
   });
+
+  const { loading: loadingSystems, data: systems } = useQuery<GetCedarSystems>(
+    GetCedarSystemsQuery
+  );
+
+  const {
+    loading: loadingBookmarks,
+    data: systemsBookmarks,
+    refetch: refetchBookmarks
+  } = useQuery<GetCedarSystemBookmarks>(GetCedarSystemBookmarksQuery);
+
+  const systemsTableData = (systems?.cedarSystems ?? []) as CedarSystem[];
+  const bookmarks: CedarSystemBookmark[] =
+    systemsBookmarks?.cedarSystemBookmarks ?? [];
 
   const renderView = () => {
     if (isUserSet) {
@@ -62,15 +89,19 @@ const Home = () => {
                 </Alert>
               </div>
             )}
-            <div className="tablet:grid-col-12">
+            <Grid tablet={{ col: 12 }}>
               <PageHeading className="margin-bottom-0">
                 {t('home:title')}
               </PageHeading>
+
               <p className="line-height-body-5 font-body-lg text-light margin-bottom-5 margin-top-1">
                 {t('home:subtitle')}
               </p>
-              <hr className="margin-bottom-4" aria-hidden />
-              <h2 className="margin-bottom-2">{t('home:actionTitle')}</h2>
+
+              <hr className="margin-bottom-3" aria-hidden />
+
+              <h2 className="margin-y-2">{t('home:actionTitle')}</h2>
+
               <Grid row gap={2}>
                 {[
                   { ITGov: requestTypes.ITGov },
@@ -88,10 +119,33 @@ const Home = () => {
               <h3 className="margin-top-4">
                 {t('home:requestsTable.heading')}
               </h3>
-            </div>
-            <div className="tablet:grid-col-12">
+            </Grid>
+
+            <Grid tablet={{ col: 12 }}>
               <Table defaultPageSize={10} />
-            </div>
+            </Grid>
+
+            <hr className="margin-bottom-3 margin-top-4" aria-hidden />
+
+            <Grid tablet={{ col: 12 }} className="margin-bottom-6">
+              <h2 className="margin-bottom-0 margin-top-4">
+                {t('systemProfile:systemTable.title')}
+              </h2>
+
+              <p className="margin-bottom-5">
+                {t('systemProfile:systemTable.subtitle')}
+              </p>
+
+              {loadingSystems || loadingBookmarks ? (
+                <PageLoading />
+              ) : (
+                <SystemsListTable
+                  systems={systemsTableData}
+                  savedBookmarks={bookmarks}
+                  refetchBookmarks={refetchBookmarks}
+                />
+              )}
+            </Grid>
           </div>
         );
       }

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -43,14 +43,19 @@ const Home = () => {
   });
 
   const { loading: loadingSystems, data: systems } = useQuery<GetCedarSystems>(
-    GetCedarSystemsQuery
+    GetCedarSystemsQuery,
+    {
+      skip: !user.isBasicUser(userGroups, flags)
+    }
   );
 
   const {
     loading: loadingBookmarks,
     data: systemsBookmarks,
     refetch: refetchBookmarks
-  } = useQuery<GetCedarSystemBookmarks>(GetCedarSystemBookmarksQuery);
+  } = useQuery<GetCedarSystemBookmarks>(GetCedarSystemBookmarksQuery, {
+    skip: !user.isBasicUser(userGroups, flags)
+  });
 
   const systemsTableData = (systems?.cedarSystems ?? []) as CedarSystem[];
   const bookmarks: CedarSystemBookmark[] =

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { Alert } from '@trussworks/react-uswds';
+import { Alert, Grid } from '@trussworks/react-uswds';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 
-import LinkCard from 'components/LinkCard';
+import LinkCard, { LinkRequestType } from 'components/LinkCard';
 import MainContent from 'components/MainContent';
 import PageHeading from 'components/PageHeading';
 import RequestRepository from 'components/RequestRepository';
@@ -24,6 +24,10 @@ const Home = () => {
   const flags = useFlags();
 
   const { message } = useMessage();
+
+  const requestTypes: Record<LinkRequestType, any> = t('home:actions', {
+    returnObjects: true
+  });
 
   const renderView = () => {
     if (isUserSet) {
@@ -66,28 +70,27 @@ const Home = () => {
                 {t('home:subtitle')}
               </p>
               <hr className="margin-bottom-4" aria-hidden />
-              <h2 className="margin-bottom-2">{t('home:actions.title')}</h2>
-              <div className="display-flex flex-row">
-                <LinkCard
-                  link="/system/making-a-request"
-                  heading={t('home:actions.itg.heading')}
-                  className="margin-right-2"
-                >
-                  {t('home:actions.itg.body')}
-                </LinkCard>
-                <LinkCard
-                  link="/508/making-a-request"
-                  heading={t('home:actions.508.heading')}
-                >
-                  {t('home:actions.508.body')}
-                </LinkCard>
-              </div>
+              <h2 className="margin-bottom-2">{t('home:actionTitle')}</h2>
+              <Grid row gap={2}>
+                {[
+                  { ITGov: requestTypes.ITGov },
+                  { TRB: requestTypes.TRB },
+                  { 508: requestTypes[508] }
+                ].map(requestType => (
+                  <Grid tablet={{ col: 4 }} key={Object.keys(requestType)[0]}>
+                    <LinkCard
+                      type={Object.keys(requestType)[0] as LinkRequestType}
+                    />
+                  </Grid>
+                ))}
+              </Grid>
+
               <h3 className="margin-top-4">
                 {t('home:requestsTable.heading')}
               </h3>
             </div>
             <div className="tablet:grid-col-12">
-              <Table defaultPageSize={50} />
+              <Table defaultPageSize={10} />
             </div>
           </div>
         );

--- a/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
+++ b/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
@@ -435,66 +435,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
     </div>
     <div
       class="grid-row grid-gap grid-gap-lg"
-    >
-      <nav
-        aria-label="Pagination"
-        class="usa-pagination padding-bottom-1 desktop:grid-col-fill"
-        data-testid="table-pagination"
-      >
-        <ul
-          class="usa-pagination__list"
-        >
-          <li
-            class="usa-pagination__item usa-pagination__page-no"
-          >
-            <div>
-              <div
-                class="usa-pagination__item"
-              >
-                <button
-                  aria-label="Page 1"
-                  class="usa-pagination__button usa-current"
-                  type="button"
-                >
-                  1
-                </button>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </nav>
-      <div
-        class="desktop:margin-top-2 desktop:grid-col-auto"
-      >
-        <select
-          class="usa-select margin-top-0 width-auto"
-          data-testid="table-page-size"
-          id="table-page-size"
-          name="tablePageSize"
-        >
-          <option
-            value="10"
-          >
-            Show 10
-          </option>
-          <option
-            value="25"
-          >
-            Show 25
-          </option>
-          <option
-            value="50"
-          >
-            Show 50
-          </option>
-          <option
-            value="100"
-          >
-            Show 100
-          </option>
-        </select>
-      </div>
-    </div>
+    />
     <div
       aria-live="polite"
       class="usa-sr-only usa-table__announcement-region"

--- a/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
+++ b/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
     >
       <span>
         <div>
-          Showing 1-4 of 4 results 
+          Showing 1-5 of 5 results 
         </div>
       </span>
     </div>
@@ -256,6 +256,44 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
         <tbody
           role="rowgroup"
         >
+          <tr
+            role="row"
+          >
+            <th
+              role="cell"
+              scope="row"
+              style="padding-left: 0px;"
+            >
+              <a
+                class="usa-link"
+                href="/"
+              >
+                My excellent question
+              </a>
+            </th>
+            <td
+              role="cell"
+              style="width: 150px; padding-left: 0px;"
+            >
+              TRB
+            </td>
+            <td
+              role="cell"
+              style="width: 150px; padding-left: 0px;"
+            >
+              03/07/2023
+            </td>
+            <td
+              role="cell"
+              style="width: 200px; padding-left: 0px;"
+            />
+            <td
+              role="cell"
+              style="width: 150px; padding-left: 0px;"
+            >
+              None
+            </td>
+          </tr>
           <tr
             role="row"
           >

--- a/src/views/MyRequests/Table/index.test.tsx
+++ b/src/views/MyRequests/Table/index.test.tsx
@@ -5,7 +5,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import GetRequestsQuery from 'queries/GetRequestsQuery';
-import { RequestType } from 'types/graphql-global-types';
+import { GetRequests as GetRequestsQueryType } from 'queries/types/GetRequests';
+import { RequestType, TRBRequestStatus } from 'types/graphql-global-types';
 
 import Table from '.';
 
@@ -22,7 +23,8 @@ describe('My Requests Table', () => {
             data: {
               requests: {
                 edges: []
-              }
+              },
+              trbRequests: []
             }
           }
         }
@@ -45,6 +47,79 @@ describe('My Requests Table', () => {
   });
 
   describe('when there are requests', () => {
+    const mockRequestData: GetRequestsQueryType = {
+      requests: {
+        __typename: 'RequestsConnection',
+        edges: [
+          {
+            __typename: 'RequestEdge',
+            node: {
+              __typename: 'Request',
+              id: '123',
+              name: '508 Test 1',
+              submittedAt: '2021-05-25T19:22:40Z',
+              type: RequestType.ACCESSIBILITY_REQUEST,
+              status: 'OPEN',
+              statusCreatedAt: '2021-05-25T19:22:40Z',
+              lcid: null,
+              nextMeetingDate: null
+            }
+          },
+          {
+            __typename: 'RequestEdge',
+            node: {
+              __typename: 'Request',
+              id: '909',
+              name: '508 Test 2',
+              submittedAt: '2021-05-25T19:22:40Z',
+              type: RequestType.ACCESSIBILITY_REQUEST,
+              status: 'IN_REMEDIATION',
+              statusCreatedAt: '2021-05-26T19:22:40Z',
+              lcid: null,
+              nextMeetingDate: null
+            }
+          },
+          {
+            __typename: 'RequestEdge',
+            node: {
+              __typename: 'Request',
+              id: '456',
+              name: 'Intake 1',
+              submittedAt: '2021-05-22T19:22:40Z',
+              type: RequestType.GOVERNANCE_REQUEST,
+              status: 'INTAKE_DRAFT',
+              statusCreatedAt: null,
+              lcid: null,
+              nextMeetingDate: null
+            }
+          },
+          {
+            __typename: 'RequestEdge',
+            node: {
+              __typename: 'Request',
+              id: '789',
+              name: 'Intake 2',
+              submittedAt: '2021-05-20T19:22:40Z',
+              type: RequestType.GOVERNANCE_REQUEST,
+              status: 'LCID_ISSUED',
+              statusCreatedAt: null,
+              lcid: 'A123456',
+              nextMeetingDate: null
+            }
+          }
+        ]
+      },
+      trbRequests: [
+        {
+          id: '1afc9242-f244-47a3-9f91-4d6fedd8eb91',
+          name: 'My excellent question',
+          nextMeetingDate: null,
+          status: TRBRequestStatus.OPEN,
+          submittedAt: '2023-03-07T15:09:17.694681Z',
+          __typename: 'TRBRequest'
+        }
+      ]
+    };
     const mocks = [
       {
         request: {
@@ -52,60 +127,7 @@ describe('My Requests Table', () => {
           variables: { first: 20 }
         },
         result: {
-          data: {
-            requests: {
-              edges: [
-                {
-                  node: {
-                    id: '123',
-                    name: '508 Test 1',
-                    submittedAt: '2021-05-25T19:22:40Z',
-                    type: 'ACCESSIBILITY_REQUEST',
-                    status: 'OPEN',
-                    statusCreatedAt: '2021-05-25T19:22:40Z',
-                    lcid: null,
-                    nextMeetingDate: null
-                  }
-                },
-                {
-                  node: {
-                    id: '909',
-                    name: '508 Test 2',
-                    submittedAt: '2021-05-25T19:22:40Z',
-                    type: 'ACCESSIBILITY_REQUEST',
-                    status: 'IN_REMEDIATION',
-                    statusCreatedAt: '2021-05-26T19:22:40Z',
-                    lcid: null,
-                    nextMeetingDate: null
-                  }
-                },
-                {
-                  node: {
-                    id: '456',
-                    name: 'Intake 1',
-                    submittedAt: '2021-05-22T19:22:40Z',
-                    type: 'GOVERNANCE_REQUEST',
-                    status: 'INTAKE_DRAFT',
-                    statusCreatedAt: null,
-                    lcid: null,
-                    nextMeetingDate: null
-                  }
-                },
-                {
-                  node: {
-                    id: '789',
-                    name: 'Intake 2',
-                    submittedAt: '2021-05-20T19:22:40Z',
-                    type: 'GOVERNANCE_REQUEST',
-                    status: 'LCID_ISSUED',
-                    statusCreatedAt: null,
-                    lcid: 'A123456',
-                    nextMeetingDate: null
-                  }
-                }
-              ]
-            }
-          }
+          data: mockRequestData
         }
       }
     ];
@@ -120,6 +142,10 @@ describe('My Requests Table', () => {
       );
 
       expect(await screen.findByRole('table')).toBeInTheDocument();
+      expect(await screen.findByText('Intake 2')).toBeInTheDocument();
+      expect(
+        await screen.findByText('My excellent question')
+      ).toBeInTheDocument();
     });
 
     it('displays an IT Goverance request only table with hidden columns', async () => {

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -43,7 +43,12 @@ const Table = ({
   hiddenColumns,
   defaultPageSize = 10
 }: myRequestsTableProps) => {
-  const { t } = useTranslation(['home', 'intake', 'accessibility']);
+  const { t } = useTranslation([
+    'home',
+    'intake',
+    'accessibility',
+    'technicalAssistance'
+  ]);
   const { loading, error, data: tableData } = useQuery<
     GetRequests,
     GetRequestsVariables
@@ -51,6 +56,8 @@ const Table = ({
     variables: { first: 20 },
     fetchPolicy: 'cache-and-network'
   });
+
+  console.log(tableData);
 
   const columns: any = useMemo(() => {
     return [
@@ -112,6 +119,8 @@ const Table = ({
               if (row.original.lcid) {
                 return `${value}: ${row.original.lcid}`;
               }
+              return value;
+            case t(`requestsTable.types.TRB`):
               return value;
             default:
               return '';

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -28,7 +28,7 @@ import {
   sortColumnValues
 } from 'utils/tableSort';
 
-import tableMap from './tableMap';
+import tableMap, { isTRBRequestType } from './tableMap';
 
 import '../index.scss';
 
@@ -57,8 +57,6 @@ const Table = ({
     fetchPolicy: 'cache-and-network'
   });
 
-  console.log(tableData);
-
   const columns: any = useMemo(() => {
     return [
       {
@@ -66,16 +64,22 @@ const Table = ({
         accessor: 'name',
         Cell: ({ row, value }: any) => {
           let link: string;
-          switch (row.original.type) {
-            case t('requestsTable.types.ACCESSIBILITY_REQUEST'):
-              link = `/508/requests/${row.original.id}`;
-              break;
-            case t('requestsTable.types.GOVERNANCE_REQUEST'):
-              link = `/governance-task-list/${row.original.id}`;
-              break;
-            default:
-              link = '/';
+
+          if (isTRBRequestType(row.original)) {
+            link = `/trb/task-list/${row.original.id}`;
+          } else {
+            switch (row.original.type) {
+              case t('requestsTable.types.ACCESSIBILITY_REQUEST'):
+                link = `/508/requests/${row.original.id}`;
+                break;
+              case t('requestsTable.types.GOVERNANCE_REQUEST'):
+                link = `/governance-task-list/${row.original.id}`;
+                break;
+              default:
+                link = '/';
+            }
           }
+
           return <UswdsReactLink to={link}>{value}</UswdsReactLink>;
         },
         width: '220px',

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -304,25 +304,30 @@ const Table = ({
       </UswdsTable>
 
       <div className="grid-row grid-gap grid-gap-lg">
-        <TablePagination
-          gotoPage={gotoPage}
-          previousPage={previousPage}
-          nextPage={nextPage}
-          canNextPage={canNextPage}
-          pageIndex={state.pageIndex}
-          pageOptions={pageOptions}
-          canPreviousPage={canPreviousPage}
-          pageCount={pageCount}
-          pageSize={state.pageSize}
-          setPageSize={setPageSize}
-          page={[]}
-          className="desktop:grid-col-fill"
-        />
-        <TablePageSize
-          className="desktop:grid-col-auto"
-          pageSize={state.pageSize}
-          setPageSize={setPageSize}
-        />
+        {data.length > 10 && (
+          <TablePagination
+            gotoPage={gotoPage}
+            previousPage={previousPage}
+            nextPage={nextPage}
+            canNextPage={canNextPage}
+            pageIndex={state.pageIndex}
+            pageOptions={pageOptions}
+            canPreviousPage={canPreviousPage}
+            pageCount={pageCount}
+            pageSize={state.pageSize}
+            setPageSize={setPageSize}
+            page={[]}
+            className="desktop:grid-col-fill"
+          />
+        )}
+
+        {data.length > 10 && (
+          <TablePageSize
+            className="desktop:grid-col-auto"
+            pageSize={state.pageSize}
+            setPageSize={setPageSize}
+          />
+        )}
       </div>
 
       <div

--- a/src/views/MyRequests/Table/tableMap.ts
+++ b/src/views/MyRequests/Table/tableMap.ts
@@ -1,6 +1,10 @@
 import { TFunction } from 'i18next';
 
-import { GetRequests } from 'queries/types/GetRequests';
+import {
+  GetRequests,
+  GetRequests_requests_edges_node as GetRequestsType,
+  GetRequests_trbRequests as GetTRBRequestsType
+} from 'queries/types/GetRequests';
 import { RequestType } from 'types/graphql-global-types';
 import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
 
@@ -9,43 +13,71 @@ import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
 // Here is where the data can be modified and used appropriately for sorting.
 // Modifed data can then be configured with JSX components in column cell configuration
 
+type MergedRequests = GetRequestsType | GetTRBRequestsType;
+
+// Type guard for checking request is of type GetTRBRequestsType/TRB
+// https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types
+const isTRBRequestType = (
+  request: MergedRequests
+): request is GetTRBRequestsType => {
+  /* eslint no-underscore-dangle: 0 */
+  return request.__typename === 'TRBRequest';
+};
+
 const tableMap = (
   tableData: GetRequests,
   t: TFunction,
   requestType?: RequestType
 ) => {
-  const requests = tableData?.requests?.edges.map(edge => {
-    return edge.node;
-  });
+  const requests: GetRequestsType[] =
+    tableData?.requests?.edges.map(edge => {
+      return edge.node;
+    }) || ([] as GetRequestsType[]);
 
-  const mappedData = requests
-    ?.filter(request => (!requestType ? true : request.type === requestType)) // if filter prop exists, filter by the request type
+  const trbRequests: GetTRBRequestsType[] = tableData?.trbRequests || [];
+
+  const mergedRequests: MergedRequests[] = [...requests, ...trbRequests];
+
+  const mappedData = mergedRequests
+    ?.filter(request =>
+      !requestType
+        ? true
+        : !isTRBRequestType(request) && request.type === requestType
+    ) // if filter prop exists, filter by the request type
     .map(request => {
       const name = request.name ? request.name : 'Draft';
 
-      const type: string = request.type
-        ? t(`requestsTable.types.${request.type}`)
-        : '';
+      const type: string =
+        !isTRBRequestType(request) && request.type
+          ? t(`requestsTable.types.${request.type}`)
+          : t(`requestsTable.types.TRB`);
 
-      let status;
-      switch (request.type) {
-        case RequestType.ACCESSIBILITY_REQUEST:
-          // Status hasn't changed if the status record created at is the same
-          // as the 508 request's submitted at
-          if (request.submittedAt === request.statusCreatedAt) {
+      let status = '';
+      if (!isTRBRequestType(request)) {
+        switch (request.type) {
+          case RequestType.ACCESSIBILITY_REQUEST:
+            // Status hasn't changed if the status record created at is the same
+            // as the 508 request's submitted at
+            if (request.submittedAt === request.statusCreatedAt) {
+              status = accessibilityRequestStatusMap[request.status];
+            }
             status = accessibilityRequestStatusMap[request.status];
-          }
-          status = accessibilityRequestStatusMap[request.status];
-          break;
-        case RequestType.GOVERNANCE_REQUEST:
-          status = t(`intake:statusMap.${request.status}`);
-          if (request.lcid) {
-            status = `${status}: ${request.lcid}`;
-          }
-          break;
-        default:
-          status = '';
-          break;
+            break;
+          case RequestType.GOVERNANCE_REQUEST:
+            status = t(`intake:statusMap.${request.status}`);
+            if (request.lcid) {
+              status = `${status}: ${request.lcid}`;
+            }
+            break;
+          default:
+            status = '';
+            break;
+        }
+      } else {
+        // TRB status
+        status = t(`adminHome.requestStatuses.${request.status}`, {
+          ns: 'technicalAssistance'
+        });
       }
 
       return {

--- a/src/views/MyRequests/Table/tableMap.ts
+++ b/src/views/MyRequests/Table/tableMap.ts
@@ -17,7 +17,7 @@ type MergedRequests = GetRequestsType | GetTRBRequestsType;
 
 // Type guard for checking request is of type GetTRBRequestsType/TRB
 // https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types
-const isTRBRequestType = (
+export const isTRBRequestType = (
   request: MergedRequests
 ): request is GetTRBRequestsType => {
   /* eslint no-underscore-dangle: 0 */

--- a/src/views/SystemList/Table.tsx
+++ b/src/views/SystemList/Table.tsx
@@ -207,6 +207,10 @@ export const Table = ({
 
   rows.map(row => prepareRow(row));
 
+  if (rows.length === 0) {
+    return <p>{t('systemTable.noResults')}</p>;
+  }
+
   return (
     <>
       <GlobalClientFilter


### PR DESCRIPTION
# EASI-2583
# EASI-1806

[Figma](https://www.figma.com/file/iGatgTnlzTuqW9CQFYHDam/TRB-Intake-e2e?node-id=390%3A46545&t=TZLHJ3hHkjJ0dBpz-0)

## Changes and Description

This PR is a combination of `EASI-2583` and `EASI-1806`, as I think it made sense to handle these together.  Adding the system list table was really straightforward.

- Added TRB requests to GetRequestsQuery
- Added type handling and data mapping for new combined query
  -  This is most likely temporary until the BE offloads this complexity
- Updated Basic user home page UI per Figma
- Adjusted `LinkCard` to better suit new UI
- Changed default table to 10 rows and only render table footer elements if more than 10
- Updated unit tests

![Screenshot 2023-03-07 at 3 30 34 PM](https://user-images.githubusercontent.com/95709965/223545239-ca41d6bf-a87e-4cea-a540-ab990f9b7042.png)

## How to test this change

- Verify TRB requests are now rendered in basic user home page
- Figma matches
- Tests succeed
- Can't break

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
