### PR TITLE
[EASI-2504] - TRB downgrade flag

### DIFF
--- a/src/types/flags.ts
+++ b/src/types/flags.ts
@@ -3,6 +3,7 @@ export type Flags = {
   downgradeGovTeam: boolean;
   downgrade508User: boolean;
   downgrade508Tester: boolean;
+  downgradeTrbAdmin: boolean;
   systemProfile: boolean;
   systemProfileHiddenFields: boolean;
   cedar508Requests: boolean;

--- a/src/utils/user.test.ts
+++ b/src/utils/user.test.ts
@@ -5,7 +5,9 @@ import {
   ACCESSIBILITY_TESTER_PROD,
   BASIC_USER_PROD,
   GOVTEAM_DEV,
-  GOVTEAM_PROD
+  GOVTEAM_PROD,
+  TRB_ADMIN_DEV,
+  TRB_ADMIN_PROD
 } from 'constants/jobCodes';
 import { Flags } from 'types/flags';
 
@@ -14,7 +16,8 @@ import {
   isAccessibilityTeam,
   isAccessibilityTester,
   isBasicUser,
-  isGrtReviewer
+  isGrtReviewer,
+  isTrbAdmin
 } from './user';
 
 describe('user', () => {
@@ -46,7 +49,7 @@ describe('user', () => {
       });
     });
 
-    describe('flags', () => {
+    describe('Gov team downgrade flags', () => {
       const groups = [GOVTEAM_DEV];
 
       describe('the downgrade flag is false', () => {
@@ -60,6 +63,23 @@ describe('user', () => {
         const flags = { downgradeGovTeam: true } as Flags;
         it('returns false', () => {
           expect(isGrtReviewer(groups, flags)).toBe(false);
+        });
+      });
+    });
+
+    describe('TRB downgrade flags', () => {
+      const groups = [TRB_ADMIN_DEV, TRB_ADMIN_PROD];
+      describe('the TRB downgrade flag is false', () => {
+        const flags = { downgradeTrbAdmin: false } as Flags;
+        it('returns true', () => {
+          expect(isTrbAdmin(groups, flags)).toBe(true);
+        });
+      });
+
+      describe('the TRB downgrade flag is true', () => {
+        const flags = { downgradeTrbAdmin: true } as Flags;
+        it('returns false', () => {
+          expect(isTrbAdmin(groups, flags)).toBe(false);
         });
       });
     });

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -11,7 +11,11 @@ import {
 } from 'constants/jobCodes';
 import { Flags } from 'types/flags';
 
-export const isTrbAdmin = (groups: Array<String> = []) => {
+export const isTrbAdmin = (groups: Array<String> = [], flags: Flags) => {
+  if (flags.downgradeTrbAdmin) {
+    return false;
+  }
+
   if (groups.includes(TRB_ADMIN_DEV) || groups.includes(TRB_ADMIN_PROD)) {
     return true;
   }
@@ -86,7 +90,7 @@ export const isBasicUser = (groups: Array<String> = [], flags: Flags) => {
   if (
     !isAccessibilityTeam(groups, flags) &&
     !isGrtReviewer(groups, flags) &&
-    !isTrbAdmin(groups)
+    !isTrbAdmin(groups, flags)
   ) {
     return true;
   }

--- a/src/views/FlagsWrapper/index.tsx
+++ b/src/views/FlagsWrapper/index.tsx
@@ -35,6 +35,7 @@ const UserTargetingWrapper = ({ children }: WrapperProps) => {
             downgradeGovTeam: false,
             downgrade508User: false,
             downgrade508Tester: false,
+            downgradeTrbAdmin: false,
             systemProfile: true,
             systemProfileHiddenFields: false,
             cedar508Requests: false,

--- a/src/views/Home/index.test.tsx
+++ b/src/views/Home/index.test.tsx
@@ -38,6 +38,7 @@ const defaultFlags: Flags = {
   downgrade508Tester: false,
   downgrade508User: false,
   downgradeGovTeam: false,
+  downgradeTrbAdmin: false,
   sandbox: true
 } as Flags;
 

--- a/src/views/Navigation/index.scss
+++ b/src/views/Navigation/index.scss
@@ -9,6 +9,9 @@
         background-color: 'white';
         z-index: 100;
     }
+
+    flex: 1 0 auto;
+    width: 100%;
 }
 
 .sticky-nav-header {

--- a/src/views/TechnicalAssistance/AdminHome/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/index.tsx
@@ -5,6 +5,7 @@ import { Link, Route, useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import { Grid, GridContainer, IconArrowBack } from '@trussworks/react-uswds';
 import classNames from 'classnames';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import PageLoading from 'components/PageLoading';
 import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
@@ -74,6 +75,8 @@ export default function AdminHome() {
   // Current user info from redux
   const { groups, isUserSet } = useSelector((state: AppState) => state.auth);
 
+  const flags = useFlags();
+
   // Get url params
   const { id, activePage } = useParams<{
     id: string;
@@ -131,7 +134,7 @@ export default function AdminHome() {
   }
 
   // If TRB request does not exist or user is not TRB admin, return page not found
-  if (!trbRequest || !user.isTrbAdmin(groups)) {
+  if (!trbRequest || !user.isTrbAdmin(groups, flags)) {
     return <NotFound />;
   }
 

--- a/src/views/TechnicalAssistance/Homepage.tsx
+++ b/src/views/TechnicalAssistance/Homepage.tsx
@@ -24,6 +24,7 @@ import {
   SiteAlert,
   Table
 } from '@trussworks/react-uswds';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import PageHeading from 'components/PageHeading';
@@ -52,6 +53,8 @@ import NotFound from 'views/NotFound';
 function Homepage() {
   const { t } = useTranslation('technicalAssistance');
   const { url } = useRouteMatch();
+
+  const flags = useFlags();
 
   // Current user info from redux
   const { groups, isUserSet } = useSelector((state: AppState) => state.auth);
@@ -155,7 +158,7 @@ function Homepage() {
     <>
       {
         // Admin site alert
-        user.isTrbAdmin(groups) && (
+        user.isTrbAdmin(groups, flags) && (
           <SiteAlert
             variant="info"
             heading={t('adminInfoBox.heading')}

--- a/src/views/User/index.tsx
+++ b/src/views/User/index.tsx
@@ -39,6 +39,8 @@ const UserInfo = () => {
           {`${user.isAccessibilityTester(userGroups, flags)}`}
         </p>
 
+        <p>User is TRB Admin: {`${user.isTrbAdmin(userGroups, flags)}`}</p>
+
         <h2>Raw Access Token Claims</h2>
         <pre>
           {JSON.stringify(


### PR DESCRIPTION
# EASI-2504

## Changes and Description

- Added LD flag for downgrading TRB Admin - `downgradeTrbAdmin`
- Added unit test

Additional minor change
- Added scss to ensure footer stays at bottom

<!-- Put a description here! -->

Log in as TRB admin with user targeting set in LD.  Verify the experience is downgraded to regular TRB user

Visit `/user-diagnostics` to verify

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
