### PR TITLE
[NOREF] Updated calculation of TRB feedback status when edits are requested

### DIFF
--- a/pkg/graph/resolvers/trb_request_status.go
+++ b/pkg/graph/resolvers/trb_request_status.go
@@ -44,8 +44,13 @@ func getTRBFeedbackStatus(ctx context.Context, store *storage.Store, trbRequestI
 	if feedback != nil {
 		// If the latest feedback exists, calculate the status based on the action
 		if feedback.Action == models.TRBFeedbackActionRequestEdits {
-			// If latest feedback requests edits, return "edits requested" status
-			status = models.TRBFeedbackStatus(models.TRBFeedbackStatusEditsRequested)
+			if form.Status == models.TRBFormStatusCompleted {
+				// If the form is completed, that means the edits were made
+				status = models.TRBFeedbackStatus(models.TRBFeedbackStatusInReview)
+			} else {
+				// If the form isn't complete, then "edits requested" still applies
+				status = models.TRBFeedbackStatus(models.TRBFeedbackStatusEditsRequested)
+			}
 		} else if feedback.Action == models.TRBFeedbackActionReadyForConsult {
 			// If latest feedback action is "ready for consult", return "completed" status
 			status = models.TRBFeedbackStatusCompleted


### PR DESCRIPTION
# NOREF

## Changes and Description

- Changed calculation of TRB feedback status to properly reflect when a form has been re-submitted for review after edits were requested

## How to test this change
Refer to https://github.com/CMSgov/easi-app/pull/1824 for detailed testing instructions

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
