### PR TITLE
[EASI-2754] - Table state persistence

### DIFF
--- a/src/components/AccessibilityRequestsTable/index.test.tsx
+++ b/src/components/AccessibilityRequestsTable/index.test.tsx
@@ -81,15 +81,15 @@ describe('AccessibilityRequestsTable', () => {
     );
 
     // User event to typing in query with debounce
-    await waitFor(() => {
-      userEvent.type(screen.getByRole('searchbox'), 'Burrito v1');
-    });
+    userEvent.type(screen.getByRole('searchbox'), 'Burrito v1');
 
     // Mocked time for debounce of input
     await waitFor(() => new Promise(res => setTimeout(res, 200)));
 
+    expect(screen.getByRole('searchbox')).toHaveValue('Burrito v1');
+
     // Burrito v2 is a mocked table row text item that should not be included in filtered results
-    expect(await screen.queryByText('Burrito v2')).toBeNull();
+    expect(screen.queryByText('Burrito v2')).toBeNull();
   });
 
   it('contains the expected values in the rows', () => {

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -58,6 +58,8 @@ const RequestRepository = () => {
 
   const { itGovAdmin } = useContext(TableStateContext);
 
+  // console.log(itGovAdmin);
+
   const [activeTable, setActiveTable] = useState<ActiveStateType>(
     itGovAdmin.current.activeTableState
   );

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -44,7 +44,7 @@ import {
   getHeaderSortIcon,
   sortColumnValues
 } from 'utils/tableSort';
-import { TableStateContext, TableTypes } from 'views/TableStateWrapper';
+import { ActiveStateType, TableStateContext } from 'views/TableStateWrapper';
 
 import csvHeaderMap from './csvHeaderMap';
 import tableMap from './tableMap';
@@ -58,7 +58,7 @@ const RequestRepository = () => {
 
   const { itGovAdmin } = useContext(TableStateContext);
 
-  const [activeTable, setActiveTable] = useState<TableTypes>(
+  const [activeTable, setActiveTable] = useState<ActiveStateType>(
     itGovAdmin.current.activeTableState
   );
 
@@ -68,14 +68,14 @@ const RequestRepository = () => {
 
   // Last sort states on active tables with their initial sort rules
   const [lastSort, setLastSort] = useState<
-    Record<TableTypes, SortingRule<{}>[]>
+    Record<ActiveStateType, SortingRule<{}>[]>
   >({
     open: [{ id: 'submittedAt', desc: true }],
     closed: [{ id: 'lastAdminNote', desc: true }]
   });
 
   // Select an active table and restore its last sort state
-  function selectActiveTable(nextActiveTable: TableTypes) {
+  function selectActiveTable(nextActiveTable: ActiveStateType) {
     if (nextActiveTable === activeTable) return;
     gotoPage(0);
     setLastSort(prev => ({ ...prev, [activeTable]: state.sortBy }));

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -58,8 +58,6 @@ const RequestRepository = () => {
 
   const { itGovAdmin } = useContext(TableStateContext);
 
-  // console.log(itGovAdmin);
-
   const [activeTable, setActiveTable] = useState<ActiveStateType>(
     itGovAdmin.current.activeTableState
   );

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -44,11 +44,7 @@ import {
   getHeaderSortIcon,
   sortColumnValues
 } from 'utils/tableSort';
-import {
-  TableSortType,
-  TableStateContext,
-  TableTypes
-} from 'views/TableStateWrapper';
+import { TableStateContext, TableTypes } from 'views/TableStateWrapper';
 
 import csvHeaderMap from './csvHeaderMap';
 import tableMap from './tableMap';
@@ -72,7 +68,7 @@ const RequestRepository = () => {
 
   // Last sort states on active tables with their initial sort rules
   const [lastSort, setLastSort] = useState<
-    Record<TableTypes, SortingRule<TableSortType>[]>
+    Record<TableTypes, SortingRule<string>[]>
   >({
     open: [{ id: 'submittedAt', desc: true }],
     closed: [{ id: 'lastAdminNote', desc: true }]

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -21,7 +21,6 @@ import {
   Table
 } from '@trussworks/react-uswds';
 import classnames from 'classnames';
-import { merge, omit } from 'lodash';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import MainContent from 'components/MainContent';
@@ -33,6 +32,7 @@ import TablePagination from 'components/TablePagination';
 import TableResults from 'components/TableResults';
 import { convertIntakeToCSV } from 'data/systemIntake';
 import useCheckResponsiveScreen from 'hooks/checkMobile';
+import useTableState from 'hooks/useTableState';
 import { GetSystemIntake_systemIntake_lastAdminNote as LastAdminNote } from 'queries/types/GetSystemIntake';
 import { AppState } from 'reducers/rootReducer';
 import { fetchSystemIntakes } from 'types/routines';
@@ -346,43 +346,8 @@ const RequestRepository = () => {
     return intakes.map(intake => convertIntakeToCSV(intake));
   };
 
-  // Navigates to previously view page || 0
-  useEffect(() => {
-    gotoPage(tableState.current.pageIndex!);
-  }, [gotoPage, tableState]);
-
-  // Sorts by previous view sort || desc:true, id: 'submittedAt'
-  useEffect(() => {
-    // console.log(tableState);
-    setSortBy(tableState.current.sortBy!);
-  }, [setSortBy, tableState]);
-
-  // Filters by previous search term || ''
-  useEffect(() => {
-    if (data.length) {
-      setGlobalFilter(tableState.current.globalFilter);
-    }
-  }, [data.length, setGlobalFilter, tableState]);
-
-  // Set's context on unmount and sets previous active table || 'open'
-  useEffect(() => {
-    activeTableState.current = activeTable;
-
-    return () => {
-      // Sortby is deep and not merged by shallow merge
-      tableState.current = merge(omit(tableState.current, 'sortBy'), state);
-      tableState.current.sortBy = state.sortBy;
-    };
-  }, [
-    tableState,
-    state.pageIndex,
-    activeTable,
-    state.globalFilter,
-    state.sortBy,
-    state.pageSize,
-    activeTableState,
-    state
-  ]);
+  // Sets persisted table state and stores state on unmount
+  useTableState(state, gotoPage, setSortBy, setGlobalFilter, activeTable, data);
 
   return (
     <MainContent className="padding-x-4 margin-bottom-5">

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -66,6 +66,10 @@ const RequestRepository = () => {
     activeTableState.current
   );
 
+  const defaultPageSize: number = window.localStorage['request-table-page-size']
+    ? Number(window.localStorage['request-table-page-size'])
+    : 50;
+
   // Last sort states on active tables with their initial sort rules
   const [lastSort, setLastSort] = useState<
     Record<TableTypes, SortingRule<TableSortType>[]>
@@ -77,6 +81,7 @@ const RequestRepository = () => {
   // Select an active table and restore its last sort state
   function selectActiveTable(nextActiveTable: TableTypes) {
     if (nextActiveTable === activeTable) return;
+    gotoPage(0);
     setLastSort(prev => ({ ...prev, [activeTable]: state.sortBy }));
     setActiveTable(nextActiveTable);
     setSortBy(lastSort[nextActiveTable]);
@@ -329,7 +334,7 @@ const RequestRepository = () => {
       autoResetPage: false,
       initialState: {
         sortBy: useMemo(() => lastSort[activeTable], [lastSort, activeTable]),
-        pageSize: tableState.current.pageSize
+        pageSize: defaultPageSize
       }
     },
     useFilters,

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -43,7 +43,11 @@ import {
   getHeaderSortIcon,
   sortColumnValues
 } from 'utils/tableSort';
-import { TableStateContext, TableTypes } from 'views/TableStateWrapper';
+import {
+  TableSortType,
+  TableStateContext,
+  TableTypes
+} from 'views/TableStateWrapper';
 
 import csvHeaderMap from './csvHeaderMap';
 import tableMap from './tableMap';
@@ -55,7 +59,9 @@ const RequestRepository = () => {
   const { t } = useTranslation('governanceReviewTeam');
   const dispatch = useDispatch();
 
-  const { tableState, tableQuery, tablePage } = useContext(TableStateContext);
+  const { tableState, tableQuery, tablePage, tableSort } = useContext(
+    TableStateContext
+  );
 
   const [activeTable, setActiveTable] = useState<TableTypes>(
     tableState.current
@@ -63,7 +69,7 @@ const RequestRepository = () => {
 
   // Last sort states on active tables with their initial sort rules
   const [lastSort, setLastSort] = useState<
-    Record<TableTypes, SortingRule<object>[]>
+    Record<TableTypes, SortingRule<TableSortType>[]>
   >({
     open: [{ id: 'submittedAt', desc: true }],
     closed: [{ id: 'lastAdminNote', desc: true }]
@@ -346,6 +352,10 @@ const RequestRepository = () => {
   }, [gotoPage, tablePage]);
 
   useEffect(() => {
+    setSortBy(tableSort.current);
+  }, [setSortBy, tableSort]);
+
+  useEffect(() => {
     if (data.length) {
       setGlobalFilter(tableQuery.current);
     }
@@ -360,6 +370,7 @@ const RequestRepository = () => {
 
     return () => {
       tableQuery.current = state.globalFilter;
+      tableSort.current = state.sortBy;
     };
   }, [
     tableState,
@@ -367,7 +378,9 @@ const RequestRepository = () => {
     tablePage,
     activeTable,
     tableQuery,
-    state.globalFilter
+    state.globalFilter,
+    tableSort,
+    state.sortBy
   ]);
 
   return (

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -59,9 +59,13 @@ const RequestRepository = () => {
   const { t } = useTranslation('governanceReviewTeam');
   const dispatch = useDispatch();
 
-  const { tableState, tableQuery, tablePage, tableSort } = useContext(
-    TableStateContext
-  );
+  const {
+    tableState,
+    tableQuery,
+    tablePage,
+    tableSort,
+    tablePageSize
+  } = useContext(TableStateContext);
 
   const [activeTable, setActiveTable] = useState<TableTypes>(
     tableState.current
@@ -330,7 +334,7 @@ const RequestRepository = () => {
       autoResetPage: false,
       initialState: {
         sortBy: useMemo(() => lastSort[activeTable], [lastSort, activeTable]),
-        pageSize: 10
+        pageSize: tablePageSize.current
       }
     },
     useFilters,
@@ -368,13 +372,11 @@ const RequestRepository = () => {
   useEffect(() => {
     tableState.current = activeTable;
 
-    if (tablePage.current !== state.pageIndex) {
-      tablePage.current = state.pageIndex;
-    }
-
     return () => {
+      tablePage.current = state.pageIndex;
       tableQuery.current = state.globalFilter;
       tableSort.current = state.sortBy;
+      tablePageSize.current = state.pageSize;
     };
   }, [
     tableState,
@@ -384,7 +386,9 @@ const RequestRepository = () => {
     tableQuery,
     state.globalFilter,
     tableSort,
-    state.sortBy
+    state.sortBy,
+    tablePageSize,
+    state.pageSize
   ]);
 
   return (

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -347,20 +347,24 @@ const RequestRepository = () => {
     return intakes.map(intake => convertIntakeToCSV(intake));
   };
 
+  // Navigates to previously view page || 0
   useEffect(() => {
     gotoPage(tablePage.current);
   }, [gotoPage, tablePage]);
 
+  // Sorts by previous view sort || desc:true, id: 'submittedAt'
   useEffect(() => {
     setSortBy(tableSort.current);
   }, [setSortBy, tableSort]);
 
+  // Filters by previous search term || ''
   useEffect(() => {
     if (data.length) {
       setGlobalFilter(tableQuery.current);
     }
   }, [data.length, setGlobalFilter, tableQuery]);
 
+  // Set's context on unmount and sets previous active table || 'open'
   useEffect(() => {
     tableState.current = activeTable;
 

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -68,7 +68,7 @@ const RequestRepository = () => {
 
   // Last sort states on active tables with their initial sort rules
   const [lastSort, setLastSort] = useState<
-    Record<TableTypes, SortingRule<string>[]>
+    Record<TableTypes, SortingRule<{}>[]>
   >({
     open: [{ id: 'submittedAt', desc: true }],
     closed: [{ id: 'lastAdminNote', desc: true }]

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -3,6 +3,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState
 } from 'react';
 import { CSVLink } from 'react-csv';
@@ -64,6 +65,9 @@ const RequestRepository = () => {
   const { tableState, setTableState, tableQuery, setTableQuery } = useContext(
     TableStateContext
   );
+
+  const searchTerm = useRef<string>(tableQuery);
+  const pageIndex = useRef<number>(tableState.pageIndex);
 
   const [activeTable, setActiveTable] = useState<TableTypes>('open');
 
@@ -370,18 +374,14 @@ const RequestRepository = () => {
   }, [state.globalFilter, setTableQuery]);
 
   useEffect(() => {
-    if (tableState.pageIndex !== state.pageIndex) {
-      gotoPage(tableState.pageIndex);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    gotoPage(pageIndex.current);
+  }, [gotoPage]);
 
   useEffect(() => {
     if (data.length) {
-      setGlobalFilter(tableQuery);
+      setGlobalFilter(searchTerm.current);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data.length]);
+  }, [data.length, setGlobalFilter]);
 
   useEffect(() => {
     selectActiveTable(tableState.state);

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -21,7 +21,7 @@ import {
   Table
 } from '@trussworks/react-uswds';
 import classnames from 'classnames';
-import { merge } from 'lodash';
+import { merge, omit } from 'lodash';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import MainContent from 'components/MainContent';
@@ -353,6 +353,7 @@ const RequestRepository = () => {
 
   // Sorts by previous view sort || desc:true, id: 'submittedAt'
   useEffect(() => {
+    // console.log(tableState);
     setSortBy(tableState.current.sortBy!);
   }, [setSortBy, tableState]);
 
@@ -368,7 +369,9 @@ const RequestRepository = () => {
     activeTableState.current = activeTable;
 
     return () => {
-      tableState.current = merge(tableState.current, state);
+      // Sortby is deep and not merged by shallow merge
+      tableState.current = merge(omit(tableState.current, 'sortBy'), state);
+      tableState.current.sortBy = state.sortBy;
     };
   }, [
     tableState,

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -60,10 +60,10 @@ const RequestRepository = () => {
   const { t } = useTranslation('governanceReviewTeam');
   const dispatch = useDispatch();
 
-  const { tableState, activeTableState } = useContext(TableStateContext);
+  const { itGovAdmin } = useContext(TableStateContext);
 
   const [activeTable, setActiveTable] = useState<TableTypes>(
-    activeTableState.current
+    itGovAdmin.current.activeTableState
   );
 
   const defaultPageSize: number = window.localStorage['request-table-page-size']
@@ -352,7 +352,15 @@ const RequestRepository = () => {
   };
 
   // Sets persisted table state and stores state on unmount
-  useTableState(state, gotoPage, setSortBy, setGlobalFilter, activeTable, data);
+  useTableState(
+    'itGovAdmin',
+    state,
+    gotoPage,
+    setSortBy,
+    setGlobalFilter,
+    activeTable,
+    data
+  );
 
   return (
     <MainContent className="padding-x-4 margin-bottom-5">
@@ -425,7 +433,7 @@ const RequestRepository = () => {
 
       <GlobalClientFilter
         setGlobalFilter={setGlobalFilter}
-        initialFilter={tableState.current.globalFilter}
+        initialFilter={itGovAdmin.current.state.globalFilter}
         tableID={t('requestRepository.id')}
         tableName={t('requestRepository.title')}
         className="margin-bottom-4"

--- a/src/components/TableFilter/__snapshots__/index.test.tsx.snap
+++ b/src/components/TableFilter/__snapshots__/index.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`Table Filter Componenet matches snapshot 1`] = `
       name="table-name Search"
       role="searchbox"
       type="search"
+      value=""
     />
     <button
       class="usa-button grid-row flex-justify-center flex-align-center no-pointer"

--- a/src/components/TableFilter/index.tsx
+++ b/src/components/TableFilter/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FilterValue, useAsyncDebounce } from 'react-table';
 import {
@@ -17,6 +17,7 @@ import './index.scss';
 
 type GlobalClientFilterProps = {
   setGlobalFilter: (filterValue: FilterValue) => void;
+  initialFilter?: string | undefined;
   tableID: string;
   tableName: string;
   className?: string;
@@ -25,11 +26,15 @@ type GlobalClientFilterProps = {
 // Component for Global Filter for Client Side filtering
 const GlobalClientFilter = ({
   setGlobalFilter,
+  initialFilter,
   tableID,
   tableName,
   className
 }: GlobalClientFilterProps) => {
   const { t } = useTranslation('systemProfile');
+
+  const [query, setQuery] = useState<string>(initialFilter || '');
+
   // Set a debounce to capture set input before re-rendering on each character.  Preparation for BE fetching/filtering.
   // May not be necessary until then
   const onChange = useAsyncDebounce(value => {
@@ -56,7 +61,9 @@ const GlobalClientFilter = ({
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           // Currently only client-side filtering - updates search filter onChange
           onChange(e.target.value);
+          setQuery(e.target.value);
         }}
+        value={query}
         name={`${tableName} Search`}
       />
       {/* Right not search button doesn't need to do anything, it searches onChange -

--- a/src/hooks/useTableState.ts
+++ b/src/hooks/useTableState.ts
@@ -1,0 +1,60 @@
+// Custom hook for handling mouse clicks outside of mobile expanded side nav
+
+import { useContext, useEffect } from 'react';
+import { FilterValue, SortingRule, TableState } from 'react-table';
+import { merge, omit } from 'lodash';
+
+import { TableStateContext, TableTypes } from 'views/TableStateWrapper';
+
+const useTableState = (
+  state: Partial<TableState>,
+  gotoPage: (updater: ((pageIndex: number) => number) | number) => void,
+  setSortBy: (sortBy: Array<SortingRule<{}>>) => void,
+  setGlobalFilter: (filterValue: FilterValue) => void,
+  activeTable: TableTypes,
+  data: any[]
+) => {
+  const { tableState, activeTableState } = useContext(TableStateContext);
+
+  // Navigates to previously view page || 0
+  useEffect(() => {
+    gotoPage(tableState.current.pageIndex!);
+  }, [gotoPage, tableState]);
+
+  // Sorts by previous view sort || desc:true, id: 'submittedAt'
+  useEffect(() => {
+    // console.log(tableState);
+    setSortBy(tableState.current.sortBy!);
+  }, [setSortBy, tableState]);
+
+  // Filters by previous search term || ''
+  useEffect(() => {
+    if (data.length) {
+      setGlobalFilter(tableState.current.globalFilter);
+    }
+  }, [data.length, setGlobalFilter, tableState]);
+
+  // Set's context on unmount and sets previous active table || 'open'
+  useEffect(() => {
+    activeTableState.current = activeTable;
+
+    return () => {
+      // Sortby is deep and not merged by shallow merge
+      tableState.current = merge(omit(tableState.current, 'sortBy'), state);
+      tableState.current.sortBy = state.sortBy;
+    };
+  }, [
+    tableState,
+    state.pageIndex,
+    activeTable,
+    state.globalFilter,
+    state.sortBy,
+    state.pageSize,
+    activeTableState,
+    state
+  ]);
+
+  return { tableState, activeTableState };
+};
+
+export default useTableState;

--- a/src/hooks/useTableState.ts
+++ b/src/hooks/useTableState.ts
@@ -31,6 +31,8 @@ const useTableState = (
 
   const tableState = tableStates[tableName];
 
+  console.log(tableState);
+
   // Stores page size in local storage on every selection change
   useEffect(() => {
     localStorage.setItem(

--- a/src/hooks/useTableState.ts
+++ b/src/hooks/useTableState.ts
@@ -52,16 +52,14 @@ const useTableState = (
   // Navigates to previously view page || 0
   // Sorts by previous view sort || desc:true, id: 'submittedAt'
   useEffect(() => {
-    gotoPage(tableState.current.state.pageIndex || 0);
-    setSortBy(
-      tableState.current.state.sortBy || [{ desc: true, id: 'submittedAt' }]
-    );
+    gotoPage(tableState.current.state.pageIndex);
+    setSortBy(tableState.current.state.sortBy);
   }, [gotoPage, setSortBy, tableState]);
 
   // Filters by previous search term || ''
   useEffect(() => {
     if (data.length) {
-      setGlobalFilter(tableState.current.state.globalFilter || '');
+      setGlobalFilter(tableState.current.state.globalFilter);
     }
   }, [data.length, setGlobalFilter, tableState]);
 

--- a/src/hooks/useTableState.ts
+++ b/src/hooks/useTableState.ts
@@ -31,8 +31,6 @@ const useTableState = (
 
   const tableState = tableStates[tableName];
 
-  console.log(tableState);
-
   // Stores page size in local storage on every selection change
   useEffect(() => {
     localStorage.setItem(

--- a/src/hooks/useTableState.ts
+++ b/src/hooks/useTableState.ts
@@ -6,10 +6,11 @@ Table setters are dependent on react-table exposed methods
 */
 
 import { useContext, useEffect } from 'react';
-import { FilterValue, SortingRule, TableState } from 'react-table';
+import { FilterValue, SortingRule } from 'react-table';
 import { assign } from 'lodash';
 
 import {
+  ReactTableStateType,
   TableStateContext,
   TableStatesTypes,
   TableTypes
@@ -17,7 +18,7 @@ import {
 
 const useTableState = (
   tableName: string,
-  state: Partial<TableState>,
+  state: ReactTableStateType,
   gotoPage: (updater: ((pageIndex: number) => number) | number) => void,
   setSortBy: (sortBy: Array<SortingRule<{}>>) => void,
   setGlobalFilter: (filterValue: FilterValue) => void,
@@ -58,6 +59,7 @@ const useTableState = (
 
   // Filters by previous search term || ''
   useEffect(() => {
+    // Needs to wait for data to be present - react-table resets globalFilter if initialized before data
     if (data.length) {
       setGlobalFilter(tableState.current.state.globalFilter);
     }

--- a/src/hooks/useTableState.ts
+++ b/src/hooks/useTableState.ts
@@ -10,10 +10,10 @@ import { FilterValue, SortingRule } from 'react-table';
 import { assign } from 'lodash';
 
 import {
+  ActiveStateType,
   ReactTableStateType,
   TableStateContext,
-  TableStatesTypes,
-  TableTypes
+  TableStates
 } from 'views/TableStateWrapper';
 
 const useTableState = (
@@ -22,10 +22,10 @@ const useTableState = (
   gotoPage: (updater: ((pageIndex: number) => number) | number) => void,
   setSortBy: (sortBy: Array<SortingRule<{}>>) => void,
   setGlobalFilter: (filterValue: FilterValue) => void,
-  activeTable: TableTypes,
+  activeTable: ActiveStateType,
   data: any[]
 ) => {
-  const tableStates: Record<string, TableStatesTypes> = useContext(
+  const tableStates: Record<string, TableStates> = useContext(
     TableStateContext
   );
 

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -42,6 +42,7 @@ import Sandbox from 'views/Sandbox';
 import SystemIntake from 'views/SystemIntake';
 import SystemList from 'views/SystemList';
 import SystemProfile from 'views/SystemProfile';
+import TableStateWrapper from 'views/TableStateWrapper';
 import TechnicalAssistance from 'views/TechnicalAssistance';
 import TermsAndConditions from 'views/TermsAndConditions';
 import TimeOutWrapper from 'views/TimeOutWrapper';
@@ -228,14 +229,16 @@ const App = () => {
               <UserInfoWrapper>
                 <TimeOutWrapper>
                   <NavContextProvider>
-                    <PageWrapper>
-                      <GovBanner />
-                      <Header />
-                      <Navigation>
-                        <AppRoutes />
-                      </Navigation>
-                      <Footer />
-                    </PageWrapper>
+                    <TableStateWrapper>
+                      <PageWrapper>
+                        <GovBanner />
+                        <Header />
+                        <Navigation>
+                          <AppRoutes />
+                        </Navigation>
+                        <Footer />
+                      </PageWrapper>
+                    </TableStateWrapper>
                   </NavContextProvider>
                 </TimeOutWrapper>
               </UserInfoWrapper>

--- a/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
+++ b/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
         name="Request Table Search"
         role="searchbox"
         type="search"
+        value=""
       />
       <button
         class="usa-button grid-row flex-justify-center flex-align-center no-pointer"

--- a/src/views/SystemList/__snapshots__/index.test.tsx.snap
+++ b/src/views/SystemList/__snapshots__/index.test.tsx.snap
@@ -96,6 +96,7 @@ exports[`System List View when there are requests matches snapshot 1`] = `
         name="All Systems Search"
         role="searchbox"
         type="search"
+        value=""
       />
       <button
         class="usa-button grid-row flex-justify-center flex-align-center no-pointer"

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -33,11 +33,7 @@ type ITGovRefType = MutableRefObject<ITGovTableState>;
 // Making extensible here for future table implementations
 export type TableStatesTypes = ITGovRefType;
 
-type TableStateContextType = {
-  [key: string]: TableStatesTypes;
-};
-
-const initialTableState: TableStateContextType = {
+const initialTableState: Record<string, TableStatesTypes> = {
   itGovAdmin: {
     current: {
       state: {
@@ -52,9 +48,9 @@ const initialTableState: TableStateContextType = {
 };
 
 // Create the table state context - fetched from IT gov table
-export const TableStateContext = createContext<TableStateContextType>(
-  initialTableState
-);
+export const TableStateContext = createContext<
+  Record<string, TableStatesTypes>
+>(initialTableState);
 
 const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
   // Checks to see if the current route is a part of IT Gov or home

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -1,6 +1,8 @@
 /*
-Context wrapper for getting and setting table states
+Context wrapper for persisting and setting react-table states
+Ex: <RequestRepository />
 */
+
 import React, {
   createContext,
   MutableRefObject,
@@ -69,6 +71,7 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
     initialTableState.tableSort.current
   );
 
+  // Reset the state to their inital state in the abscence of isGovTeamRoute
   useEffect(() => {
     if (!isGovTeamRoute) {
       tableQuery.current = initialTableState.tableQuery.current;

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -35,7 +35,6 @@ export type TableStatesTypes = ITGovRevType;
 
 type TableStateContextType = {
   [key: string]: TableStatesTypes;
-  itGovAdmin: ITGovRevType;
 };
 
 const initialTableState: TableStateContextType = {

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -59,14 +59,14 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
   const isGovTeamRoute: boolean =
     routeParams[1] === 'governance-review-team' || pathname === '/';
 
-  const itGovAdmin = useRef<ITGovTableState>(
-    initialTableStates.itGovAdmin.current
-  );
+  const itGovAdmin = useRef<ITGovTableState>({
+    ...initialTableStates.itGovAdmin.current
+  });
 
   // Reset the state to their inital state in the abscence of isGovTeamRoute
   useEffect(() => {
     if (!isGovTeamRoute) {
-      itGovAdmin.current = initialTableStates.itGovAdmin.current;
+      itGovAdmin.current = { ...initialTableStates.itGovAdmin.current };
     }
   }, [isGovTeamRoute]);
 

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -16,13 +16,14 @@ type TableStateWrapperProps = {
   children: React.ReactNode;
 };
 
-export type ActiveStateType = 'open' | 'closed';
-
 export type ReactTableStateType = Pick<
   TableState,
   'pageIndex' | 'globalFilter' | 'sortBy' | 'pageSize'
 >;
 
+export type ActiveStateType = 'open' | 'closed';
+
+// React-Table state properties / EASI table properties
 interface ITGovTableState {
   state: ReactTableStateType;
   activeTableState: ActiveStateType;

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -18,8 +18,13 @@ type TableStateWrapperProps = {
 
 export type TableTypes = 'open' | 'closed';
 
+export type ReactTableStateType = Pick<
+  TableState,
+  'pageIndex' | 'globalFilter' | 'sortBy' | 'pageSize'
+>;
+
 type ITGovTableState = {
-  state: Pick<TableState, 'pageIndex' | 'globalFilter' | 'sortBy' | 'pageSize'>;
+  state: ReactTableStateType;
   activeTableState: TableTypes;
 };
 

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -1,7 +1,6 @@
 /*
 Context wrapper for getting and setting table states
 */
-
 import React, {
   createContext,
   MutableRefObject,
@@ -9,6 +8,7 @@ import React, {
   useRef
 } from 'react';
 import { useLocation } from 'react-router-dom';
+import { SortingRule } from 'react-table';
 
 type TableStateWrapperProps = {
   children: React.ReactNode;
@@ -16,10 +16,16 @@ type TableStateWrapperProps = {
 
 export type TableTypes = 'open' | 'closed';
 
+export type TableSortType = {
+  desc: boolean;
+  id: string;
+};
+
 type TableStateContextType = {
   tableQuery: MutableRefObject<string>;
   tablePage: MutableRefObject<number>;
   tableState: MutableRefObject<TableTypes>;
+  tableSort: MutableRefObject<SortingRule<TableSortType>[]>;
 };
 
 const initialTableState: TableStateContextType = {
@@ -31,6 +37,14 @@ const initialTableState: TableStateContextType = {
   },
   tableState: {
     current: 'open'
+  },
+  tableSort: {
+    current: [
+      {
+        desc: true,
+        id: 'submittedAt'
+      }
+    ]
   }
 };
 
@@ -51,12 +65,16 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
   const tableQuery = useRef<string>(initialTableState.tableQuery.current);
   const tablePage = useRef<number>(initialTableState.tablePage.current);
   const tableState = useRef<TableTypes>(initialTableState.tableState.current);
+  const tableSort = useRef<SortingRule<TableSortType>[]>(
+    initialTableState.tableSort.current
+  );
 
   useEffect(() => {
     if (!isGovTeamRoute) {
       tableQuery.current = initialTableState.tableQuery.current;
       tablePage.current = initialTableState.tablePage.current;
       tableState.current = initialTableState.tableState.current;
+      tableSort.current = initialTableState.tableSort.current;
     }
   }, [isGovTeamRoute]);
 
@@ -64,9 +82,10 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
     // The Provider gives access to the context to its children
     <TableStateContext.Provider
       value={{
-        tableState,
         tableQuery,
-        tablePage
+        tablePage,
+        tableState,
+        tableSort
       }}
     >
       {children}

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -16,24 +16,22 @@ type TableStateWrapperProps = {
   children: React.ReactNode;
 };
 
-export type TableTypes = 'open' | 'closed';
+export type ActiveStateType = 'open' | 'closed';
 
 export type ReactTableStateType = Pick<
   TableState,
   'pageIndex' | 'globalFilter' | 'sortBy' | 'pageSize'
 >;
 
-type ITGovTableState = {
+interface ITGovTableState {
   state: ReactTableStateType;
-  activeTableState: TableTypes;
-};
-
-type ITGovRefType = MutableRefObject<ITGovTableState>;
+  activeTableState: ActiveStateType;
+}
 
 // Making extensible here for future table implementations
-export type TableStatesTypes = ITGovRefType;
+export interface TableStates extends MutableRefObject<ITGovTableState> {}
 
-const initialTableState: Record<string, TableStatesTypes> = {
+const initialTableState: Record<string, TableStates> = {
   itGovAdmin: {
     current: {
       state: {
@@ -48,9 +46,9 @@ const initialTableState: Record<string, TableStatesTypes> = {
 };
 
 // Create the table state context - fetched from IT gov table
-export const TableStateContext = createContext<
-  Record<string, TableStatesTypes>
->(initialTableState);
+export const TableStateContext = createContext<Record<string, TableStates>>(
+  initialTableState
+);
 
 const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
   // Checks to see if the current route is a part of IT Gov or home

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -2,7 +2,12 @@
 Context wrapper for getting and setting table states
 */
 
-import React, { createContext, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  MutableRefObject,
+  useEffect,
+  useRef
+} from 'react';
 import { useLocation } from 'react-router-dom';
 
 type TableStateWrapperProps = {
@@ -11,33 +16,28 @@ type TableStateWrapperProps = {
 
 export type TableTypes = 'open' | 'closed';
 
-type TableStateType = {
-  state: TableTypes;
-  pageIndex: number;
+type TableStateContextType = {
+  tableQuery: MutableRefObject<string>;
+  tablePage: MutableRefObject<number>;
+  tableState: MutableRefObject<TableTypes>;
 };
 
-type TableStateContextType = {
-  tableQuery: string;
-  tableState: TableStateType;
-  setTableState: React.Dispatch<React.SetStateAction<TableStateType>>;
-  setTableQuery: React.Dispatch<React.SetStateAction<string>>;
+const initialTableState: TableStateContextType = {
+  tableQuery: {
+    current: ''
+  },
+  tablePage: {
+    current: 0
+  },
+  tableState: {
+    current: 'open'
+  }
 };
 
 // Create the table state context - fetched from IT gov table
-export const TableStateContext = createContext<TableStateContextType>({
-  tableQuery: '',
-  tableState: {
-    state: 'open',
-    pageIndex: 0
-  },
-  setTableState: () => null,
-  setTableQuery: () => null
-});
-
-const initialTableState: TableStateType = {
-  state: 'open',
-  pageIndex: 0
-};
+export const TableStateContext = createContext<TableStateContextType>(
+  initialTableState
+);
 
 const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
   // Checks to see if the current route is a part of IT Gov or home
@@ -48,16 +48,15 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
   const isGovTeamRoute: boolean =
     routeParams[1] === 'governance-review-team' || pathname === '/';
 
-  const [tableState, setTableState] = useState<TableStateType>(
-    initialTableState
-  );
-
-  const [tableQuery, setTableQuery] = useState<string>('');
+  const tableQuery = useRef<string>(initialTableState.tableQuery.current);
+  const tablePage = useRef<number>(initialTableState.tablePage.current);
+  const tableState = useRef<TableTypes>(initialTableState.tableState.current);
 
   useEffect(() => {
     if (!isGovTeamRoute) {
-      setTableState(initialTableState);
-      setTableQuery('');
+      tableQuery.current = initialTableState.tableQuery.current;
+      tablePage.current = initialTableState.tablePage.current;
+      tableState.current = initialTableState.tableState.current;
     }
   }, [isGovTeamRoute]);
 
@@ -67,8 +66,7 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
       value={{
         tableState,
         tableQuery,
-        setTableQuery,
-        setTableState
+        tablePage
       }}
     >
       {children}

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -10,7 +10,7 @@ import React, {
   useRef
 } from 'react';
 import { useLocation } from 'react-router-dom';
-import { SortingRule } from 'react-table';
+import { TableState } from 'react-table';
 
 type TableStateWrapperProps = {
   children: React.ReactNode;
@@ -24,33 +24,21 @@ export type TableSortType = {
 };
 
 type TableStateContextType = {
-  tableQuery: MutableRefObject<string>;
-  tablePage: MutableRefObject<number>;
-  tablePageSize: MutableRefObject<number>;
-  tableState: MutableRefObject<TableTypes>;
-  tableSort: MutableRefObject<SortingRule<TableSortType>[]>;
+  tableState: MutableRefObject<Partial<TableState>>;
+  activeTableState: MutableRefObject<TableTypes>;
 };
 
 const initialTableState: TableStateContextType = {
-  tableQuery: {
-    current: ''
-  },
-  tablePage: {
-    current: 0
-  },
-  tablePageSize: {
-    current: 50
-  },
   tableState: {
-    current: 'open'
+    current: {
+      pageIndex: 0,
+      globalFilter: '',
+      sortBy: [{ desc: true, id: 'submittedAt' }],
+      pageSize: 50
+    }
   },
-  tableSort: {
-    current: [
-      {
-        desc: true,
-        id: 'submittedAt'
-      }
-    ]
+  activeTableState: {
+    current: 'open'
   }
 };
 
@@ -68,22 +56,18 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
   const isGovTeamRoute: boolean =
     routeParams[1] === 'governance-review-team' || pathname === '/';
 
-  const tableQuery = useRef<string>(initialTableState.tableQuery.current);
-  const tablePage = useRef<number>(initialTableState.tablePage.current);
-  const tablePageSize = useRef<number>(initialTableState.tablePageSize.current);
-  const tableState = useRef<TableTypes>(initialTableState.tableState.current);
-  const tableSort = useRef<SortingRule<TableSortType>[]>(
-    initialTableState.tableSort.current
+  const tableState = useRef<Partial<TableState>>(
+    initialTableState.tableState.current
+  );
+  const activeTableState = useRef<TableTypes>(
+    initialTableState.activeTableState.current
   );
 
   // Reset the state to their inital state in the abscence of isGovTeamRoute
   useEffect(() => {
     if (!isGovTeamRoute) {
-      tableQuery.current = initialTableState.tableQuery.current;
-      tablePage.current = initialTableState.tablePage.current;
-      tablePageSize.current = initialTableState.tablePageSize.current;
       tableState.current = initialTableState.tableState.current;
-      tableSort.current = initialTableState.tableSort.current;
+      activeTableState.current = initialTableState.activeTableState.current;
     }
   }, [isGovTeamRoute]);
 
@@ -91,11 +75,8 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
     // The Provider gives access to the context to its children
     <TableStateContext.Provider
       value={{
-        tableQuery,
-        tablePage,
-        tablePageSize,
         tableState,
-        tableSort
+        activeTableState
       }}
     >
       {children}

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -24,14 +24,14 @@ export type TableSortType = {
 };
 
 type ITGovTableState = {
-  state: Partial<TableState>;
+  state: Pick<TableState, 'pageIndex' | 'globalFilter' | 'sortBy' | 'pageSize'>;
   activeTableState: TableTypes;
 };
 
-type ITGovRevType = MutableRefObject<ITGovTableState>;
+type ITGovRefType = MutableRefObject<ITGovTableState>;
 
 // Making extensible here for future table implementations
-export type TableStatesTypes = ITGovRevType;
+export type TableStatesTypes = ITGovRefType;
 
 type TableStateContextType = {
   [key: string]: TableStatesTypes;

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -1,0 +1,79 @@
+/*
+Context wrapper for getting and setting table states
+*/
+
+import React, { createContext, useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+type TableStateWrapperProps = {
+  children: React.ReactNode;
+};
+
+export type TableTypes = 'open' | 'closed';
+
+type TableStateType = {
+  state: TableTypes;
+  pageIndex: number;
+};
+
+type TableStateContextType = {
+  tableQuery: string;
+  tableState: TableStateType;
+  setTableState: React.Dispatch<React.SetStateAction<TableStateType>>;
+  setTableQuery: React.Dispatch<React.SetStateAction<string>>;
+};
+
+// Create the table state context - fetched from IT gov table
+export const TableStateContext = createContext<TableStateContextType>({
+  tableQuery: '',
+  tableState: {
+    state: 'open',
+    pageIndex: 0
+  },
+  setTableState: () => null,
+  setTableQuery: () => null
+});
+
+const initialTableState: TableStateType = {
+  state: 'open',
+  pageIndex: 0
+};
+
+const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
+  // Checks to see if the current route is a part of IT Gov or home
+  const { pathname } = useLocation();
+
+  const routeParams: string[] = pathname.split('/');
+
+  const isGovTeamRoute: boolean =
+    routeParams[1] === 'governance-review-team' || pathname === '/';
+
+  const [tableState, setTableState] = useState<TableStateType>(
+    initialTableState
+  );
+
+  const [tableQuery, setTableQuery] = useState<string>('');
+
+  useEffect(() => {
+    if (!isGovTeamRoute) {
+      setTableState(initialTableState);
+      setTableQuery('');
+    }
+  }, [isGovTeamRoute]);
+
+  return (
+    // The Provider gives access to the context to its children
+    <TableStateContext.Provider
+      value={{
+        tableState,
+        tableQuery,
+        setTableQuery,
+        setTableState
+      }}
+    >
+      {children}
+    </TableStateContext.Provider>
+  );
+};
+
+export default TableStateWrapper;

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -18,11 +18,6 @@ type TableStateWrapperProps = {
 
 export type TableTypes = 'open' | 'closed';
 
-export type TableSortType = {
-  desc: boolean;
-  id: string;
-};
-
 type ITGovTableState = {
   state: Pick<TableState, 'pageIndex' | 'globalFilter' | 'sortBy' | 'pageSize'>;
   activeTableState: TableTypes;

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -26,6 +26,7 @@ export type TableSortType = {
 type TableStateContextType = {
   tableQuery: MutableRefObject<string>;
   tablePage: MutableRefObject<number>;
+  tablePageSize: MutableRefObject<number>;
   tableState: MutableRefObject<TableTypes>;
   tableSort: MutableRefObject<SortingRule<TableSortType>[]>;
 };
@@ -36,6 +37,9 @@ const initialTableState: TableStateContextType = {
   },
   tablePage: {
     current: 0
+  },
+  tablePageSize: {
+    current: 50
   },
   tableState: {
     current: 'open'
@@ -66,6 +70,7 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
 
   const tableQuery = useRef<string>(initialTableState.tableQuery.current);
   const tablePage = useRef<number>(initialTableState.tablePage.current);
+  const tablePageSize = useRef<number>(initialTableState.tablePageSize.current);
   const tableState = useRef<TableTypes>(initialTableState.tableState.current);
   const tableSort = useRef<SortingRule<TableSortType>[]>(
     initialTableState.tableSort.current
@@ -76,6 +81,7 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
     if (!isGovTeamRoute) {
       tableQuery.current = initialTableState.tableQuery.current;
       tablePage.current = initialTableState.tablePage.current;
+      tablePageSize.current = initialTableState.tablePageSize.current;
       tableState.current = initialTableState.tableState.current;
       tableSort.current = initialTableState.tableSort.current;
     }
@@ -87,6 +93,7 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
       value={{
         tableQuery,
         tablePage,
+        tablePageSize,
         tableState,
         tableSort
       }}

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -32,7 +32,7 @@ interface ITGovTableState {
 // Making extensible here for future table implementations
 export interface TableStates extends MutableRefObject<ITGovTableState> {}
 
-const initialTableState: Record<string, TableStates> = {
+const initialTableStates: Record<string, TableStates> = {
   itGovAdmin: {
     current: {
       state: {
@@ -46,9 +46,8 @@ const initialTableState: Record<string, TableStates> = {
   }
 };
 
-// Create the table state context - fetched from IT gov table
 export const TableStateContext = createContext<Record<string, TableStates>>(
-  initialTableState
+  initialTableStates
 );
 
 const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
@@ -61,13 +60,13 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
     routeParams[1] === 'governance-review-team' || pathname === '/';
 
   const itGovAdmin = useRef<ITGovTableState>(
-    initialTableState.itGovAdmin.current
+    initialTableStates.itGovAdmin.current
   );
 
   // Reset the state to their inital state in the abscence of isGovTeamRoute
   useEffect(() => {
     if (!isGovTeamRoute) {
-      itGovAdmin.current = initialTableState.itGovAdmin.current;
+      itGovAdmin.current = initialTableStates.itGovAdmin.current;
     }
   }, [isGovTeamRoute]);
 

--- a/src/views/TableStateWrapper/index.tsx
+++ b/src/views/TableStateWrapper/index.tsx
@@ -23,22 +23,32 @@ export type TableSortType = {
   id: string;
 };
 
+type ITGovTableState = {
+  state: Partial<TableState>;
+  activeTableState: TableTypes;
+};
+
+type ITGovRevType = MutableRefObject<ITGovTableState>;
+
+// Making extensible here for future table implementations
+export type TableStatesTypes = ITGovRevType;
+
 type TableStateContextType = {
-  tableState: MutableRefObject<Partial<TableState>>;
-  activeTableState: MutableRefObject<TableTypes>;
+  [key: string]: TableStatesTypes;
+  itGovAdmin: ITGovRevType;
 };
 
 const initialTableState: TableStateContextType = {
-  tableState: {
+  itGovAdmin: {
     current: {
-      pageIndex: 0,
-      globalFilter: '',
-      sortBy: [{ desc: true, id: 'submittedAt' }],
-      pageSize: 50
+      state: {
+        pageIndex: 0,
+        globalFilter: '',
+        sortBy: [{ desc: true, id: 'submittedAt' }],
+        pageSize: 50
+      },
+      activeTableState: 'open'
     }
-  },
-  activeTableState: {
-    current: 'open'
   }
 };
 
@@ -56,29 +66,20 @@ const TableStateWrapper = ({ children }: TableStateWrapperProps) => {
   const isGovTeamRoute: boolean =
     routeParams[1] === 'governance-review-team' || pathname === '/';
 
-  const tableState = useRef<Partial<TableState>>(
-    initialTableState.tableState.current
-  );
-  const activeTableState = useRef<TableTypes>(
-    initialTableState.activeTableState.current
+  const itGovAdmin = useRef<ITGovTableState>(
+    initialTableState.itGovAdmin.current
   );
 
   // Reset the state to their inital state in the abscence of isGovTeamRoute
   useEffect(() => {
     if (!isGovTeamRoute) {
-      tableState.current = initialTableState.tableState.current;
-      activeTableState.current = initialTableState.activeTableState.current;
+      itGovAdmin.current = initialTableState.itGovAdmin.current;
     }
   }, [isGovTeamRoute]);
 
   return (
     // The Provider gives access to the context to its children
-    <TableStateContext.Provider
-      value={{
-        tableState,
-        activeTableState
-      }}
-    >
+    <TableStateContext.Provider value={{ itGovAdmin }}>
       {children}
     </TableStateContext.Provider>
   );

--- a/src/views/TechnicalAssistance/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/__snapshots__/index.test.tsx.snap
@@ -604,6 +604,7 @@ exports[`Technical Assistance (TRB) homepage renders the homepage with a list of
             name="systemTable.title Search"
             role="searchbox"
             type="search"
+            value=""
           />
           <button
             class="usa-button grid-row flex-justify-center flex-align-center no-pointer"


### PR DESCRIPTION
# EASI-2754

## Changes and Description

- Added context for storing/removing table state
  - Context state is refreshed on absence of IT Gov routes `/governance-review-team`
- Added method to persist page size in local storage for more permanent persistence
- Added hook `useTableState` for setting and storing state for react-table
- Updated test

Persisted Context State:
Active table (open/closed)
Page index
Column Sort
Query/global filter

Persisted Local Storage State:
Page size

As is, local storage page size is set to a single string key, may want to develop this further if we find users want different page sizes for difference tables.  

This state management is only configured for IT Gov admin home table, but can be expanded in the future if needed

## How to test this change

- Log in as IT Gov admin
- Change page index, sort, query, or active table
- Navigate to an admin view of request
- Navigate to different pages within the request
- Return to home table and verify state was persisted and set
- Navigate to any other page besides IT Gov request and return to. home table
- Verify state has been reset
Page size is the only state to persist in local storage on selection change
- Change page size selection and immediate refresh the browser to verify state persisted and set

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
