### PR TITLE
[NOREF] - useCacheQuery hook for 'cache-and-network' fetchPolicy

### DIFF
--- a/src/hooks/useCacheQuery.ts
+++ b/src/hooks/useCacheQuery.ts
@@ -3,6 +3,28 @@ useQuery wrapper hook to return an accurate loading state for the fetch-policy o
 Computes loading state of both cache and network loading
 Returns loading=false if cache exists, regardless if network is making a request
 Returns loading=true if cache does not exist and network is making a request
+
+Current EASI Apollo fetchPolicy is set to 'cache-and-network' as default
+Apollo's loading state only reflects network requests, despite the presence of cache
+Since 'cache-and-network' always sends a network request, the loading state will never reflect the presence of cache
+
+Issue and alternative solutions referenced here:
+https://github.com/apollographql/react-apollo/issues/2601
+*/
+
+/*
+Implementation (should be identical to `useQuery`):
+
+const { data, loading, error } = useCacheQuery<
+    GetQueryType,
+    GetQueryVariables
+  >(GetQuery, {
+    variables: { id: id }
+  });
+
+if (loading) {
+    return <PageLoading />
+}
 */
 
 import {

--- a/src/hooks/useCacheQuery.ts
+++ b/src/hooks/useCacheQuery.ts
@@ -1,0 +1,41 @@
+/*
+useQuery wrapper hook to return an accurate loading state for the fetch-policy of cache-and-network
+Computes loading state of both cache and network loading
+Returns loading=false if cache exists, regardless if network is making a request
+Returns loading=true if cache does not exist and network is making a request
+*/
+
+import {
+  DocumentNode,
+  OperationVariables,
+  QueryHookOptions,
+  QueryResult,
+  TypedDocumentNode,
+  useApolloClient,
+  useQuery
+} from '@apollo/client';
+
+export default function useCacheQuery<
+  TData = any,
+  TVariables = OperationVariables
+>(
+  query: DocumentNode | TypedDocumentNode<TData, TVariables>,
+  options?: QueryHookOptions<TData, TVariables>
+): QueryResult<TData, TVariables> {
+  const { cache } = useApolloClient();
+
+  const queryResult = useQuery<TData, TVariables>(query, options);
+
+  return {
+    ...queryResult,
+    loading:
+      // Checks to see if the existing cache can be fetched for the current request
+      // Returns a combined state of an existing complete cache and network loading
+      !cache.diff({
+        query: cache.transformDocument(query),
+        variables: options?.variables,
+        returnPartialData: true,
+        optimistic: false
+      }).complete && queryResult.loading
+  };
+}


### PR DESCRIPTION
# NOREF

## Changes and Description

- Added hook for accurate loading state of cache-and-network fetchPolicy

https://oddball.slack.com/archives/C037ZNEQ7DH/p1679922179511309

## How to test this change

Use this hook in the exact same way as you would `useQuery` for any fetchPolicy
Should accurately reflect loading state despite cache or network requests

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
