### PR TITLE
[EASI-2717] Sanitize CSV input

### DIFF
--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -269,7 +269,7 @@ export const convertIntakeToCSV = (
     });
   }
 
-  return {
+  return cleanCSVData({
     ...intake,
     ...collaboratorTeams,
     lastAdminNote: intake.lastAdminNote
@@ -294,7 +294,43 @@ export const convertIntakeToCSV = (
     createdAt: intake.createdAt,
     decidedAt: intake.decidedAt,
     archivedAt: intake.archivedAt
-  };
+  });
+};
+
+// Sanitize data for CSV export by escaping characters that could cause Excel DDE issues.
+// https://github.com/react-csv/react-csv/issues/156#issuecomment-517017565
+// https://jiraent.cms.gov/browse/EASI-2717
+export const cleanCSVData = (data: any): any => {
+  /** safety check because typeof null === 'object' */
+  if (data === null) {
+    return null;
+  }
+
+  /** if the child is an array, recursively sanitize the data */
+  if (Array.isArray(data)) {
+    return data.map(eachValue => {
+      return cleanCSVData(eachValue);
+    });
+  }
+
+  /** if the child is an object,  recursively clean the values of each key */
+  if (typeof data === 'object') {
+    return Object.keys(data).reduce((acc: any, eachKey) => {
+      acc[eachKey] = cleanCSVData(data[eachKey]);
+      return acc;
+    }, {});
+  }
+
+  /** if it's a boolean or number, no need to sanitize */
+  if (typeof data === 'boolean' || typeof data === 'number') {
+    return data;
+  }
+
+  /**
+   * fairly confident this should be typecast as a string by now
+   * basically, just chuck a backslash in front of any + or = characters
+   */
+  return (data as string).replace(/[+|=]/g, match => `\\${match}`);
 };
 
 /**


### PR DESCRIPTION
# EASI-2717

## Changes and Description

- Added CSV sanitization to intake download

## How to test this change

- Start the app with `scripts/dev up`
- Seed the database with `scripts/dev db:seed`
- Create and submit a new intake that contains `=` and `+` in it
- As an IT Gov admin, go to the home page and download all requests as csv
- Ensure that `+` and `=` characters have slashes before them to ensure that Excel won't parse this data as a formula

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
