### PR TITLE
[NOREF] - Corrected contactRole enum mapping

### DIFF
--- a/src/components/EmailRecipientFields/__snapshots__/index.test.tsx.snap
+++ b/src/components/EmailRecipientFields/__snapshots__/index.test.tsx.snap
@@ -426,7 +426,7 @@ exports[`Email recipient fields component renders Add Attendee form 1`] = `
             />
             <option
               label="Contracting Officer’s Representative (COR)"
-              value="CONTRACT_REP"
+              value="CONTRACT_OFFICE_RSREPRESENTATIVE"
             />
             <option
               label="Cloud Navigator"

--- a/src/i18n/en-US/technicalAssistance.ts
+++ b/src/i18n/en-US/technicalAssistance.ts
@@ -566,7 +566,8 @@ const technicalAssistance = {
       PRODUCT_OWNER: 'Product Owner',
       SYSTEM_OWNER: 'System Owner',
       SYSTEM_MAINTAINER: 'System Maintainer',
-      CONTRACT_REP: 'Contracting Officer’s Representative (COR)',
+      CONTRACT_OFFICE_RSREPRESENTATIVE:
+        'Contracting Officer’s Representative (COR)',
       CLOUD_NAVIGATOR: 'Cloud Navigator',
       PRIVACY_ADVISOR: 'Privacy Advisor',
       CRA: 'CRA',


### PR DESCRIPTION
# EASI-000

## Changes and Description

`Contracting Officer’s Representative (COR)` (contactRoles translation)role selection on TRB attendees was not mapped properly to enum `PersonRoles` and failing schema validation that was expecting `PersonRoles`

- Corrected contactRole enum mapping
- Updated snap

<!-- Put a description here! -->

## How to test this change

Verify you can set `Contracting Officer’s Representative (COR)` role on the requester or attenddee

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
