### PR TITLE
[EASI-2567] Frontend for Editing System Intake Admin Notes

### DIFF
--- a/cypress/e2e/governanceReviewTeam.cy.js
+++ b/cypress/e2e/governanceReviewTeam.cy.js
@@ -130,6 +130,49 @@ describe('Governance Review Team', () => {
     });
   });
 
+  it('can edit a note', () => {
+    // Selecting name based on pre-seeded data
+    // A Completed Intake Form - af7a3924-3ff7-48ec-8a54-b8b4bc95610b
+    cy.contains('a', 'A Completed Intake Form').should('be.visible').click();
+    cy.get(
+      'a[href="/governance-review-team/af7a3924-3ff7-48ec-8a54-b8b4bc95610b/notes"]'
+    ).click();
+
+    cy.get('[data-testid="user-note"]').then(() => {
+      cy.get('#GovernanceReviewTeam-EditNoteButton').click();
+
+      const noteFixture = 'Test note';
+      cy.get('#GovernanceReviewTeam-EditNote').contains(noteFixture);
+
+      cy.get('#GovernanceReviewTeam-EditNote')
+        .type(' edited', { force: true })
+        .should('have.value', 'Test note edited');
+
+      cy.get('#GovernanceReviewTeam-SaveEditsButton').click({ force: true });
+
+      cy.get('[data-testid="user-note"]').first().contains('Test note edited');
+    });
+  });
+
+  it('can remove/archive a note', () => {
+    // Selecting name based on pre-seeded data
+    // A Completed Intake Form - af7a3924-3ff7-48ec-8a54-b8b4bc95610b
+    cy.contains('a', 'A Completed Intake Form').should('be.visible').click();
+    cy.get(
+      'a[href="/governance-review-team/af7a3924-3ff7-48ec-8a54-b8b4bc95610b/notes"]'
+    ).click();
+
+    cy.get('[data-testid="user-note"]').then(notes => {
+      const numOfNotes = notes.length;
+
+      cy.get('#GovernanceReviewTeam-RemoveNoteButton').click();
+
+      cy.get('#GovernanceReviewTeam-SaveArchiveButton').click({ force: true });
+
+      cy.get('[data-testid="user-note"]').should('have.length', numOfNotes - 1);
+    });
+  });
+
   it('can issue a Lifecycle ID', () => {
     // Selecting name based on pre-seeded data
     // A Completed Intake Form - af7a3924-3ff7-48ec-8a54-b8b4bc95610b

--- a/src/i18n/en-US/articles/governanceReviewTeam.ts
+++ b/src/i18n/en-US/articles/governanceReviewTeam.ts
@@ -112,6 +112,26 @@ const governanceReviewTeam = {
     }
   },
   notes: {
+    edit: 'Edit this note',
+    editModal: {
+      header: 'Edit note',
+      description:
+        'Editing your admin note will replace the current note. If you have new information to add, please consider adding a new note. Also, editing this note will not update the original timestamp. Please add a new note if you wish to update the timestamp.',
+      contentLabel: 'Note content',
+      saveEdits: 'Save edits',
+      cancel: 'Cancel',
+      error:
+        'There was a problem saving your edits. Please try again. If the error persists, please try again at a later date.'
+    },
+    remove: 'Remove this note',
+    removeModal: {
+      header: 'Are you sure you want to remove this admin note?',
+      description: 'This action cannot be undone',
+      removeNote: 'Remove note',
+      cancel: 'Cancel',
+      error:
+        'There was a problem removing your note. Please try again. If the error persists, please try again at a later date.'
+    },
     heading: 'Admin team notes',
     addNote: 'Add a note',
     addNoteCta: 'Add note',

--- a/src/queries/GetAdminNotesAndActionsQuery.ts
+++ b/src/queries/GetAdminNotesAndActionsQuery.ts
@@ -1,9 +1,9 @@
 import { gql } from '@apollo/client';
 
+// TODO: look into adding id field into systemIntake return object - doing this causes some weird behavior with caching (and thus not refetching system intakes)
 export default gql`
   query GetAdminNotesAndActions($id: UUID!) {
     systemIntake(id: $id) {
-      id
       lcid
       notes {
         id

--- a/src/queries/GetAdminNotesAndActionsQuery.ts
+++ b/src/queries/GetAdminNotesAndActionsQuery.ts
@@ -3,11 +3,18 @@ import { gql } from '@apollo/client';
 export default gql`
   query GetAdminNotesAndActions($id: UUID!) {
     systemIntake(id: $id) {
+      id
       lcid
       notes {
         id
         createdAt
         content
+        editor {
+          commonName
+        }
+        modifiedBy
+        modifiedAt
+        isArchived
         author {
           name
           eua

--- a/src/queries/UpdateSystemIntakeNoteQuery.ts
+++ b/src/queries/UpdateSystemIntakeNoteQuery.ts
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  mutation UpdateSystemIntakeNote($input: UpdateSystemIntakeNoteInput!) {
+    updateSystemIntakeNote(input: $input) {
+      id
+      content
+    }
+  }
+`;

--- a/src/queries/types/GetAdminNotesAndActions.ts
+++ b/src/queries/types/GetAdminNotesAndActions.ts
@@ -62,7 +62,6 @@ export interface GetAdminNotesAndActions_systemIntake_actions {
 
 export interface GetAdminNotesAndActions_systemIntake {
   __typename: "SystemIntake";
-  id: UUID;
   lcid: string | null;
   notes: GetAdminNotesAndActions_systemIntake_notes[];
   actions: GetAdminNotesAndActions_systemIntake_actions[];

--- a/src/queries/types/GetAdminNotesAndActions.ts
+++ b/src/queries/types/GetAdminNotesAndActions.ts
@@ -9,6 +9,11 @@ import { SystemIntakeActionType } from "./../../types/graphql-global-types";
 // GraphQL query operation: GetAdminNotesAndActions
 // ====================================================
 
+export interface GetAdminNotesAndActions_systemIntake_notes_editor {
+  __typename: "UserInfo";
+  commonName: string;
+}
+
 export interface GetAdminNotesAndActions_systemIntake_notes_author {
   __typename: "SystemIntakeNoteAuthor";
   name: string;
@@ -20,6 +25,10 @@ export interface GetAdminNotesAndActions_systemIntake_notes {
   id: UUID;
   createdAt: Time;
   content: string;
+  editor: GetAdminNotesAndActions_systemIntake_notes_editor | null;
+  modifiedBy: string | null;
+  modifiedAt: Time | null;
+  isArchived: boolean;
   author: GetAdminNotesAndActions_systemIntake_notes_author;
 }
 
@@ -53,6 +62,7 @@ export interface GetAdminNotesAndActions_systemIntake_actions {
 
 export interface GetAdminNotesAndActions_systemIntake {
   __typename: "SystemIntake";
+  id: UUID;
   lcid: string | null;
   notes: GetAdminNotesAndActions_systemIntake_notes[];
   actions: GetAdminNotesAndActions_systemIntake_actions[];

--- a/src/queries/types/UpdateSystemIntakeNote.ts
+++ b/src/queries/types/UpdateSystemIntakeNote.ts
@@ -1,0 +1,24 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { UpdateSystemIntakeNoteInput } from "./../../types/graphql-global-types";
+
+// ====================================================
+// GraphQL mutation operation: UpdateSystemIntakeNote
+// ====================================================
+
+export interface UpdateSystemIntakeNote_updateSystemIntakeNote {
+  __typename: "SystemIntakeNote";
+  id: UUID;
+  content: string;
+}
+
+export interface UpdateSystemIntakeNote {
+  updateSystemIntakeNote: UpdateSystemIntakeNote_updateSystemIntakeNote;
+}
+
+export interface UpdateSystemIntakeNoteVariables {
+  input: UpdateSystemIntakeNoteInput;
+}

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -762,6 +762,15 @@ export interface UpdateSystemIntakeContractDetailsInput {
 }
 
 /**
+ * Input data for updating an IT governance admin note
+ */
+export interface UpdateSystemIntakeNoteInput {
+  content: string;
+  isArchived: boolean;
+  id: UUID;
+}
+
+/**
  * Input to update some fields on a system request
  */
 export interface UpdateSystemIntakeRequestDetailsInput {

--- a/src/views/GovernanceReviewTeam/Notes/index.scss
+++ b/src/views/GovernanceReviewTeam/Notes/index.scss
@@ -7,3 +7,7 @@
         margin-left: 0;
     }
 }
+
+.easi-grt__note-textarea {
+    resize: none;
+}

--- a/src/views/GovernanceReviewTeam/Notes/index.tsx
+++ b/src/views/GovernanceReviewTeam/Notes/index.tsx
@@ -46,7 +46,7 @@ type NoteForm = {
 const Notes = () => {
   const { systemId } = useParams<{ systemId: string }>();
   const authState = useSelector((state: AppState) => state.auth);
-  const [mutate, mutationResult] = useMutation<
+  const [createNoteMutation, createMutationResult] = useMutation<
     CreateSystemIntakeNote,
     CreateSystemIntakeNoteVariables
   >(CreateSystemIntakeNoteQuery, {
@@ -67,7 +67,7 @@ const Notes = () => {
     variables: {
       id: systemId
     },
-    fetchPolicy: 'no-cache'
+    fetchPolicy: 'cache-and-network'
   });
 
   const [
@@ -137,10 +137,11 @@ const Notes = () => {
       authorName: authState.name,
       content: values.note
     };
-    mutate({ variables: { input } }).then(response => {
+    createNoteMutation({ variables: { input } }).then(response => {
       if (!response.errors) {
         resetForm();
       }
+      refetchAdminNotesAndActions();
     });
   };
 
@@ -509,10 +510,10 @@ const Notes = () => {
           const { values, handleSubmit } = formikProps;
           return (
             <div className="tablet:grid-col-9 margin-bottom-7">
-              {mutationResult && mutationResult.error && (
+              {createMutationResult && createMutationResult.error && (
                 <ErrorAlert heading="Error">
                   <ErrorAlertMessage
-                    message={mutationResult.error.message}
+                    message={createMutationResult.error.message}
                     errorKey="note"
                   />
                 </ErrorAlert>


### PR DESCRIPTION
# EASI-2567

## Changes and Description

- Modify GovernanceReviewTeam Notes component to allow for editing and removal of admin notes
- Add new GraphQL mutation for editing/removing note and edit GraphQL query for retrieving notes to add new edit fields
- Add Cypress test cases for new functionality

<!-- Put a description here! -->

## Notes

 - This implementation varies slightly from the Figma mockups (https://www.figma.com/file/JE39JNLbCSha4fk1m9ayPP/IT-Governance-Updates?node-id=1647-102385) - in that the error messages are displayed in the notes component itself rather than the overarching GovernanceReviewTeam page. Zoe cleared and is ok with this change.


## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
