### PR TITLE
[NOREF] Make 'my' TRB request query

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -594,6 +594,7 @@ type ComplexityRoot struct {
 		CurrentUser              func(childComplexity int) int
 		Deployments              func(childComplexity int, cedarSystemID string, deploymentType *string, state *string, status *string) int
 		Exchanges                func(childComplexity int, cedarSystemID string) int
+		MyTrbRequests            func(childComplexity int, archived bool) int
 		RelatedSystemIntakes     func(childComplexity int, id uuid.UUID) int
 		Requests                 func(childComplexity int, after *string, first int) int
 		RoleTypes                func(childComplexity int) int
@@ -1241,6 +1242,7 @@ type QueryResolver interface {
 	RelatedSystemIntakes(ctx context.Context, id uuid.UUID) ([]*models.SystemIntake, error)
 	TrbRequest(ctx context.Context, id uuid.UUID) (*models.TRBRequest, error)
 	TrbRequests(ctx context.Context, archived bool) ([]*models.TRBRequest, error)
+	MyTrbRequests(ctx context.Context, archived bool) ([]*models.TRBRequest, error)
 	TrbLeadOptions(ctx context.Context) ([]*models.UserInfo, error)
 	TrbAdminNote(ctx context.Context, id uuid.UUID) (*models.TRBAdminNote, error)
 }
@@ -4421,6 +4423,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Exchanges(childComplexity, args["cedarSystemId"].(string)), true
+
+	case "Query.myTrbRequests":
+		if e.complexity.Query.MyTrbRequests == nil {
+			break
+		}
+
+		args, err := ec.field_Query_myTrbRequests_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.MyTrbRequests(childComplexity, args["archived"].(bool)), true
 
 	case "Query.relatedSystemIntakes":
 		if e.complexity.Query.RelatedSystemIntakes == nil {
@@ -8834,7 +8848,8 @@ type Query {
   systemIntakeContacts(id: UUID!): SystemIntakeContactsPayload!
   relatedSystemIntakes(id: UUID!): [SystemIntake!]!
   trbRequest(id: UUID!): TRBRequest!
-  trbRequests(archived: Boolean! = false): [TRBRequest!]!
+  trbRequests(archived: Boolean! = false): [TRBRequest!]! @hasRole(role: EASI_TRB_ADMIN)
+  myTrbRequests(archived: Boolean! = false): [TRBRequest!]!
   trbLeadOptions: [UserInfo!]!
   trbAdminNote(id: UUID!): TRBAdminNote!
     @hasRole(role: EASI_TRB_ADMIN)
@@ -10247,6 +10262,21 @@ func (ec *executionContext) field_Query_exchanges_args(ctx context.Context, rawA
 		}
 	}
 	args["cedarSystemId"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_myTrbRequests_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 bool
+	if tmp, ok := rawArgs["archived"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("archived"))
+		arg0, err = ec.unmarshalNBoolean2bool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["archived"] = arg0
 	return args, nil
 }
 
@@ -31282,8 +31312,32 @@ func (ec *executionContext) _Query_trbRequests(ctx context.Context, field graphq
 		}
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().TrbRequests(rctx, fc.Args["archived"].(bool))
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Query().TrbRequests(rctx, fc.Args["archived"].(bool))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "EASI_TRB_ADMIN")
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.HasRole == nil {
+				return nil, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, role)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.([]*models.TRBRequest); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be []*github.com/cmsgov/easi-app/pkg/models.TRBRequest`, tmp)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -31367,6 +31421,110 @@ func (ec *executionContext) fieldContext_Query_trbRequests(ctx context.Context, 
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_trbRequests_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_myTrbRequests(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_myTrbRequests(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().MyTrbRequests(rctx, fc.Args["archived"].(bool))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*models.TRBRequest)
+	fc.Result = res
+	return ec.marshalNTRBRequest2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐTRBRequestᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_myTrbRequests(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TRBRequest_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TRBRequest_name(ctx, field)
+			case "archived":
+				return ec.fieldContext_TRBRequest_archived(ctx, field)
+			case "type":
+				return ec.fieldContext_TRBRequest_type(ctx, field)
+			case "state":
+				return ec.fieldContext_TRBRequest_state(ctx, field)
+			case "status":
+				return ec.fieldContext_TRBRequest_status(ctx, field)
+			case "attendees":
+				return ec.fieldContext_TRBRequest_attendees(ctx, field)
+			case "feedback":
+				return ec.fieldContext_TRBRequest_feedback(ctx, field)
+			case "documents":
+				return ec.fieldContext_TRBRequest_documents(ctx, field)
+			case "form":
+				return ec.fieldContext_TRBRequest_form(ctx, field)
+			case "adviceLetter":
+				return ec.fieldContext_TRBRequest_adviceLetter(ctx, field)
+			case "taskStatuses":
+				return ec.fieldContext_TRBRequest_taskStatuses(ctx, field)
+			case "consultMeetingTime":
+				return ec.fieldContext_TRBRequest_consultMeetingTime(ctx, field)
+			case "trbLead":
+				return ec.fieldContext_TRBRequest_trbLead(ctx, field)
+			case "trbLeadInfo":
+				return ec.fieldContext_TRBRequest_trbLeadInfo(ctx, field)
+			case "trbLeadComponent":
+				return ec.fieldContext_TRBRequest_trbLeadComponent(ctx, field)
+			case "requesterInfo":
+				return ec.fieldContext_TRBRequest_requesterInfo(ctx, field)
+			case "requesterComponent":
+				return ec.fieldContext_TRBRequest_requesterComponent(ctx, field)
+			case "adminNotes":
+				return ec.fieldContext_TRBRequest_adminNotes(ctx, field)
+			case "isRecent":
+				return ec.fieldContext_TRBRequest_isRecent(ctx, field)
+			case "createdBy":
+				return ec.fieldContext_TRBRequest_createdBy(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TRBRequest_createdAt(ctx, field)
+			case "modifiedBy":
+				return ec.fieldContext_TRBRequest_modifiedBy(ctx, field)
+			case "modifiedAt":
+				return ec.fieldContext_TRBRequest_modifiedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TRBRequest", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_myTrbRequests_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -53442,6 +53600,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_trbRequests(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "myTrbRequests":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_myTrbRequests(ctx, field)
 				return res
 			}
 

--- a/pkg/graph/resolvers/trb_request.go
+++ b/pkg/graph/resolvers/trb_request.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -93,6 +94,15 @@ func GetTRBRequestByID(ctx context.Context, id uuid.UUID, store *storage.Store) 
 // GetTRBRequests returns all TRB Requests
 func GetTRBRequests(ctx context.Context, archived bool, store *storage.Store) ([]*models.TRBRequest, error) {
 	TRBRequests, err := store.GetTRBRequests(ctx, archived)
+	if err != nil {
+		return nil, err
+	}
+	return TRBRequests, err
+}
+
+// GetMyTRBRequests returns all TRB Requests that belong to the principal in the context
+func GetMyTRBRequests(ctx context.Context, archived bool, store *storage.Store) ([]*models.TRBRequest, error) {
+	TRBRequests, err := store.GetMyTRBRequests(ctx, archived)
 	if err != nil {
 		return nil, err
 	}
@@ -432,6 +442,7 @@ func GetTRBLeadInfo(ctx context.Context, trbLead *string) (*models.UserInfo, err
 // GetTRBRequesterInfo retrieves the user info of a TRB request's requester
 func GetTRBRequesterInfo(ctx context.Context, requesterEUA string) (*models.UserInfo, error) {
 	requesterInfo, err := dataloaders.GetUserInfo(ctx, requesterEUA)
+	fmt.Println("REQUESTER INFO", requesterEUA, requesterInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -2230,7 +2230,8 @@ type Query {
   systemIntakeContacts(id: UUID!): SystemIntakeContactsPayload!
   relatedSystemIntakes(id: UUID!): [SystemIntake!]!
   trbRequest(id: UUID!): TRBRequest!
-  trbRequests(archived: Boolean! = false): [TRBRequest!]!
+  trbRequests(archived: Boolean! = false): [TRBRequest!]! @hasRole(role: EASI_TRB_ADMIN)
+  myTrbRequests(archived: Boolean! = false): [TRBRequest!]!
   trbLeadOptions: [UserInfo!]!
   trbAdminNote(id: UUID!): TRBAdminNote!
     @hasRole(role: EASI_TRB_ADMIN)

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -2492,6 +2492,11 @@ func (r *queryResolver) TrbRequests(ctx context.Context, archived bool) ([]*mode
 	return resolvers.GetTRBRequests(ctx, archived, r.store)
 }
 
+// MyTrbRequests is the resolver for the myTrbRequests field.
+func (r *queryResolver) MyTrbRequests(ctx context.Context, archived bool) ([]*models.TRBRequest, error) {
+	return resolvers.GetMyTRBRequests(ctx, archived, r.store)
+}
+
 // TrbLeadOptions is the resolver for the trbLeadOptions field.
 func (r *queryResolver) TrbLeadOptions(ctx context.Context) ([]*models.UserInfo, error) {
 	return resolvers.GetTRBLeadOptions(ctx, r.store, r.service.FetchUserInfos)

--- a/pkg/storage/SQL/trb_request_collection_get_my.sql
+++ b/pkg/storage/SQL/trb_request_collection_get_my.sql
@@ -1,0 +1,14 @@
+SELECT id,
+    name,
+    archived,
+    type,
+    state,
+    consult_meeting_time,
+    trb_lead,
+    created_by,
+    created_at,
+    modified_by,
+    modified_at
+    FROM trb_request
+    WHERE archived = :archived
+    AND created_by = :created_by

--- a/src/queries/GetRequestsQuery.ts
+++ b/src/queries/GetRequestsQuery.ts
@@ -16,7 +16,7 @@ export default gql`
         }
       }
     }
-    trbRequests(archived: false) {
+    myTrbRequests(archived: false) {
       id
       name
       submittedAt: createdAt

--- a/src/queries/GetTrbRequestsQuery.ts
+++ b/src/queries/GetTrbRequestsQuery.ts
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client';
 
 export default gql`
   query GetTrbRequests {
-    trbRequests(archived: false) {
+    myTrbRequests(archived: false) {
       id
       name
       status

--- a/src/queries/types/GetRequests.ts
+++ b/src/queries/types/GetRequests.ts
@@ -31,7 +31,7 @@ export interface GetRequests_requests {
   edges: GetRequests_requests_edges[];
 }
 
-export interface GetRequests_trbRequests {
+export interface GetRequests_myTrbRequests {
   __typename: "TRBRequest";
   id: UUID;
   name: string;
@@ -42,7 +42,7 @@ export interface GetRequests_trbRequests {
 
 export interface GetRequests {
   requests: GetRequests_requests | null;
-  trbRequests: GetRequests_trbRequests[];
+  myTrbRequests: GetRequests_myTrbRequests[];
 }
 
 export interface GetRequestsVariables {

--- a/src/queries/types/GetTrbRequests.ts
+++ b/src/queries/types/GetTrbRequests.ts
@@ -9,20 +9,20 @@ import { TRBRequestStatus } from "./../../types/graphql-global-types";
 // GraphQL query operation: GetTrbRequests
 // ====================================================
 
-export interface GetTrbRequests_trbRequests_form {
+export interface GetTrbRequests_myTrbRequests_form {
   __typename: "TRBRequestForm";
   submittedAt: Time | null;
 }
 
-export interface GetTrbRequests_trbRequests {
+export interface GetTrbRequests_myTrbRequests {
   __typename: "TRBRequest";
   id: UUID;
   name: string;
   status: TRBRequestStatus;
   createdAt: Time;
-  form: GetTrbRequests_trbRequests_form;
+  form: GetTrbRequests_myTrbRequests_form;
 }
 
 export interface GetTrbRequests {
-  trbRequests: GetTrbRequests_trbRequests[];
+  myTrbRequests: GetTrbRequests_myTrbRequests[];
 }

--- a/src/views/MyRequests/Table/index.test.tsx
+++ b/src/views/MyRequests/Table/index.test.tsx
@@ -109,7 +109,7 @@ describe('My Requests Table', () => {
           }
         ]
       },
-      trbRequests: [
+      myTrbRequests: [
         {
           id: '1afc9242-f244-47a3-9f91-4d6fedd8eb91',
           name: 'My excellent question',

--- a/src/views/MyRequests/Table/tableMap.ts
+++ b/src/views/MyRequests/Table/tableMap.ts
@@ -2,8 +2,8 @@ import { TFunction } from 'i18next';
 
 import {
   GetRequests,
-  GetRequests_requests_edges_node as GetRequestsType,
-  GetRequests_trbRequests as GetTRBRequestsType
+  GetRequests_myTrbRequests as GetTRBRequestsType,
+  GetRequests_requests_edges_node as GetRequestsType
 } from 'queries/types/GetRequests';
 import { RequestType } from 'types/graphql-global-types';
 import { accessibilityRequestStatusMap } from 'utils/accessibilityRequest';
@@ -34,9 +34,9 @@ const tableMap = (
       return edge.node;
     }) || ([] as GetRequestsType[]);
 
-  const trbRequests: GetTRBRequestsType[] = tableData?.trbRequests || [];
+  const myTrbRequests: GetTRBRequestsType[] = tableData?.myTrbRequests || [];
 
-  const mergedRequests: MergedRequests[] = [...requests, ...trbRequests];
+  const mergedRequests: MergedRequests[] = [...requests, ...myTrbRequests];
 
   const mappedData = mergedRequests
     ?.filter(request =>

--- a/src/views/TechnicalAssistance/Homepage.tsx
+++ b/src/views/TechnicalAssistance/Homepage.tsx
@@ -37,7 +37,7 @@ import GetTrbRequestsQuery from 'queries/GetTrbRequestsQuery';
 import {
   GetTrbRequests,
   // eslint-disable-next-line camelcase
-  GetTrbRequests_trbRequests
+  GetTrbRequests_myTrbRequests
 } from 'queries/types/GetTrbRequests';
 import { AppState } from 'reducers/rootReducer';
 import { formatDateLocal } from 'utils/date';
@@ -70,7 +70,7 @@ function Homepage() {
   // @ts-ignore
   // Ignoring due to accessor props with dot property string values which break react-table typescripting
   // eslint-disable-next-line camelcase
-  const columns = useMemo<Column<GetTrbRequests_trbRequests>[]>(() => {
+  const columns = useMemo<Column<GetTrbRequests_myTrbRequests>[]>(() => {
     return [
       {
         Header: t<string>('table.header.requestName'),
@@ -79,7 +79,7 @@ function Homepage() {
           value,
           row
         }: // eslint-disable-next-line camelcase
-        CellProps<GetTrbRequests_trbRequests, string>) => {
+        CellProps<GetTrbRequests_myTrbRequests, string>) => {
           return (
             <UswdsReactLink
               to={`/trb/task-list/${row.original.id}`}
@@ -126,7 +126,7 @@ function Homepage() {
     {
       columns,
       globalFilter: useMemo(() => globalFilterCellText, []),
-      data: useMemo(() => data?.trbRequests || [], [data?.trbRequests]),
+      data: useMemo(() => data?.myTrbRequests || [], [data?.myTrbRequests]),
       autoResetSortBy: false,
       autoResetPage: false,
       initialState: {

--- a/src/views/TechnicalAssistance/index.test.tsx
+++ b/src/views/TechnicalAssistance/index.test.tsx
@@ -11,6 +11,7 @@ import {
   GetTrbRequests_myTrbRequests
 } from 'queries/types/GetTrbRequests';
 import { TRBRequestStatus } from 'types/graphql-global-types';
+import VerboseMockedProvider from 'utils/testing/VerboseMockedProvider';
 
 import ProcessFlow from './ProcessFlow';
 import RequestType from './RequestType';
@@ -20,7 +21,7 @@ const mockStore = configureMockStore();
 
 describe('Technical Assistance (TRB) homepage', () => {
   // eslint-disable-next-line camelcase
-  const trbRequests: GetTrbRequests_myTrbRequests[] = [
+  const myTrbRequests: GetTrbRequests_myTrbRequests[] = [
     {
       id: '1afc9242-f244-47a3-9f91-4d6fedd8eb91',
       name: 'My excellent question',
@@ -60,7 +61,7 @@ describe('Technical Assistance (TRB) homepage', () => {
       <MemoryRouter initialEntries={['/trb']}>
         <Provider store={mockStore({ auth })}>
           <Route path="/trb">
-            <MockedProvider
+            <VerboseMockedProvider
               mocks={[
                 {
                   request: {
@@ -68,14 +69,14 @@ describe('Technical Assistance (TRB) homepage', () => {
                   },
                   result: {
                     data: {
-                      trbRequests
+                      myTrbRequests
                     }
                   }
                 }
               ]}
             >
               <TechnicalAssistance />
-            </MockedProvider>
+            </VerboseMockedProvider>
           </Route>
         </Provider>
       </MemoryRouter>
@@ -86,7 +87,7 @@ describe('Technical Assistance (TRB) homepage', () => {
     const { asFragment, findByTestId } = renderHomepage();
 
     /** TRB request */
-    const request = await findByTestId(`trbRequest-${trbRequests[0].id}`);
+    const request = await findByTestId(`trbRequest-${myTrbRequests[0].id}`);
     // Check that request is in document
     expect(request).toBeInTheDocument();
 

--- a/src/views/TechnicalAssistance/index.test.tsx
+++ b/src/views/TechnicalAssistance/index.test.tsx
@@ -8,7 +8,7 @@ import configureMockStore from 'redux-mock-store';
 import GetTrbRequestsQuery from 'queries/GetTrbRequestsQuery';
 import {
   // eslint-disable-next-line camelcase
-  GetTrbRequests_trbRequests
+  GetTrbRequests_myTrbRequests
 } from 'queries/types/GetTrbRequests';
 import { TRBRequestStatus } from 'types/graphql-global-types';
 
@@ -20,7 +20,7 @@ const mockStore = configureMockStore();
 
 describe('Technical Assistance (TRB) homepage', () => {
   // eslint-disable-next-line camelcase
-  const trbRequests: GetTrbRequests_trbRequests[] = [
+  const trbRequests: GetTrbRequests_myTrbRequests[] = [
     {
       id: '1afc9242-f244-47a3-9f91-4d6fedd8eb91',
       name: 'My excellent question',


### PR DESCRIPTION
# EASI-000

## Changes and Description

- Introduce query that only retrieves a users TRB requests

We only had a single query that was always fetching ALL trb requests. This meant that I was seeing other people's requests show up in my TRB tab - oops!

## How to test this change

- Start the app
- Log in as `TEST`
- Make some TRB requests
- Make sure they show up in the TRB Tab table
- Log in as `ABCD`
- Make sure you don't see the other requests
- Make some more TRB requests
- Ensure you only see yours in the TRB Table
- Login as an admin
- Ensure you can see ALL trb requests on the admin home

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
