### PR TITLE
[NOREF] - TRB unit test fixes

### DIFF
--- a/src/components/EmailRecipientFields/__snapshots__/index.test.tsx.snap
+++ b/src/components/EmailRecipientFields/__snapshots__/index.test.tsx.snap
@@ -97,13 +97,13 @@ exports[`Email recipient fields component renders Add Attendee form 1`] = `
           id="notifyEuaIds.1"
           name="notifyEuaIds"
           type="checkbox"
-          value="SF13"
+          value="ADMI"
         />
         <label
           class="usa-checkbox__label"
           for="notifyEuaIds.1"
         >
-          Jerry Seinfeld (Product Owner)
+          Audrey Abrams (Privacy Advisor)
         </label>
       </div>
       <div
@@ -114,13 +114,13 @@ exports[`Email recipient fields component renders Add Attendee form 1`] = `
           id="notifyEuaIds.2"
           name="notifyEuaIds"
           type="checkbox"
-          value="ADMI"
+          value="ADMN"
         />
         <label
           class="usa-checkbox__label"
           for="notifyEuaIds.2"
         >
-          Audrey Abrams (System Owner)
+          Aaron Adams (System Maintainer)
         </label>
       </div>
       <fieldset
@@ -164,7 +164,7 @@ exports[`Email recipient fields component renders Add Attendee form 1`] = `
               >
                 <div
                   class="cedar-contact-select__input-container css-1pndypt-Input"
-                  data-value="Anabelle Jerde, JTTC"
+                  data-value="Ally Anderson, A11Y"
                 >
                   <input
                     aria-autocomplete="list"
@@ -182,7 +182,7 @@ exports[`Email recipient fields component renders Add Attendee form 1`] = `
                     style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
                     tabindex="0"
                     type="text"
-                    value="Anabelle Jerde, JTTC"
+                    value="Ally Anderson, A11Y"
                   />
                 </div>
               </div>
@@ -579,13 +579,13 @@ exports[`Email recipient fields component renders recipients 1`] = `
           id="notifyEuaIds.1"
           name="notifyEuaIds"
           type="checkbox"
-          value="SF13"
+          value="ADMI"
         />
         <label
           class="usa-checkbox__label"
           for="notifyEuaIds.1"
         >
-          Jerry Seinfeld (Product Owner)
+          Audrey Abrams (Privacy Advisor)
         </label>
       </div>
       <div
@@ -596,13 +596,13 @@ exports[`Email recipient fields component renders recipients 1`] = `
           id="notifyEuaIds.2"
           name="notifyEuaIds"
           type="checkbox"
-          value="ADMI"
+          value="ADMN"
         />
         <label
           class="usa-checkbox__label"
           for="notifyEuaIds.2"
         >
-          Audrey Abrams (System Owner)
+          Aaron Adams (System Maintainer)
         </label>
       </div>
       <button

--- a/src/components/EmailRecipientFields/index.test.tsx
+++ b/src/components/EmailRecipientFields/index.test.tsx
@@ -4,15 +4,13 @@ import { MockedProvider } from '@apollo/react-testing';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { attendees as attendeesData, requester } from 'data/mock/trbRequest';
+import { attendees as mockAttendees, requester } from 'data/mock/trbRequest';
 import GetCedarContactsQuery from 'queries/GetCedarContactsQuery';
 
 import EmailRecipientFields from '.';
 
+const [newAttendee, ...attendees] = mockAttendees;
 const { trbRequestId } = requester;
-
-const attendees = attendeesData.slice(1, attendeesData.length);
-const newAttendee = attendeesData[0];
 
 const cedarContactsMock = (commonName: string) => ({
   request: {
@@ -38,7 +36,7 @@ const TestComponent = () => {
   });
   return (
     <MockedProvider
-      mocks={[cedarContactsMock('An'), cedarContactsMock('Anabelle Jerde')]}
+      mocks={[cedarContactsMock('Al'), cedarContactsMock('Ally Anderson')]}
     >
       <FormProvider {...formMethods}>
         <EmailRecipientFields
@@ -93,7 +91,7 @@ describe('Email recipient fields component', () => {
     const submitButton = getByRole('button', { name: 'Add recipient' });
     expect(submitButton).toBeDisabled();
 
-    userEvent.type(getByRole('combobox', { name: 'Cedar-Users' }), 'An');
+    userEvent.type(getByRole('combobox', { name: 'Cedar-Users' }), 'Al');
     userEvent.click(
       await findByText(
         `${newAttendee.userInfo?.commonName}, ${newAttendee.userInfo?.euaUserId}`

--- a/src/constants/enums/cmsDivisionsAndOffices.ts
+++ b/src/constants/enums/cmsDivisionsAndOffices.ts
@@ -106,5 +106,6 @@ const cmsDivisionsAndOffices = [
 ] as const;
 
 export type CMSOfficeAcronym = typeof cmsDivisionsAndOffices[number]['acronym'];
+export type CMSOffice = typeof cmsDivisionsAndOffices[number]['name'];
 
 export default cmsDivisionsAndOffices;

--- a/src/data/mock/trbRequest.ts
+++ b/src/data/mock/trbRequest.ts
@@ -89,7 +89,7 @@ const adminNotes: GetTrbAdminNotes['trbRequest']['adminNotes'] = [
     id: '861fa6c5-c9af-4cda-a559-0995b7b76855',
     isArchived: false,
     category: TRBAdminNoteCategory.GENERAL_REQUEST,
-    noteText: 'Test Note Text',
+    noteText: 'My cute note',
     author: {
       __typename: 'UserInfo',
       commonName: requester.userInfo.commonName

--- a/src/data/mock/trbRequest.ts
+++ b/src/data/mock/trbRequest.ts
@@ -1,3 +1,4 @@
+import GetRequestsQuery from 'queries/GetRequestsQuery';
 import GetTrbAdminNotesQuery from 'queries/GetTrbAdminNotesQuery';
 import GetTrbAdminTeamHomeQuery from 'queries/GetTrbAdminTeamHomeQuery';
 import GetTrbLeadOptionsQuery from 'queries/GetTrbLeadOptionsQuery';
@@ -5,6 +6,12 @@ import GetTrbRequestQuery from 'queries/GetTrbRequestQuery';
 import GetTrbRequestSummaryQuery from 'queries/GetTrbRequestSummaryQuery';
 import { GetTrbAdviceLetterQuery } from 'queries/TrbAdviceLetterQueries';
 import { GetTRBRequestAttendeesQuery } from 'queries/TrbAttendeeQueries';
+import {
+  GetRequests,
+  GetRequests_myTrbRequests as MyTrbRequests,
+  GetRequests_requests as Requests,
+  GetRequestsVariables
+} from 'queries/types/GetRequests';
 import {
   GetTrbAdminNotes,
   GetTrbAdminNotesVariables
@@ -36,6 +43,7 @@ import {
 import UpdateTrbRequestConsultMeetingQuery from 'queries/UpdateTrbRequestConsultMeetingQuery';
 import {
   PersonRole,
+  RequestType,
   TRBAdminNoteCategory,
   TRBAdviceLetterStatus,
   TRBAttendConsultStatus,
@@ -183,6 +191,99 @@ export const getTrbRequestSummaryQuery: MockedQuery<
     }
   }
 };
+
+const getRequestsData: {
+  edges: Requests['edges'];
+  myTrbRequests: MyTrbRequests[];
+} = {
+  edges: [
+    {
+      __typename: 'RequestEdge',
+      node: {
+        __typename: 'Request',
+        id: '123',
+        name: '508 Test 1',
+        submittedAt: '2021-05-25T19:22:40Z',
+        type: RequestType.ACCESSIBILITY_REQUEST,
+        status: 'OPEN',
+        statusCreatedAt: '2021-05-25T19:22:40Z',
+        lcid: null,
+        nextMeetingDate: null
+      }
+    },
+    {
+      __typename: 'RequestEdge',
+      node: {
+        __typename: 'Request',
+        id: '909',
+        name: '508 Test 2',
+        submittedAt: '2021-05-25T19:22:40Z',
+        type: RequestType.ACCESSIBILITY_REQUEST,
+        status: 'IN_REMEDIATION',
+        statusCreatedAt: '2021-05-26T19:22:40Z',
+        lcid: null,
+        nextMeetingDate: null
+      }
+    },
+    {
+      __typename: 'RequestEdge',
+      node: {
+        __typename: 'Request',
+        id: '456',
+        name: 'Intake 1',
+        submittedAt: '2021-05-22T19:22:40Z',
+        type: RequestType.GOVERNANCE_REQUEST,
+        status: 'INTAKE_DRAFT',
+        statusCreatedAt: null,
+        lcid: null,
+        nextMeetingDate: null
+      }
+    },
+    {
+      __typename: 'RequestEdge',
+      node: {
+        __typename: 'Request',
+        id: '789',
+        name: 'Intake 2',
+        submittedAt: '2021-05-20T19:22:40Z',
+        type: RequestType.GOVERNANCE_REQUEST,
+        status: 'LCID_ISSUED',
+        statusCreatedAt: null,
+        lcid: 'A123456',
+        nextMeetingDate: null
+      }
+    }
+  ],
+  myTrbRequests: [
+    {
+      id: '1afc9242-f244-47a3-9f91-4d6fedd8eb91',
+      name: 'My excellent question',
+      nextMeetingDate: null,
+      status: TRBRequestStatus.CONSULT_COMPLETE,
+      submittedAt: '2023-03-07T15:09:17.694681Z',
+      __typename: 'TRBRequest'
+    }
+  ]
+};
+
+export const getRequestsQuery = (
+  edges: Requests['edges'] = getRequestsData.edges,
+  myTrbRequests: MyTrbRequests[] = getRequestsData.myTrbRequests
+): MockedQuery<GetRequests, GetRequestsVariables> => ({
+  request: {
+    query: GetRequestsQuery,
+    variables: { first: 20 }
+  },
+  result: {
+    data: {
+      requests: {
+        __typename: 'RequestsConnection',
+        edges
+      },
+      myTrbRequests
+    }
+  }
+});
 
 export const getTRBRequestAttendeesQuery: MockedQuery<
   GetTRBRequestAttendees,

--- a/src/data/mock/trbRequest.ts
+++ b/src/data/mock/trbRequest.ts
@@ -1,109 +1,233 @@
-import { GetTrbAdviceLetter_trbRequest_adviceLetter as AdviceLetter } from 'queries/types/GetTrbAdviceLetter';
-import { GetTrbRequest_trbRequest as TrbRequest } from 'queries/types/GetTrbRequest';
-import { GetTRBRequestAttendees_trbRequest_attendees as TRBAttendee } from 'queries/types/GetTRBRequestAttendees';
-import { GetTrbRequestSummary_trbRequest as Summary } from 'queries/types/GetTrbRequestSummary';
+import GetTrbAdminNotesQuery from 'queries/GetTrbAdminNotesQuery';
+import GetTrbAdminTeamHomeQuery from 'queries/GetTrbAdminTeamHomeQuery';
+import GetTrbRequestQuery from 'queries/GetTrbRequestQuery';
+import GetTrbRequestSummaryQuery from 'queries/GetTrbRequestSummaryQuery';
+import { GetTrbAdviceLetterQuery } from 'queries/TrbAdviceLetterQueries';
+import { GetTRBRequestAttendeesQuery } from 'queries/TrbAttendeeQueries';
+import {
+  GetTrbAdminNotes,
+  GetTrbAdminNotesVariables
+} from 'queries/types/GetTrbAdminNotes';
+import { GetTrbAdminTeamHome } from 'queries/types/GetTrbAdminTeamHome';
+import {
+  GetTrbAdviceLetter,
+  GetTrbAdviceLetterVariables
+} from 'queries/types/GetTrbAdviceLetter';
+import {
+  GetTrbRequest,
+  GetTrbRequestVariables
+} from 'queries/types/GetTrbRequest';
+import {
+  GetTRBRequestAttendees,
+  GetTRBRequestAttendeesVariables
+} from 'queries/types/GetTRBRequestAttendees';
+import {
+  GetTrbRequestSummary,
+  GetTrbRequestSummary_trbRequest as Summary,
+  GetTrbRequestSummaryVariables
+} from 'queries/types/GetTrbRequestSummary';
+import { TrbRequestFormFields_taskStatuses as TaskStatuses } from 'queries/types/TrbRequestFormFields';
+import {
+  UpdateTrbRequestConsultMeeting,
+  UpdateTrbRequestConsultMeetingVariables
+} from 'queries/types/UpdateTrbRequestConsultMeeting';
+import UpdateTrbRequestConsultMeetingQuery from 'queries/UpdateTrbRequestConsultMeetingQuery';
 import {
   PersonRole,
+  TRBAdminNoteCategory,
   TRBAdviceLetterStatus,
   TRBAttendConsultStatus,
+  TRBCollabGroupOption,
   TRBConsultPrepStatus,
   TRBFeedbackStatus,
   TRBFormStatus,
   TRBRequestState,
   TRBRequestStatus,
-  TRBRequestType
+  TRBRequestType,
+  TRBWhereInProcessOption
 } from 'types/graphql-global-types';
-import { TrbAdminTeamHomeRequest } from 'types/technicalAssistance';
+import { MockedQuery } from 'types/util';
+import MockTrbAttendees, {
+  MockTrbAttendee
+} from 'utils/testing/MockTrbAttendees';
 
-const trbRequestId: string = '441cb9e0-2cb3-43ca-b168-9d6a2a13ec91';
+const trbRequestId = 'd8ebedca-0031-4ccd-9690-37390726c50e';
+const users = new MockTrbAttendees({ trbRequestId });
 
-const euaUserId: string = 'ABCD';
+export const requester: MockTrbAttendee = users.findByEuaUserId('ABCD')!;
+export const attendees: MockTrbAttendee[] = [
+  users.next({
+    role: PersonRole.CLOUD_NAVIGATOR,
+    component: 'Center for Clinical Standards and Quality'
+  })!,
+  users.next({
+    role: PersonRole.PRIVACY_ADVISOR,
+    component: 'Center for Medicare'
+  })!,
+  users.next({
+    role: PersonRole.SYSTEM_MAINTAINER,
+    component: 'Center for Program Integrity'
+  })!
+];
 
-export const requester: TRBAttendee = {
-  __typename: 'TRBRequestAttendee',
-  id: '330459da-b5d0-4265-b290-137c1273a0bc',
-  trbRequestId,
-  userInfo: {
-    __typename: 'UserInfo',
-    commonName: 'Adeline Aarons',
-    euaUserId,
-    email: 'adeline.aarons@local.fake'
-  },
-  component: 'CMS Wide',
-  role: PersonRole.PRODUCT_OWNER,
-  createdAt: '2023-01-05T07:26:16.036618Z'
+const taskStatuses: TaskStatuses = {
+  __typename: 'TRBTaskStatuses',
+  formStatus: TRBFormStatus.IN_PROGRESS,
+  feedbackStatus: TRBFeedbackStatus.CANNOT_START_YET,
+  consultPrepStatus: TRBConsultPrepStatus.CANNOT_START_YET,
+  attendConsultStatus: TRBAttendConsultStatus.CANNOT_START_YET,
+  adviceLetterStatus: TRBAdviceLetterStatus.CANNOT_START_YET
 };
 
-export const attendees: TRBAttendee[] = [
+const adminNotes: GetTrbAdminNotes['trbRequest']['adminNotes'] = [
   {
-    __typename: 'TRBRequestAttendee',
-    id: '9a6a3b4e-1a46-4a07-9e0e-e10f8aaf4f82',
-    trbRequestId,
-    userInfo: {
+    __typename: 'TRBAdminNote',
+    id: '861fa6c5-c9af-4cda-a559-0995b7b76855',
+    isArchived: false,
+    category: TRBAdminNoteCategory.GENERAL_REQUEST,
+    noteText: 'Test Note Text',
+    author: {
       __typename: 'UserInfo',
-      commonName: 'Anabelle Jerde',
-      email: 'anabelle.jerde@local.fake',
-      euaUserId: 'JTTC'
+      commonName: requester.userInfo.commonName
     },
-    component: 'Center for Program Integrity',
-    role: PersonRole.PRIVACY_ADVISOR,
-    createdAt: '2023-01-05T07:26:16.036618Z'
-  },
-  {
-    __typename: 'TRBRequestAttendee',
-    id: '91a14322-34a8-4838-bde3-17b1d483fb63',
-    trbRequestId,
-    userInfo: {
-      __typename: 'UserInfo',
-      commonName: 'Jerry Seinfeld',
-      email: 'jerry.seinfeld@local.fake',
-      euaUserId: 'SF13'
-    },
-    component: 'Office of Equal Opportunity and Civil Rights',
-    role: PersonRole.PRODUCT_OWNER,
-    createdAt: '2023-01-05T07:26:16.036618Z'
-  },
-  {
-    __typename: 'TRBRequestAttendee',
-    id: 'a86ca9bb-518a-4669-9ce9-fd7f79f8262a',
-    trbRequestId,
-    userInfo: {
-      __typename: 'UserInfo',
-      commonName: 'Audrey Abrams',
-      email: 'audrey.abrams@local.fake',
-      euaUserId: 'ADMI'
-    },
-    component: 'CMS Wide',
-    role: PersonRole.SYSTEM_OWNER,
-    createdAt: '2023-01-05T07:26:16.036618Z'
+    createdAt: '2024-03-28T13:20:37.852099Z'
   }
 ];
+
+export const trbRequest: GetTrbRequest['trbRequest'] = {
+  __typename: 'TRBRequest',
+  id: trbRequestId,
+  name: 'Mock TRB Request',
+  type: TRBRequestType.NEED_HELP,
+  state: TRBRequestState.OPEN,
+  taskStatuses,
+  feedback: [],
+  form: {
+    id: '452cf444-69b2-41a9-b8ab-ed354d209307',
+    component: 'Center for Medicaid and CHIP Services',
+    needsAssistanceWith: 'x',
+    hasSolutionInMind: false,
+    proposedSolution: null,
+    whereInProcess:
+      TRBWhereInProcessOption.I_HAVE_AN_IDEA_AND_WANT_TO_BRAINSTORM,
+    whereInProcessOther: null,
+    hasExpectedStartEndDates: false,
+    expectedStartDate: null,
+    expectedEndDate: null,
+    collabGroups: [TRBCollabGroupOption.ENTERPRISE_ARCHITECTURE],
+    collabDateSecurity: null,
+    collabDateEnterpriseArchitecture: 'x',
+    collabDateCloud: null,
+    collabDatePrivacyAdvisor: null,
+    collabDateGovernanceReviewBoard: null,
+    collabDateOther: null,
+    collabGroupOther: null,
+    collabGRBConsultRequested: null,
+    subjectAreaOptions: null,
+    subjectAreaOptionOther: null,
+    fundingSources: null,
+    submittedAt: null,
+    __typename: 'TRBRequestForm'
+  }
+};
+
+export const getTrbRequestQuery: MockedQuery<
+  GetTrbRequest,
+  GetTrbRequestVariables
+> = {
+  request: {
+    query: GetTrbRequestQuery,
+    variables: {
+      id: trbRequestId
+    }
+  },
+  result: {
+    data: {
+      trbRequest
+    }
+  }
+};
 
 export const trbRequestSummary: Summary = {
   __typename: 'TRBRequest',
   id: trbRequestId,
-  name: 'TRB Request Mock',
+  name: 'Mock TRB Request',
   type: TRBRequestType.NEED_HELP,
   state: TRBRequestState.OPEN,
   trbLead: null,
   createdAt: '2023-01-05T07:26:16.036618Z',
-  taskStatuses: {
-    __typename: 'TRBTaskStatuses',
-    attendConsultStatus: TRBAttendConsultStatus.CANNOT_START_YET,
-    consultPrepStatus: TRBConsultPrepStatus.CANNOT_START_YET,
-    feedbackStatus: TRBFeedbackStatus.CANNOT_START_YET,
-    formStatus: TRBFormStatus.READY_TO_START,
-    adviceLetterStatus: TRBAdviceLetterStatus.CANNOT_START_YET
-  },
-  adminNotes: [
-    {
-      __typename: 'TRBAdminNote',
-      id: '123'
-    }
-  ]
+  taskStatuses,
+  adminNotes
 };
 
-export const trbRequestAdviceLetter: AdviceLetter = {
+export const getTrbRequestSummaryQuery: MockedQuery<
+  GetTrbRequestSummary,
+  GetTrbRequestSummaryVariables
+> = {
+  request: {
+    query: GetTrbRequestSummaryQuery,
+    variables: {
+      id: trbRequestId
+    }
+  },
+  result: {
+    data: {
+      trbRequest: trbRequestSummary
+    }
+  }
+};
+
+export const getTRBRequestAttendeesQuery: MockedQuery<
+  GetTRBRequestAttendees,
+  GetTRBRequestAttendeesVariables
+> = {
+  request: {
+    query: GetTRBRequestAttendeesQuery,
+    variables: {
+      id: trbRequestId
+    }
+  },
+  result: {
+    data: {
+      trbRequest: {
+        __typename: 'TRBRequest',
+        id: trbRequestId,
+        attendees: [requester, ...attendees]
+      }
+    }
+  }
+};
+
+export const updateTrbRequestConsultMeetingQuery: MockedQuery<
+  UpdateTrbRequestConsultMeeting,
+  UpdateTrbRequestConsultMeetingVariables
+> = {
+  request: {
+    query: UpdateTrbRequestConsultMeetingQuery,
+    variables: {
+      input: {
+        trbRequestId,
+        consultMeetingTime: '2023-02-23T13:00:00.000Z',
+        notes: '',
+        copyTrbMailbox: true,
+        notifyEuaIds: [requester.userInfo.euaUserId]
+      }
+    }
+  },
+  result: {
+    data: {
+      updateTRBRequestConsultMeetingTime: {
+        __typename: 'TRBRequest',
+        id: trbRequestId,
+        consultMeetingTime: '2023-02-23T13:00:00.000Z'
+      }
+    }
+  }
+};
+
+export const adviceLetter: NonNullable<
+  GetTrbAdviceLetter['trbRequest']['adviceLetter']
+> = {
   __typename: 'TRBAdviceLetter',
   id: '1b68aeca-f0d4-42e8-90ef-70ed2de1a34b',
   meetingSummary: 'Meeting summary text',
@@ -129,57 +253,61 @@ export const trbRequestAdviceLetter: AdviceLetter = {
   ],
   author: {
     __typename: 'UserInfo',
-    euaUserId: 'SF13',
-    commonName: 'Jerry Seinfeld'
+    euaUserId: attendees[0].userInfo.euaUserId,
+    commonName: attendees[0].userInfo.commonName
   },
-  createdAt: '2023-01-05T07:26:16.036618Z',
+  createdAt: '2023-01-08T07:26:16.036618Z',
   modifiedAt: null
 };
 
-export const trbRequest: TrbRequest = {
-  id: trbRequestId,
-  name: 'Draft',
-  taskStatuses: {
-    __typename: 'TRBTaskStatuses',
-    attendConsultStatus: TRBAttendConsultStatus.CANNOT_START_YET,
-    consultPrepStatus: TRBConsultPrepStatus.CANNOT_START_YET,
-    feedbackStatus: TRBFeedbackStatus.CANNOT_START_YET,
-    formStatus: TRBFormStatus.READY_TO_START,
-    adviceLetterStatus: TRBAdviceLetterStatus.CANNOT_START_YET
+export const getTrbAdviceLetterQuery: MockedQuery<
+  GetTrbAdviceLetter,
+  GetTrbAdviceLetterVariables
+> = {
+  request: {
+    query: GetTrbAdviceLetterQuery,
+    variables: {
+      id: trbRequestId
+    }
   },
-  feedback: [],
-  state: TRBRequestState.OPEN,
-  type: TRBRequestType.NEED_HELP,
-  form: {
-    id: '452cf444-69b2-41a9-b8ab-ed354d209307',
-    component: null,
-    needsAssistanceWith: null,
-    hasSolutionInMind: null,
-    proposedSolution: null,
-    whereInProcess: null,
-    whereInProcessOther: null,
-    hasExpectedStartEndDates: null,
-    expectedStartDate: null,
-    expectedEndDate: null,
-    collabGroups: [],
-    collabDateSecurity: null,
-    collabDateEnterpriseArchitecture: null,
-    collabDateCloud: null,
-    collabDatePrivacyAdvisor: null,
-    collabDateGovernanceReviewBoard: null,
-    collabDateOther: null,
-    collabGroupOther: null,
-    collabGRBConsultRequested: null,
-    subjectAreaOptions: null,
-    subjectAreaOptionOther: null,
-    fundingSources: null,
-    submittedAt: null,
-    __typename: 'TRBRequestForm'
-  },
-  __typename: 'TRBRequest'
+  result: {
+    data: {
+      trbRequest: {
+        __typename: 'TRBRequest',
+        id: trbRequestId,
+        name: trbRequest.name,
+        taskStatuses: {
+          ...taskStatuses,
+          adviceLetterStatus: TRBAdviceLetterStatus.COMPLETED
+        },
+        adviceLetter
+      }
+    }
+  }
 };
 
-export const trbAdminTeamHomeRequests: TrbAdminTeamHomeRequest[] = [
+export const getTrbAdminNotesQuery: MockedQuery<
+  GetTrbAdminNotes,
+  GetTrbAdminNotesVariables
+> = {
+  request: {
+    query: GetTrbAdminNotesQuery,
+    variables: {
+      id: trbRequestId
+    }
+  },
+  result: {
+    data: {
+      trbRequest: {
+        __typename: 'TRBRequest',
+        id: trbRequestId,
+        adminNotes
+      }
+    }
+  }
+};
+
+export const trbAdminTeamHomeRequests: GetTrbAdminTeamHome['trbRequests'] = [
   {
     id: '0ba435ac-50ee-44d1-94cc-4dd480b70a75',
     name: 'First help',
@@ -195,17 +323,10 @@ export const trbAdminTeamHomeRequests: TrbAdminTeamHomeRequest[] = [
     },
     requesterComponent: null,
     requesterInfo: {
-      commonName: 'Wava Upton',
+      commonName: users.next()?.userInfo.commonName!,
       __typename: 'UserInfo'
     },
-    taskStatuses: {
-      attendConsultStatus: TRBAttendConsultStatus.CANNOT_START_YET,
-      consultPrepStatus: TRBConsultPrepStatus.CANNOT_START_YET,
-      feedbackStatus: TRBFeedbackStatus.CANNOT_START_YET,
-      formStatus: TRBFormStatus.READY_TO_START,
-      adviceLetterStatus: TRBAdviceLetterStatus.CANNOT_START_YET,
-      __typename: 'TRBTaskStatuses'
-    },
+    taskStatuses,
     form: {
       submittedAt: '2023-03-01T01:23:45Z',
       __typename: 'TRBRequestForm'
@@ -227,17 +348,10 @@ export const trbAdminTeamHomeRequests: TrbAdminTeamHomeRequest[] = [
     },
     requesterComponent: null,
     requesterInfo: {
-      commonName: 'Derick Koss',
+      commonName: users.next()?.userInfo.commonName!,
       __typename: 'UserInfo'
     },
-    taskStatuses: {
-      attendConsultStatus: TRBAttendConsultStatus.CANNOT_START_YET,
-      consultPrepStatus: TRBConsultPrepStatus.CANNOT_START_YET,
-      feedbackStatus: TRBFeedbackStatus.CANNOT_START_YET,
-      formStatus: TRBFormStatus.READY_TO_START,
-      adviceLetterStatus: TRBAdviceLetterStatus.CANNOT_START_YET,
-      __typename: 'TRBTaskStatuses'
-    },
+    taskStatuses,
     form: {
       submittedAt: '2023-03-02T01:23:45Z',
       __typename: 'TRBRequestForm'
@@ -254,22 +368,15 @@ export const trbAdminTeamHomeRequests: TrbAdminTeamHomeRequest[] = [
     consultMeetingTime: null,
     trbLeadComponent: null,
     trbLeadInfo: {
-      commonName: 'Astrid Howell',
+      commonName: users.next()?.userInfo.commonName!,
       __typename: 'UserInfo'
     },
     requesterComponent: null,
     requesterInfo: {
-      commonName: 'Loraine Kirlin',
+      commonName: users.next()?.userInfo.commonName!,
       __typename: 'UserInfo'
     },
-    taskStatuses: {
-      attendConsultStatus: TRBAttendConsultStatus.CANNOT_START_YET,
-      consultPrepStatus: TRBConsultPrepStatus.CANNOT_START_YET,
-      feedbackStatus: TRBFeedbackStatus.CANNOT_START_YET,
-      formStatus: TRBFormStatus.READY_TO_START,
-      adviceLetterStatus: TRBAdviceLetterStatus.CANNOT_START_YET,
-      __typename: 'TRBTaskStatuses'
-    },
+    taskStatuses,
     form: {
       submittedAt: '2023-03-03T01:23:45Z',
       __typename: 'TRBRequestForm'
@@ -286,22 +393,15 @@ export const trbAdminTeamHomeRequests: TrbAdminTeamHomeRequest[] = [
     consultMeetingTime: '2023-04-01T09:23:45Z',
     trbLeadComponent: null,
     trbLeadInfo: {
-      commonName: 'Polly Sauer',
+      commonName: users.next()?.userInfo.commonName!,
       __typename: 'UserInfo'
     },
     requesterComponent: null,
     requesterInfo: {
-      commonName: 'Clotilde Goodwin',
+      commonName: users.next()?.userInfo.commonName!,
       __typename: 'UserInfo'
     },
-    taskStatuses: {
-      attendConsultStatus: TRBAttendConsultStatus.CANNOT_START_YET,
-      consultPrepStatus: TRBConsultPrepStatus.CANNOT_START_YET,
-      feedbackStatus: TRBFeedbackStatus.CANNOT_START_YET,
-      formStatus: TRBFormStatus.READY_TO_START,
-      adviceLetterStatus: TRBAdviceLetterStatus.CANNOT_START_YET,
-      __typename: 'TRBTaskStatuses'
-    },
+    taskStatuses,
     form: {
       submittedAt: '2023-03-04T01:23:45Z',
       __typename: 'TRBRequestForm'
@@ -318,22 +418,15 @@ export const trbAdminTeamHomeRequests: TrbAdminTeamHomeRequest[] = [
     consultMeetingTime: '2023-04-02T09:23:45Z',
     trbLeadComponent: null,
     trbLeadInfo: {
-      commonName: 'Sydni Reynolds',
+      commonName: users.next()?.userInfo.commonName!,
       __typename: 'UserInfo'
     },
     requesterComponent: null,
     requesterInfo: {
-      commonName: 'Sylvester Mante',
+      commonName: users.next()?.userInfo.commonName!,
       __typename: 'UserInfo'
     },
-    taskStatuses: {
-      attendConsultStatus: TRBAttendConsultStatus.CANNOT_START_YET,
-      consultPrepStatus: TRBConsultPrepStatus.CANNOT_START_YET,
-      feedbackStatus: TRBFeedbackStatus.CANNOT_START_YET,
-      formStatus: TRBFormStatus.READY_TO_START,
-      adviceLetterStatus: TRBAdviceLetterStatus.CANNOT_START_YET,
-      __typename: 'TRBTaskStatuses'
-    },
+    taskStatuses,
     form: {
       submittedAt: '2023-03-05T01:23:45Z',
       __typename: 'TRBRequestForm'
@@ -350,22 +443,15 @@ export const trbAdminTeamHomeRequests: TrbAdminTeamHomeRequest[] = [
     consultMeetingTime: '2023-04-02T09:23:45Z',
     trbLeadComponent: 'TRB',
     trbLeadInfo: {
-      commonName: 'Hosea Lemke',
+      commonName: users.next()?.userInfo.commonName!,
       __typename: 'UserInfo'
     },
-    requesterComponent: 'BBQ',
+    requesterComponent: 'CMS Wide',
     requesterInfo: {
-      commonName: 'Damaris Langosh',
+      commonName: users.next()?.userInfo.commonName!,
       __typename: 'UserInfo'
     },
-    taskStatuses: {
-      attendConsultStatus: TRBAttendConsultStatus.CANNOT_START_YET,
-      consultPrepStatus: TRBConsultPrepStatus.CANNOT_START_YET,
-      feedbackStatus: TRBFeedbackStatus.CANNOT_START_YET,
-      formStatus: TRBFormStatus.READY_TO_START,
-      adviceLetterStatus: TRBAdviceLetterStatus.CANNOT_START_YET,
-      __typename: 'TRBTaskStatuses'
-    },
+    taskStatuses,
     form: {
       submittedAt: '2023-03-06T01:23:45Z',
       __typename: 'TRBRequestForm'
@@ -373,3 +459,12 @@ export const trbAdminTeamHomeRequests: TrbAdminTeamHomeRequest[] = [
     __typename: 'TRBRequest'
   }
 ];
+
+export const getTrbAdminTeamHomeQuery: MockedQuery<GetTrbAdminTeamHome> = {
+  request: { query: GetTrbAdminTeamHomeQuery, variables: {} },
+  result: {
+    data: {
+      trbRequests: { ...trbAdminTeamHomeRequests }
+    }
+  }
+};

--- a/src/data/mock/trbRequest.ts
+++ b/src/data/mock/trbRequest.ts
@@ -1,5 +1,6 @@
 import GetTrbAdminNotesQuery from 'queries/GetTrbAdminNotesQuery';
 import GetTrbAdminTeamHomeQuery from 'queries/GetTrbAdminTeamHomeQuery';
+import GetTrbLeadOptionsQuery from 'queries/GetTrbLeadOptionsQuery';
 import GetTrbRequestQuery from 'queries/GetTrbRequestQuery';
 import GetTrbRequestSummaryQuery from 'queries/GetTrbRequestSummaryQuery';
 import { GetTrbAdviceLetterQuery } from 'queries/TrbAdviceLetterQueries';
@@ -13,6 +14,7 @@ import {
   GetTrbAdviceLetter,
   GetTrbAdviceLetterVariables
 } from 'queries/types/GetTrbAdviceLetter';
+import { GetTrbLeadOptions } from 'queries/types/GetTrbLeadOptions';
 import {
   GetTrbRequest,
   GetTrbRequestVariables
@@ -50,6 +52,8 @@ import { MockedQuery } from 'types/util';
 import MockTrbAttendees, {
   MockTrbAttendee
 } from 'utils/testing/MockTrbAttendees';
+
+import { MockUserInfo } from './users';
 
 const trbRequestId = 'd8ebedca-0031-4ccd-9690-37390726c50e';
 const users = new MockTrbAttendees({ trbRequestId });
@@ -467,7 +471,25 @@ export const getTrbAdminTeamHomeQuery: MockedQuery<GetTrbAdminTeamHome> = {
   request: { query: GetTrbAdminTeamHomeQuery, variables: {} },
   result: {
     data: {
-      trbRequests: { ...trbAdminTeamHomeRequests }
+      trbRequests: [...trbAdminTeamHomeRequests]
+    }
+  }
+};
+
+export const trbLeadOptions: MockUserInfo[] = [
+  users.next()?.userInfo!,
+  users.next()?.userInfo!,
+  users.next()?.userInfo!
+];
+
+export const getTrbLeadOptionsQuery: MockedQuery<GetTrbLeadOptions> = {
+  request: {
+    query: GetTrbLeadOptionsQuery,
+    variables: {}
+  },
+  result: {
+    data: {
+      trbLeadOptions
     }
   }
 };

--- a/src/data/mock/users.ts
+++ b/src/data/mock/users.ts
@@ -1,0 +1,383 @@
+/**
+ * Array containing all mock users for testing purposes
+ */
+export const users = [
+  {
+    __typename: 'UserInfo',
+    commonName: 'Ally Anderson',
+    email: 'ally.anderson@local.fake',
+    euaUserId: 'A11Y'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Adeline Aarons',
+    email: 'adeline.aarons@local.fake',
+    euaUserId: 'ABCD'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Audrey Abrams',
+    email: 'audrey.abrams@local.fake',
+    euaUserId: 'ADMI'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Aaron Adams',
+    email: 'aaron.adams@local.fake',
+    euaUserId: 'ADMN'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Avis Anderson',
+    email: 'avis.anderson@local.fake',
+    euaUserId: 'ATSI'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Otilia Abbott',
+    email: 'otilia.abbott@local.fake',
+    euaUserId: 'AX0Q'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Theo Crooks',
+    email: 'theo.crooks@local.fake',
+    euaUserId: 'CJRW'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Charlie Campbell',
+    email: 'charlie.campbell@local.fake',
+    euaUserId: 'CMSU'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Yasmine Dare',
+    email: 'yasmine.dare@local.fake',
+    euaUserId: 'D2AC'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Marjory Doyle',
+    email: 'marjory.doyle@local.fake',
+    euaUserId: 'D7R3'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Litzy Emard',
+    email: 'litzy.emard@local.fake',
+    euaUserId: 'ER3Z'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Mckayla Fritsch',
+    email: 'mckayla.fritsch@local.fake',
+    euaUserId: 'FAUI'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Hilbert Gislason',
+    email: 'hilbert.gislason@local.fake',
+    euaUserId: 'G4A7'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Delphia Green',
+    email: 'delphia.green@local.fake',
+    euaUserId: 'GBRG'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Hellen Grimes',
+    email: 'hellen.grimes@local.fake',
+    euaUserId: 'GFRY'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Leatha Gorczany',
+    email: 'leatha.gorczany@local.fake',
+    euaUserId: 'GP87'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Gary Gordon',
+    email: 'gary.gordon@local.fake',
+    euaUserId: 'GRTB'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Adrianna Gottlieb',
+    email: 'adrianna.gottlieb@local.fake',
+    euaUserId: 'GT98'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Kenna Gerhold',
+    email: 'kenna.gerhold@local.fake',
+    euaUserId: 'GZP4'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Lucinda Hansen',
+    email: 'lucinda.hansen@local.fake',
+    euaUserId: 'H2KQ'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Alyce Haag',
+    email: 'alyce.haag@local.fake',
+    euaUserId: 'HBGM'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Savanna Hyatt',
+    email: 'savanna.hyatt@local.fake',
+    euaUserId: 'HCNK'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Cecelia Hahn',
+    email: 'cecelia.hahn@local.fake',
+    euaUserId: 'HGDS'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Doyle Heller',
+    email: 'doyle.heller@local.fake',
+    euaUserId: 'HIV3'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Eldred Hammes',
+    email: 'eldred.hammes@local.fake',
+    euaUserId: 'HY0W'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Karianne Hickle',
+    email: 'karianne.hickle@local.fake',
+    euaUserId: 'HYG2'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Brooks Johnson',
+    email: 'brooks.johnson@local.fake',
+    euaUserId: 'J3C8'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Dawn Jaskolski',
+    email: 'dawn.jaskolski@local.fake',
+    euaUserId: 'JG1B'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Anabelle Jerde',
+    email: 'anabelle.jerde@local.fake',
+    euaUserId: 'JTTC'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Nat Krajcik',
+    email: 'nat.krajcik@local.fake',
+    euaUserId: 'K0AM'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Lance Konopelski',
+    email: 'lance.konopelski@local.fake',
+    euaUserId: 'K0LR'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Bernhard Koss',
+    email: 'bernhard.koss@local.fake',
+    euaUserId: 'K9W1'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Deonte Kassulke',
+    email: 'deonte.kassulke@local.fake',
+    euaUserId: 'KDYZ'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Cosmo Kramer',
+    email: 'cosmo.kramer@local.fake',
+    euaUserId: 'KR14'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Isobel Koelpin',
+    email: 'isobel.koelpin@local.fake',
+    euaUserId: 'KT77'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Kennedy Kuhic',
+    email: 'kennedy.kuhic@local.fake',
+    euaUserId: 'KVB3'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Annetta Lockman',
+    email: 'annetta.lockman@local.fake',
+    euaUserId: 'LW40'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Aurelie Morar',
+    email: 'aurelie.morar@local.fake',
+    euaUserId: 'MN3Q'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Gust Murray',
+    email: 'gust.murray@local.fake',
+    euaUserId: 'MR92'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Desmond Nolan',
+    email: 'desmond.nolan@local.fake',
+    euaUserId: 'N60U'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: "Hallie O'Hara",
+    email: 'hallie.ohara@local.fake',
+    euaUserId: 'OQYV'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Rudolph Pagac',
+    email: 'rudolph.pagac@local.fake',
+    euaUserId: 'POJG'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Laverne Roberts',
+    email: 'laverne.roberts@local.fake',
+    euaUserId: 'R0EI'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Catherine Rice',
+    email: 'catherine.rice@local.fake',
+    euaUserId: 'RH4V'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Elva Ruecker',
+    email: 'elva.ruecker@local.fake',
+    euaUserId: 'RP20'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Lauriane Stoltenberg',
+    email: 'lauriane.stoltenberg@local.fake',
+    euaUserId: 'S3W0'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Jerry Seinfeld',
+    email: 'jerry.seinfeld@local.fake',
+    euaUserId: 'SF13'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Alexander Stark',
+    email: 'alexander.stark@local.fake',
+    euaUserId: 'SKZO'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Isidro Swaniawski',
+    email: 'isidro.swaniawski@local.fake',
+    euaUserId: 'SM7H'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Caden Schmeler',
+    email: 'caden.schmeler@local.fake',
+    euaUserId: 'SPJW'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Earnest Torp',
+    email: 'earnest.torp@local.fake',
+    euaUserId: 'TD4Z'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Terry Thompson',
+    email: 'terry.thompson@local.fake',
+    euaUserId: 'TEST'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Waylon Tromp',
+    email: 'waylon.tromp@local.fake',
+    euaUserId: 'TWAW'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Palma Towne',
+    email: 'palma.towne@local.fake',
+    euaUserId: 'TX4A'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'User One',
+    email: 'user.one@local.fake',
+    euaUserId: 'USR1'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'User Two',
+    email: 'user.two@local.fake',
+    euaUserId: 'USR2'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'User Three',
+    email: 'user.three@local.fake',
+    euaUserId: 'USR3'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'User Four',
+    email: 'user.four@local.fake',
+    euaUserId: 'USR4'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'User Five',
+    email: 'user.five@local.fake',
+    euaUserId: 'USR5'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Zechariah Wyman',
+    email: 'zechariah.wyman@local.fake',
+    euaUserId: 'W1I4'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Rolando Weber',
+    email: 'rolando.weber@local.fake',
+    euaUserId: 'WNZ3'
+  },
+  {
+    __typename: 'UserInfo',
+    commonName: 'Kayla Zulauf',
+    email: 'kayla.zulauf@local.fake',
+    euaUserId: 'ZOCN'
+  }
+] as const;
+
+export type MockUserInfo = typeof users[number];
+export type MockEuaUserId = MockUserInfo['euaUserId'];
+export type MockUserName = MockUserInfo['commonName'];
+
+export default users;

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -1,5 +1,25 @@
+import { DocumentNode, FetchResult, GraphQLRequest } from '@apollo/client';
+import { MockedResponse } from '@apollo/react-testing';
+
 export type NonNullableProps<T> = {
   [P in keyof T]: NonNullable<T[P]>;
 };
 
 export type FormFieldProps<T> = NonNullableProps<Required<T>>;
+
+/** Extends `GraphQLRequest` to optionally enforce stricter typing on `variables` property */
+interface MockedRequest<
+  TVariables extends Record<string, any> = Record<string, any>
+> extends GraphQLRequest {
+  query: DocumentNode;
+  variables: TVariables;
+}
+
+/** Extends `MockedResponse` to optionally enforce stricter typing on `request` and `result` properties */
+export interface MockedQuery<
+  TData extends Record<string, any> = Record<string, any>,
+  TVariables extends Record<string, any> = Record<string, any>
+> extends MockedResponse<TData> {
+  request: MockedRequest<TVariables>;
+  result: FetchResult<TData>;
+}

--- a/src/utils/testing/MockTrbAttendees.ts
+++ b/src/utils/testing/MockTrbAttendees.ts
@@ -30,9 +30,9 @@ type MockTrbAttendeeOptions = MockUserOptions<
 };
 
 /** Extends MockUsers class to mock TRB attendees for testing */
-class MockTrbAttendees extends MockUsers<MockTrbAttendee> {
+export default class MockTrbAttendees extends MockUsers<MockTrbAttendee> {
   constructor({
-    trbRequestId = mockTrbRequestId,
+    trbRequestId,
     allowDuplicates = false,
     defaultProps
   }: MockTrbAttendeeOptions = {}) {
@@ -41,11 +41,9 @@ class MockTrbAttendees extends MockUsers<MockTrbAttendee> {
       defaultProps: userInfo => ({
         ...defaultMockAttendeeProps,
         ...defaultProps,
-        trbRequestId,
+        ...(trbRequestId ? { trbRequestId } : {}),
         id: `user-${userInfo.euaUserId}`
       })
     });
   }
 }
-
-export default MockTrbAttendees;

--- a/src/utils/testing/MockTrbAttendees.ts
+++ b/src/utils/testing/MockTrbAttendees.ts
@@ -1,0 +1,51 @@
+import { CMSOffice } from 'constants/enums/cmsDivisionsAndOffices';
+import { PersonRole } from 'types/graphql-global-types';
+
+import MockUsers, { MockUser, MockUserOptions } from './MockUsers';
+
+export interface MockTrbAttendee extends MockUser {
+  __typename: 'TRBRequestAttendee';
+  trbRequestId: string;
+  id: string;
+  component: CMSOffice;
+  role: PersonRole;
+  createdAt: string;
+}
+
+export const mockTrbRequestId = 'd8ebedca-0031-4ccd-9690-37390726c50e';
+
+export const defaultMockAttendeeProps: Omit<MockTrbAttendee, 'userInfo'> = {
+  __typename: 'TRBRequestAttendee',
+  id: '',
+  trbRequestId: mockTrbRequestId,
+  component: 'CMS Wide',
+  role: PersonRole.PRODUCT_OWNER,
+  createdAt: '2023-01-05T07:26:16.036618Z'
+};
+
+type MockTrbAttendeeOptions = MockUserOptions<
+  Omit<MockTrbAttendee, 'trbRequestId'>
+> & {
+  trbRequestId?: string;
+};
+
+/** Extends MockUsers class to mock TRB attendees for testing */
+class MockTrbAttendees extends MockUsers<MockTrbAttendee> {
+  constructor({
+    trbRequestId = mockTrbRequestId,
+    allowDuplicates = false,
+    defaultProps
+  }: MockTrbAttendeeOptions = {}) {
+    super({
+      allowDuplicates,
+      defaultProps: userInfo => ({
+        ...defaultMockAttendeeProps,
+        ...defaultProps,
+        trbRequestId,
+        id: `user-${userInfo.euaUserId}`
+      })
+    });
+  }
+}
+
+export default MockTrbAttendees;

--- a/src/utils/testing/MockUsers.test.ts
+++ b/src/utils/testing/MockUsers.test.ts
@@ -1,0 +1,95 @@
+import { CMSOffice } from 'constants/enums/cmsDivisionsAndOffices';
+import users, { MockUserInfo } from 'data/mock/users';
+import { PersonRole } from 'types/graphql-global-types';
+
+import MockTrbAttendees, {
+  defaultMockAttendeeProps,
+  MockTrbAttendee
+} from './MockTrbAttendees';
+import MockUsers from './MockUsers';
+
+const userOne: MockUserInfo = {
+  __typename: 'UserInfo',
+  commonName: 'Otilia Abbott',
+  email: 'otilia.abbott@local.fake',
+  euaUserId: 'AX0Q'
+};
+
+const userTwo: MockUserInfo = {
+  __typename: 'UserInfo',
+  commonName: 'Delphia Green',
+  email: 'delphia.green@local.fake',
+  euaUserId: 'GBRG'
+};
+
+const attendeeOne: MockTrbAttendee = {
+  ...defaultMockAttendeeProps,
+  userInfo: users[0],
+  id: `user-${users[0].euaUserId}`
+};
+
+describe('Mock user data', () => {
+  it('Mocks users for testing', () => {
+    const mockUsers = new MockUsers();
+
+    const initialUserCount = mockUsers.length;
+
+    expect(mockUsers.next()?.userInfo).toEqual(users[0]);
+
+    expect(mockUsers.findByEuaUserId(userOne.euaUserId)?.userInfo).toEqual(
+      userOne
+    );
+    // Check that user was removed from array
+    expect(mockUsers.findByEuaUserId(userOne.euaUserId)).toBeUndefined();
+
+    expect(mockUsers.findByCommonName(userTwo.commonName)?.userInfo).toEqual(
+      userTwo
+    );
+    // Check that user was removed from array
+    expect(mockUsers.findByCommonName(userTwo.commonName)).toBeUndefined();
+
+    // mockUsers should have three less users
+    expect(mockUsers.length).toEqual(initialUserCount - 3);
+  });
+
+  it('Allows duplicate users', () => {
+    const mockUsers = new MockUsers({ allowDuplicates: true });
+
+    const initialUserCount = mockUsers.length;
+
+    // Mock three users
+    mockUsers.next();
+    mockUsers.next();
+    mockUsers.next();
+
+    // mockUsers length should stay the same
+    expect(mockUsers.length).toEqual(initialUserCount);
+  });
+
+  it('Mocks TRB attendees', () => {
+    const attendees = new MockTrbAttendees();
+
+    expect(attendees.next()).toEqual(attendeeOne);
+  });
+
+  it('Mocks TRB attendees with props', () => {
+    const trbRequestId = 'aed81cfe-e3b5-4152-8924-947586f966e4';
+
+    // Mock attendees with updated trbRequestId
+    const attendees = new MockTrbAttendees({ trbRequestId });
+
+    // Check that trbRequestId was updated from default
+    expect(attendees.next()).toEqual({ ...attendeeOne, trbRequestId });
+
+    // Mock attendee with props
+    const component: CMSOffice = 'Center for Program Integrity';
+    const role = PersonRole.SYSTEM_OWNER;
+    const attendeeWithProps = attendees.findByEuaUserId(userOne.euaUserId, {
+      component,
+      role
+    });
+
+    expect(attendeeWithProps?.component).toEqual(component);
+    expect(attendeeWithProps?.role).toEqual(role);
+  });
+});

--- a/src/utils/testing/MockUsers.ts
+++ b/src/utils/testing/MockUsers.ts
@@ -1,0 +1,122 @@
+/* eslint-disable no-underscore-dangle */
+
+import users, {
+  MockEuaUserId,
+  MockUserInfo,
+  MockUserName
+} from 'data/mock/users';
+
+export interface MockUser {
+  userInfo: MockUserInfo;
+}
+
+type UserProps<T extends MockUser> =
+  | ((userInfo: MockUserInfo) => Partial<Omit<T, 'userInfo'>>)
+  | Partial<Omit<T, 'userInfo'>>;
+
+export type MockUserOptions<T extends MockUser> =
+  | {
+      /** Whether class will return duplicate users - defaults to false */
+      allowDuplicates?: boolean;
+      /** Default user props */
+      defaultProps?: UserProps<T>;
+    }
+  | undefined;
+
+export class MockUsers<
+  UserType extends MockUser = MockUser
+> extends Array<UserType> {
+  _currentIndex: number = 0;
+
+  _allowDuplicates: boolean;
+
+  constructor({
+    allowDuplicates = false,
+    defaultProps
+  }: MockUserOptions<UserType> = {}) {
+    super(
+      ...(users.map(userInfo => ({
+        userInfo,
+        ...(typeof defaultProps === 'function'
+          ? defaultProps?.(userInfo)
+          : defaultProps)
+      })) as UserType[])
+    );
+    this._allowDuplicates = allowDuplicates;
+  }
+
+  /** Remove user from array if `allowDuplicates` prop is set to false */
+  removeUser(index: number) {
+    this.splice(index, 1);
+
+    // Reset `currentIndex` to reflect new array size
+    if (index < this._currentIndex) {
+      this._currentIndex -= 1;
+    }
+  }
+
+  /** Get next user in array */
+  next(props?: UserProps<UserType>): UserType | undefined {
+    let user: UserType | undefined;
+
+    if (this._allowDuplicates) {
+      // If past end of array, reset `currentIndex` to 0
+      if (this._currentIndex > this.length) {
+        this._currentIndex = 0;
+      }
+      user = { ...this[this._currentIndex], ...props };
+      this._currentIndex += 1;
+    } else {
+      // If past end of array, return undefined
+      if (this._currentIndex > this.length) {
+        return undefined;
+      }
+      user = { ...this[this._currentIndex], ...props };
+      this.removeUser(this._currentIndex);
+    }
+
+    return user;
+  }
+
+  /** Get user by commonName */
+  findByCommonName(
+    commonName: MockUserName,
+    props?: UserProps<UserType>
+  ): UserType | undefined {
+    const userIndex = this.findIndex(
+      ({ userInfo }) => userInfo.commonName === commonName
+    );
+
+    if (userIndex === -1) return undefined;
+
+    const user = { ...this[userIndex], ...props };
+
+    if (!this._allowDuplicates) {
+      this.removeUser(userIndex);
+    }
+
+    return user;
+  }
+
+  /** Get user by euaUserId */
+  findByEuaUserId(
+    euaUserId: MockEuaUserId,
+    props?: UserProps<UserType>
+  ): UserType | undefined {
+    const userIndex = this.findIndex(
+      ({ userInfo }) => userInfo.euaUserId === euaUserId
+    );
+
+    if (userIndex === -1) return undefined;
+
+    const user = { ...this[userIndex], ...props };
+
+    if (!this._allowDuplicates) {
+      this.removeUser(userIndex);
+    }
+
+    return user;
+  }
+}
+
+export default MockUsers;

--- a/src/utils/testing/VerboseMockedProvider.tsx
+++ b/src/utils/testing/VerboseMockedProvider.tsx
@@ -37,7 +37,7 @@ const VerboseMockedProvider = (props: Props) => {
       );
     }
 
-    if (networkError) {
+    if (networkError && !!networkError.message) {
       console.log(`[Network error]: ${networkError}`);
     }
   });

--- a/src/utils/testing/easiMockStore.ts
+++ b/src/utils/testing/easiMockStore.ts
@@ -1,0 +1,34 @@
+import configureMockStore from 'redux-mock-store';
+
+import users, { MockEuaUserId } from 'data/mock/users';
+
+type EasiMockStoreProps =
+  | {
+      euaUserId?: MockEuaUserId;
+      isUserSet?: boolean;
+      groups?: string[];
+    }
+  | undefined;
+
+/**
+ * Returns mock store for testing
+ */
+const easiMockStore = ({
+  euaUserId = 'ABCD',
+  isUserSet = true,
+  groups
+}: EasiMockStoreProps = {}) => {
+  const mockStore = configureMockStore();
+  const user = users.find(userInfo => userInfo.euaUserId === euaUserId)!;
+
+  return mockStore({
+    auth: {
+      euaId: euaUserId,
+      name: user.commonName,
+      isUserSet,
+      groups
+    }
+  });
+};
+
+export default easiMockStore;

--- a/src/views/Home/index.test.tsx
+++ b/src/views/Home/index.test.tsx
@@ -7,11 +7,11 @@ import { mount, ReactWrapper, shallow } from 'enzyme';
 import { mockFlags, resetLDMocks } from 'jest-launchdarkly-mock';
 import configureMockStore from 'redux-mock-store';
 
+import { getRequestsQuery } from 'data/mock/trbRequest';
 import { initialSystemIntakeForm } from 'data/systemIntake';
 import { MessageProvider } from 'hooks/useMessage';
 import GetCedarSystemBookmarksQuery from 'queries/GetCedarSystemBookmarksQuery';
 import GetCedarSystemsQuery from 'queries/GetCedarSystemsQuery';
-import GetRequestsQuery from 'queries/GetRequestsQuery';
 import { Flags } from 'types/flags';
 import Table from 'views/MyRequests/Table';
 
@@ -27,7 +27,7 @@ jest.mock('@okta/okta-react', () => ({
         getAccessToken: () => Promise.resolve('test-access-token'),
         getUser: () =>
           Promise.resolve({
-            name: 'John Doe'
+            name: 'Jerry Seinfeld'
           })
       }
     };
@@ -43,20 +43,7 @@ const defaultFlags: Flags = {
 } as Flags;
 
 const mocks = [
-  {
-    request: {
-      query: GetRequestsQuery,
-      variables: { first: 20 }
-    },
-    result: {
-      data: {
-        requests: {
-          edges: []
-        },
-        trbRequests: []
-      }
-    }
-  },
+  getRequestsQuery([], []),
   {
     request: {
       query: GetCedarSystemsQuery

--- a/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
+++ b/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
@@ -267,7 +267,7 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             >
               <a
                 class="usa-link"
-                href="/"
+                href="/trb/task-list/1afc9242-f244-47a3-9f91-4d6fedd8eb91"
               >
                 My excellent question
               </a>
@@ -287,7 +287,9 @@ exports[`My Requests Table when there are requests matches snapshot 1`] = `
             <td
               role="cell"
               style="width: 200px; padding-left: 0px;"
-            />
+            >
+              Consult complete
+            </td>
             <td
               role="cell"
               style="width: 150px; padding-left: 0px;"

--- a/src/views/MyRequests/Table/index.test.tsx
+++ b/src/views/MyRequests/Table/index.test.tsx
@@ -5,34 +5,42 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import GetRequestsQuery from 'queries/GetRequestsQuery';
-import { GetRequests as GetRequestsQueryType } from 'queries/types/GetRequests';
+import {
+  GetRequests as GetRequestsQueryType,
+  GetRequests_myTrbRequests as MyTrbRequests,
+  GetRequests_requests as Requests,
+  GetRequestsVariables
+} from 'queries/types/GetRequests';
 import { RequestType, TRBRequestStatus } from 'types/graphql-global-types';
+import { MockedQuery } from 'types/util';
 
 import Table from '.';
+
+const getRequestsQuery = (
+  edges: Requests['edges'] = [],
+  myTrbRequests: MyTrbRequests[] = []
+): MockedQuery<GetRequestsQueryType, GetRequestsVariables> => ({
+  request: {
+    query: GetRequestsQuery,
+    variables: { first: 20 }
+  },
+  result: {
+    data: {
+      requests: {
+        __typename: 'RequestsConnection',
+        edges
+      },
+      myTrbRequests
+    }
+  }
+});
 
 describe('My Requests Table', () => {
   describe('when there are no requests', () => {
     it('displays an empty message', async () => {
-      const mocks = [
-        {
-          request: {
-            query: GetRequestsQuery,
-            variables: { first: 20 }
-          },
-          result: {
-            data: {
-              requests: {
-                edges: []
-              },
-              trbRequests: []
-            }
-          }
-        }
-      ];
-
       render(
         <MemoryRouter>
-          <MockedProvider mocks={mocks} addTypename={false}>
+          <MockedProvider mocks={[getRequestsQuery()]}>
             <Table />
           </MockedProvider>
         </MemoryRouter>
@@ -47,10 +55,9 @@ describe('My Requests Table', () => {
   });
 
   describe('when there are requests', () => {
-    const mockRequestData: GetRequestsQueryType = {
-      requests: {
-        __typename: 'RequestsConnection',
-        edges: [
+    const mocks = [
+      getRequestsQuery(
+        [
           {
             __typename: 'RequestEdge',
             node: {
@@ -107,35 +114,24 @@ describe('My Requests Table', () => {
               nextMeetingDate: null
             }
           }
+        ],
+        [
+          {
+            id: '1afc9242-f244-47a3-9f91-4d6fedd8eb91',
+            name: 'My excellent question',
+            nextMeetingDate: null,
+            status: TRBRequestStatus.CONSULT_COMPLETE,
+            submittedAt: '2023-03-07T15:09:17.694681Z',
+            __typename: 'TRBRequest'
+          }
         ]
-      },
-      myTrbRequests: [
-        {
-          id: '1afc9242-f244-47a3-9f91-4d6fedd8eb91',
-          name: 'My excellent question',
-          nextMeetingDate: null,
-          status: TRBRequestStatus.CONSULT_COMPLETE,
-          submittedAt: '2023-03-07T15:09:17.694681Z',
-          __typename: 'TRBRequest'
-        }
-      ]
-    };
-    const mocks = [
-      {
-        request: {
-          query: GetRequestsQuery,
-          variables: { first: 20 }
-        },
-        result: {
-          data: mockRequestData
-        }
-      }
+      )
     ];
 
     it('displays a table', async () => {
       render(
         <MemoryRouter>
-          <MockedProvider mocks={mocks} addTypename={false}>
+          <MockedProvider mocks={mocks}>
             <Table />
           </MockedProvider>
         </MemoryRouter>
@@ -151,7 +147,7 @@ describe('My Requests Table', () => {
     it('displays an IT Goverance request only table with hidden columns', async () => {
       render(
         <MemoryRouter>
-          <MockedProvider mocks={mocks} addTypename={false}>
+          <MockedProvider mocks={mocks}>
             <Table
               type={RequestType.GOVERNANCE_REQUEST}
               hiddenColumns={['Governance', 'Upcoming meeting date']}
@@ -168,7 +164,7 @@ describe('My Requests Table', () => {
     it('displays a 508 request only table with hidden columns', async () => {
       render(
         <MemoryRouter>
-          <MockedProvider mocks={mocks} addTypename={false}>
+          <MockedProvider mocks={mocks}>
             <Table
               type={RequestType.ACCESSIBILITY_REQUEST}
               hiddenColumns={['Governance', 'Upcoming meeting date']}
@@ -183,7 +179,7 @@ describe('My Requests Table', () => {
     it('displays relevant results from filter', async () => {
       render(
         <MemoryRouter>
-          <MockedProvider mocks={mocks} addTypename={false}>
+          <MockedProvider mocks={mocks}>
             <Table />
           </MockedProvider>
         </MemoryRouter>
@@ -204,7 +200,7 @@ describe('My Requests Table', () => {
     it('matches snapshot', async () => {
       const { asFragment } = render(
         <MemoryRouter>
-          <MockedProvider mocks={mocks} addTypename={false}>
+          <MockedProvider mocks={mocks}>
             <Table />
           </MockedProvider>
         </MemoryRouter>

--- a/src/views/MyRequests/Table/index.test.tsx
+++ b/src/views/MyRequests/Table/index.test.tsx
@@ -4,43 +4,17 @@ import { MockedProvider } from '@apollo/client/testing';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import GetRequestsQuery from 'queries/GetRequestsQuery';
-import {
-  GetRequests as GetRequestsQueryType,
-  GetRequests_myTrbRequests as MyTrbRequests,
-  GetRequests_requests as Requests,
-  GetRequestsVariables
-} from 'queries/types/GetRequests';
-import { RequestType, TRBRequestStatus } from 'types/graphql-global-types';
-import { MockedQuery } from 'types/util';
+import { getRequestsQuery } from 'data/mock/trbRequest';
+import { RequestType } from 'types/graphql-global-types';
 
 import Table from '.';
-
-const getRequestsQuery = (
-  edges: Requests['edges'] = [],
-  myTrbRequests: MyTrbRequests[] = []
-): MockedQuery<GetRequestsQueryType, GetRequestsVariables> => ({
-  request: {
-    query: GetRequestsQuery,
-    variables: { first: 20 }
-  },
-  result: {
-    data: {
-      requests: {
-        __typename: 'RequestsConnection',
-        edges
-      },
-      myTrbRequests
-    }
-  }
-});
 
 describe('My Requests Table', () => {
   describe('when there are no requests', () => {
     it('displays an empty message', async () => {
       render(
         <MemoryRouter>
-          <MockedProvider mocks={[getRequestsQuery()]}>
+          <MockedProvider mocks={[getRequestsQuery([], [])]}>
             <Table />
           </MockedProvider>
         </MemoryRouter>
@@ -55,83 +29,10 @@ describe('My Requests Table', () => {
   });
 
   describe('when there are requests', () => {
-    const mocks = [
-      getRequestsQuery(
-        [
-          {
-            __typename: 'RequestEdge',
-            node: {
-              __typename: 'Request',
-              id: '123',
-              name: '508 Test 1',
-              submittedAt: '2021-05-25T19:22:40Z',
-              type: RequestType.ACCESSIBILITY_REQUEST,
-              status: 'OPEN',
-              statusCreatedAt: '2021-05-25T19:22:40Z',
-              lcid: null,
-              nextMeetingDate: null
-            }
-          },
-          {
-            __typename: 'RequestEdge',
-            node: {
-              __typename: 'Request',
-              id: '909',
-              name: '508 Test 2',
-              submittedAt: '2021-05-25T19:22:40Z',
-              type: RequestType.ACCESSIBILITY_REQUEST,
-              status: 'IN_REMEDIATION',
-              statusCreatedAt: '2021-05-26T19:22:40Z',
-              lcid: null,
-              nextMeetingDate: null
-            }
-          },
-          {
-            __typename: 'RequestEdge',
-            node: {
-              __typename: 'Request',
-              id: '456',
-              name: 'Intake 1',
-              submittedAt: '2021-05-22T19:22:40Z',
-              type: RequestType.GOVERNANCE_REQUEST,
-              status: 'INTAKE_DRAFT',
-              statusCreatedAt: null,
-              lcid: null,
-              nextMeetingDate: null
-            }
-          },
-          {
-            __typename: 'RequestEdge',
-            node: {
-              __typename: 'Request',
-              id: '789',
-              name: 'Intake 2',
-              submittedAt: '2021-05-20T19:22:40Z',
-              type: RequestType.GOVERNANCE_REQUEST,
-              status: 'LCID_ISSUED',
-              statusCreatedAt: null,
-              lcid: 'A123456',
-              nextMeetingDate: null
-            }
-          }
-        ],
-        [
-          {
-            id: '1afc9242-f244-47a3-9f91-4d6fedd8eb91',
-            name: 'My excellent question',
-            nextMeetingDate: null,
-            status: TRBRequestStatus.CONSULT_COMPLETE,
-            submittedAt: '2023-03-07T15:09:17.694681Z',
-            __typename: 'TRBRequest'
-          }
-        ]
-      )
-    ];
-
     it('displays a table', async () => {
       render(
         <MemoryRouter>
-          <MockedProvider mocks={mocks}>
+          <MockedProvider mocks={[getRequestsQuery()]}>
             <Table />
           </MockedProvider>
         </MemoryRouter>
@@ -147,7 +48,7 @@ describe('My Requests Table', () => {
     it('displays an IT Goverance request only table with hidden columns', async () => {
       render(
         <MemoryRouter>
-          <MockedProvider mocks={mocks}>
+          <MockedProvider mocks={[getRequestsQuery()]}>
             <Table
               type={RequestType.GOVERNANCE_REQUEST}
               hiddenColumns={['Governance', 'Upcoming meeting date']}
@@ -164,7 +65,7 @@ describe('My Requests Table', () => {
     it('displays a 508 request only table with hidden columns', async () => {
       render(
         <MemoryRouter>
-          <MockedProvider mocks={mocks}>
+          <MockedProvider mocks={[getRequestsQuery()]}>
             <Table
               type={RequestType.ACCESSIBILITY_REQUEST}
               hiddenColumns={['Governance', 'Upcoming meeting date']}
@@ -179,7 +80,7 @@ describe('My Requests Table', () => {
     it('displays relevant results from filter', async () => {
       render(
         <MemoryRouter>
-          <MockedProvider mocks={mocks}>
+          <MockedProvider mocks={[getRequestsQuery()]}>
             <Table />
           </MockedProvider>
         </MemoryRouter>
@@ -200,7 +101,7 @@ describe('My Requests Table', () => {
     it('matches snapshot', async () => {
       const { asFragment } = render(
         <MemoryRouter>
-          <MockedProvider mocks={mocks}>
+          <MockedProvider mocks={[getRequestsQuery()]}>
             <Table />
           </MockedProvider>
         </MemoryRouter>

--- a/src/views/MyRequests/Table/tableMap.ts
+++ b/src/views/MyRequests/Table/tableMap.ts
@@ -75,7 +75,7 @@ const tableMap = (
         }
       } else {
         // TRB status
-        status = t(`adminHome.requestStatuses.${request.status}`, {
+        status = t(`table.requestStatus.${request.status}`, {
           ns: 'technicalAssistance'
         });
       }

--- a/src/views/TechnicalAssistance/AdminHome/AddNote.test.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/AddNote.test.tsx
@@ -2,156 +2,129 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import i18next from 'i18next';
-import configureMockStore from 'redux-mock-store';
 
+import {
+  getTRBRequestAttendeesQuery,
+  getTrbRequestSummaryQuery,
+  requester
+} from 'data/mock/trbRequest';
 import { MessageProvider } from 'hooks/useMessage';
 import CreateTrbAdminNote from 'queries/CreateTrbAdminNote';
-import GetTrbRequestSummaryQuery from 'queries/GetTrbRequestSummaryQuery';
-import { GetTRBRequestAttendeesQuery } from 'queries/TrbAttendeeQueries';
+import {
+  CreateTrbAdminNote as CreateTrbAdminNoteType,
+  CreateTrbAdminNoteVariables
+} from 'queries/types/CreateTrbAdminNote';
 import { TRBAdminNoteCategory } from 'types/graphql-global-types';
+import { MockedQuery } from 'types/util';
+import easiMockStore from 'utils/testing/easiMockStore';
+import { mockTrbRequestId } from 'utils/testing/MockTrbAttendees';
 
 import AddNote from './AddNote';
 import TRBRequestInfoWrapper from './RequestContext';
 import AdminHome from '.';
 
+const createTrbAdminNoteQuery: MockedQuery<
+  CreateTrbAdminNoteType,
+  CreateTrbAdminNoteVariables
+> = {
+  request: {
+    query: CreateTrbAdminNote,
+    variables: {
+      input: {
+        trbRequestId: mockTrbRequestId,
+        category: TRBAdminNoteCategory.GENERAL_REQUEST,
+        noteText: 'Note text'
+      }
+    }
+  },
+  result: {
+    data: {
+      createTRBAdminNote: {
+        __typename: 'TRBAdminNote',
+        createdAt: '2023-02-16T15:21:34.156885Z',
+        id: 'd35a1f08-e04e-48f9-8d58-7f2409bae8fe',
+        isArchived: false,
+        category: TRBAdminNoteCategory.GENERAL_REQUEST,
+        noteText: 'Note text',
+        author: {
+          __typename: 'UserInfo',
+          commonName: requester.userInfo.commonName
+        }
+      }
+    }
+  }
+};
+
 describe('Trb Admin Notes: Add Note', () => {
   Element.prototype.scrollIntoView = jest.fn();
 
-  const mockStore = configureMockStore();
-  const store = mockStore({
-    auth: {
-      euaId: 'ABCD',
-      name: 'Jerry Seinfeld',
-      isUserSet: true,
-      groups: ['EASI_TRB_ADMIN_D']
-    }
-  });
-  const trbRequestId = '449ea115-8bfa-48c3-b1dd-5a613d79fbae';
+  const store = easiMockStore();
 
   it('submits successfully ', async () => {
-    const { getByText, getByLabelText, getByRole } = render(
-      <Provider store={store}>
-        <MockedProvider
-          defaultOptions={{
-            watchQuery: { fetchPolicy: 'no-cache' },
-            query: { fetchPolicy: 'no-cache' }
-          }}
-          mocks={[
-            {
-              request: {
-                query: CreateTrbAdminNote,
-                variables: {
-                  input: {
-                    trbRequestId,
-                    category: '' as TRBAdminNoteCategory,
-                    noteText: ''
-                  }
-                }
-              },
-              result: {
-                data: {
-                  updateTRBRequestConsultMeetingTime: {
-                    id: 'd35a1f08-e04e-48f9-8d58-7f2409bae8fe',
-                    __typename: 'TRBRequest'
-                  }
-                }
-              }
-            },
-            {
-              request: {
-                query: GetTrbRequestSummaryQuery,
-                variables: {
-                  id: trbRequestId
-                }
-              },
-              result: {
-                data: {
-                  trbRequest: {
-                    name: 'Draft',
-                    type: 'NEED_HELP',
-                    state: 'OPEN',
-                    trbLead: null,
-                    createdAt: '2023-02-16T15:21:34.156885Z',
-                    taskStatuses: {
-                      formStatus: 'IN_PROGRESS',
-                      feedbackStatus: 'EDITS_REQUESTED',
-                      consultPrepStatus: 'CANNOT_START_YET',
-                      attendConsultStatus: 'CANNOT_START_YET',
-                      adviceLetterStatus: 'IN_PROGRESS',
-                      __typename: 'TRBTaskStatuses'
-                    },
-                    __typename: 'TRBRequest'
-                  }
-                }
-              }
-            },
-            {
-              request: {
-                query: GetTRBRequestAttendeesQuery,
-                variables: {
-                  id: trbRequestId
-                }
-              },
-              result: {
-                data: {
-                  trbRequest: {
-                    id: trbRequestId,
-                    attendees: []
-                  }
-                }
-              }
-            }
-          ]}
-        >
-          <MemoryRouter
-            initialEntries={[`/trb/${trbRequestId}/notes/add-note`]}
+    await act(async () => {
+      const { getByText, getByLabelText, getByRole } = render(
+        <Provider store={store}>
+          <MockedProvider
+            defaultOptions={{
+              watchQuery: { fetchPolicy: 'no-cache' },
+              query: { fetchPolicy: 'no-cache' }
+            }}
+            mocks={[
+              createTrbAdminNoteQuery,
+              getTrbRequestSummaryQuery,
+              getTRBRequestAttendeesQuery
+            ]}
           >
-            <TRBRequestInfoWrapper>
-              <MessageProvider>
-                <Route exact path="/trb/:id/:activePage">
-                  <AdminHome />
-                </Route>
+            <MemoryRouter
+              initialEntries={[`/trb/${mockTrbRequestId}/notes/add-note`]}
+            >
+              <TRBRequestInfoWrapper>
+                <MessageProvider>
+                  <Route exact path="/trb/:id/:activePage">
+                    <AdminHome />
+                  </Route>
 
-                <Route exact path="/trb/:id/notes/add-note">
-                  <AddNote />
-                </Route>
-              </MessageProvider>
-            </TRBRequestInfoWrapper>
-          </MemoryRouter>
-        </MockedProvider>
-      </Provider>
-    );
+                  <Route exact path="/trb/:id/notes/add-note">
+                    <AddNote />
+                  </Route>
+                </MessageProvider>
+              </TRBRequestInfoWrapper>
+            </MemoryRouter>
+          </MockedProvider>
+        </Provider>
+      );
 
-    getByText(
-      i18next.t<string>('technicalAssistance:notes.addNoteDescription')
-    );
+      getByText(
+        i18next.t<string>('technicalAssistance:notes.addNoteDescription')
+      );
 
-    const submitButton = getByRole('button', {
-      name: i18next.t<string>('technicalAssistance:notes.saveNote')
+      const submitButton = getByRole('button', {
+        name: i18next.t<string>('technicalAssistance:notes.saveNote')
+      });
+
+      expect(submitButton).toBeDisabled();
+
+      // Select note category
+      userEvent.selectOptions(
+        getByLabelText(
+          RegExp(i18next.t<string>('technicalAssistance:notes.labels.category'))
+        ),
+        ['Supporting documents']
+      );
+
+      // Enter note text
+      userEvent.type(
+        getByLabelText(
+          RegExp(i18next.t<string>('technicalAssistance:notes.labels.noteText'))
+        ),
+        'My cute note'
+      );
+
+      userEvent.click(submitButton);
     });
-
-    expect(submitButton).toBeDisabled();
-
-    // Select note category
-    userEvent.selectOptions(
-      getByLabelText(
-        RegExp(i18next.t<string>('technicalAssistance:notes.labels.category'))
-      ),
-      ['Supporting documents']
-    );
-
-    // Enter note text
-    userEvent.type(
-      getByLabelText(
-        RegExp(i18next.t<string>('technicalAssistance:notes.labels.noteText'))
-      ),
-      'My cute note'
-    );
-
-    userEvent.click(submitButton);
   });
 
   it('shows an error notice when submission fails', async () => {
@@ -159,21 +132,14 @@ describe('Trb Admin Notes: Add Note', () => {
       <MockedProvider
         mocks={[
           {
-            request: {
-              query: CreateTrbAdminNote,
-              variables: {
-                input: {
-                  trbRequestId,
-                  category: '' as TRBAdminNoteCategory,
-                  noteText: ''
-                }
-              }
-            },
+            ...createTrbAdminNoteQuery,
             error: new Error()
           }
         ]}
       >
-        <MemoryRouter initialEntries={[`/trb/${trbRequestId}/notes/add-note`]}>
+        <MemoryRouter
+          initialEntries={[`/trb/${mockTrbRequestId}/notes/add-note`]}
+        >
           <TRBRequestInfoWrapper>
             <MessageProvider>
               <Route exact path="/trb/:id/notes/add-note">

--- a/src/views/TechnicalAssistance/AdminHome/AddNote.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/AddNote.tsx
@@ -6,7 +6,6 @@ import { useMutation } from '@apollo/client';
 import {
   Alert,
   Button,
-  CharacterCount,
   Dropdown,
   ErrorMessage,
   Form,
@@ -20,6 +19,7 @@ import classNames from 'classnames';
 import UswdsReactLink from 'components/LinkWrapper';
 import PageHeading from 'components/PageHeading';
 import { ErrorAlertMessage } from 'components/shared/ErrorAlert';
+import TextAreaField from 'components/shared/TextAreaField';
 import useMessage from 'hooks/useMessage';
 import CreateTrbAdminNote from 'queries/CreateTrbAdminNote';
 import { TRBAdminNoteFragment } from 'queries/GetTrbAdminNotesQuery';
@@ -264,13 +264,10 @@ const AddNote = ({
                     <span className="text-red">*</span>
                   </Label>
 
-                  <CharacterCount
+                  <TextAreaField
                     {...field}
                     ref={null}
-                    id="noteText"
-                    maxLength={2000}
-                    isTextArea
-                    rows={2}
+                    id={field.name}
                     error={!!error}
                   />
                 </FormGroup>

--- a/src/views/TechnicalAssistance/AdminHome/Consult.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/Consult.tsx
@@ -104,7 +104,7 @@ function Consult() {
                 trbRequestId: id,
                 consultMeetingTime,
                 notes: formData.notes,
-                copyTrbMailbox: false,
+                copyTrbMailbox: true,
                 notifyEuaIds: ['ABCD']
               }
             }

--- a/src/views/TechnicalAssistance/AdminHome/Consult.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/Consult.tsx
@@ -6,7 +6,6 @@ import { useMutation } from '@apollo/client';
 import {
   Alert,
   Button,
-  CharacterCount,
   DatePicker,
   ErrorMessage,
   Form,
@@ -22,6 +21,7 @@ import { DateTime } from 'luxon';
 import UswdsReactLink from 'components/LinkWrapper';
 import PageHeading from 'components/PageHeading';
 import { ErrorAlertMessage } from 'components/shared/ErrorAlert';
+import TextAreaField from 'components/shared/TextAreaField';
 import useMessage from 'hooks/useMessage';
 import {
   UpdateTrbRequestConsultMeeting,
@@ -255,13 +255,10 @@ function Consult() {
                   <Label htmlFor="notes" className="text-normal">
                     {t('actionScheduleConsult.labels.notes')}
                   </Label>
-                  <CharacterCount
+                  <TextAreaField
                     {...field}
                     ref={null}
-                    id="notes"
-                    maxLength={2000}
-                    isTextArea
-                    rows={2}
+                    id={field.name}
                     aria-describedby="notes-info notes-hint"
                     error={!!error}
                   />

--- a/src/views/TechnicalAssistance/AdminHome/InitialRequestForm.test.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/InitialRequestForm.test.tsx
@@ -3,88 +3,48 @@ import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import i18next from 'i18next';
-import configureMockStore from 'redux-mock-store';
 
-import { attendees, requester } from 'data/mock/trbRequest';
-import GetTrbAdminNotesQuery from 'queries/GetTrbAdminNotesQuery';
-import GetTrbRequestDocumentsQuery from 'queries/GetTrbRequestDocumentsQuery';
-import GetTrbRequestQuery from 'queries/GetTrbRequestQuery';
-import { GetTRBRequestAttendeesQuery } from 'queries/TrbAttendeeQueries';
-import { GetTrbRequest_trbRequest as TrbRequest } from 'queries/types/GetTrbRequest';
-import { TRBAttendee } from 'queries/types/TRBAttendee';
 import {
-  TRBAdminNoteCategory,
-  TRBAdviceLetterStatus,
-  TRBAttendConsultStatus,
-  TRBConsultPrepStatus,
-  TRBFeedbackStatus,
-  TRBFormStatus,
-  TRBRequestState,
-  TRBRequestType
-} from 'types/graphql-global-types';
+  getTrbAdminNotesQuery,
+  getTRBRequestAttendeesQuery,
+  getTrbRequestQuery,
+  getTrbRequestSummaryQuery
+} from 'data/mock/trbRequest';
+import GetTrbRequestDocumentsQuery from 'queries/GetTrbRequestDocumentsQuery';
+import {
+  GetTrbRequestDocuments,
+  GetTrbRequestDocumentsVariables
+} from 'queries/types/GetTrbRequestDocuments';
+import { MockedQuery } from 'types/util';
+import mockUserAuth from 'utils/testing/easiMockStore';
+import { mockTrbRequestId } from 'utils/testing/MockTrbAttendees';
 import VerboseMockedProvider from 'utils/testing/VerboseMockedProvider';
 
 import InitialRequestForm from './InitialRequestForm';
 import TRBRequestInfoWrapper from './RequestContext';
 
-const mockTrbRequestData: TrbRequest = {
-  id: 'f3b4cff8-321d-4d2a-a9a2-4b05810756d7',
-  name: 'Lorem ipsum dolor sit amet, consectetur',
-  type: TRBRequestType.NEED_HELP,
-  state: TRBRequestState.OPEN,
-  taskStatuses: {
-    formStatus: TRBFormStatus.IN_PROGRESS,
-    feedbackStatus: TRBFeedbackStatus.CANNOT_START_YET,
-    consultPrepStatus: TRBConsultPrepStatus.CANNOT_START_YET,
-    attendConsultStatus: TRBAttendConsultStatus.CANNOT_START_YET,
-    adviceLetterStatus: TRBAdviceLetterStatus.CANNOT_START_YET,
-    __typename: 'TRBTaskStatuses'
+const getTrbRequestDocumentsQuery: MockedQuery<
+  GetTrbRequestDocuments,
+  GetTrbRequestDocumentsVariables
+> = {
+  request: {
+    query: GetTrbRequestDocumentsQuery,
+    variables: { id: mockTrbRequestId }
   },
-  form: {
-    id: '452cf444-69b2-41a9-b8ab-ed354d209307',
-    component: null,
-    needsAssistanceWith: null,
-    hasSolutionInMind: false,
-    proposedSolution: null,
-    whereInProcess: null,
-    whereInProcessOther: null,
-    hasExpectedStartEndDates: false,
-    expectedStartDate: null,
-    expectedEndDate: null,
-    collabGroups: [],
-    collabDateSecurity: null,
-    collabDateEnterpriseArchitecture: null,
-    collabDateCloud: null,
-    collabDatePrivacyAdvisor: null,
-    collabDateGovernanceReviewBoard: null,
-    collabDateOther: null,
-    collabGroupOther: null,
-    collabGRBConsultRequested: null,
-    subjectAreaOptions: null,
-    subjectAreaOptionOther: null,
-    fundingSources: null,
-    submittedAt: null,
-    __typename: 'TRBRequestForm'
-  },
-  __typename: 'TRBRequest',
-  feedback: []
-};
-
-const initialRequester: TRBAttendee = {
-  ...requester,
-  component: null,
-  role: null
+  result: {
+    data: {
+      trbRequest: {
+        __typename: 'TRBRequest',
+        id: mockTrbRequestId,
+        documents: []
+      }
+    }
+  }
 };
 
 describe('Trb Admin Initial Request Form', () => {
-  it('renders', async () => {
-    const mockStore = configureMockStore();
-    const store = mockStore({
-      auth: {
-        euaId: requester?.userInfo?.euaUserId,
-        name: requester?.userInfo?.commonName
-      }
-    });
+  it.only('renders', async () => {
+    const store = mockUserAuth();
     const { getByText, queryByText, queryAllByText, findByText } = render(
       <VerboseMockedProvider
         defaultOptions={{
@@ -92,81 +52,21 @@ describe('Trb Admin Initial Request Form', () => {
           query: { fetchPolicy: 'no-cache' }
         }}
         mocks={[
-          {
-            request: {
-              query: GetTrbRequestQuery,
-              variables: { id: mockTrbRequestData.id }
-            },
-            result: { data: { trbRequest: mockTrbRequestData } }
-          },
-          {
-            request: {
-              query: GetTRBRequestAttendeesQuery,
-              variables: {
-                id: mockTrbRequestData.id
-              }
-            },
-            result: {
-              data: {
-                trbRequest: {
-                  id: mockTrbRequestData.id,
-                  attendees: [initialRequester, ...attendees]
-                }
-              }
-            }
-          },
-          {
-            request: {
-              query: GetTrbRequestDocumentsQuery,
-              variables: { id: mockTrbRequestData.id }
-            },
-            result: {
-              data: {
-                trbRequest: { id: mockTrbRequestData.id, documents: [] }
-              }
-            }
-          },
-          {
-            request: {
-              query: GetTrbAdminNotesQuery,
-              variables: {
-                id: mockTrbRequestData.id
-              }
-            },
-            result: {
-              data: {
-                trbRequest: {
-                  id: mockTrbRequestData.id,
-                  adminNotes: [
-                    {
-                      id: '861fa6c5-c9af-4cda-a559-0995b7b76855',
-                      isArchived: false,
-                      category: TRBAdminNoteCategory.GENERAL_REQUEST,
-                      noteText: 'My cute original note',
-                      author: {
-                        __typename: 'UserInfo',
-                        commonName: 'Jerry Seinfeld'
-                      },
-                      createdAt: '2024-03-28T13:20:37.852099Z',
-                      __typename: 'TRBAdminNote'
-                    }
-                  ]
-                }
-              }
-            }
-          }
+          getTrbRequestQuery,
+          getTrbRequestSummaryQuery,
+          getTRBRequestAttendeesQuery,
+          getTrbRequestDocumentsQuery,
+          getTrbAdminNotesQuery
         ]}
       >
         <Provider store={store}>
           <MemoryRouter
-            initialEntries={[
-              `/trb/${mockTrbRequestData.id}/initial-request-form`
-            ]}
+            initialEntries={[`/trb/${mockTrbRequestId}/initial-request-form`]}
           >
             <TRBRequestInfoWrapper>
               <Route exact path="/trb/:id/:activePage">
                 <InitialRequestForm
-                  trbRequestId={mockTrbRequestData.id}
+                  trbRequestId={mockTrbRequestId}
                   noteCount={0}
                 />
               </Route>

--- a/src/views/TechnicalAssistance/AdminHome/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/AdminHome/__snapshots__/index.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`TRB admin home matches the snapshot 1`] = `
           <h2
             class="margin-top-05 margin-bottom-0"
           >
-            TRB Request Mock
+            Mock TRB Request
           </h2>
           <div
             class="grid-row"
@@ -133,7 +133,7 @@ exports[`TRB admin home matches the snapshot 1`] = `
               <p
                 class="margin-y-0 text-base"
               >
-                Ready to start request form
+                Draft request form
               </p>
             </div>
             <div

--- a/src/views/TechnicalAssistance/AdminHome/components/ReviewAdviceLetter/index.test.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/ReviewAdviceLetter/index.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
-import { trbRequestAdviceLetter } from 'data/mock/trbRequest';
+import { adviceLetter } from 'data/mock/trbRequest';
 
 import ReviewAdviceLetter from '.';
 
 describe('TRB Advice Letter review component', () => {
   it('Matches the snapshot', async () => {
     const { getByText, asFragment } = render(
-      <ReviewAdviceLetter adviceLetter={trbRequestAdviceLetter} />
+      <ReviewAdviceLetter adviceLetter={adviceLetter} />
     );
 
     // Advice letter renders

--- a/src/views/TechnicalAssistance/AdminHome/components/Summary/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/AdminHome/components/Summary/__snapshots__/index.test.tsx.snap
@@ -37,14 +37,14 @@ exports[`TRB Admin Home summary renders TRB request details 1`] = `
               aria-current="page"
               class="usa-breadcrumb__list-item usa-current"
             >
-              Request a4093ec7-caec-4e73-be3d-a8d6262bc61b
+              Request d8ebedca-0031-4ccd-9690-37390726c50e
             </li>
           </ol>
         </nav>
         <h2
           class="margin-top-05 margin-bottom-0"
         >
-          TRB Request Mock
+          Mock TRB Request
         </h2>
         <div
           class="grid-row"
@@ -136,7 +136,7 @@ exports[`TRB Admin Home summary renders TRB request details 1`] = `
             <p
               class="margin-y-0 text-base"
             >
-              Ready to start request form
+              Draft request form
             </p>
           </div>
           <div

--- a/src/views/TechnicalAssistance/AdminHome/components/Summary/index.test.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/Summary/index.test.tsx
@@ -3,67 +3,33 @@ import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { render, within } from '@testing-library/react';
-import configureMockStore from 'redux-mock-store';
 
-import { requester, trbRequestSummary } from 'data/mock/trbRequest';
-import GetTrbRequestSummaryQuery from 'queries/GetTrbRequestSummaryQuery';
-import { GetTRBRequestAttendeesQuery } from 'queries/TrbAttendeeQueries';
+import {
+  getTRBRequestAttendeesQuery,
+  getTrbRequestQuery,
+  requester,
+  trbRequestSummary
+} from 'data/mock/trbRequest';
+import easiMockStore from 'utils/testing/easiMockStore';
+import { mockTrbRequestId } from 'utils/testing/MockTrbAttendees';
 
 import Summary from '.';
 
-const trbRequestId = 'a4093ec7-caec-4e73-be3d-a8d6262bc61b';
-
-const getTrbRequestQuery = {
-  request: {
-    query: GetTrbRequestSummaryQuery,
-    variables: {
-      id: trbRequestId
-    }
-  },
-  result: {
-    data: { trbRequest: trbRequestSummary }
-  }
-};
-
-const getTrbAttendeesQuery = {
-  request: {
-    query: GetTRBRequestAttendeesQuery,
-    variables: {
-      id: trbRequestId
-    }
-  },
-  result: {
-    data: {
-      trbRequest: {
-        attendees: [
-          {
-            ...requester,
-            trbRequestId
-          }
-        ]
-      }
-    }
-  }
-};
-
-const mockStore = configureMockStore();
-const defaultStore = mockStore({
-  auth: {
-    euaId: 'SF13',
-    name: 'Jerry Seinfeld',
-    isUserSet: true,
-    groups: ['EASI_TRB_ADMIN_D']
-  }
+const defaultStore = easiMockStore({
+  euaUserId: 'SF13',
+  groups: ['EASI_TRB_ADMIN_D']
 });
 
 describe('TRB Admin Home summary', () => {
   it('renders TRB request details', async () => {
     const { asFragment, findByTestId, getByTestId } = render(
       <MemoryRouter>
-        <MockedProvider mocks={[getTrbRequestQuery, getTrbAttendeesQuery]}>
+        <MockedProvider
+          mocks={[getTrbRequestQuery, getTRBRequestAttendeesQuery]}
+        >
           <Provider store={defaultStore}>
             <Summary
-              trbRequestId={trbRequestId}
+              trbRequestId={mockTrbRequestId}
               name={trbRequestSummary.name}
               requestType={trbRequestSummary.type}
               createdAt={trbRequestSummary.createdAt}
@@ -94,7 +60,7 @@ describe('TRB Admin Home summary', () => {
 
     // Check that correct task status is rendered
     expect(getByTestId('trbSummary-status')).toHaveTextContent(
-      'Ready to start request form'
+      'Draft request form'
     );
 
     /** TRB Lead container */

--- a/src/views/TechnicalAssistance/RequestForm/Basic.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/Basic.tsx
@@ -6,7 +6,6 @@ import { ApolloError, useMutation } from '@apollo/client';
 import { yupResolver } from '@hookform/resolvers/yup';
 import {
   Alert,
-  CharacterCount,
   Checkbox,
   Dropdown,
   ErrorMessage,
@@ -25,6 +24,7 @@ import DatePickerFormatted from 'components/shared/DatePickerFormatted';
 import Divider from 'components/shared/Divider';
 import { ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import RequiredAsterisk from 'components/shared/RequiredAsterisk';
+import TextAreaField from 'components/shared/TextAreaField';
 import intakeFundingSources from 'constants/enums/intakeFundingSources';
 import DeleteTRBRequestFundingSource from 'queries/DeleteTRBRequestFundingSource';
 import {
@@ -411,13 +411,10 @@ function Basic({
                 {error && (
                   <ErrorMessage>{t('errors.includeExplanation')}</ErrorMessage>
                 )}
-                <CharacterCount
+                <TextAreaField
                   {...field}
                   ref={null}
                   id="needsAssistanceWith"
-                  maxLength={2000}
-                  isTextArea
-                  rows={2}
                   aria-describedby="needsAssistanceWith-info needsAssistanceWith-hint"
                   error={!!error}
                 />
@@ -466,13 +463,10 @@ function Basic({
                                 {t('errors.includeExplanation')}
                               </ErrorMessage>
                             )}
-                            <CharacterCount
+                            <TextAreaField
                               {...field}
                               ref={null}
                               id="proposedSolution"
-                              maxLength={2000}
-                              isTextArea
-                              rows={2}
                               aria-describedby="proposedSolution-info proposedSolution-hint"
                               error={!!error}
                             />

--- a/src/views/TechnicalAssistance/RequestForm/__snapshots__/Basic.test.tsx.snap
+++ b/src/views/TechnicalAssistance/RequestForm/__snapshots__/Basic.test.tsx.snap
@@ -250,20 +250,10 @@ exports[`Trb Request form: Basic submits the form successfully after a failed at
           </label>
           <textarea
             aria-describedby="needsAssistanceWith-info needsAssistanceWith-hint"
-            class="usa-textarea usa-character-count__field"
-            data-testid="textarea"
+            class="usa-textarea"
             id="needsAssistanceWith"
             name="needsAssistanceWith"
-            rows="2"
           />
-          <span
-            aria-live="polite"
-            class="usa-hint usa-character-count__message"
-            data-testid="characterCountMessage"
-            id="needsAssistanceWith-info"
-          >
-            2000 characters allowed
-          </span>
         </div>
         <div
           class="usa-form-group"

--- a/src/views/TechnicalAssistance/RequestForm/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/RequestForm/__snapshots__/index.test.tsx.snap
@@ -810,20 +810,12 @@ exports[`TRB Request Form Feedback shows the View feedback warning banner in the
             </label>
             <textarea
               aria-describedby="needsAssistanceWith-info needsAssistanceWith-hint"
-              class="usa-textarea usa-character-count__field"
-              data-testid="textarea"
+              class="usa-textarea"
               id="needsAssistanceWith"
               name="needsAssistanceWith"
-              rows="2"
-            />
-            <span
-              aria-live="polite"
-              class="usa-hint usa-character-count__message"
-              data-testid="characterCountMessage"
-              id="needsAssistanceWith-info"
             >
-              2000 characters allowed
-            </span>
+              x
+            </textarea>
           </div>
           <div
             class="usa-form-group"

--- a/src/views/TechnicalAssistance/RequestForm/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/RequestForm/__snapshots__/index.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`TRB Request Form Feedback goes to and renders the feedback view 1`] = `
         >
           <a
             class="usa-breadcrumb__link"
-            href="/trb/task-list/f727cb0d-5ba1-40a3-8172-00e4ce86da3c"
+            href="/trb/task-list/d8ebedca-0031-4ccd-9690-37390726c50e"
           >
             <span>
               Task list
@@ -43,7 +43,7 @@ exports[`TRB Request Form Feedback goes to and renders the feedback view 1`] = `
         >
           <a
             class="usa-breadcrumb__link"
-            href="/trb/requests/f727cb0d-5ba1-40a3-8172-00e4ce86da3c/check"
+            href="/trb/requests/d8ebedca-0031-4ccd-9690-37390726c50e/check"
           >
             <span>
               TRB Request
@@ -69,7 +69,7 @@ exports[`TRB Request Form Feedback goes to and renders the feedback view 1`] = `
     </h1>
     <a
       class="usa-link"
-      href="/trb/requests/f727cb0d-5ba1-40a3-8172-00e4ce86da3c/check"
+      href="/trb/requests/d8ebedca-0031-4ccd-9690-37390726c50e/check"
     >
       <svg
         class="usa-icon margin-right-1 text-middle"
@@ -126,7 +126,7 @@ exports[`TRB Request Form Feedback goes to and renders the feedback view 1`] = `
             Feedback from
           </dt>
           <dd>
-            George Louis Costanza, TRB
+            Audrey Abrams, TRB
           </dd>
         </dl>
       </div>
@@ -176,7 +176,7 @@ exports[`TRB Request Form Feedback goes to and renders the feedback view 1`] = `
             Feedback from
           </dt>
           <dd>
-            George Louis Costanza, TRB
+            Audrey Abrams, TRB
           </dd>
         </dl>
       </div>
@@ -199,7 +199,7 @@ exports[`TRB Request Form Feedback goes to and renders the feedback view 1`] = `
     >
       <a
         class="usa-link"
-        href="/trb/requests/f727cb0d-5ba1-40a3-8172-00e4ce86da3c/check"
+        href="/trb/requests/d8ebedca-0031-4ccd-9690-37390726c50e/check"
       >
         <svg
           class="usa-icon margin-right-1 text-middle"
@@ -274,7 +274,7 @@ exports[`TRB Request Form Feedback shows the View feedback warning banner in the
                 >
                   <a
                     class="usa-breadcrumb__link"
-                    href="/trb/task-list/f727cb0d-5ba1-40a3-8172-00e4ce86da3c"
+                    href="/trb/task-list/d8ebedca-0031-4ccd-9690-37390726c50e"
                   >
                     <span>
                       Task list
@@ -376,7 +376,7 @@ exports[`TRB Request Form Feedback shows the View feedback warning banner in the
         >
           <a
             class="usa-button usa-button--outline"
-            href="/trb/requests/f727cb0d-5ba1-40a3-8172-00e4ce86da3c/feedback"
+            href="/trb/requests/d8ebedca-0031-4ccd-9690-37390726c50e/feedback"
           >
             View feedback
           </a>
@@ -610,7 +610,7 @@ exports[`TRB Request Form Feedback shows the View feedback warning banner in the
               id="name"
               name="name"
               type="text"
-              value="Draft"
+              value="Mock TRB Request"
             />
           </div>
           <div

--- a/src/views/TechnicalAssistance/RequestForm/index.test.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/index.test.tsx
@@ -5,121 +5,75 @@ import { MockedProvider } from '@apollo/client/testing';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import i18next from 'i18next';
-import configureMockStore from 'redux-mock-store';
 
-import { requester } from 'data/mock/trbRequest';
-import GetTrbRequestQuery from 'queries/GetTrbRequestQuery';
+import {
+  attendees,
+  getTrbRequestQuery,
+  trbRequest
+} from 'data/mock/trbRequest';
+import {
+  GetTrbRequest,
+  GetTrbRequestVariables
+} from 'queries/types/GetTrbRequest';
+import {
+  TRBFeedbackAction,
+  TRBFeedbackStatus
+} from 'types/graphql-global-types';
+import { MockedQuery } from 'types/util';
+import easiMockStore from 'utils/testing/easiMockStore';
+import { mockTrbRequestId } from 'utils/testing/MockTrbAttendees';
 
 import RequestForm from '.';
 
-function renderFeedbackTest() {
-  const mockStore = configureMockStore();
-  const store = mockStore({
-    auth: {
-      euaId: requester?.userInfo?.euaUserId,
-      name: requester?.userInfo?.commonName
-    }
-  });
-  return render(
-    <MemoryRouter
-      initialEntries={[
-        '/trb/requests/f727cb0d-5ba1-40a3-8172-00e4ce86da3c/basic'
-      ]}
-    >
-      <MockedProvider
-        mocks={[
+const getTrbRequestQueryWithFeedback: MockedQuery<
+  GetTrbRequest,
+  GetTrbRequestVariables
+> = {
+  ...getTrbRequestQuery,
+  result: {
+    data: {
+      trbRequest: {
+        ...trbRequest,
+        taskStatuses: {
+          ...trbRequest.taskStatuses,
+          feedbackStatus: TRBFeedbackStatus.EDITS_REQUESTED
+        },
+        feedback: [
           {
-            request: {
-              query: GetTrbRequestQuery,
-              variables: { id: 'f727cb0d-5ba1-40a3-8172-00e4ce86da3c' }
+            id: 'edf39ac2-ced6-4cfd-a328-a1707c2e04c7',
+            feedbackMessage:
+              'Purus morbi pellentesque eget erat. Egestas venenatis vitae pretium pretium, orci, elit praesent tortor. Turpis semper sollicitudin sagittis pellentesque est dictum. Rhoncus, nulla turpis netus praesent consequat leo orci, vel.',
+            action: TRBFeedbackAction.REQUEST_EDITS,
+            author: {
+              commonName: attendees[1].userInfo.commonName,
+              __typename: 'UserInfo'
             },
-            result: {
-              data: {
-                trbRequest: {
-                  id: 'f727cb0d-5ba1-40a3-8172-00e4ce86da3c',
-                  name: 'Draft',
-                  createdBy: 'ABCD',
-                  createdAt: '2023-01-31T16:23:06.111436Z',
-                  type: 'NEED_HELP',
-                  status: 'OPEN',
-                  taskStatuses: {
-                    formStatus: 'IN_PROGRESS',
-                    feedbackStatus: 'EDITS_REQUESTED',
-                    consultPrepStatus: 'CANNOT_START_YET',
-                    attendConsultStatus: 'CANNOT_START_YET',
-                    adviceLetterStatus: 'CANNOT_START_YET',
-                    __typename: 'TRBTaskStatuses'
-                  },
-                  trbLead: null,
-                  form: {
-                    id: '9c1e6ece-e398-4ef7-8964-e8bca1515a93',
-                    component: 'Center for Medicaid and CHIP Services',
-                    needsAssistanceWith: 'x',
-                    hasSolutionInMind: false,
-                    proposedSolution: null,
-                    whereInProcess: 'I_HAVE_AN_IDEA_AND_WANT_TO_BRAINSTORM',
-                    whereInProcessOther: null,
-                    hasExpectedStartEndDates: false,
-                    expectedStartDate: null,
-                    expectedEndDate: null,
-                    collabGroups: ['ENTERPRISE_ARCHITECTURE'],
-                    collabDateSecurity: null,
-                    collabDateEnterpriseArchitecture: 'x',
-                    collabDateCloud: null,
-                    collabDatePrivacyAdvisor: null,
-                    collabDateGovernanceReviewBoard: null,
-                    collabDateOther: null,
-                    collabGroupOther: null,
-                    subjectAreaTechnicalReferenceArchitecture: [],
-                    subjectAreaNetworkAndSecurity: [],
-                    subjectAreaCloudAndInfrastructure: [],
-                    subjectAreaApplicationDevelopment: [],
-                    subjectAreaDataAndDataManagement: [],
-                    subjectAreaGovernmentProcessesAndPolicies: [],
-                    subjectAreaOtherTechnicalTopics: [],
-                    subjectAreaTechnicalReferenceArchitectureOther: null,
-                    subjectAreaNetworkAndSecurityOther: null,
-                    subjectAreaCloudAndInfrastructureOther: null,
-                    subjectAreaApplicationDevelopmentOther: null,
-                    subjectAreaDataAndDataManagementOther: null,
-                    subjectAreaGovernmentProcessesAndPoliciesOther: null,
-                    subjectAreaOtherTechnicalTopicsOther: null,
-                    submittedAt: null,
-                    __typename: 'TRBRequestForm'
-                  },
-                  feedback: [
-                    {
-                      id: 'edf39ac2-ced6-4cfd-a328-a1707c2e04c7',
-                      feedbackMessage:
-                        'Purus morbi pellentesque eget erat. Egestas venenatis vitae pretium pretium, orci, elit praesent tortor. Turpis semper sollicitudin sagittis pellentesque est dictum. Rhoncus, nulla turpis netus praesent consequat leo orci, vel.',
-                      action: 'REQUEST_EDITS',
-                      author: {
-                        commonName: 'George Louis Costanza',
-                        __typename: 'UserInfo'
-                      },
-                      createdAt: '2023-01-30T16:23:34.576076Z',
-                      __typename: 'TRBRequestFeedback'
-                    },
-                    {
-                      id: 'eeb2dab6-d436-433a-90a9-673c8e9256f5',
-                      feedbackMessage:
-                        'Id mauris pharetra volutpat, praesent faucibus aliquam, penatibus. Convallis maecenas cras dignissim in diam duis odio maecenas. Mi amet ullamcorper dolor tempus vulputate elit a volutpat purus. Nunc, vel arcu imperdiet duis enim leo quis. Aliquam nibh tincidunt aliquam morbi non. A in porttitor suspendisse nunc turpis turpis eros, at ultrices. Scelerisque netus quisque semper ullamcorper porta interdum scelerisque elementum. Egestas enim egestas imperdiet sociis porta.',
-                      action: 'REQUEST_EDITS',
-                      author: {
-                        commonName: 'George Louis Costanza',
-                        __typename: 'UserInfo'
-                      },
-                      createdAt: '2023-01-31T18:22:13.029728Z',
-                      __typename: 'TRBRequestFeedback'
-                    }
-                  ],
-                  __typename: 'TRBRequest'
-                }
-              }
-            }
+            createdAt: '2023-01-30T16:23:34.576076Z',
+            __typename: 'TRBRequestFeedback'
+          },
+          {
+            id: 'eeb2dab6-d436-433a-90a9-673c8e9256f5',
+            feedbackMessage:
+              'Id mauris pharetra volutpat, praesent faucibus aliquam, penatibus. Convallis maecenas cras dignissim in diam duis odio maecenas. Mi amet ullamcorper dolor tempus vulputate elit a volutpat purus. Nunc, vel arcu imperdiet duis enim leo quis. Aliquam nibh tincidunt aliquam morbi non. A in porttitor suspendisse nunc turpis turpis eros, at ultrices. Scelerisque netus quisque semper ullamcorper porta interdum scelerisque elementum. Egestas enim egestas imperdiet sociis porta.',
+            action: TRBFeedbackAction.REQUEST_EDITS,
+            author: {
+              commonName: attendees[1].userInfo.commonName,
+              __typename: 'UserInfo'
+            },
+            createdAt: '2023-01-31T18:22:13.029728Z',
+            __typename: 'TRBRequestFeedback'
           }
-        ]}
-      >
+        ]
+      }
+    }
+  }
+};
+
+function renderFeedbackTest() {
+  const store = easiMockStore();
+  return render(
+    <MemoryRouter initialEntries={[`/trb/requests/${mockTrbRequestId}/basic`]}>
+      <MockedProvider mocks={[getTrbRequestQueryWithFeedback]}>
         <Route exact path="/trb/requests/:id/:step?/:view?">
           <Provider store={store}>
             <RequestForm />
@@ -164,7 +118,7 @@ describe('TRB Request Form Feedback', () => {
     );
 
     // Check feedback author name
-    getAllByText(/George Louis Costanza/);
+    getAllByText(/Audrey Abrams/);
 
     // Check feedback ordered by dates desc
     const sortedDates = getAllByTestId('feedback-date');

--- a/src/views/TechnicalAssistance/TrbAdminTeamHome.test.tsx
+++ b/src/views/TechnicalAssistance/TrbAdminTeamHome.test.tsx
@@ -5,11 +5,15 @@ import { MockedProvider } from '@apollo/react-testing';
 import { render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import i18next from 'i18next';
-import configureMockStore from 'redux-mock-store';
 
-import { trbAdminTeamHomeRequests } from 'data/mock/trbRequest';
+import {
+  getTrbAdminTeamHomeQuery,
+  getTrbLeadOptionsQuery,
+  trbAdminTeamHomeRequests
+} from 'data/mock/trbRequest';
 import { MessageProvider } from 'hooks/useMessage';
 import GetTrbAdminTeamHomeQuery from 'queries/GetTrbAdminTeamHomeQuery';
+import easiMockStore from 'utils/testing/easiMockStore';
 
 import TrbAdminTeamHome, {
   getTrbRequestDataAsCsv,
@@ -17,15 +21,7 @@ import TrbAdminTeamHome, {
 } from './TrbAdminTeamHome';
 
 describe('Trb Admin Team Home', () => {
-  const mockStore = configureMockStore();
-  const store = mockStore({
-    auth: {
-      euaId: 'SF13',
-      name: 'Jerry Seinfeld',
-      isUserSet: true,
-      groups: ['EASI_TRB_ADMIN_D']
-    }
-  });
+  const store = easiMockStore({ euaUserId: 'SF13' });
 
   it('parses csv data from trb request data', () => {
     const csv = getTrbRequestDataAsCsv(trbAdminTeamHomeRequests);
@@ -34,7 +30,7 @@ describe('Trb Admin Team Home', () => {
       [
         '03/01/2023',
         'First help',
-        'Wava Upton',
+        trbAdminTeamHomeRequests[0].requesterInfo.commonName,
         'System problem',
         '',
         i18next.t<string>('technicalAssistance:table.requestStatus.NEW'),
@@ -43,7 +39,7 @@ describe('Trb Admin Team Home', () => {
       [
         '03/02/2023',
         'Second brainstorm',
-        'Derick Koss',
+        trbAdminTeamHomeRequests[1].requesterInfo.commonName,
         'Idea feedback',
         '',
         i18next.t<string>('technicalAssistance:table.requestStatus.NEW'),
@@ -52,9 +48,9 @@ describe('Trb Admin Team Home', () => {
       [
         '03/03/2023',
         'Third open',
-        'Loraine Kirlin',
+        trbAdminTeamHomeRequests[2].requesterInfo.commonName,
         'System problem',
-        'Astrid Howell',
+        trbAdminTeamHomeRequests[2].trbLeadInfo.commonName,
         i18next.t<string>(
           'technicalAssistance:table.requestStatus.DRAFT_REQUEST_FORM'
         ),
@@ -63,9 +59,9 @@ describe('Trb Admin Team Home', () => {
       [
         '03/04/2023',
         'Fourth open with date',
-        'Clotilde Goodwin',
+        trbAdminTeamHomeRequests[3].requesterInfo.commonName,
         'System problem',
-        'Polly Sauer',
+        trbAdminTeamHomeRequests[3].trbLeadInfo.commonName,
         i18next.t<string>(
           'technicalAssistance:table.requestStatus.REQUEST_FORM_COMPLETE'
         ),
@@ -74,9 +70,9 @@ describe('Trb Admin Team Home', () => {
       [
         '03/05/2023',
         'Fifth closed',
-        'Sylvester Mante',
+        trbAdminTeamHomeRequests[4].requesterInfo.commonName,
         'System problem',
-        'Sydni Reynolds',
+        trbAdminTeamHomeRequests[4].trbLeadInfo.commonName,
         i18next.t<string>(
           'technicalAssistance:table.requestStatus.READY_FOR_CONSULT'
         ),
@@ -85,9 +81,9 @@ describe('Trb Admin Team Home', () => {
       [
         '03/06/2023',
         'Sixth open with component',
-        'Damaris Langosh, BBQ',
+        `${trbAdminTeamHomeRequests[5].requesterInfo.commonName}, ${trbAdminTeamHomeRequests[5].requesterComponent}`,
         'System problem',
-        'Hosea Lemke, TRB',
+        `${trbAdminTeamHomeRequests[5].trbLeadInfo.commonName}, TRB`,
         i18next.t<string>(
           'technicalAssistance:table.requestStatus.CONSULT_SCHEDULED'
         ),
@@ -105,7 +101,8 @@ describe('Trb Admin Team Home', () => {
               {
                 request: { query: GetTrbAdminTeamHomeQuery, variables: {} },
                 result: { data: { trbRequests: [] } }
-              }
+              },
+              getTrbLeadOptionsQuery
             ]}
           >
             <MessageProvider>
@@ -134,12 +131,7 @@ describe('Trb Admin Team Home', () => {
       <Provider store={store}>
         <MemoryRouter>
           <MockedProvider
-            mocks={[
-              {
-                request: { query: GetTrbAdminTeamHomeQuery, variables: {} },
-                result: { data: { trbRequests: trbAdminTeamHomeRequests } }
-              }
-            ]}
+            mocks={[getTrbAdminTeamHomeQuery, getTrbLeadOptionsQuery]}
           >
             <MessageProvider>
               <TrbAdminTeamHome />
@@ -184,12 +176,7 @@ describe('Trb Admin Team Home', () => {
       <Provider store={store}>
         <MemoryRouter>
           <MockedProvider
-            mocks={[
-              {
-                request: { query: GetTrbAdminTeamHomeQuery, variables: {} },
-                result: { data: { trbRequests: trbAdminTeamHomeRequests } }
-              }
-            ]}
+            mocks={[getTrbAdminTeamHomeQuery, getTrbLeadOptionsQuery]}
           >
             <MessageProvider>
               <TrbAdminTeamHome />
@@ -230,7 +217,7 @@ describe('Trb Admin Team Home', () => {
 
     // Requester without component
     expect(await findByTestId('trb-new-cell-1-2')).toHaveTextContent(
-      'Wava Upton'
+      trbAdminTeamHomeRequests[0].requesterInfo.commonName
     );
 
     // Action links column of new requests
@@ -243,7 +230,7 @@ describe('Trb Admin Team Home', () => {
     // Existing requests
     // TRB Lead with Component
     expect(await findByTestId('trb-existing-cell-0-3')).toHaveTextContent(
-      'Hosea Lemke, TRB'
+      `${trbAdminTeamHomeRequests[5].trbLeadInfo.commonName}, TRB`
     );
     // TRB consult date
     expect(await findByTestId('trb-existing-cell-0-5')).toHaveTextContent(
@@ -268,12 +255,7 @@ describe('Trb Admin Team Home', () => {
       <Provider store={store}>
         <MemoryRouter>
           <MockedProvider
-            mocks={[
-              {
-                request: { query: GetTrbAdminTeamHomeQuery, variables: {} },
-                result: { data: { trbRequests: trbAdminTeamHomeRequests } }
-              }
-            ]}
+            mocks={[getTrbAdminTeamHomeQuery, getTrbLeadOptionsQuery]}
           >
             <MessageProvider>
               <TrbAdminTeamHome />


### PR DESCRIPTION
# NOREF

## Changes and Description

Fixes console errors and warnings from the TRB unit tests. A lot of these stemmed from queries not being updated to reflect schema changes and using user info that was different from the mock user data.

- Updated TRB mock data in [src/data/mock/trbRequest.ts](https://github.com/CMSgov/easi-app/blob/NOREF/unit-test-fixes/src/data/mock/trbRequest.ts)
  - Fixed console warnings from missing query data and type errors
  - Updated _most_ TRB test files to use the standardized mock data so that we only have to update in one place
- Updated `VerboseMockedProvider` to hide console statements from empty errors
  - Purposefully throwing a gql error ([example here](https://github.com/CMSgov/easi-app/blob/4c5a8ce0ec171622ba3ab4b9b464e57561a705e8/src/views/TechnicalAssistance/AdminHome/Consult.test.tsx#L187-L195)) was showing an empty error in the console. Updated component to only log errors that have a message.
- Replaced `CharacterCounter` with `TextAreaField` to fix console errors
  - `CharacterCounter` throws a console error when used in React Hook Forms. We could probably troubleshoot this so we can use the component, but I thought it was easier to just replace the component for now.

---

This also introduces a few utilities to standardize mock user data and enforce query types:

### [MockedQuery](https://github.com/CMSgov/easi-app/blob/4c5a8ce0ec171622ba3ab4b9b464e57561a705e8/src/types/util.ts#L10-L25)
- Utility type to enforce query types in mocked queries
- Helps to make sure correct data is used in mock queries and tests are updated with schema changes
```ts
const getTrbRequestSummaryQuery: MockedQuery<
  GetTrbRequestSummary,
  GetTrbRequestSummaryVariables
> = {
  request: {
    query: GetTrbRequestSummaryQuery,
    /**
     * GetTrbRequestSummaryVariables type enforced here
     * If no variables needed, pass empty object
     */
    variables: {
      id
    }
  },
  result: { 
    // GetTrbRequestSummary type enforced here
    data: {
      trbRequest
    }
  }
};
```

### [easiMockStore](https://github.com/CMSgov/easi-app/blob/NOREF/unit-test-fixes/src/utils/testing/easiMockStore.ts)
- Utility function that returns mock store with `euaId` and `name` props from mock user data
- Prevents tests from running with inaccurate user data
```ts
// All props are optional
const store = easiMockStore({
  euaUserId: 'SF13', // defaults to ABCD
  isUserSet: true, // defaults to true
  groups: ['EASI_TRB_ADMIN_D'] // defaults to []
});
```
### [users.ts](https://github.com/CMSgov/easi-app/blob/NOREF/unit-test-fixes/src/data/mock/users.ts)
- Array of mock users to match data in [pkg/local/cedar_ldap.go](https://github.com/CMSgov/easi-app/blob/4c5a8ce0ec171622ba3ab4b9b464e57561a705e8/pkg/local/cedar_ldap.go#L28)
- Used to create mock user utility classes (see below)
- Contains `MockUserInfo`, `MockEuaUserId`, and `MockUserName` types

### [MockUsers](https://github.com/CMSgov/easi-app/blob/NOREF/unit-test-fixes/src/utils/testing/MockUsers.ts)
- Utility class to mock users for testing
- Can be extended with additional props to mock different user types (see [src/utils/testing/MockTrbAttendees.ts](https://github.com/CMSgov/easi-app/blob/4c5a8ce0ec171622ba3ab4b9b464e57561a705e8/src/utils/testing/MockTrbAttendees.ts#L33-L49) for example)

```ts
const users = new MockUsers({
  // If set to false, MockUsers will only return a user once before removing from instance
  allowDuplicates: false, // defaults to false
  /**
   * UserInfo prop cannot be set with default value, so defaultProps is only
   * applicable when MockUsers is extended with additional props
   */
  defaultProps: {
    prop: 'Default value for all users'
  }
});

// Returns next mocked user
const nextUser = users.next();

// Returns user by euaUserId
const userByEua = users.findByEuaUserId('SF13');

// Returns user by name
const userByName = users.findByCommonName('Cosmo Kramer');

// If allowDuplicates is set to false, getting Cosmo Kramer a second time would return undefined
const undefinedUser = users.findByCommonName('Cosmo Kramer');

```

### [MockTrbAttendees](https://github.com/CMSgov/easi-app/blob/NOREF/unit-test-fixes/src/utils/testing/MockTrbAttendees.ts)
- Extends MockUsers to mock TRB attendees for testing
- Mocked requester and attendees are available for use in tests from [src/data/mock/trbRequest](https://github.com/CMSgov/easi-app/blob/4c5a8ce0ec171622ba3ab4b9b464e57561a705e8/src/data/mock/trbRequest.ts#L67-L83)

```ts
// Returns mocked attendees with default props
const attendees = new MockTrbAttendees({
  // optional - has default value
  trbRequestId: '03e5c4b6-754e-4b29-a7e9-95a86849a9bf'
});

// Get next attendee with optional props
const nextAttendee = attendees.next({
  // Role and component props are type enforced
  role: PersonRole.PRIVACY_ADVISOR,
  component: 'Center for Medicare'
})
```

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
