### PR TITLE
[NOREF] - update golangci version number

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,8 @@ linters:
     - errcheck #requires patching code
 issues:
   exclude-use-default: false
+  exclude:
+    - "package-comments"
 
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
           )$
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.48.0
+    rev: v1.52.2
     hooks:
       - id: golangci-lint
         name: Lint go files
@@ -101,7 +101,7 @@ repos:
         pass_filenames: false
 
   # for some reason, trying to call "go run cmd/intake_schema_gen/main.go" directly from this config doesn't work;
-  # so call scripts/gen_intake_schema, which calls that command and works 
+  # so call scripts/gen_intake_schema, which calls that command and works
   - repo: local
     hooks:
       - id: check-intake-schema-generation

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
           )$
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.52.2
+    rev: v1.51.0
     hooks:
       - id: golangci-lint
         name: Lint go files

--- a/pkg/models/base_struct.go
+++ b/pkg/models/base_struct.go
@@ -8,14 +8,14 @@ import (
 
 // IBaseStruct is an interface that all models must implement
 type IBaseStruct interface {
-	GetBaseStruct() *baseStruct
+	GetBaseStruct() *BaseStruct
 	GetID() uuid.UUID
 	GetCreatedBy() string
 	GetModifiedBy() *string
 }
 
-// baseStruct represents the shared data in common betwen all models
-type baseStruct struct {
+// BaseStruct represents the shared data in common betwen all models
+type BaseStruct struct {
 	ID         uuid.UUID  `json:"id" db:"id"`
 	CreatedBy  string     `json:"createdBy" db:"created_by"`
 	CreatedAt  time.Time  `json:"createdAt" db:"created_at"`
@@ -24,28 +24,28 @@ type baseStruct struct {
 }
 
 // NewBaseStruct returns a base struct object
-func NewBaseStruct(createdBy string) baseStruct {
-	return baseStruct{
+func NewBaseStruct(createdBy string) BaseStruct {
+	return BaseStruct{
 		CreatedBy: createdBy,
 	}
 }
 
 // GetBaseStruct returns the Base Struct
-func (b *baseStruct) GetBaseStruct() *baseStruct {
+func (b *BaseStruct) GetBaseStruct() *BaseStruct {
 	return b
 }
 
 // GetID returns the ID property for a PlanBasics struct
-func (b baseStruct) GetID() uuid.UUID {
+func (b BaseStruct) GetID() uuid.UUID {
 	return b.ID
 }
 
 // GetModifiedBy returns the ModifiedBy property for a PlanBasics struct
-func (b baseStruct) GetModifiedBy() *string {
+func (b BaseStruct) GetModifiedBy() *string {
 	return b.ModifiedBy
 }
 
 // GetCreatedBy implements the CreatedBy property
-func (b baseStruct) GetCreatedBy() string {
+func (b BaseStruct) GetCreatedBy() string {
 	return b.CreatedBy
 }

--- a/pkg/models/trb_admin_note.go
+++ b/pkg/models/trb_admin_note.go
@@ -16,7 +16,7 @@ const (
 
 // TRBAdminNote represents the data for a note attached to a TRB request by an admin
 type TRBAdminNote struct {
-	baseStruct
+	BaseStruct
 	TRBRequestID uuid.UUID            `json:"trbRequestId" db:"trb_request_id"`
 	Category     TRBAdminNoteCategory `json:"category" db:"category"`
 	NoteText     string               `json:"noteText" db:"note_text"`

--- a/pkg/models/trb_advice_letter.go
+++ b/pkg/models/trb_advice_letter.go
@@ -20,7 +20,7 @@ const (
 
 // TRBAdviceLetter represents the data for a TRB advice letter
 type TRBAdviceLetter struct {
-	baseStruct
+	BaseStruct
 	TRBRequestID          uuid.UUID             `json:"trbRequestId" db:"trb_request_id"`
 	Status                TRBAdviceLetterStatus `json:"status" db:"status"`
 	MeetingSummary        *string               `json:"meetingSummary" db:"meeting_summary"`

--- a/pkg/models/trb_advice_letter_recommendation.go
+++ b/pkg/models/trb_advice_letter_recommendation.go
@@ -7,7 +7,7 @@ import (
 
 // TRBAdviceLetterRecommendation represents the data for a TRB advice letter recommendation
 type TRBAdviceLetterRecommendation struct {
-	baseStruct
+	BaseStruct
 	TRBRequestID   uuid.UUID      `json:"trbRequestId" db:"trb_request_id"`
 	Title          string         `json:"title" db:"title"`
 	Recommendation string         `json:"recommendation" db:"recommendation"`

--- a/pkg/models/trb_lead_option.go
+++ b/pkg/models/trb_lead_option.go
@@ -2,6 +2,6 @@ package models
 
 // TRBLeadOption represents an EUA user who can be assigned as a TRB lead for a TRB request
 type TRBLeadOption struct {
-	baseStruct
+	BaseStruct
 	EUAUserID string `json:"euaUserId" db:"eua_user_id"`
 }

--- a/pkg/models/trb_request.go
+++ b/pkg/models/trb_request.go
@@ -4,7 +4,7 @@ import "time"
 
 // TRBRequest represents a TRB request object
 type TRBRequest struct {
-	baseStruct
+	BaseStruct
 	Name               string          `json:"name" db:"name"`
 	Archived           bool            `json:"archived" db:"archived"`
 	Type               TRBRequestType  `json:"type" db:"type"`
@@ -17,7 +17,7 @@ type TRBRequest struct {
 func NewTRBRequest(createdBy string) *TRBRequest {
 	return &TRBRequest{
 		Name:       "Draft",
-		baseStruct: NewBaseStruct(createdBy),
+		BaseStruct: NewBaseStruct(createdBy),
 	}
 
 }

--- a/pkg/models/trb_request_attendee.go
+++ b/pkg/models/trb_request_attendee.go
@@ -31,7 +31,7 @@ const (
 
 // TRBRequestAttendee represents an EUA user who is included as an attendee for a TRB request
 type TRBRequestAttendee struct {
-	baseStruct
+	BaseStruct
 	EUAUserID    string      `json:"euaUserId" db:"eua_user_id"`
 	TRBRequestID uuid.UUID   `json:"trbRequestId" db:"trb_request_id"`
 	Component    *string     `json:"component" db:"component"`

--- a/pkg/models/trb_request_document.go
+++ b/pkg/models/trb_request_document.go
@@ -28,7 +28,7 @@ const (
 
 // TRBRequestDocument represents a document attached to a TRB request that has been uploaded to S3
 type TRBRequestDocument struct {
-	baseStruct
+	BaseStruct
 	TRBRequestID       uuid.UUID             `json:"trbRequestId" db:"trb_request_id"`
 	CommonDocumentType TRBDocumentCommonType `db:"document_type"`
 	OtherType          string                `db:"other_type"`

--- a/pkg/models/trb_request_feedback.go
+++ b/pkg/models/trb_request_feedback.go
@@ -17,7 +17,7 @@ const (
 
 // TRBRequestFeedback represents an individual feedback item given on a TRB request
 type TRBRequestFeedback struct {
-	baseStruct
+	BaseStruct
 	TRBRequestID    uuid.UUID         `json:"trbRequestId" db:"trb_request_id"`
 	FeedbackMessage string            `json:"feedbackMessage" db:"feedback_message"`
 	CopyTRBMailbox  bool              `json:"copyTrbMailbox" db:"copy_trb_mailbox"`

--- a/pkg/models/trb_request_form.go
+++ b/pkg/models/trb_request_form.go
@@ -74,7 +74,7 @@ const (
 
 // TRBRequestForm represents the data entered into the TRB request form
 type TRBRequestForm struct {
-	baseStruct
+	BaseStruct
 	TRBRequestID             uuid.UUID                `json:"trbRequestId" db:"trb_request_id"`
 	Status                   TRBFormStatus            `json:"status" db:"status"`
 	Component                *string                  `json:"component" db:"component"`

--- a/pkg/models/trb_request_funding_source.go
+++ b/pkg/models/trb_request_funding_source.go
@@ -6,7 +6,7 @@ import (
 
 // TRBFundingSource represents one of multiple funding selections that can be added to a TRBRequestForm
 type TRBFundingSource struct {
-	baseStruct
+	BaseStruct
 	TRBRequestID  uuid.UUID `json:"trbRequestId" db:"trb_request_id"`
 	Source        string    `json:"source" db:"source"`
 	FundingNumber string    `json:"fundingNumber" db:"funding_number"`

--- a/pkg/models/trb_request_lcid.go
+++ b/pkg/models/trb_request_lcid.go
@@ -6,7 +6,7 @@ import (
 
 // TRBRequestSystemIntake represents a system intake that has been associated with a TRB request
 type TRBRequestSystemIntake struct {
-	baseStruct
+	BaseStruct
 	TRBRequestID   uuid.UUID `json:"trbRequestId" db:"trb_request_id"`
 	SystemIntakeID uuid.UUID `json:"systemIntakeId" db:"system_intake_id"`
 }


### PR DESCRIPTION
## Changes and Description

- Updates [golangci-lint](https://github.com/golangci/golangci-lint) to its [latest version](https://github.com/golangci/golangci-lint/releases/tag/v1.52.2).

I've had lots of trouble on version 1.48, but 1.52.2 seems to run fine for me.

## How to test this change

Pull, then checkout to `NOREF/update-golangci-lint-version` and run

```
pre-commit run golangci-lint --all-files
```

## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
