### PR TITLE
[NOREF] - Added a refetch to parent intake query after lcid issued

### DIFF
--- a/src/queries/GetAdminNotesAndActionsQuery.ts
+++ b/src/queries/GetAdminNotesAndActionsQuery.ts
@@ -4,6 +4,7 @@ import { gql } from '@apollo/client';
 export default gql`
   query GetAdminNotesAndActions($id: UUID!) {
     systemIntake(id: $id) {
+      id
       lcid
       notes {
         id

--- a/src/queries/types/GetAdminNotesAndActions.ts
+++ b/src/queries/types/GetAdminNotesAndActions.ts
@@ -62,6 +62,7 @@ export interface GetAdminNotesAndActions_systemIntake_actions {
 
 export interface GetAdminNotesAndActions_systemIntake {
   __typename: "SystemIntake";
+  id: UUID;
   lcid: string | null;
   notes: GetAdminNotesAndActions_systemIntake_notes[];
   actions: GetAdminNotesAndActions_systemIntake_actions[];

--- a/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/IssueLifecycleId.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
-import { ApolloError, useMutation } from '@apollo/client';
+import { ApolloError, ApolloQueryResult, useMutation } from '@apollo/client';
 import { Button } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikHelpers, FormikProps } from 'formik';
 import { DateTime } from 'luxon';
@@ -23,6 +23,7 @@ import TextAreaField from 'components/shared/TextAreaField';
 import TextField from 'components/shared/TextField';
 import useSystemIntakeContacts from 'hooks/useSystemIntakeContacts';
 import IssueLifecycleIdQuery from 'queries/IssueLifecycleIdQuery';
+import { GetSystemIntake } from 'queries/types/GetSystemIntake';
 import {
   IssueLifecycleId as IssueLifecycleIdType,
   IssueLifecycleIdVariables
@@ -37,7 +38,11 @@ import EmailRecipientsFields from './EmailRecipientsFields';
 
 const RADIX = 10;
 
-const IssueLifecycleId = () => {
+type IssueLifecycleIdProps = {
+  refetch(): Promise<ApolloQueryResult<GetSystemIntake>>;
+};
+
+const IssueLifecycleId = ({ refetch }: IssueLifecycleIdProps) => {
   const { systemId } = useParams<{ systemId: string }>();
   const history = useHistory();
   const { t } = useTranslation('action');
@@ -127,6 +132,7 @@ const IssueLifecycleId = () => {
       .then(({ errors }) => {
         if (!errors) {
           // If no errors, view intake action notes
+          refetch();
           history.push(`/governance-review-team/${systemId}/notes`);
         }
       })

--- a/src/views/GovernanceReviewTeam/Notes/index.tsx
+++ b/src/views/GovernanceReviewTeam/Notes/index.tsx
@@ -66,8 +66,7 @@ const Notes = () => {
   >(GetAdminNotesAndActionsQuery, {
     variables: {
       id: systemId
-    },
-    fetchPolicy: 'cache-and-network'
+    }
   });
 
   const [

--- a/src/views/GovernanceReviewTeam/RequestOverview.tsx
+++ b/src/views/GovernanceReviewTeam/RequestOverview.tsx
@@ -302,7 +302,7 @@ const RequestOverview = () => {
             />
             <Route
               path="/governance-review-team/:systemId/actions/issue-lcid"
-              render={() => <IssueLifecycleId />}
+              render={() => <IssueLifecycleId refetch={refetch} />}
             />
 
             {/* Only display extend LCID action if status is LCID_ISSUED or there has been an lcid issued in the past */}


### PR DESCRIPTION
# NOREF

## Changes and Description

- Addressed the `TODO` on [1979](https://github.com/CMSgov/easi-app/pull/1979)
- Added a refetch on the parent query after issuing an LCID

## How to test this change

- Issue an LCID
- Navigate to `Decision` side nav
- Verified that the decision is approved/ parent query data refreshed

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
