### PR TITLE
[NOREF] Replace storage methods that used context

### DIFF
--- a/pkg/storage/cedar_system_bookmark.go
+++ b/pkg/storage/cedar_system_bookmark.go
@@ -30,8 +30,7 @@ func (s *Store) CreateCedarSystemBookmark(ctx context.Context, cedarSystemBookma
 			:cedar_system_id,
 			:created_at
 		) ON CONFLICT ON CONSTRAINT cedar_system_bookmarks_pkey DO UPDATE SET created_at = :created_at`
-	_, err := s.db.NamedExecContext(
-		ctx,
+	_, err := s.db.NamedExec(
 		createCedarSystemBookmarkSQL,
 		cedarSystemBookmark,
 	)
@@ -47,7 +46,7 @@ func (s *Store) FetchCedarSystemBookmarks(ctx context.Context) ([]*models.CedarS
 	results := []*models.CedarSystemBookmark{}
 
 	euaUserID := appcontext.Principal(ctx).ID()
-	err := s.db.SelectContext(ctx, &results, `SELECT * FROM cedar_system_bookmarks WHERE eua_user_id=$1`, euaUserID)
+	err := s.db.Select(&results, `SELECT * FROM cedar_system_bookmarks WHERE eua_user_id=$1`, euaUserID)
 
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		appcontext.ZLogger(ctx).Error("Failed to fetch cedar system bookmarks", zap.Error(err), zap.String("id", euaUserID))

--- a/pkg/storage/grt_feedback.go
+++ b/pkg/storage/grt_feedback.go
@@ -36,8 +36,7 @@ func (s *Store) CreateGRTFeedback(ctx context.Context, grtFeedback *models.GRTFe
 		    :created_at,
 			:updated_at
 		)`
-	_, err := s.db.NamedExecContext(
-		ctx,
+	_, err := s.db.NamedExec(
 		createGRTFeedbackSQL,
 		grtFeedback,
 	)
@@ -52,7 +51,7 @@ func (s *Store) CreateGRTFeedback(ctx context.Context, grtFeedback *models.GRTFe
 func (s *Store) FetchGRTFeedbackByID(ctx context.Context, id uuid.UUID) (*models.GRTFeedback, error) {
 	grtFeedback := models.GRTFeedback{}
 
-	err := s.db.GetContext(ctx, &grtFeedback, `SELECT * FROM grt_feedback WHERE id=$1`, id)
+	err := s.db.Get(&grtFeedback, `SELECT * FROM grt_feedback WHERE id=$1`, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, &apperrors.ResourceNotFoundError{Err: err, Resource: models.SystemIntake{}}
@@ -72,7 +71,7 @@ func (s *Store) FetchGRTFeedbackByID(ctx context.Context, id uuid.UUID) (*models
 func (s *Store) FetchGRTFeedbacksByIntakeID(ctx context.Context, intakeID uuid.UUID) ([]*models.GRTFeedback, error) {
 	grtFeedbacks := []*models.GRTFeedback{}
 
-	err := s.db.SelectContext(ctx, &grtFeedbacks, `SELECT * FROM grt_feedback WHERE intake_id=$1 ORDER BY created_at DESC`, intakeID)
+	err := s.db.Select(&grtFeedbacks, `SELECT * FROM grt_feedback WHERE intake_id=$1 ORDER BY created_at DESC`, intakeID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return grtFeedbacks, nil

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -231,7 +231,7 @@ func (s *Store) FetchSystemIntakeByID(ctx context.Context, id uuid.UUID) (*model
 	const idMatchClause = `
 		WHERE system_intakes.id=$1
 `
-	err := s.db.GetContext(ctx, &intake, fetchSystemIntakeSQL+idMatchClause, id)
+	err := s.db.Get(&intake, fetchSystemIntakeSQL+idMatchClause, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			appcontext.ZLogger(ctx).Info(
@@ -263,7 +263,7 @@ func (s *Store) FetchSystemIntakeByID(ctx context.Context, id uuid.UUID) (*model
 	// required explicitly specifying all of the system intake columns, which seemed less than ideal
 	// given that any changes made to the models.SystemIntake struct would require also code changes to
 	// the code that would handle the joined query result.
-	err = s.db.SelectContext(ctx, &sources, `
+	err = s.db.Select(&sources, `
 		SELECT *
 		FROM system_intake_funding_sources
 		WHERE system_intake_id=$1
@@ -652,7 +652,7 @@ func (s *Store) FetchRelatedSystemIntakes(ctx context.Context, id uuid.UUID) ([]
 			intakes_a.id = $1 AND intakes_b.id != $1;
 	`
 
-	err := s.db.SelectContext(ctx, &intakes, query, id)
+	err := s.db.Select(&intakes, query, id)
 	if err != nil {
 		return nil, err
 	}
@@ -662,7 +662,7 @@ func (s *Store) FetchRelatedSystemIntakes(ctx context.Context, id uuid.UUID) ([]
 // GetSystemIntakesWithLCIDs retrieves all LCIDs that are in use
 func (s *Store) GetSystemIntakesWithLCIDs(ctx context.Context) ([]*models.SystemIntake, error) {
 	intakes := []*models.SystemIntake{}
-	err := s.db.SelectContext(ctx, &intakes,
+	err := s.db.Select(&intakes,
 		fetchSystemIntakeSQL+`
 		WHERE lcid IS NOT NULL;
 	`)

--- a/pkg/storage/system_intake_contact.go
+++ b/pkg/storage/system_intake_contact.go
@@ -44,8 +44,7 @@ func (s *Store) CreateSystemIntakeContact(ctx context.Context, systemIntakeConta
 			:created_at,
 			:updated_at
 		)`
-	_, err := s.db.NamedExecContext(
-		ctx,
+	_, err := s.db.NamedExec(
 		createSystemIntakeContactSQL,
 		systemIntakeContact,
 	)
@@ -70,8 +69,7 @@ func (s *Store) UpdateSystemIntakeContact(ctx context.Context, systemIntakeConta
 			updated_at = :updated_at
 		WHERE system_intake_contacts.id = :id
 	`
-	_, err := s.db.NamedExecContext(
-		ctx,
+	_, err := s.db.NamedExec(
 		createSystemIntakeContactSQL,
 		systemIntakeContact,
 	)
@@ -86,7 +84,7 @@ func (s *Store) UpdateSystemIntakeContact(ctx context.Context, systemIntakeConta
 func (s *Store) FetchSystemIntakeContactsBySystemIntakeID(ctx context.Context, systemIntakeID uuid.UUID) ([]*models.SystemIntakeContact, error) {
 	results := []*models.SystemIntakeContact{}
 
-	err := s.db.SelectContext(ctx, &results, `SELECT * FROM system_intake_contacts WHERE system_intake_id=$1`, systemIntakeID)
+	err := s.db.Select(&results, `SELECT * FROM system_intake_contacts WHERE system_intake_id=$1`, systemIntakeID)
 
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		appcontext.ZLogger(ctx).Error("Failed to fetch system intake contacts", zap.Error(err), zap.String("id", systemIntakeID.String()))

--- a/pkg/storage/test_date.go
+++ b/pkg/storage/test_date.go
@@ -38,8 +38,7 @@ func (s *Store) CreateTestDate(ctx context.Context, testDate *models.TestDate) (
 		    :created_at,
 			:updated_at
 		)`
-	_, err := s.db.NamedExecContext(
-		ctx,
+	_, err := s.db.NamedExec(
 		createTestDateSQL,
 		testDate,
 	)
@@ -54,7 +53,7 @@ func (s *Store) CreateTestDate(ctx context.Context, testDate *models.TestDate) (
 func (s *Store) FetchTestDateByID(ctx context.Context, id uuid.UUID) (*models.TestDate, error) {
 	testDate := models.TestDate{}
 
-	err := s.db.GetContext(ctx, &testDate, `SELECT * FROM test_dates WHERE id=$1 AND deleted_at IS NULL`, id)
+	err := s.db.Get(&testDate, `SELECT * FROM test_dates WHERE id=$1 AND deleted_at IS NULL`, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, &apperrors.ResourceNotFoundError{Err: err, Resource: models.SystemIntake{}}
@@ -74,7 +73,7 @@ func (s *Store) FetchTestDateByID(ctx context.Context, id uuid.UUID) (*models.Te
 func (s *Store) FetchTestDatesByRequestID(ctx context.Context, requestID uuid.UUID) ([]*models.TestDate, error) {
 	results := []*models.TestDate{}
 
-	err := s.db.SelectContext(ctx, &results, `SELECT * FROM test_dates WHERE request_id=$1 AND deleted_at IS NULL`, requestID)
+	err := s.db.Select(&results, `SELECT * FROM test_dates WHERE request_id=$1 AND deleted_at IS NULL`, requestID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		appcontext.ZLogger(ctx).Error("Failed to fetch test dates", zap.Error(err), zap.String("requestID", requestID.String()))
 		return nil, &apperrors.QueryError{
@@ -98,8 +97,7 @@ func (s *Store) UpdateTestDate(ctx context.Context, testDate *models.TestDate) (
 		    score = :score,
 			updated_at = :updated_at
 		WHERE test_dates.id = :id`
-	_, err := s.db.NamedExecContext(
-		ctx,
+	_, err := s.db.NamedExec(
 		createTestDateSQL,
 		testDate,
 	)
@@ -123,8 +121,7 @@ func (s *Store) DeleteTestDate(ctx context.Context, testDate *models.TestDate) (
 			updated_at = :updated_at
 		WHERE test_dates.id = :id`
 
-	_, err := s.db.NamedExecContext(
-		ctx,
+	_, err := s.db.NamedExec(
 		deleteTestDateSQL,
 		testDate,
 	)


### PR DESCRIPTION
# NOREF

## Changes and Description

- Replace sqlx context methods with ones that don't take context.

This should hopefully reduce (elimiate) the issues where a context object is cancelled during a sqlx/DB call.

## How to test this change

This isn't something we've caught locally, so just ensure that the app still works as expected locally and that all tests pass.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
