### PR TITLE
[EASI-2907] Disable next button if adding funding source

### DIFF
--- a/src/types/systemIntake.ts
+++ b/src/types/systemIntake.ts
@@ -153,7 +153,7 @@ export type UpdateFundingSources =
 
 /** Update active funding source in form */
 export type UpdateActiveFundingSource = {
-  action: 'Add' | 'Edit' | 'Reset';
+  action: 'Add' | 'Edit' | null;
   data?: MultiFundingSource;
 };
 
@@ -166,7 +166,7 @@ export type UseIntakeFundingSources = {
   activeFundingSource: [
     activeFundingSource: MultiFundingSource,
     updateActiveFundingSource: (payload: UpdateActiveFundingSource) => void,
-    action: 'Add' | 'Edit' | 'Reset'
+    action: 'Add' | 'Edit' | null
   ];
 };
 

--- a/src/views/SystemIntake/ContractDetails/FundingSources.tsx
+++ b/src/views/SystemIntake/ContractDetails/FundingSources.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Fieldset, Label, Link } from '@trussworks/react-uswds';
 import classNames from 'classnames';
@@ -84,7 +84,7 @@ type FundingSourceFormProps = {
   fundingSources: FormattedFundingSourcesObject;
   setFundingSources: ({ action, data }: UpdateFundingSources) => void;
   fundingSourceOptions: string[];
-  action: 'Add' | 'Edit' | 'Reset';
+  action: 'Add' | 'Edit' | null;
 };
 
 const FundingSourceForm = ({
@@ -242,7 +242,7 @@ const FundingSourceForm = ({
         type="button"
         onClick={() =>
           setActiveFundingSource({
-            action: 'Reset'
+            action: null
           })
         }
         className="display-inline-block margin-top-2"
@@ -257,7 +257,7 @@ const FundingSourceForm = ({
           const { err } = onSubmit();
           if (!err) {
             setActiveFundingSource({
-              action: 'Reset'
+              action: null
             });
           }
         }}
@@ -275,6 +275,7 @@ type FundingSourcesProps = {
   initialValues: FundingSource[];
   fundingSourceOptions: string[];
   setFieldValue: (field: string, value: any) => void;
+  setFieldActive?: (active: boolean) => void;
   combinedFields?: boolean;
 };
 
@@ -283,6 +284,7 @@ const FundingSources = ({
   initialValues,
   fundingSourceOptions,
   setFieldValue,
+  setFieldActive,
   combinedFields = false
 }: FundingSourcesProps) => {
   // Get funding sources actions from useIntakeFundingSources custom hook
@@ -299,6 +301,10 @@ const FundingSources = ({
   ] = fundingSourcesData.activeFundingSource;
   const { t } = useTranslation('intake');
   const editFundingSourceNumber = useRef('');
+
+  useEffect(() => {
+    setFieldActive?.(!!action);
+  }, [action, setFieldActive]);
 
   return (
     <>
@@ -352,7 +358,7 @@ const FundingSources = ({
           action={action}
         />
       )}
-      {action === 'Reset' && (
+      {!action && (
         <Button
           type="button"
           data-testid="fundingSourcesAction-add"

--- a/src/views/SystemIntake/ContractDetails/useIntakeFundingSources.tsx
+++ b/src/views/SystemIntake/ContractDetails/useIntakeFundingSources.tsx
@@ -79,8 +79,8 @@ export default function useIntakeFundingSources(
   // Active funding source - used in form
   const [activeFundingSource, setActiveFundingSource] = useState<{
     data: MultiFundingSource;
-    action: 'Add' | 'Edit' | 'Reset';
-  }>({ data: emptyFundingSource, action: 'Reset' });
+    action: 'Add' | 'Edit' | null;
+  }>({ data: emptyFundingSource, action: null });
 
   // Update active funding source - used in form
   const updateActiveFundingSource = ({
@@ -146,7 +146,7 @@ export default function useIntakeFundingSources(
   // When funding source form is submitted, reset active funding source
   useEffect(() => {
     setActiveFundingSource({
-      action: 'Reset',
+      action: null,
       data: emptyFundingSource
     });
   }, [fundingSources]);

--- a/src/views/TechnicalAssistance/RequestForm/Basic.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/Basic.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
@@ -98,6 +98,10 @@ function Basic({
 }: FormStepComponentProps) {
   const history = useHistory();
   const { t } = useTranslation('technicalAssistance');
+
+  const [fundingSourcesFormActive, setFundingSourcesFormActive] = useState(
+    false
+  );
 
   const {
     data,
@@ -717,6 +721,7 @@ function Basic({
                     }
                   }}
                   fundingSourceOptions={intakeFundingSources}
+                  setFieldActive={setFundingSourcesFormActive}
                   combinedFields
                 />
               </FormGroup>
@@ -964,7 +969,7 @@ function Basic({
       <Pager
         className="margin-top-5"
         next={{
-          disabled: isSubmitting,
+          disabled: isSubmitting || fundingSourcesFormActive,
           onClick: () => {
             submit(() => {
               history.push(stepUrl.next);


### PR DESCRIPTION
# EASI-2907

## Changes and Description

- Disabled next button if funding sources form is open

<!-- Put a description here! -->

## How to test this change

- Create TRB request and navigate to request form
- Click "Add funding source"
- Confirm next button is disabled

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
