### PR TITLE
[EASI-2944] - Action alert for admin IRF state = draft/ready

### DIFF
--- a/src/i18n/en-US/technicalAssistance.ts
+++ b/src/i18n/en-US/technicalAssistance.ts
@@ -919,6 +919,10 @@ const technicalAssistance = {
       'There are <bold>{{docCount}}</bold> additional documents uploaded as a part of this request.',
     reviewInitialRequest:
       'Please review the initial request form before setting a date and time in EASi.',
+    requestInDraft:
+      'Please wait until the initial request form is submitted, then review the form before setting a date and time in EASi.',
+    requestInDraftAlt:
+      'This request is still in a draft state. You will receive an email notification once the requester has submitted it for review.',
     viewDocs: 'View documents',
     open: 'Open',
     closed: 'Closed',

--- a/src/i18n/en-US/technicalAssistance.ts
+++ b/src/i18n/en-US/technicalAssistance.ts
@@ -918,8 +918,6 @@ const technicalAssistance = {
     docInfoPlural:
       'There are <bold>{{docCount}}</bold> additional documents uploaded as a part of this request.',
     reviewInitialRequest:
-      'Please review the initial request form before setting a date and time in EASi.',
-    requestInDraft:
       'Please wait until the initial request form is submitted, then review the form before setting a date and time in EASi.',
     requestInDraftAlt:
       'This request is still in a draft state. You will receive an email notification once the requester has submitted it for review.',

--- a/src/views/TechnicalAssistance/AdminHome/InitialRequestForm.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/InitialRequestForm.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import PageLoading from 'components/PageLoading';
+import Alert from 'components/shared/Alert';
 import useCacheQuery from 'hooks/useCacheQuery';
 import GetTrbRequestQuery from 'queries/GetTrbRequestQuery';
 import {
@@ -62,6 +63,14 @@ const InitialRequestForm = ({
     >
       {loading && <PageLoading />}
       {error && <NotFoundPartial />}
+
+      {/* Alert for  initial request form still in draft */}
+      {request?.taskStatuses.formStatus === TRBFormStatus.IN_PROGRESS && (
+        <Alert type="info" slim>
+          {t('adminHome.requestInDraftAlt')}
+        </Alert>
+      )}
+
       {request && (
         <>
           <SubmittedRequest

--- a/src/views/TechnicalAssistance/AdminHome/InitialRequestForm.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/InitialRequestForm.tsx
@@ -65,7 +65,7 @@ const InitialRequestForm = ({
       {error && <NotFoundPartial />}
 
       {/* Alert for  initial request form still in draft */}
-      {request?.taskStatuses.formStatus === TRBFormStatus.IN_PROGRESS && (
+      {request && request.taskStatuses.formStatus !== TRBFormStatus.COMPLETED && (
         <Alert type="info" slim>
           {t('adminHome.requestInDraftAlt')}
         </Alert>

--- a/src/views/TechnicalAssistance/AdminHome/RequestHome.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/RequestHome.tsx
@@ -74,10 +74,10 @@ const RequestHome = ({
 
           <p className="text-bold margin-bottom-1">{t('adminHome.dateTime')}</p>
 
-          {taskStatuses?.formStatus !== TRBFormStatus.COMPLETED ? (
+          {taskStatuses?.formStatus === TRBFormStatus.IN_PROGRESS ? (
             // Unable to set consult until initial request form complete
             <Alert type="info" slim className="margin-y-1 margin-top-2">
-              {t('adminHome.reviewInitialRequest')}
+              {t('adminHome.requestInDraft')}
             </Alert>
           ) : (
             <div>

--- a/src/views/TechnicalAssistance/AdminHome/RequestHome.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/RequestHome.tsx
@@ -74,10 +74,10 @@ const RequestHome = ({
 
           <p className="text-bold margin-bottom-1">{t('adminHome.dateTime')}</p>
 
-          {taskStatuses?.formStatus === TRBFormStatus.IN_PROGRESS ? (
+          {taskStatuses?.formStatus !== TRBFormStatus.COMPLETED ? (
             // Unable to set consult until initial request form complete
             <Alert type="info" slim className="margin-y-1 margin-top-2">
-              {t('adminHome.requestInDraft')}
+              {t('adminHome.reviewInitialRequest')}
             </Alert>
           ) : (
             <div>

--- a/src/views/TechnicalAssistance/AdminHome/__snapshots__/RequestHome.test.tsx.snap
+++ b/src/views/TechnicalAssistance/AdminHome/__snapshots__/RequestHome.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`Trb Admin Request Home renders successfully with empty data 1`] = `
         <p
           class="usa-alert__text"
         >
-          Please review the initial request form before setting a date and time in EASi.
+          Please wait until the initial request form is submitted, then review the form before setting a date and time in EASi.
         </p>
       </div>
     </div>

--- a/src/views/TechnicalAssistance/AdminHome/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/AdminHome/__snapshots__/index.test.tsx.snap
@@ -422,7 +422,7 @@ exports[`TRB admin home matches the snapshot 1`] = `
                 <p
                   class="usa-alert__text"
                 >
-                  Please review the initial request form before setting a date and time in EASi.
+                  Please wait until the initial request form is submitted, then review the form before setting a date and time in EASi.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
# EASI-2944

## Changes and Description

- Added alert for Admin Initial Request Form when state is `READy_TO_START` or `IN_PROGRESS`
- Updated unit tests

<!-- Put a description here! -->

## How to test this change

- Create a new request without submitting IRF
- View request as admin (will need to paste/replace ID in URL)
- Verify Figma alerts
- Request Edits
- Repeat

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
