### PR TITLE
[EASI-2903] Fix TRB "Other" type issues

### DIFF
--- a/src/i18n/en-US/technicalAssistance.ts
+++ b/src/i18n/en-US/technicalAssistance.ts
@@ -312,7 +312,8 @@ const technicalAssistance = {
     },
     requestTypes: {
       NEED_HELP: 'System problem',
-      BRAINSTORM: 'Idea feedback'
+      BRAINSTORM: 'Idea feedback',
+      OTHER: 'Other'
     },
     requestStatus: {
       NEW: 'New',

--- a/src/views/TechnicalAssistance/RequestType.tsx
+++ b/src/views/TechnicalAssistance/RequestType.tsx
@@ -156,15 +156,30 @@ function RequestType() {
         </h3>
         <ul className="list-style-none padding-0">
           <li>
-            <UswdsReactLink
-              to={{
-                pathname: '/trb/process',
-                state: { requestType: TRBRequestType.OTHER }
-              }}
-            >
-              {t('requestType.services.other')}
-              <IconArrowForward className="margin-left-05 margin-bottom-2px text-tbottom" />
-            </UswdsReactLink>
+            {isNew ? (
+              <UswdsReactLink
+                to={{
+                  pathname: '/trb/process',
+                  state: { requestType: TRBRequestType.OTHER }
+                }}
+              >
+                {t('requestType.services.other')}
+                <IconArrowForward className="margin-left-05 margin-bottom-2px text-tbottom" />
+              </UswdsReactLink>
+            ) : (
+              <Button
+                type="button"
+                className="usa-button usa-button--unstyled"
+                onClick={() => {
+                  mutate({
+                    variables: { id, type: TRBRequestType.OTHER }
+                  });
+                }}
+              >
+                {t('requestType.services.other')}
+                <IconArrowForward className="margin-left-05 margin-bottom-2px text-tbottom" />
+              </Button>
+            )}
           </li>
         </ul>
       </div>

--- a/src/views/TechnicalAssistance/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/__snapshots__/index.test.tsx.snap
@@ -452,9 +452,10 @@ exports[`TRB Subview snapshots matches Request Type 1`] = `
         class="list-style-none padding-0"
       >
         <li>
-          <a
-            class="usa-link"
-            href="/trb/process"
+          <button
+            class="usa-button usa-button usa-button--unstyled"
+            data-testid="button"
+            type="button"
           >
             Other (I don’t see what I’m looking for)
             <svg
@@ -474,7 +475,7 @@ exports[`TRB Subview snapshots matches Request Type 1`] = `
                 d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
               />
             </svg>
-          </a>
+          </button>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
# EASI-2903

## Changes and Description

- Fixed missing translation for "other" type requests on the Admin Home
- Fixed changing an existing request type to "other" instead making a new request

## How to test this change

- Make a TRB request of any type besides "other"
- After making the request, change the request type to other (ensure that it modifies the existing request instead of making a new one)
- Go to the TRB Admin home and ensure the request type renders properly

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
