### PR TITLE
[NOREF] Use EST when sending TRB Email times

### DIFF
--- a/pkg/email/trb_request_consult_meeting.go
+++ b/pkg/email/trb_request_consult_meeting.go
@@ -38,10 +38,15 @@ type trbConsultMeetingEmailTemplateParams struct {
 // SendTRBRequestConsultMeetingEmail sends an email to the EASI team containing a user's request for help
 func (c Client) SendTRBRequestConsultMeetingEmail(ctx context.Context, input SendTRBRequestConsultMeetingEmailInput) error {
 	subject := "TRB consult session scheduled for " + input.TRBRequestName
+	est, err := time.LoadLocation("America/New_York")
+
+	if err != nil {
+		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}
+	}
 
 	templateParams := trbConsultMeetingEmailTemplateParams{
 		TRBRequestName:              input.TRBRequestName,
-		ConsultMeetingTimeFormatted: input.ConsultMeetingTime.Format("January 2, 2006 at 03:04 PM EST"),
+		ConsultMeetingTimeFormatted: input.ConsultMeetingTime.In(est).Format("January 2, 2006 at 03:04 PM EST"),
 		Notes:                       input.Notes,
 		RequesterName:               input.RequesterName,
 		TRBRequestLink:              c.urlFromPath(path.Join("trb", "task-list", input.TRBRequestID.String())),
@@ -50,7 +55,7 @@ func (c Client) SendTRBRequestConsultMeetingEmail(ctx context.Context, input Sen
 	}
 
 	var b bytes.Buffer
-	err := c.templates.trbRequestConsultMeeting.Execute(&b, templateParams)
+	err = c.templates.trbRequestConsultMeeting.Execute(&b, templateParams)
 
 	if err != nil {
 		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}

--- a/pkg/email/trb_request_consult_meeting_test.go
+++ b/pkg/email/trb_request_consult_meeting_test.go
@@ -15,7 +15,7 @@ func (s *EmailTestSuite) TestTRBRequestConsultMeetingEmail() {
 	sender := mockSender{}
 	ctx := context.Background()
 
-	meetingTime, err := time.Parse(time.RFC3339, "2022-01-01T13:30:00+00:00")
+	meetingTime, err := time.Parse(time.RFC3339, "2022-01-01T18:33:00+00:00") // UTC time, will convert to 13:33, or 01:33 PM EST
 	s.NoError(err)
 
 	trbID := uuid.New()
@@ -49,7 +49,7 @@ func (s *EmailTestSuite) TestTRBRequestConsultMeetingEmail() {
 
 <span style="font-size:15px; line-height: 18px; color: #71767A">Easy Access to System Information</span>
 
-<p>The Technical Review Board (TRB) has scheduled a consult session for Test TRB Request on January 1, 2022 at 01:30 PM EST. You should receive a calendar invite shortly if you have not already.
+<p>The Technical Review Board (TRB) has scheduled a consult session for Test TRB Request on January 1, 2022 at 01:33 PM EST. You should receive a calendar invite shortly if you have not already.
 
 <p>Additional notes about this consult session: Some notes</p>
 


### PR DESCRIPTION
# NOREF

## Changes and Description

- Convert time objects (stored as UTC) to EST before sending emails

## How to test this change

- `scripts/dev up`
- `scripts/dev db:seed`
- Log in as `ABCD` with EASI and TRB Admin permissions
- Find Case #3 in the admin home
- Set a consult date
- Ensure the time looks correct in EST

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
