### PR TITLE
[EASI-2983] UX should haves part 4 & 5

### DIFF
--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -72,27 +72,29 @@ const NavigationBar = ({
   const flags = useFlags();
   const { groups, isUserSet } = useSelector((state: AppState) => state.auth);
 
-  const primaryLinks = navLinks(flags, groups, isUserSet).map(
-    route =>
-      route.isEnabled && (
-        <div className="easi-nav" key={route.label}>
-          <NavLink
-            to={route.link}
-            activeClassName="usa-current"
-            className="easi-nav__link"
-            onClick={() => toggle(false)}
-            exact={route.link === '/'}
-          >
-            <em
-              className="usa-logo__text easi-nav__label"
-              aria-label={t(`header:${route.label}`)}
+  const primaryLinks = navLinks(flags, groups, isUserSet)
+    .map(
+      route =>
+        route.isEnabled && (
+          <div className="easi-nav" key={route.label}>
+            <NavLink
+              to={route.link}
+              activeClassName="usa-current"
+              className="easi-nav__link"
+              onClick={() => toggle(false)}
+              exact={route.link === '/'}
             >
-              {t(`header:${route.label}`)}
-            </em>
-          </NavLink>
-        </div>
-      )
-  );
+              <em
+                className="usa-logo__text easi-nav__label"
+                aria-label={t(`header:${route.label}`)}
+              >
+                {t(`header:${route.label}`)}
+              </em>
+            </NavLink>
+          </div>
+        )
+    )
+    .filter(nav => nav);
 
   const userLinks = (
     <div className="easi-nav__signout-container">

--- a/src/i18n/en-US/technicalAssistance.ts
+++ b/src/i18n/en-US/technicalAssistance.ts
@@ -684,6 +684,8 @@ const technicalAssistance = {
     continueWithoutAdding: 'Continue without adding attendees',
     dontAddAndReturn: "Don't add and return to previous page",
     dontEditAndReturn: "Don't edit and return to previous page",
+    noAttendees:
+      'You have not added any additional attendees to this consult session. Use the button below to invite project team members or anyone else who should be present.',
     attendeeHelpText:
       'Please provide the name, CMS component, and role for this attendee.',
     attendeeNameHelpText:

--- a/src/i18n/en-US/technicalAssistance.ts
+++ b/src/i18n/en-US/technicalAssistance.ts
@@ -596,7 +596,7 @@ const technicalAssistance = {
       whereInProcess:
         'This helps the TRB provide the right type of support for your request.',
       whenMeet:
-        'Please include specific date(s) if you are able. If not, specifying the month, quarter, or year is acceptable.',
+        'Format mm/dd/yyyy. If you are unsure of the specific date, you may pick a date that is your best guess.',
       fundingSources:
         'If you are unsure, please get in touch with your Contracting Officer Representative (COR). If this will not use an existing funding source, skip this question.',
       relatedLCIDS:

--- a/src/i18n/en-US/technicalAssistance.ts
+++ b/src/i18n/en-US/technicalAssistance.ts
@@ -315,6 +315,9 @@ const technicalAssistance = {
       BRAINSTORM: 'Idea feedback',
       OTHER: 'Other'
     },
+    requestState: {
+      CLOSED: 'Closed'
+    },
     requestStatus: {
       NEW: 'New',
       DRAFT_REQUEST_FORM: 'Draft request form',

--- a/src/queries/GetTrbRequestsQuery.ts
+++ b/src/queries/GetTrbRequestsQuery.ts
@@ -6,6 +6,7 @@ export default gql`
       id
       name
       status
+      state
       createdAt
 
       form {

--- a/src/queries/types/GetTrbRequests.ts
+++ b/src/queries/types/GetTrbRequests.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { TRBRequestStatus } from "./../../types/graphql-global-types";
+import { TRBRequestStatus, TRBRequestState } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL query operation: GetTrbRequests
@@ -19,6 +19,7 @@ export interface GetTrbRequests_myTrbRequests {
   id: UUID;
   name: string;
   status: TRBRequestStatus;
+  state: TRBRequestState;
   createdAt: Time;
   form: GetTrbRequests_myTrbRequests_form;
 }

--- a/src/views/TechnicalAssistance/AdminHome/AddNote.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/AddNote.tsx
@@ -40,11 +40,13 @@ import { TRBRequestContext } from './RequestContext';
 const AddNote = ({
   trbRequestId,
   setModalView, // prop used to conditionall render text/links/etc specifically for modal
-  setModalMessage
+  setModalMessage,
+  defaultSelect
 }: {
   trbRequestId?: string;
   setModalView?: React.Dispatch<React.SetStateAction<ModalViewType>>;
   setModalMessage?: React.Dispatch<React.SetStateAction<string>>;
+  defaultSelect?: TRBAdminNoteCategory;
 }) => {
   const { t } = useTranslation('technicalAssistance');
 
@@ -82,7 +84,7 @@ const AddNote = ({
   });
 
   const defaultValues: Omit<CreateTRBAdminNoteInput, 'trbRequestId'> = {
-    category: '' as TRBAdminNoteCategory,
+    category: defaultSelect || ('' as TRBAdminNoteCategory),
     noteText: ''
   };
 

--- a/src/views/TechnicalAssistance/AdminHome/Consult.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/Consult.tsx
@@ -46,9 +46,8 @@ interface ConsultFields extends TrbRecipientFields {
 function Consult() {
   const { t } = useTranslation('technicalAssistance');
 
-  const { id, activePage } = useParams<{
+  const { id } = useParams<{
     id: string;
-    activePage: string;
     action: 'schedule-consult';
   }>();
   const history = useHistory();
@@ -60,7 +59,7 @@ function Consult() {
     createAttendee
   } = useTRBAttendees(id);
 
-  const requestUrl = `/trb/${id}/${activePage}`;
+  const requestUrl = `/trb/${id}/request`;
 
   const [mutate, mutationResult] = useMutation<
     UpdateTrbRequestConsultMeeting,

--- a/src/views/TechnicalAssistance/AdminHome/InitialRequestForm.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/InitialRequestForm.tsx
@@ -43,6 +43,7 @@ const InitialRequestForm = ({
       trbRequestId={id}
       title={t('adminHome.initialRequestForm')}
       noteCount={trbRequest.adminNotes.length}
+      renderBottom
       disableStep={
         trbRequest.status === TRBRequestStatus.READY_FOR_CONSULT ||
         trbRequest.status === TRBRequestStatus.CONSULT_COMPLETE ||

--- a/src/views/TechnicalAssistance/AdminHome/Notes.test.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/Notes.test.tsx
@@ -149,6 +149,9 @@ describe('Trb Admin Notes: View Notes', () => {
                     type: 'NEED_HELP',
                     state: 'OPEN',
                     trbLead: null,
+                    trbLeadInfo: {
+                      commonName: 'John Doe'
+                    },
                     createdAt: '2023-02-16T15:21:34.156885Z',
                     taskStatuses: {
                       formStatus: 'IN_PROGRESS',

--- a/src/views/TechnicalAssistance/AdminHome/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/AdminHome/__snapshots__/index.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`TRB admin home matches the snapshot 1`] = `
                 Status
               </h4>
               <span
-                class="bg-info-dark text-white text-bold padding-y-05 padding-x-105 margin-x-1"
+                class="text-white text-bold padding-y-05 padding-x-105 margin-x-1 bg-info-dark"
               >
                 Open
               </span>

--- a/src/views/TechnicalAssistance/AdminHome/components/InformationCard/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/InformationCard/index.tsx
@@ -53,6 +53,24 @@ const InformationCard = ({ trbRequest, type }: InformationCardProps) => {
     disabled: false
   };
 
+  const returnAdviceText = () => {
+    if (
+      trbRequest.taskStatuses.adviceLetterStatus ===
+        TRBAdviceLetterStatus.CANNOT_START_YET ||
+      trbRequest.taskStatuses.adviceLetterStatus ===
+        TRBAdviceLetterStatus.READY_TO_START
+    ) {
+      return t('adminHome.startAdvice');
+    }
+    if (
+      trbRequest.taskStatuses.adviceLetterStatus ===
+      TRBAdviceLetterStatus.COMPLETED
+    ) {
+      return t('adminHome.view');
+    }
+    return t('adminHome.viewAdvice');
+  };
+
   switch (type) {
     case 'initialRequestForm':
       cardDetails = {
@@ -73,14 +91,12 @@ const InformationCard = ({ trbRequest, type }: InformationCardProps) => {
         header: t('adminHome.adviceLetter'),
         description: t('adminHome.toBeCompleted'),
         status: trbRequest.taskStatuses.adviceLetterStatus,
-        buttonText:
+        buttonText: returnAdviceText(),
+        buttonClass:
           trbRequest.taskStatuses.adviceLetterStatus ===
-            TRBAdviceLetterStatus.CANNOT_START_YET ||
-          trbRequest.taskStatuses.adviceLetterStatus ===
-            TRBAdviceLetterStatus.READY_TO_START
-            ? t('adminHome.startAdvice')
-            : t('adminHome.viewAdvice'),
-        buttonClass: '',
+          TRBAdviceLetterStatus.COMPLETED
+            ? 'usa-button--outline'
+            : '',
         buttonLink: 'advice',
         modified: trbRequest.adviceLetter?.modifiedAt
           ? formatDateLocal(trbRequest.adviceLetter.modifiedAt, 'MMMM d, yyyy')

--- a/src/views/TechnicalAssistance/AdminHome/components/NoteBox/index.test.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/NoteBox/index.test.tsx
@@ -9,6 +9,7 @@ describe('TRB Admin Note Box', () => {
       <NoteBox
         trbRequestId="861fa6c5-c9af-4cda-a559-0995b7b76855"
         noteCount={4}
+        activePage="advice"
       />
     );
 

--- a/src/views/TechnicalAssistance/AdminHome/components/NoteBox/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/NoteBox/index.tsx
@@ -7,14 +7,25 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Grid } from '@trussworks/react-uswds';
 
+import { TRBAdminNoteCategory } from 'types/graphql-global-types';
+import { TrbAdminPath } from 'types/technicalAssistance';
+
 import NotesModal from '../NoteModal';
+
+export const noteCategoryPageMap: Record<string, TRBAdminNoteCategory> = {
+  advice: TRBAdminNoteCategory.ADVICE_LETTER,
+  request: TRBAdminNoteCategory.GENERAL_REQUEST,
+  'initial-request-form': TRBAdminNoteCategory.INITIAL_REQUEST_FORM,
+  documents: TRBAdminNoteCategory.SUPPORTING_DOCUMENTS
+};
 
 type NoteBoxProps = {
   trbRequestId: string;
   noteCount: number;
+  activePage: TrbAdminPath;
 };
 
-const NoteBox = ({ trbRequestId, noteCount }: NoteBoxProps) => {
+const NoteBox = ({ trbRequestId, noteCount, activePage }: NoteBoxProps) => {
   const { t } = useTranslation('technicalAssistance');
 
   const [isNotesOpen, setIsNotesOpen] = useState<boolean>(false);
@@ -30,6 +41,7 @@ const NoteBox = ({ trbRequestId, noteCount }: NoteBoxProps) => {
           trbRequestId={trbRequestId}
           addNote={addNote}
           openModal={setIsNotesOpen}
+          defaultSelect={noteCategoryPageMap[activePage]}
         />
       )}
       <div

--- a/src/views/TechnicalAssistance/AdminHome/components/NoteModal/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/NoteModal/index.tsx
@@ -10,6 +10,8 @@ import {
 } from '@trussworks/react-uswds';
 import noScroll from 'no-scroll';
 
+import { TRBAdminNoteCategory } from 'types/graphql-global-types';
+
 import AddNote from '../../AddNote';
 import Notes from '../../Notes';
 
@@ -22,13 +24,15 @@ type NotesModalWrapperProps = {
   trbRequestId: string;
   addNote?: boolean;
   openModal: React.Dispatch<React.SetStateAction<boolean>>;
+  defaultSelect?: TRBAdminNoteCategory;
 };
 
 const NotesModal = ({
   isOpen,
   trbRequestId,
   addNote,
-  openModal
+  openModal,
+  defaultSelect
 }: NotesModalWrapperProps) => {
   const { t } = useTranslation('technicalAssistance');
 
@@ -101,6 +105,7 @@ const NotesModal = ({
                 trbRequestId={trbRequestId}
                 setModalView={setViewType}
                 setModalMessage={setModalMessage}
+                defaultSelect={defaultSelect}
               />
             )}
           </Grid>

--- a/src/views/TechnicalAssistance/AdminHome/components/Summary/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/AdminHome/components/Summary/__snapshots__/index.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`TRB Admin Home summary renders TRB request details 1`] = `
               Status
             </h4>
             <span
-              class="bg-info-dark text-white text-bold padding-y-05 padding-x-105 margin-x-1"
+              class="text-white text-bold padding-y-05 padding-x-105 margin-x-1 bg-info-dark"
             >
               Open
             </span>

--- a/src/views/TechnicalAssistance/AdminHome/components/Summary/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/Summary/index.tsx
@@ -10,6 +10,7 @@ import {
   IconError,
   ModalRef
 } from '@trussworks/react-uswds';
+import classNames from 'classnames';
 
 import { TRBAttendee } from 'queries/types/TRBAttendee';
 import {
@@ -130,7 +131,15 @@ export default function Summary({
               className="display-flex flex-align-center margin-y-05"
             >
               <h4 className="margin-y-0">{t('adminHome.status')}</h4>
-              <span className="bg-info-dark text-white text-bold padding-y-05 padding-x-105 margin-x-1">
+              <span
+                className={classNames(
+                  'text-white text-bold padding-y-05 padding-x-105 margin-x-1',
+                  {
+                    'bg-base': state === TRBRequestState.CLOSED,
+                    'bg-info-dark': state === TRBRequestState.OPEN
+                  }
+                )}
+              >
                 {t(`adminHome.${state.toLowerCase()}`)}
               </span>
               <p className="margin-y-0 text-base">{taskStatusText}</p>

--- a/src/views/TechnicalAssistance/AdminHome/components/TrbAdminWrapper/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/TrbAdminWrapper/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Grid, ModalRef } from '@trussworks/react-uswds';
 import classNames from 'classnames';
@@ -11,7 +11,8 @@ import { TRBRequestState, TRBRequestStatus } from 'types/graphql-global-types';
 import { TrbAdminPath, TrbRequestIdRef } from 'types/technicalAssistance';
 
 import AdminTaskStatusTag from '../AdminTaskStatusTag';
-import NoteBox from '../NoteBox';
+import NoteBox, { noteCategoryPageMap } from '../NoteBox';
+import NotesModal from '../NoteModal';
 
 import useTrbAdminActionButtons from './useTrbAdminActionButtons';
 
@@ -130,13 +131,16 @@ export default function TrbAdminWrapper({
   const { status, state, assignLeadModalRef, assignLeadModalTrbRequestIdRef } =
     adminActionProps || {};
 
+  const [notesOpen, openNotes] = useState<boolean>(false);
+
   const actionButtons = useTrbAdminActionButtons({
     activePage,
     trbRequestId,
     status,
     state,
     assignLeadModalRef,
-    assignLeadModalTrbRequestIdRef
+    assignLeadModalTrbRequestIdRef,
+    openNotes
   });
 
   return (
@@ -147,6 +151,16 @@ export default function TrbAdminWrapper({
       id={`trbAdmin__${activePage}`}
       data-testid={`trb-admin-home__${activePage}`}
     >
+      {notesOpen && (
+        <NotesModal
+          isOpen={notesOpen}
+          trbRequestId={trbRequestId}
+          addNote
+          openModal={openNotes}
+          defaultSelect={noteCategoryPageMap[activePage]}
+        />
+      )}
+
       <Grid row gap="lg">
         <Grid tablet={{ col: 8 }}>
           <h1 className="margin-top-0 margin-bottom-1">{t(title)}</h1>
@@ -167,7 +181,11 @@ export default function TrbAdminWrapper({
 
         {noteCount !== undefined && (
           <Grid tablet={{ col: 4 }}>
-            <NoteBox trbRequestId={trbRequestId} noteCount={noteCount} />
+            <NoteBox
+              trbRequestId={trbRequestId}
+              noteCount={noteCount}
+              activePage={activePage}
+            />
           </Grid>
         )}
       </Grid>

--- a/src/views/TechnicalAssistance/AdminHome/components/TrbAdminWrapper/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/TrbAdminWrapper/index.tsx
@@ -110,6 +110,7 @@ type TrbAdminWrapperProps = {
     name: string;
     date: string;
   };
+  renderBottom?: boolean;
 };
 
 export default function TrbAdminWrapper({
@@ -121,7 +122,8 @@ export default function TrbAdminWrapper({
   disableStep,
   adminActionProps,
   noteCount,
-  statusTagProps
+  statusTagProps,
+  renderBottom
 }: TrbAdminWrapperProps) {
   const { t } = useTranslation('technicalAssistance');
 
@@ -183,6 +185,21 @@ export default function TrbAdminWrapper({
       )}
 
       {children}
+
+      {/* Admin Action box rendered additionally at bottom */}
+      {renderBottom &&
+        actionButtons.length > 0 &&
+        adminActionProps &&
+        !disableStep && (
+          <TrbAdminAction
+            translationKey={`technicalAssistance:adminAction.statuses.${
+              adminActionProps.state === TRBRequestState.CLOSED
+                ? adminActionProps.state
+                : adminActionProps.status
+            }`}
+            actionButtons={actionButtons}
+          />
+        )}
     </Grid>
   );
 }

--- a/src/views/TechnicalAssistance/AdminHome/components/TrbAdminWrapper/useTrbAdminActionButtons.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/TrbAdminWrapper/useTrbAdminActionButtons.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { Dispatch, SetStateAction, useContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
@@ -24,6 +24,7 @@ type ActionButtonsProps = {
   assignLeadModalTrbRequestIdRef:
     | React.MutableRefObject<TrbRequestIdRef>
     | undefined;
+  openNotes: Dispatch<SetStateAction<boolean>>;
 };
 
 type ActionButtonKey =
@@ -48,7 +49,8 @@ const useTrbAdminActionButtons = ({
   status,
   state,
   assignLeadModalRef,
-  assignLeadModalTrbRequestIdRef
+  assignLeadModalTrbRequestIdRef,
+  openNotes
 }: ActionButtonsProps): AdminActionButton[] => {
   const { t } = useTranslation('technicalAssistance');
   const history = useHistory();
@@ -142,7 +144,7 @@ const useTrbAdminActionButtons = ({
       },
       addNote: {
         label: t('adminAction.buttons.addNote'),
-        link: `/trb/${trbRequestId}/notes/add-note`
+        onClick: () => openNotes(true)
       }
     };
 

--- a/src/views/TechnicalAssistance/AdminHome/components/TrbAdminWrapper/useTrbAdminActionButtons.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/TrbAdminWrapper/useTrbAdminActionButtons.tsx
@@ -237,7 +237,8 @@ const useTrbAdminActionButtons = ({
     createAdviceLetter,
     assignLeadModalRef,
     assignLeadModalTrbRequestIdRef,
-    leadAssigned
+    leadAssigned,
+    openNotes
   ]);
 
   return actionButtons;

--- a/src/views/TechnicalAssistance/AdminHome/components/TrbAdminWrapper/useTrbAdminActionButtons.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/TrbAdminWrapper/useTrbAdminActionButtons.tsx
@@ -55,7 +55,8 @@ const useTrbAdminActionButtons = ({
 
   const trbContextData = useContext(TRBRequestContext);
 
-  const leadAssigned = !!trbContextData.data?.trbRequest.trbLeadInfo.commonName;
+  const leadAssigned = !!trbContextData.data?.trbRequest?.trbLeadInfo
+    ?.commonName;
 
   const [createAdviceLetter] = useMutation<
     CreateTrbAdviceLetter,

--- a/src/views/TechnicalAssistance/AdminHome/components/TrbAdminWrapper/useTrbAdminActionButtons.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/TrbAdminWrapper/useTrbAdminActionButtons.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
@@ -12,6 +12,8 @@ import {
 } from 'queries/types/CreateTrbAdviceLetter';
 import { TRBRequestState, TRBRequestStatus } from 'types/graphql-global-types';
 import { TrbAdminPath, TrbRequestIdRef } from 'types/technicalAssistance';
+
+import { TRBRequestContext } from '../../RequestContext';
 
 type ActionButtonsProps = {
   trbRequestId: string;
@@ -50,6 +52,10 @@ const useTrbAdminActionButtons = ({
 }: ActionButtonsProps): AdminActionButton[] => {
   const { t } = useTranslation('technicalAssistance');
   const history = useHistory();
+
+  const trbContextData = useContext(TRBRequestContext);
+
+  const leadAssigned = !!trbContextData.data?.trbRequest.trbLeadInfo.commonName;
 
   const [createAdviceLetter] = useMutation<
     CreateTrbAdviceLetter,
@@ -158,7 +164,7 @@ const useTrbAdminActionButtons = ({
       case TRBRequestStatus.READY_FOR_CONSULT:
         return [
           buttons.addDateTime,
-          buttons.assignTrbLead,
+          ...(!leadAssigned ? [buttons.assignTrbLead] : []),
           buttons.orCloseRequest
         ];
       case TRBRequestStatus.CONSULT_SCHEDULED:
@@ -166,20 +172,24 @@ const useTrbAdminActionButtons = ({
           case 'initial-request-form':
             return [
               { ...buttons.viewSupportingDocuments, outline: true },
-              { ...buttons.assignTrbLead, outline: true },
+              ...(!leadAssigned
+                ? [{ ...buttons.assignTrbLead, outline: true }]
+                : []),
               buttons.orCloseRequest
             ];
           case 'documents':
             return [
               { ...buttons.viewRequestForm, outline: true },
-              { ...buttons.assignTrbLead, outline: true },
+              ...(!leadAssigned
+                ? [{ ...buttons.assignTrbLead, outline: true }]
+                : []),
               buttons.orCloseRequest
             ];
           default:
             return [
               buttons.viewRequestForm,
               buttons.viewSupportingDocuments,
-              buttons.assignTrbLead,
+              ...(!leadAssigned ? [buttons.assignTrbLead] : []),
               buttons.orCloseRequest
             ];
         }
@@ -223,7 +233,8 @@ const useTrbAdminActionButtons = ({
     history,
     createAdviceLetter,
     assignLeadModalRef,
-    assignLeadModalTrbRequestIdRef
+    assignLeadModalTrbRequestIdRef,
+    leadAssigned
   ]);
 
   return actionButtons;

--- a/src/views/TechnicalAssistance/Homepage.tsx
+++ b/src/views/TechnicalAssistance/Homepage.tsx
@@ -40,6 +40,7 @@ import {
   GetTrbRequests_myTrbRequests
 } from 'queries/types/GetTrbRequests';
 import { AppState } from 'reducers/rootReducer';
+import { TRBRequestState } from 'types/graphql-global-types';
 import { formatDateLocal } from 'utils/date';
 import globalFilterCellText from 'utils/globalFilterCellText';
 import {
@@ -90,9 +91,13 @@ function Homepage() {
           );
         }
       },
+
       {
         Header: t<string>('table.header.status'),
-        accessor: ({ status }) => t(`table.requestStatus.${status}`)
+        accessor: ({ status, state }) =>
+          state === TRBRequestState.CLOSED
+            ? t(`table.requestState.${state}`)
+            : t(`table.requestStatus.${status}`)
       },
       {
         Header: t<string>('table.header.submissionDate'),

--- a/src/views/TechnicalAssistance/RequestForm/Attendees.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/Attendees.tsx
@@ -15,6 +15,7 @@ import classNames from 'classnames';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import PageLoading from 'components/PageLoading';
+import Alert from 'components/shared/Alert';
 import Divider from 'components/shared/Divider';
 import useTRBAttendees from 'hooks/useTRBAttendees';
 import {
@@ -276,6 +277,7 @@ function Attendees({
                 <p className="line-height-body-5 margin-top-0 margin-bottom-2">
                   {t('attendees.description')}
                 </p>
+
                 <UswdsReactLink
                   to={`/trb/task-list/${trbID}`}
                   className="display-block margin-bottom-5"
@@ -285,6 +287,12 @@ function Attendees({
                     {t('requestFeedback.returnToTaskList')}
                   </span>
                 </UswdsReactLink>
+
+                {attendees?.length === 0 && (
+                  <Alert type="info" slim className="margin-bottom-3">
+                    {t('attendees.noAttendees')}
+                  </Alert>
+                )}
               </>
             )}
 

--- a/src/views/TechnicalAssistance/RequestForm/Basic.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/Basic.tsx
@@ -852,6 +852,7 @@ function Basic({
                                       {t('errors.fillBlank')}
                                     </ErrorMessage>
                                   )}
+
                                   <TextInput
                                     {...field}
                                     ref={null}
@@ -892,13 +893,18 @@ function Basic({
                                           {t('errors.fillBlank')}
                                         </ErrorMessage>
                                       )}
-                                      <TextInput
-                                        {...field}
-                                        ref={null}
-                                        id={collabDateKey}
-                                        type="text"
-                                        validationStatus={error && 'error'}
-                                      />
+
+                                      <Grid row>
+                                        <Grid tablet={{ col: 6 }}>
+                                          <DatePickerFormatted
+                                            id={collabDateKey}
+                                            {...field}
+                                            defaultValue={field.value}
+                                            ref={null}
+                                          />{' '}
+                                        </Grid>
+                                      </Grid>
+
                                       {val === 'GOVERNANCE_REVIEW_BOARD' && (
                                         <Controller
                                           name="collabGRBConsultRequested"

--- a/src/views/TechnicalAssistance/RequestForm/DocumentUpload.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/DocumentUpload.tsx
@@ -278,7 +278,7 @@ const DocumentUpload = ({
         <div>
           <Button
             type="submit"
-            disabled={!isDirty || isSubmitting}
+            disabled={!watch('fileData') || isSubmitting}
             className="margin-top-4"
           >
             {t('documents.upload.uploadDocument')}

--- a/src/views/TechnicalAssistance/RequestForm/Documents.test.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/Documents.test.tsx
@@ -579,6 +579,10 @@ describe('Trb Request form: Supporting documents', () => {
 
     expect(uploadButton).toBeDisabled();
 
+    // Add a document
+    const documentUploadLabel = getByLabelText('Document upload');
+    userEvent.upload(documentUploadLabel, testFile);
+
     // Select the "Other" document type so that the form submit button is enabled
     // The file input and the other text field will be left empty to catch errors
     userEvent.click(getByTestId('documentType-OTHER'));
@@ -586,18 +590,8 @@ describe('Trb Request form: Supporting documents', () => {
     // Submit attempt
     userEvent.click(uploadButton);
 
-    // File input error
-    const fileError = await findByText('Please select a file');
     // Other document input error
     const otherDocError = await findByText('Please fill in the blank');
-
-    // Add a document
-    const documentUploadLabel = getByLabelText('Document upload');
-    userEvent.upload(documentUploadLabel, testFile);
-    // Document error gone
-    await waitFor(() => {
-      expect(fileError).not.toBeInTheDocument();
-    });
 
     // Text field error is still there
     expect(otherDocError).toBeInTheDocument();
@@ -606,7 +600,7 @@ describe('Trb Request form: Supporting documents', () => {
     userEvent.type(getByLabelText('What kind of document is this?'), 'test');
     // Text error gone
     await waitFor(() => {
-      expect(fileError).not.toBeInTheDocument();
+      expect(otherDocError).not.toBeInTheDocument();
     });
   });
 });

--- a/src/views/TechnicalAssistance/RequestForm/Feedback.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/Feedback.tsx
@@ -16,9 +16,10 @@ import TrbRequestFeedbackList from '../TrbRequestFeedbackList';
 type FeedbackProps = {
   request: TrbRequest;
   taskListUrl: string;
+  prevStep?: string;
 };
 
-function Feedback({ request, taskListUrl }: FeedbackProps) {
+function Feedback({ request, taskListUrl, prevStep }: FeedbackProps) {
   const { t } = useTranslation('technicalAssistance');
 
   const { state } = useLocation<{
@@ -29,7 +30,7 @@ function Feedback({ request, taskListUrl }: FeedbackProps) {
 
   const returnUrl = fromTaskList
     ? `/trb/task-list/${request.id}`
-    : `/trb/requests/${request.id}/check`;
+    : `/trb/requests/${request.id}/${prevStep || 'check'}`;
 
   const returnToFormLink = useMemo(
     () => (

--- a/src/views/TechnicalAssistance/RequestForm/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/RequestForm/__snapshots__/index.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`TRB Request Form Feedback goes to and renders the feedback view 1`] = `
         >
           <a
             class="usa-breadcrumb__link"
-            href="/trb/requests/d8ebedca-0031-4ccd-9690-37390726c50e/check"
+            href="/trb/requests/d8ebedca-0031-4ccd-9690-37390726c50e/basic"
           >
             <span>
               TRB Request
@@ -69,7 +69,7 @@ exports[`TRB Request Form Feedback goes to and renders the feedback view 1`] = `
     </h1>
     <a
       class="usa-link"
-      href="/trb/requests/d8ebedca-0031-4ccd-9690-37390726c50e/check"
+      href="/trb/requests/d8ebedca-0031-4ccd-9690-37390726c50e/basic"
     >
       <svg
         class="usa-icon margin-right-1 text-middle"
@@ -199,7 +199,7 @@ exports[`TRB Request Form Feedback goes to and renders the feedback view 1`] = `
     >
       <a
         class="usa-link"
-        href="/trb/requests/d8ebedca-0031-4ccd-9690-37390726c50e/check"
+        href="/trb/requests/d8ebedca-0031-4ccd-9690-37390726c50e/basic"
       >
         <svg
           class="usa-icon margin-right-1 text-middle"

--- a/src/views/TechnicalAssistance/RequestForm/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/RequestForm/__snapshots__/index.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`TRB Request Form Feedback goes to and renders the feedback view 1`] = `
         data-testid="grid"
       >
         <div
-          class="padding-3 bg-base-lightest line-height-body-5"
+          class="padding-3 bg-base-lightest line-height-body-5 text-pre-wrap"
         >
           Id mauris pharetra volutpat, praesent faucibus aliquam, penatibus. Convallis maecenas cras dignissim in diam duis odio maecenas. Mi amet ullamcorper dolor tempus vulputate elit a volutpat purus. Nunc, vel arcu imperdiet duis enim leo quis. Aliquam nibh tincidunt aliquam morbi non. A in porttitor suspendisse nunc turpis turpis eros, at ultrices. Scelerisque netus quisque semper ullamcorper porta interdum scelerisque elementum. Egestas enim egestas imperdiet sociis porta.
         </div>
@@ -185,7 +185,7 @@ exports[`TRB Request Form Feedback goes to and renders the feedback view 1`] = `
         data-testid="grid"
       >
         <div
-          class="padding-3 bg-base-lightest line-height-body-5"
+          class="padding-3 bg-base-lightest line-height-body-5 text-pre-wrap"
         >
           Purus morbi pellentesque eget erat. Egestas venenatis vitae pretium pretium, orci, elit praesent tortor. Turpis semper sollicitudin sagittis pellentesque est dictum. Rhoncus, nulla turpis netus praesent consequat leo orci, vel.
         </div>

--- a/src/views/TechnicalAssistance/RequestForm/index.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { ApolloQueryResult, useQuery } from '@apollo/client';
 import {
   Button,
@@ -224,7 +224,13 @@ function Header({
   );
 }
 
-function EditsRequestedWarning({ requestId }: { requestId: string }) {
+function EditsRequestedWarning({
+  requestId,
+  step
+}: {
+  requestId: string;
+  step?: string;
+}) {
   const { t } = useTranslation('technicalAssistance');
   return (
     <div className="bg-error-lighter padding-y-2">
@@ -242,7 +248,10 @@ function EditsRequestedWarning({ requestId }: { requestId: string }) {
           <UswdsReactLink
             variant="unstyled"
             className="usa-button usa-button--outline"
-            to={`/trb/requests/${requestId}/feedback`}
+            to={{
+              pathname: `/trb/requests/${requestId}/feedback`,
+              state: { prevStep: step }
+            }}
           >
             {t('editsRequested.viewFeedback')}
           </UswdsReactLink>
@@ -259,6 +268,10 @@ function RequestForm() {
   const { t } = useTranslation('technicalAssistance');
 
   const history = useHistory();
+
+  const { state } = useLocation<{ prevStep?: string }>();
+
+  const prevStep = state?.prevStep;
 
   const { id, step, view } = useParams<{
     /** Request id */
@@ -414,9 +427,9 @@ function RequestForm() {
     () =>
       request?.taskStatuses.feedbackStatus ===
       TRBFeedbackStatus.EDITS_REQUESTED ? (
-        <EditsRequestedWarning requestId={request.id} />
+        <EditsRequestedWarning requestId={request.id} step={step} />
       ) : null,
-    [request?.id, request?.taskStatuses.feedbackStatus]
+    [request?.id, request?.taskStatuses.feedbackStatus, step]
   );
 
   // References to the submit handler and submitting state of the current form step
@@ -467,7 +480,13 @@ function RequestForm() {
   }
 
   if (step === 'feedback' && request) {
-    return <Feedback request={request} taskListUrl={taskListUrl} />;
+    return (
+      <Feedback
+        request={request}
+        taskListUrl={taskListUrl}
+        prevStep={prevStep}
+      />
+    );
   }
 
   const stepIdx = formStepSlugs.indexOf(step as FormStepSlug);

--- a/src/views/TechnicalAssistance/TrbAdminTeamHome.tsx
+++ b/src/views/TechnicalAssistance/TrbAdminTeamHome.tsx
@@ -29,6 +29,7 @@ import TablePageSize from 'components/TablePageSize';
 import TablePagination from 'components/TablePagination';
 import GetTrbAdminTeamHomeQuery from 'queries/GetTrbAdminTeamHomeQuery';
 import { GetTrbAdminTeamHome } from 'queries/types/GetTrbAdminTeamHome';
+import { TRBRequestState } from 'types/graphql-global-types';
 import {
   TrbAdminTeamHomeRequest,
   TrbRequestIdRef
@@ -362,7 +363,10 @@ function TrbExistingRequestsTable({ requests }: TrbRequestsTableProps) {
       },
       {
         Header: t<string>('adminHome.status'),
-        accessor: ({ status }) => t(`table.requestStatus.${status}`)
+        accessor: ({ status, state }) =>
+          state === TRBRequestState.CLOSED
+            ? t(`table.requestState.${state}`)
+            : t(`table.requestStatus.${status}`)
       },
       {
         Header: t<string>('table.header.trbConsultDate'),

--- a/src/views/TechnicalAssistance/TrbRequestFeedbackList.tsx
+++ b/src/views/TechnicalAssistance/TrbRequestFeedbackList.tsx
@@ -33,7 +33,7 @@ function TrbRequestFeedbackList({ feedback }: TrbRequestFeedbackListProps) {
               </dl>
             </Grid>
             <Grid col={12}>
-              <div className="padding-3 bg-base-lightest line-height-body-5">
+              <div className="padding-3 bg-base-lightest line-height-body-5 text-pre-wrap">
                 {item.feedbackMessage}
               </div>
             </Grid>

--- a/src/views/TechnicalAssistance/__snapshots__/TrbRequestFeedbackList.test.tsx.snap
+++ b/src/views/TechnicalAssistance/__snapshots__/TrbRequestFeedbackList.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`TrbRequestFeedbackList renders 1`] = `
       data-testid="grid"
     >
       <div
-        class="padding-3 bg-base-lightest line-height-body-5"
+        class="padding-3 bg-base-lightest line-height-body-5 text-pre-wrap"
       >
         Please
       </div>
@@ -93,7 +93,7 @@ exports[`TrbRequestFeedbackList renders 1`] = `
       data-testid="grid"
     >
       <div
-        class="padding-3 bg-base-lightest line-height-body-5"
+        class="padding-3 bg-base-lightest line-height-body-5 text-pre-wrap"
       >
         Thank you
       </div>

--- a/src/views/TechnicalAssistance/index.test.tsx
+++ b/src/views/TechnicalAssistance/index.test.tsx
@@ -10,7 +10,7 @@ import {
   // eslint-disable-next-line camelcase
   GetTrbRequests_myTrbRequests
 } from 'queries/types/GetTrbRequests';
-import { TRBRequestStatus } from 'types/graphql-global-types';
+import { TRBRequestState, TRBRequestStatus } from 'types/graphql-global-types';
 import VerboseMockedProvider from 'utils/testing/VerboseMockedProvider';
 
 import ProcessFlow from './ProcessFlow';
@@ -25,6 +25,7 @@ describe('Technical Assistance (TRB) homepage', () => {
     {
       id: '1afc9242-f244-47a3-9f91-4d6fedd8eb91',
       name: 'My excellent question',
+      state: TRBRequestState.OPEN,
       status: TRBRequestStatus.NEW,
       createdAt: '2022-09-12T17:46:08.067675Z',
       form: {
@@ -36,6 +37,7 @@ describe('Technical Assistance (TRB) homepage', () => {
     {
       id: '9841c768-bdcd-4856-bae2-62cfdaffacf6',
       name: 'TACO Review',
+      state: TRBRequestState.OPEN,
       status: TRBRequestStatus.NEW,
       createdAt: '2022-09-12T17:46:08.07031Z',
       form: {


### PR DESCRIPTION
# EASI-2983
# EASI-2984

Accidentally kept working past 4 and pushed changes into 5

## Changes and Description

All of these changes are a part of the "Should haves" of the UX Findings [DOC](https://docs.google.com/document/d/1HSmSXe6Wg7emBg59s3qFn7lINZnComsbpyVBlEJHb3Y/edit#heading=h.7kn6yyrth8d7)

- Empty/invisible buttons observed when using 508 testing tool
- Edits requested/feedback requester experience back button
- Assign lead button should not appear in admin action box if lead is assigned
- Admin actions for initial request form sub-page
- “When did you meet” sub-fields should be date pickers
- Closed request tab styling
- Text areas not honoring line breaks after saving
- View button should show outlined when Advice letter is complete
- Closed request statuses
- Empty state when adding new attendees from task list step 3
- Add doc button should stay disabled if not doc is added
- Notes experience for advice letter review
- Actions returning to wrong sub-page
- Add info box about draft state

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
