### PR TITLE
[EASI-2948] Advice letter form save and exit

### DIFF
--- a/src/components/StepHeader/index.tsx
+++ b/src/components/StepHeader/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@trussworks/react-uswds';
 // eslint-disable-next-line import/no-unresolved
 import { StepIndicatorStepProps } from '@trussworks/react-uswds/lib/components/stepindicator/StepIndicatorStep/StepIndicatorStep';
+import classNames from 'classnames';
 
 import PageHeading from 'components/PageHeading';
 
@@ -17,6 +18,7 @@ export type StepHeaderStepProps = {
   label: React.ReactNode;
   description?: string;
   completed?: boolean;
+  disabled?: boolean;
   onClick?: React.MouseEventHandler<HTMLLIElement>;
 };
 
@@ -104,10 +106,14 @@ function StepHeader({
                 <StepIndicatorStep
                   key={stp.key}
                   status={status}
-                  onClick={stp.onClick ? stp.onClick : undefined}
-                  className={
-                    stp.onClick ? 'usa-step-indicator__segment--clickable' : ''
+                  onClick={
+                    stp.onClick && !stp.disabled ? stp.onClick : undefined
                   }
+                  className={classNames({
+                    'usa-step-indicator__segment--clickable':
+                      !!stp.onClick && !stp.disabled,
+                    'usa-step-indicator__segment--disabled': stp.disabled
+                  })}
                   // `label` expects a string but can render jsx
                   label={(stp.label as unknown) as string}
                 />

--- a/src/hooks/useEasiForm.ts
+++ b/src/hooks/useEasiForm.ts
@@ -1,0 +1,97 @@
+import React, { useCallback } from 'react';
+import {
+  FieldValues,
+  Path,
+  SubmitErrorHandler,
+  SubmitHandler,
+  useForm,
+  UseFormProps,
+  UseFormReturn
+} from 'react-hook-form';
+
+export type UseEasiFormHandleSubmit<TFieldValues extends FieldValues> = (
+  onValid: SubmitHandler<TFieldValues>,
+  onInvalid?: SubmitErrorHandler<TFieldValues>,
+  options?: {
+    fields: Path<TFieldValues>[];
+  }
+) => (e?: React.BaseSyntheticEvent) => Promise<void>;
+
+type PartialSubmit<TFieldValues extends FieldValues> = (
+  update: (
+    /** Object containing valid dirty field values */
+    formData: Partial<TFieldValues>
+  ) => Promise<any>,
+  options?: {
+    /** Whether to clear field error messages */
+    clearErrors?: boolean;
+    /** Callback to execute after updating */
+    callback?: () => void;
+  }
+) => Promise<void>;
+
+/**
+ * Extension of React Hook Form's `useForm` hook
+ */
+function useEasiForm<
+  TFieldValues extends FieldValues = FieldValues,
+  TContext = any
+>(
+  props: UseFormProps<TFieldValues, TContext>
+): UseFormReturn<TFieldValues, TContext> & {
+  /** Ignore errors and submit valid dirty field values */
+  partialSubmit: PartialSubmit<TFieldValues>;
+} {
+  const form = useForm<TFieldValues, TContext>(props);
+
+  const {
+    getValues,
+    clearErrors,
+    formState: { errors, dirtyFields, isDirty }
+  } = form;
+
+  /** Ignore errors and submit valid dirty field values */
+  const partialSubmit: PartialSubmit<TFieldValues> = useCallback(
+    async (update, options) => {
+      // Clear field errors
+      if (options?.clearErrors) clearErrors();
+
+      if (isDirty) {
+        const dirtyFieldKeys = Object.keys(dirtyFields)
+          // Filter out fields with errors
+          .filter(key => !errors[key]);
+
+        const values = getValues();
+
+        /** Object containing valid dirty field values */
+        const data: Partial<TFieldValues> = dirtyFieldKeys.reduce(
+          (acc, key) => {
+            return {
+              ...acc,
+              [key]: values[key]
+            };
+          },
+          {}
+        );
+
+        // Update values
+        return (
+          update(data)
+            .then(() => options?.callback?.())
+            // Ignore errors and execute callback
+            .catch(() => options?.callback?.())
+        );
+      }
+
+      return options?.callback?.();
+    },
+    [dirtyFields, getValues, errors, clearErrors, isDirty]
+  );
+
+  return {
+    ...form,
+    partialSubmit
+  };
+}
+
+export default useEasiForm;

--- a/src/views/TechnicalAssistance/AdviceLetterForm/Summary.tsx
+++ b/src/views/TechnicalAssistance/AdviceLetterForm/Summary.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ApolloError, useMutation } from '@apollo/client';
@@ -9,6 +9,7 @@ import { ErrorMessage, Form, FormGroup } from '@trussworks/react-uswds';
 import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import TextAreaField from 'components/shared/TextAreaField';
+import useEasiForm from 'hooks/useEasiForm';
 import { UpdateTrbAdviceLetterQuery } from 'queries/TrbAdviceLetterQueries';
 import {
   UpdateTrbAdviceLetter,
@@ -44,8 +45,9 @@ const Summary = ({
     handleSubmit,
     control,
     watch,
+    partialSubmit,
     formState: { isSubmitting, isDirty }
-  } = useForm<AdviceLetterSummary>({
+  } = useEasiForm<AdviceLetterSummary>({
     resolver: yupResolver(meetingSummarySchema),
     defaultValues: {
       meetingSummary
@@ -54,35 +56,62 @@ const Summary = ({
 
   /** Submit meeting summary fields and update advice letter */
   const submit = useCallback<StepSubmit>(
-    callback =>
-      handleSubmit(async formData => {
-        try {
-          if (isDirty) {
-            // UpdateTrbAdviceLetter mutation
-            await update({
-              variables: {
-                input: {
-                  trbRequestId,
-                  ...formData
+    (callback, shouldValidate) =>
+      handleSubmit(
+        async formData => {
+          try {
+            if (isDirty) {
+              // UpdateTrbAdviceLetter mutation
+              await update({
+                variables: {
+                  input: {
+                    trbRequestId,
+                    ...formData
+                  }
                 }
-              }
-            });
+              });
+            }
+            setFormAlert(null);
+            callback?.();
+          } catch (e) {
+            if (e instanceof ApolloError) {
+              setFormAlert({
+                type: 'error',
+                message: t('adviceLetterForm.error', {
+                  action: 'saving',
+                  type: 'advice letter'
+                })
+              });
+            }
           }
-          setFormAlert(null);
-          callback?.();
-        } catch (e) {
-          if (e instanceof ApolloError) {
-            setFormAlert({
-              type: 'error',
-              message: t('adviceLetterForm.error', {
-                action: 'saving',
-                type: 'advice letter'
-              })
+        },
+        async () => {
+          // Save valid dirty fields on save and exit
+          if (!shouldValidate) {
+            await partialSubmit({
+              update: formData =>
+                update({
+                  variables: {
+                    input: {
+                      trbRequestId,
+                      ...formData
+                    }
+                  }
+                }),
+              callback
             });
           }
         }
-      })(),
-    [handleSubmit, isDirty, trbRequestId, update, setFormAlert, t]
+      )(),
+    [
+      handleSubmit,
+      isDirty,
+      trbRequestId,
+      update,
+      setFormAlert,
+      t,
+      partialSubmit
+    ]
   );
 
   useEffect(() => {

--- a/src/views/TechnicalAssistance/AdviceLetterForm/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/AdviceLetterForm/__snapshots__/index.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`TRB Advice Letter Form matches the snapshot 1`] = `
         >
           <li
             aria-current="true"
-            class="usa-step-indicator__segment usa-step-indicator__segment--current usa-step-indicator__segment--clickable"
+            class="usa-step-indicator__segment usa-step-indicator__segment--current usa-step-indicator__segment--disabled"
           >
             <span
               class="usa-step-indicator__segment-label"

--- a/src/views/TechnicalAssistance/AdviceLetterForm/index.tsx
+++ b/src/views/TechnicalAssistance/AdviceLetterForm/index.tsx
@@ -132,9 +132,7 @@ const AdviceLetterForm = () => {
       return;
     }
     (async () => {
-      const completed: FormStepKey[] = stepsCompleted
-        ? [...stepsCompleted]
-        : ['recommendations'];
+      const completed: FormStepKey[] = ['recommendations'];
       const stepValidators = [];
 
       // Check the Meeting Summary step

--- a/src/views/TechnicalAssistance/AdviceLetterForm/index.tsx
+++ b/src/views/TechnicalAssistance/AdviceLetterForm/index.tsx
@@ -132,7 +132,11 @@ const AdviceLetterForm = () => {
 
   /** Redirect if previous steps are not completed */
   const redirectStep = useCallback(() => {
-    if (stepsCompleted && !checkValidSteps(currentStepIndex)) {
+    if (
+      stepsCompleted &&
+      stepsCompleted.length < 4 &&
+      !checkValidSteps(currentStepIndex)
+    ) {
       /** Returns latest available step index */
       const stepRedirectIndex = adviceFormSteps.findIndex(
         step => !stepsCompleted?.includes(step.slug)

--- a/src/views/TechnicalAssistance/AdviceLetterForm/index.tsx
+++ b/src/views/TechnicalAssistance/AdviceLetterForm/index.tsx
@@ -303,7 +303,7 @@ const AdviceLetterForm = () => {
                 onClick={() => {
                   const url = `/trb/${id}/advice`;
                   if (stepSubmit) {
-                    stepSubmit?.(() => history.push(url));
+                    stepSubmit?.(() => history.push(url), false);
                   } else {
                     history.push(url);
                   }

--- a/src/views/TechnicalAssistance/RequestForm/Pager.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/Pager.tsx
@@ -106,7 +106,7 @@ export function Pager({
             if (!submitDisabled) {
               submit?.(() => {
                 history.push(taskListUrl);
-              });
+              }, false);
             } else {
               history.push(taskListUrl);
             }

--- a/src/views/TechnicalAssistance/RequestForm/index.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/index.tsx
@@ -61,7 +61,10 @@ type ViewSlug = typeof viewSlugs[number];
  * Run the `onValid` callback after successful validation.
  * Use this to change address urls after submissions are successfully completed.
  */
-export type StepSubmit = (onValid?: () => void) => Promise<void>;
+export type StepSubmit = (
+  onValid?: () => void,
+  shouldValidate?: boolean
+) => Promise<void>;
 
 export type TrbFormAlert =
   | {


### PR DESCRIPTION
# EASI-2948

## Changes and Description

- Created `useEasiForm` hook that extends React Hook Form's `useForm` to add a `partialSubmit` function
  - `partialSubmit` clears error messages and updates only valid changed fields before executing callback
- Implemented `partialSubmit` on Advice Letter Form's "Save and Exit" button
- Removed submit handler from "back" buttons
- Fixed bug in step validation (form was redirecting user when navigating to Summary step from further in form)

<!-- Put a description here! -->

## How to test this change

- Test advice letter form
  - Confirm that valid fields are updated and errors do not show when clicking "back" or "save and exit" buttons
  - Confirm that step navigation works as expected

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
