### PR TITLE
[NOREF] Update docker image tags for multi-arch support

### DIFF
--- a/.github/workflows/build_application_images.yml
+++ b/.github/workflows/build_application_images.yml
@@ -92,7 +92,7 @@ jobs:
           if [[ $IMAGE_FOUND == 1 ]]; then
             echo "Image found, skipping build"
           else
-            docker image build --quiet --no-cache --tag "$ECR_REGISTRY/$ECR_REPOSITORY:$GIT_HASH" --file Dockerfile.db_migrations .
+            docker image build --quiet --no-cache --tag "$ECR_REGISTRY/$ECR_REPOSITORY:$GIT_HASH" --build-arg TAG=9.10-alpine --file Dockerfile.db_migrations .
             docker image push "$ECR_REGISTRY/$ECR_REPOSITORY:$GIT_HASH"
           fi
       - name: Announce failure

--- a/Dockerfile.db_clean
+++ b/Dockerfile.db_clean
@@ -1,6 +1,7 @@
-FROM flyway/flyway:7.8.2-alpine
+FROM flyway/flyway:9.10-alpine
 
 ENV FLYWAY_CONNECT_RETRIES=10
 ENV FLYWAY_IGNORE_INVALID_MIGRATION_NAMES="false"
+ENV FLYWAY_CLEAN_DISABLED="false"
 
 ENTRYPOINT ["flyway", "clean"]

--- a/Dockerfile.db_migrations
+++ b/Dockerfile.db_migrations
@@ -1,4 +1,5 @@
-FROM flyway/flyway:7.8.2-alpine
+ARG TAG=
+FROM flyway/flyway:${TAG}
 
 COPY migrations/ /flyway/sql
 

--- a/docker-compose.cypress_local.yml
+++ b/docker-compose.cypress_local.yml
@@ -8,6 +8,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.db_migrations
+      args:
+        TAG: '9.10' # Multi arch tag, rather than '9.10-alpine'
     volumes:
       - ./migrations:/flyway/sql
   db_seed:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,6 +8,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.db_migrations
+      args:
+        TAG: '9.10' # Multi arch tag, rather than '9.10-alpine'
     volumes:
       - ./migrations:/flyway/sql
   easi:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,4 +92,4 @@ services:
       /usr/bin/mc policy set public local/easi-app-file-uploads;
       "
   email:
-    image: dockage/mailcatcher:0.7.1
+    image: dockage/mailcatcher:0.8.2


### PR DESCRIPTION
# NOREF

## Changes and Description

- Update Flyway image from v7 to v9.
  - These versions of the docker image allow for multi-arch support, which should address containers occasionally failing to start locally (and consuming lots of resources) on certain machines, namely M1/M2 Macs
- Update mailcatcher to use an updated image that has multi-arch support

This change was made in MINT here. We've noticed success with the change, and haven't had any issues!
https://github.com/CMSgov/mint-app/pull/555/files

<!-- Put a description here! -->

## How to test this change

- `scripts/dev up`, and ensure all services start locally
- Ensure db migrations run as expected
- Ensure that breaking changes are honored.
  - [v7 to v8](https://github.com/flyway/flyway/issues/3247)
    - Couldn't find anything here that would affect us!
  - [v8 to v9](https://flywaydb.org/blog/version-9-is-coming-what-developers-need-to-know)
    - `flyway clean` is disabled by default, so `ENV FLYWAY_CLEAN_DISABLED="false"` was added to the db clean dockerfile to make sure it can still run

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
