### PR TITLE
[NOREF] Only render reason for closing/reopening when it is provided

### DIFF
--- a/cmd/test_email_templates/main.go
+++ b/cmd/test_email_templates/main.go
@@ -96,6 +96,46 @@ func sendTRBEmails(ctx context.Context, client *email.Client) {
 		RequesterName:      requesterName,
 	})
 	noErr(err)
+
+	err = client.SendTRBRequestClosedEmail(ctx, email.SendTRBRequestClosedEmailInput{
+		TRBRequestID:   requestID,
+		TRBRequestName: requestName,
+		RequesterName:  requesterName,
+		CopyTRBMailbox: true,
+		ReasonClosed:   "This is a reason",
+		Recipients:     emailRecipients,
+	})
+	noErr(err)
+
+	err = client.SendTRBRequestReopenedEmail(ctx, email.SendTRBRequestReopenedEmailInput{
+		TRBRequestID:   requestID,
+		TRBRequestName: requestName,
+		RequesterName:  requesterName,
+		CopyTRBMailbox: true,
+		ReasonReopened: "This is a reason to reopen",
+		Recipients:     emailRecipients,
+	})
+	noErr(err)
+
+	err = client.SendTRBRequestClosedEmail(ctx, email.SendTRBRequestClosedEmailInput{
+		TRBRequestID:   requestID,
+		TRBRequestName: requestName,
+		RequesterName:  requesterName,
+		CopyTRBMailbox: false,
+		ReasonClosed:   "",
+		Recipients:     emailRecipients,
+	})
+	noErr(err)
+
+	err = client.SendTRBRequestReopenedEmail(ctx, email.SendTRBRequestReopenedEmailInput{
+		TRBRequestID:   requestID,
+		TRBRequestName: requestName,
+		RequesterName:  requesterName,
+		CopyTRBMailbox: false,
+		ReasonReopened: "",
+		Recipients:     emailRecipients,
+	})
+	noErr(err)
 }
 
 func main() {

--- a/pkg/email/templates/trb_request_closed.gohtml
+++ b/pkg/email/templates/trb_request_closed.gohtml
@@ -2,7 +2,7 @@
 
 <p>The Technical Review Board (TRB) has closed {{.TRBRequestName}}.</p>
 
-<p>Reason for closing: {{.ReasonClosed}}</p>
+{{if .ReasonClosed}}<p>Reason for closing: {{.ReasonClosed}}</p>{{end}}
 
 <p>View this request in EASi:</p>
 <ul>

--- a/pkg/email/templates/trb_request_reopened.gohtml
+++ b/pkg/email/templates/trb_request_reopened.gohtml
@@ -2,7 +2,7 @@
 
 <p>The Technical Review Board (TRB) has re-opened {{.TRBRequestName}}.</p>
 
-<p>Reason for re-opening: {{.ReasonReopened}}</p>
+{{if .ReasonReopened}}<p>Reason for re-opening: {{.ReasonReopened}}</p>{{end}}
 
 <p>View this request in EASi:</p>
 <ul>

--- a/pkg/email/trb_reopened_email_test.go
+++ b/pkg/email/trb_reopened_email_test.go
@@ -70,3 +70,64 @@ func (s *EmailTestSuite) TestTRBRequestReopenedEmail() {
 		s.Equal(expectedBody, sender.body)
 	})
 }
+
+func (s *EmailTestSuite) TestTRBRequestReopenedEmailNoReason() {
+	sender := mockSender{}
+	ctx := context.Background()
+
+	trbID := uuid.New()
+	trbLink := fmt.Sprintf(
+		"%s://%s/%s",
+		s.config.URLScheme,
+		s.config.URLHost,
+		path.Join("trb", "task-list", trbID.String()),
+	)
+
+	trbAdminLink := fmt.Sprintf(
+		"%s://%s/%s",
+		s.config.URLScheme,
+		s.config.URLHost,
+		path.Join("trb", trbID.String(), "request"),
+	)
+
+	recipients := []models.EmailAddress{
+		models.NewEmailAddress("abcd@local.fake"),
+		models.NewEmailAddress("efgh@local.fake"),
+	}
+
+	input := SendTRBRequestReopenedEmailInput{
+		TRBRequestID:   trbID,
+		TRBRequestName: "Test TRB Request",
+		RequesterName:  "Mc Lovin",
+		Recipients:     recipients,
+		CopyTRBMailbox: true,
+		ReasonReopened: "",
+	}
+	allRecipients := append(recipients, s.config.TRBEmail)
+
+	s.Run("successful call has the right content", func() {
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+		expectedBody := `<h1 style="margin-bottom: 0.5rem;">EASi</h1>
+
+<span style="font-size:15px; line-height: 18px; color: #71767A">Easy Access to System Information</span>
+
+<p>The Technical Review Board (TRB) has re-opened ` + input.TRBRequestName + `.</p>
+
+
+
+<p>View this request in EASi:</p>
+<ul>
+<li>If you are the initial requester, you may <a href="` + trbLink + `">click here</a> to view the advice letter and your request task list.</li>
+<li>TRB team members may <a href="` + trbAdminLink + `">click here</a> to view the request details.</li>
+<li>Others should contact Mc Lovin or the TRB for more information about this request.</li>
+</ul>
+
+<p>If you have questions or need to request a reschedule, please email the TRB at <a href="mailto:` + s.config.TRBEmail.String() + `">` + s.config.TRBEmail.String() + `</a>.</p>
+`
+		err = client.SendTRBRequestReopenedEmail(ctx, input)
+		s.NoError(err)
+		s.ElementsMatch(sender.toAddresses, allRecipients)
+		s.Equal(expectedBody, sender.body)
+	})
+}

--- a/pkg/email/trb_request_closed_test.go
+++ b/pkg/email/trb_request_closed_test.go
@@ -70,3 +70,64 @@ func (s *EmailTestSuite) TestTRBRequestClosedEmail() {
 		s.Equal(expectedBody, sender.body)
 	})
 }
+
+func (s *EmailTestSuite) TestTRBRequestClosedEmailNoReason() {
+	sender := mockSender{}
+	ctx := context.Background()
+
+	trbID := uuid.New()
+	trbLink := fmt.Sprintf(
+		"%s://%s/%s",
+		s.config.URLScheme,
+		s.config.URLHost,
+		path.Join("trb", "task-list", trbID.String()),
+	)
+
+	trbAdminLink := fmt.Sprintf(
+		"%s://%s/%s",
+		s.config.URLScheme,
+		s.config.URLHost,
+		path.Join("trb", trbID.String(), "request"),
+	)
+
+	recipients := []models.EmailAddress{
+		models.NewEmailAddress("abcd@local.fake"),
+		models.NewEmailAddress("efgh@local.fake"),
+	}
+
+	input := SendTRBRequestClosedEmailInput{
+		TRBRequestID:   trbID,
+		TRBRequestName: "Test TRB Request",
+		RequesterName:  "Mc Lovin",
+		Recipients:     recipients,
+		// ReasonClosed not provided!
+		CopyTRBMailbox: true,
+	}
+	allRecipients := append(recipients, s.config.TRBEmail)
+
+	s.Run("successful call has the right content", func() {
+		client, err := NewClient(s.config, &sender)
+		s.NoError(err)
+		expectedBody := `<h1 style="margin-bottom: 0.5rem;">EASi</h1>
+
+<span style="font-size:15px; line-height: 18px; color: #71767A">Easy Access to System Information</span>
+
+<p>The Technical Review Board (TRB) has closed ` + input.TRBRequestName + `.</p>
+
+
+
+<p>View this request in EASi:</p>
+<ul>
+<li>If you are the initial requester, you may <a href="` + trbLink + `">click here</a> to view the advice letter and your request task list.</li>
+<li>TRB team members may <a href="` + trbAdminLink + `">click here</a> to view the request details.</li>
+<li>Others should contact Mc Lovin or the TRB for more information about this request.</li>
+</ul>
+
+<p>If you have questions or need to request a reschedule, please email the TRB at <a href="mailto:` + s.config.TRBEmail.String() + `">` + s.config.TRBEmail.String() + `</a>.</p>
+`
+		err = client.SendTRBRequestClosedEmail(ctx, input)
+		s.NoError(err)
+		s.ElementsMatch(sender.toAddresses, allRecipients)
+		s.Equal(expectedBody, sender.body)
+	})
+}


### PR DESCRIPTION
# NOREF

## Changes and Description

- Only render the "Reason for" reopening/closing a request when it's provided

## TODO
- Fix tests

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
