### PR TITLE
[NOREF] - Fixed advice letter send redirect

### DIFF
--- a/src/views/TechnicalAssistance/AdviceLetterForm/Review.tsx
+++ b/src/views/TechnicalAssistance/AdviceLetterForm/Review.tsx
@@ -45,7 +45,9 @@ const Review = ({
   adviceLetter,
   adviceLetterStatus,
   setFormAlert,
-  setIsStepSubmitting
+  setIsStepSubmitting,
+  stepsCompleted,
+  setStepsCompleted
 }: StepComponentProps) => {
   const { t } = useTranslation('technicalAssistance');
   const history = useHistory();
@@ -170,16 +172,30 @@ const Review = ({
             mutate({
               variables: { input: { ...formData, id: adviceLetter.id } }
             })
-              .then(() =>
+              .then(() => {
+                if (
+                  setStepsCompleted &&
+                  stepsCompleted &&
+                  !stepsCompleted?.includes('review')
+                ) {
+                  setStepsCompleted([...stepsCompleted, 'review']);
+                }
                 history.push(`/trb/${trbRequestId}/advice/done`, {
                   success: true
-                })
-              )
-              .catch(() =>
+                });
+              })
+              .catch(() => {
+                if (
+                  setStepsCompleted &&
+                  stepsCompleted &&
+                  !stepsCompleted?.includes('review')
+                ) {
+                  setStepsCompleted([...stepsCompleted, 'review']);
+                }
                 history.push(`/trb/${trbRequestId}/advice/done`, {
                   success: false
-                })
-              )
+                });
+              })
           )}
           className="maxw-full margin-bottom-205 tablet:grid-col-12 desktop:grid-col-6"
         >

--- a/src/views/TechnicalAssistance/AdviceLetterForm/index.tsx
+++ b/src/views/TechnicalAssistance/AdviceLetterForm/index.tsx
@@ -149,6 +149,7 @@ const AdviceLetterForm = () => {
           ) + 1;
 
       if (!fromAdmin && currentStepIndex === 0) return;
+      if (!adviceFormSteps[stepRedirectIndex]?.slug) return;
       // Redirect to latest available step
       history.replace(
         `/trb/${id}/advice/${adviceFormSteps[stepRedirectIndex].slug}`


### PR DESCRIPTION
# NOREF

## Changes and Description

- Fixed issue where submitting the advice letter would not redirect correctly to success page
- Added the state setter to mark step as complete

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
