### PR TITLE
Update default CEDAR URL config to use v2

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -108,7 +108,7 @@ PATH_add ./bin
 export CEDAR_ENV=dev
 export CEDAR_API_URL="webmethods-apigw.cedardev.cms.gov"
 export CEDAR_CACHE_INTERVAL="30m"
-export CEDAR_CORE_API_VERSION=1.0.0
+export CEDAR_CORE_API_VERSION="2.0.0"
 
 # Frontend Dev
 export ESLINT_NO_DEV_ERRORS=true


### PR DESCRIPTION
No ticket, just a change to the default configuration in `.envrc` to use the v2 URL for contacting CEDAR. 