### PR TITLE
[NOREF] - Fixed notes disabled when dirty/empty note email

### DIFF
--- a/cmd/test_email_templates/main.go
+++ b/cmd/test_email_templates/main.go
@@ -62,8 +62,10 @@ func sendTRBEmails(ctx context.Context, client *email.Client) {
 	err = client.SendTRBFormSubmissionNotificationToAdmins(ctx, requestID, requestName, requesterName, component)
 	noErr(err)
 
-	readyForConsultFeedback := "You're good to go for the consult meeting!"
-	err = client.SendTRBReadyForConsultNotification(ctx, emailRecipients, true, requestID, requestName, requesterName, readyForConsultFeedback)
+	// Ready for Consult (Feedback and No Feedback)
+	err = client.SendTRBReadyForConsultNotification(ctx, emailRecipients, true, requestID, requestName, requesterName, "You're good to go for the consult meeting!")
+	noErr(err)
+	err = client.SendTRBReadyForConsultNotification(ctx, emailRecipients, true, requestID, requestName, requesterName, "")
 	noErr(err)
 
 	editsRequestedFeedback := "Please provide a better form."

--- a/pkg/email/templates/trb_advice_letter_submitted.gohtml
+++ b/pkg/email/templates/trb_advice_letter_submitted.gohtml
@@ -10,7 +10,7 @@
 <ul style="padding-left: 0;">
 <li style="list-style-type: none;">Submission date: {{.SubmissionDate}}</li>
 <li style="list-style-type: none;">Requester: {{.RequesterName}}</li>
-<li style="list-style-type: none;">Component: {{if .Component}}{{.Component}}{{else}}None Selectedd{{end}}</li>
+<li style="list-style-type: none;">Component: {{if .Component}}{{.Component}}{{else}}None Selected{{end}}</li>
 <li style="list-style-type: none;">Request type: {{.RequestType}}</li>
 <li style="list-style-type: none;">Date of TRB Consult: {{.ConsultDate}}</li>
 </ul>

--- a/pkg/email/templates/trb_request_consult_meeting.gohtml
+++ b/pkg/email/templates/trb_request_consult_meeting.gohtml
@@ -2,7 +2,7 @@
 
 <p>The Technical Review Board (TRB) has scheduled a consult session for {{.TRBRequestName}} on {{.ConsultMeetingTimeFormatted}}. You should receive a calendar invite shortly if you have not already.
 
-<p>Additional notes about this consult session: {{.Notes}}</p>
+{{if .Notes}}<p>Additional notes about this consult session: {{.Notes}}</p>{{end}}
 
 <p>Next steps:</p>
 <ul>

--- a/src/views/TechnicalAssistance/AdminHome/AddNote.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/AddNote.tsx
@@ -295,9 +295,7 @@ const AddNote = ({
           <Button
             type="submit"
             name={t('notes.saveNote')}
-            disabled={
-              isSubmitting || (!!watch('category') && !watch('noteText'))
-            }
+            disabled={isSubmitting || !watch('category') || !watch('noteText')}
           >
             {t('notes.saveNote')}
           </Button>

--- a/src/views/TechnicalAssistance/AdminHome/AddNote.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/AddNote.tsx
@@ -91,7 +91,8 @@ const AddNote = ({
   const {
     control,
     handleSubmit,
-    formState: { errors, dirtyFields, isSubmitting }
+    watch,
+    formState: { errors, isSubmitting }
   } = useForm({
     defaultValues
   });
@@ -295,8 +296,7 @@ const AddNote = ({
             type="submit"
             name={t('notes.saveNote')}
             disabled={
-              Object.keys(dirtyFields).length !==
-                Object.keys(defaultValues).length || isSubmitting
+              isSubmitting || (!!watch('category') && !watch('noteText'))
             }
           >
             {t('notes.saveNote')}

--- a/src/views/TechnicalAssistance/AdminHome/components/NoteModal/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/NoteModal/index.tsx
@@ -67,7 +67,7 @@ const NotesModal = ({
       appElement={document.getElementById('root')! as HTMLElement}
     >
       <div data-testid="discussion-modal">
-        <div className="easi-notes__x-button-container display-flex text-base flex-align-center">
+        <div className="easi-notes__x-button-container display-flex text-base flex-align-center padding-y-0 padding-x-3">
           <Button
             type="button"
             data-testid="close-discussions"


### PR DESCRIPTION
# EASI-NOREF

## Changes and Description

[Note side panel via advice letter admin action does not allow for saving of note](https://docs.google.com/document/d/1HSmSXe6Wg7emBg59s3qFn7lINZnComsbpyVBlEJHb3Y/edit#heading=h.if3euto9zf3p)
[Advice letter returns to advice letter page when user clicks send](https://docs.google.com/document/d/1HSmSXe6Wg7emBg59s3qFn7lINZnComsbpyVBlEJHb3Y/edit#heading=h.eneayqfkstqf)

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
