### PR TITLE
Fix admin notes modal scroll

### DIFF
--- a/src/components/Modal/index.scss
+++ b/src/components/Modal/index.scss
@@ -20,6 +20,8 @@
     position: absolute;
     width: 100%;
     height: 100%;
+    max-height: 90vh;
+    overflow-y: auto;
     background-color: color('white');
     top: 50%;
     left: 50%;


### PR DESCRIPTION
# EASI-3051

Some css changes to adjust the modal height and overflow

Open an admin note with lots of text content