### PR TITLE
Fix TRB Admin home page crash when searching existing requests

### DIFF
--- a/src/views/TechnicalAssistance/TrbAdminTeamHome.tsx
+++ b/src/views/TechnicalAssistance/TrbAdminTeamHome.tsx
@@ -104,11 +104,9 @@ function RequestNameCell({
   value,
   row
 }: CellProps<TrbAdminTeamHomeRequest, TrbAdminTeamHomeRequest['name']>) {
-  const { t } = useTranslation('technicalAssistance');
-
   return (
     <UswdsReactLink to={`/trb/${row.original.id}/request`}>
-      {value || t('taskList.defaultName')}
+      {value || i18next.t<string>('technicalAssistance:taskList.defaultName')}
     </UswdsReactLink>
   );
 }


### PR DESCRIPTION
# EASI-3053

Looks like the `CellProps` functions passed into a useTable config object aren't always called the same way.

Replaced the `useTranslation` hook with its regular function to get around this hook ordering bug.