### PR TITLE
[NOREF] Remove comment block for system profile edit team

### DIFF
--- a/src/views/SystemProfile/index.tsx
+++ b/src/views/SystemProfile/index.tsx
@@ -62,7 +62,7 @@ import {
   systemData as mockSystemData
 } from 'views/Sandbox/mockSystemData';
 
-// import EditPageCallout from './components/EditPageCallout';
+import EditPageCallout from './components/EditPageCallout';
 // components/index contains all the sideNavItems components, routes, labels and translations
 // The sideNavItems object keys are mapped to the url param - 'subinfo'
 import sideNavItems from './components/index';
@@ -624,16 +624,13 @@ const SystemProfile = ({ id, modal }: SystemProfileProps) => {
                   {/* Side navigation for single system */}
                   <SideNav items={subNavigationLinks} />
 
-                  {
-                    /* TODO: Make callout visible in EASI-2447 */
-                    // subinfo === 'team' && (
-                    //   <EditPageCallout
-                    //     className="margin-top-3"
-                    //     // TODO: Get system modifiedAt value and add to props
-                    //     // modifiedAt={}
-                    //   />
-                    // )
-                  }
+                  {subinfo === 'team' && (
+                    <EditPageCallout
+                      className="margin-top-3"
+                      // TODO: Get system modifiedAt value and add to props
+                      // modifiedAt={}
+                    />
+                  )}
 
                   {/* Setting a ref here to reference the grid width for the fixed side nav */}
                   {modal && (
@@ -679,16 +676,13 @@ const SystemProfile = ({ id, modal }: SystemProfileProps) => {
                               systemId={systemId}
                             />
                           </div>
-                          {
-                            /* TODO: Make callout visible in EASI-2447 */
-                            // subinfo === 'team' && isMobile && (
-                            //   <EditPageCallout
-                            //     className="margin-top-4"
-                            //     // TODO: Get system modifiedAt value and add to props
-                            //     // modifiedAt={}
-                            //   />
-                            // )
-                          }
+                          {subinfo === 'team' && isMobile && (
+                            <EditPageCallout
+                              className="margin-top-4"
+                              // TODO: Get system modifiedAt value and add to props
+                              // modifiedAt={}
+                            />
+                          )}
                         </Grid>
                       )}
                     </Grid>


### PR DESCRIPTION
# NOREF

## Changes and Description

- This makes the Edit Team callout visible so that we can launch System Profile editing
- #2081 needs to be merged first

<!-- Put a description here! -->

## How to test this change

1. Connect to VPN
2. View system Team page (/systems/:ID/team)
3. Verify that "Edit Team" callout is visible below side navigation
4. Verify that callout button goes to Edit Team page

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
