### PR TITLE
[EASI-3045] Fix deleted admin notes showing in IT Gov home page

### DIFF
--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -129,8 +129,8 @@ type SystemIntake struct {
 	DecisionNextSteps           null.String                  `json:"decisionNextSteps" db:"decision_next_steps"`
 	RejectionReason             null.String                  `json:"rejectionReason" db:"rejection_reason"`
 	AdminLead                   null.String                  `json:"adminLead" db:"admin_lead"`
-	LastAdminNoteContent        null.String                  `json:"lastAdminNoteContent" db:"last_admin_note_content"`
-	LastAdminNoteCreatedAt      *time.Time                   `json:"lastAdminNoteCreatedAt" db:"last_admin_note_created_at"`
+	LastAdminNoteContent        null.String                  `json:"lastAdminNoteContent" db:"last_admin_note_content"`      // TODO break this out into it's own resolver, as this isn't actually a stored column in the DB
+	LastAdminNoteCreatedAt      *time.Time                   `json:"lastAdminNoteCreatedAt" db:"last_admin_note_created_at"` // TODO break this out into it's own resolver, as this isn't actually a stored column in the DB
 	CedarSystemID               null.String                  `json:"cedarSystemId" db:"cedar_system_id"`
 	ExistingFunding             null.Bool                    `json:"existingFunding" db:"existing_funding"`
 	FundingSource               null.String                  `json:"fundingSource" db:"funding_source"`

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -364,7 +364,7 @@ func (s *Store) FetchSystemIntakesByStatuses(ctx context.Context, allowedStatuse
 			(	SELECT
 					distinct ON (system_intakes.id) system_intakes.id, notes.content, notes.created_at
 				FROM system_intakes
-					LEFT JOIN notes on notes.system_intake = system_intakes.id
+					LEFT JOIN notes on notes.system_intake = system_intakes.id AND notes.is_archived = false
 				WHERE system_intakes.status IN (?)
 				ORDER BY system_intakes.id, notes.created_at DESC
 			) AS intakes_and_notes


### PR DESCRIPTION
# EASI-3045

## Changes and Description

- Add a condition to the JOIN statement that's made when selecting the `last_admin_note`-related fields on the System Intake

I opted not to wholly refactor this code to use it's own resolver, and instead just marked a `TODO` item to maybe do that at some point. Right now, these fields are selected by a JOIN statement and tacked onto the System Intake object, which is a bit messy and misleading, but this fix was quick enough to warrant just addressing as-is.

## How to test this change

- Start the server with `scripts/dev up`
- Seed the DB with `scripts/dev db:seed`
- Sign in using local auth as a GRT Admin
- Look in the closed requests tab (there should be an intake with a note)
- Delete the note on that intake
- Ensure it no longer shows up in the home page (the row should be there, but no admin note)
- Do the same testing, but try adding a few notes and deleting them (maybe the most recent, maybe the oldest) and ensure the correct notes content shows on the home page for IT Gov users.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
