### PR TITLE
[EASI-3076] Hide all SVGs when printing Prince PDFs

### DIFF
--- a/src/stylesheets/print.scss
+++ b/src/stylesheets/print.scss
@@ -24,6 +24,8 @@
     display: none;
   }
 
+  // Hide svg elements so that Prince doesn't try to print SVGs
+  // (which commonly have issues unless they're specifically handled for accessibility)
   svg {
     display: none !important;
   }

--- a/src/stylesheets/print.scss
+++ b/src/stylesheets/print.scss
@@ -24,6 +24,10 @@
     display: none;
   }
 
+  svg {
+    display: none !important;
+  }
+
   .easi-only-print {
     display: block;
   }


### PR DESCRIPTION
# EASI-3076

## Changes and Description

- Hide `<svg>` elements with `@media print` so that Prince doesn't try to print SVGs (which commonly have issues unless they're specifically handled for accessibility)

## How to test this change

- `scripts/dev up`
- `scripts/dev db:seed`
- Log in to the app as a GRT Admin
- Attempt to print a PDF of a System Intake form
- Ensure PDF print works (and SVGs are hidden in document table)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
