### PR TITLE
[EASI-3083] Have LCID expiration checker ignore intakes without an EUA User ID

### DIFF
--- a/cmd/devdata/main.go
+++ b/cmd/devdata/main.go
@@ -197,6 +197,16 @@ func main() {
 		c.Status = models.BusinessCaseStatusCLOSED
 	})
 
+	makeSystemIntake("Intake with expiring LCID and no EUA User ID - test case for EASI-3083", logger, store, func(i *models.SystemIntake) {
+		lifecycleExpiresAt := time.Now().Add(30 * 24 * time.Hour)
+		submittedAt := time.Now().Add(-365 * 24 * time.Hour)
+		i.LifecycleID = null.StringFrom("300001")
+		i.LifecycleExpiresAt = &lifecycleExpiresAt
+		i.Status = models.SystemIntakeStatusLCIDISSUED
+		i.SubmittedAt = &submittedAt
+		i.EUAUserID = null.StringFromPtr(nil)
+	})
+
 	// TODO - EASI-2888 - remove mention of this ticket in comments below; remove whole comment block if EASI-3019 also implemented
 	// TODO - EASI-3019 - remove mention of this ticket in comments below; remove whole comment block if EASI-2888 also implemented
 

--- a/pkg/alerts/lcid_expiration.go
+++ b/pkg/alerts/lcid_expiration.go
@@ -101,6 +101,11 @@ func checkForLCIDExpiration(
 			continue
 		}
 
+		// skip intake if it doesn't have an EUA User ID set (and thus we can't find recipients to send to)
+		if currIntake.EUAUserID.IsZero() {
+			continue
+		}
+
 		hoursUntilLCIDExpiration := currIntake.LifecycleExpiresAt.Sub(currentDate).Hours()
 
 		var hoursSinceFirstAlert float64


### PR DESCRIPTION
# EASI-3083

## Changes and Description

- Add a check to skip sending notifications for intakes with `EUAUserID` set to nil, which causes issues when calling `fetchUserInfo()`.

## How to test this change

1. Make sure `USE_OKTA_API` is set to true.
2. Comment out the block in `pkg/server/routes.go` setting `userSearchClient = local.NewCedarLdapClient(s.logger)` if `s.environment.Local() || s.environment.Test()`, so instead it'll use the Okta API.
3. Start the backend locally.
4. Run `scripts/dev db:seed`, which will add an intake with an expiring LCID and no `EUAUserID` set.
5. Comment out the check I added in `pkg/alerts/lcid_expiration.go`. This will cause the backend to restart.
6. Look at the logs from the LCID expiration checker running on startup with `docker-compose logs --no-log-prefix easi` - they should show an error from Okta, including the message `json: cannot unmarshal array into Go value of type okta.User`. This is the bug this ticket will fix.
7. Uncomment the check in  `pkg/alerts/lcid_expiration.go`, restarting the backend again.
8. Look at the logs again - no similar error should be seen from the Okta query.