### PR TITLE
Task List Section Status Logic - Feedback from initial review(2) FE

### DIFF
--- a/src/components/TaskList/index.tsx
+++ b/src/components/TaskList/index.tsx
@@ -6,7 +6,10 @@ import TaskStatusTag, {
   TaskStatus,
   taskStatusClassName
 } from 'components/shared/TaskStatusTag';
-import { ITGovIntakeFormStatus } from 'types/graphql-global-types';
+import {
+  ITGovFeedbackStatus,
+  ITGovIntakeFormStatus
+} from 'types/graphql-global-types';
 import { formatDateLocal } from 'utils/date';
 
 import './index.scss';
@@ -41,6 +44,7 @@ type TaskListItemProps = {
   testId?: string;
   completedIso?: string | null;
   lastUpdatedIso?: string | null;
+  governanceRequestFeedbackCompletedIso?: string | null;
 };
 
 const TaskListItem = ({
@@ -49,7 +53,8 @@ const TaskListItem = ({
   children,
   testId,
   completedIso,
-  lastUpdatedIso
+  lastUpdatedIso,
+  governanceRequestFeedbackCompletedIso
 }: TaskListItemProps) => {
   const { t } = useTranslation('taskList');
 
@@ -76,6 +81,11 @@ const TaskListItem = ({
     lastUpdatedIso &&
     formatDateLocal(lastUpdatedIso, 'MM/dd/yyyy');
 
+  const governanceRequestFeedbackCompletedDate =
+    status === ITGovFeedbackStatus.COMPLETED &&
+    governanceRequestFeedbackCompletedIso &&
+    formatDateLocal(governanceRequestFeedbackCompletedIso, 'MM/dd/yyyy');
+
   return (
     <li className={taskListItemClasses} data-testid={testId}>
       <div className="task-list__task-content">
@@ -87,7 +97,9 @@ const TaskListItem = ({
             {!!status && status in taskStatusClassName && (
               <TaskStatusTag status={status} />
             )}
-            {(completedDate || lastUpdatedDate) && (
+            {(completedDate ||
+              lastUpdatedDate ||
+              governanceRequestFeedbackCompletedDate) && (
               <p className="margin-top-05 margin-bottom-0 text-base">
                 {completedDate && (
                   <>
@@ -99,6 +111,12 @@ const TaskListItem = ({
                   <>
                     {t('taskStatusInfo.lastUpdated')}
                     <br /> {lastUpdatedDate}
+                  </>
+                )}
+                {governanceRequestFeedbackCompletedDate && (
+                  <>
+                    {t('taskStatusInfo.completed')}
+                    <br /> {governanceRequestFeedbackCompletedDate}
                   </>
                 )}
               </p>

--- a/src/constants/externalUrls.ts
+++ b/src/constants/externalUrls.ts
@@ -3,5 +3,7 @@ export const SLACK_OIT_DEV_FEEDBACK =
 
 export const CMS_TRB_EMAIL = 'cms-trb@cms.hhs.gov';
 
+export const IT_GOV_EMAIL = 'IT_Governance@cms.hhs.gov';
+
 export const TRB_DECK_TEMPLATES =
   'https://share.cms.gov/cms-wide/Systems/TRB/Templates/Forms/AllItems.aspx';

--- a/src/data/mock/govTaskList.ts
+++ b/src/data/mock/govTaskList.ts
@@ -1,7 +1,5 @@
 import { GetGovernanceTaskList } from 'queries/types/GetGovernanceTaskList';
 import {
-  GovernanceRequestFeedbackSourceAction,
-  GovernanceRequestFeedbackTargetForm,
   ITGovDecisionStatus,
   ITGovDraftBusinessCaseStatus,
   ITGovFeedbackStatus,
@@ -94,9 +92,7 @@ export const taskListState: { [k: string]: GetGovernanceTaskList } = {
       governanceRequestFeedbacks: [
         {
           __typename: 'GovernanceRequestFeedback',
-          id,
-          sourceAction: GovernanceRequestFeedbackSourceAction.REQUEST_EDITS,
-          targetForm: GovernanceRequestFeedbackTargetForm.INTAKE_REQUEST
+          id
         }
       ],
       submittedAt: '2023-07-07T00:30:28Z',
@@ -121,9 +117,7 @@ export const taskListState: { [k: string]: GetGovernanceTaskList } = {
       governanceRequestFeedbacks: [
         {
           __typename: 'GovernanceRequestFeedback',
-          id,
-          sourceAction: GovernanceRequestFeedbackSourceAction.REQUEST_EDITS,
-          targetForm: GovernanceRequestFeedbackTargetForm.INTAKE_REQUEST
+          id
         }
       ],
       submittedAt: '2023-07-09T00:30:28Z',
@@ -205,9 +199,7 @@ export const taskListState: { [k: string]: GetGovernanceTaskList } = {
       governanceRequestFeedbacks: [
         {
           __typename: 'GovernanceRequestFeedback',
-          id,
-          sourceAction: GovernanceRequestFeedbackSourceAction.REQUEST_EDITS,
-          targetForm: GovernanceRequestFeedbackTargetForm.INTAKE_REQUEST
+          id
         }
       ],
       submittedAt: null,
@@ -231,9 +223,7 @@ export const taskListState: { [k: string]: GetGovernanceTaskList } = {
       governanceRequestFeedbacks: [
         {
           __typename: 'GovernanceRequestFeedback',
-          id,
-          sourceAction: GovernanceRequestFeedbackSourceAction.REQUEST_EDITS,
-          targetForm: GovernanceRequestFeedbackTargetForm.INTAKE_REQUEST
+          id
         }
       ],
       submittedAt: null,

--- a/src/data/mock/govTaskList.ts
+++ b/src/data/mock/govTaskList.ts
@@ -129,5 +129,115 @@ export const taskListState: { [k: string]: GetGovernanceTaskList } = {
       submittedAt: '2023-07-09T00:30:28Z',
       updatedAt: '2023-07-09T00:30:28Z'
     }
+  },
+
+  feedbackFromInitialReviewCantStart: {
+    systemIntake: {
+      __typename: 'SystemIntake',
+      id,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.IN_PROGRESS,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.CANT_START,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.CANT_START,
+        grtMeetingStatus: ITGovGRTStatus.CANT_START,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
+        grbMeetingStatus: ITGovGRBStatus.CANT_START
+      },
+      governanceRequestFeedbacks: [],
+      submittedAt: null,
+      updatedAt: null
+    }
+  },
+  feedbackFromInitialReviewInProgress: {
+    systemIntake: {
+      __typename: 'SystemIntake',
+      id,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.IN_REVIEW,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.CANT_START,
+        grtMeetingStatus: ITGovGRTStatus.CANT_START,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
+        grbMeetingStatus: ITGovGRBStatus.CANT_START
+      },
+      governanceRequestFeedbacks: [],
+      submittedAt: null,
+      updatedAt: null
+    }
+  },
+  feedbackFromInitialReviewDoneNoFeedback: {
+    systemIntake: {
+      __typename: 'SystemIntake',
+      id,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.COMPLETED,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.CANT_START,
+        grtMeetingStatus: ITGovGRTStatus.CANT_START,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
+        grbMeetingStatus: ITGovGRBStatus.CANT_START
+      },
+      governanceRequestFeedbacks: [],
+      submittedAt: null,
+      updatedAt: null
+    }
+  },
+  feedbackFromInitialReviewDoneWithFeedback: {
+    systemIntake: {
+      __typename: 'SystemIntake',
+      id,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.COMPLETED,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.CANT_START,
+        grtMeetingStatus: ITGovGRTStatus.CANT_START,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
+        grbMeetingStatus: ITGovGRBStatus.CANT_START
+      },
+      governanceRequestFeedbacks: [
+        {
+          __typename: 'GovernanceRequestFeedback',
+          id,
+          sourceAction: GovernanceRequestFeedbackSourceAction.REQUEST_EDITS,
+          targetForm: GovernanceRequestFeedbackTargetForm.INTAKE_REQUEST
+        }
+      ],
+      submittedAt: null,
+      updatedAt: null
+    }
+  },
+  feedbackFromInitialReviewResubmittedWithFeedback: {
+    systemIntake: {
+      __typename: 'SystemIntake',
+      id,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.IN_REVIEW,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.CANT_START,
+        grtMeetingStatus: ITGovGRTStatus.CANT_START,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
+        grbMeetingStatus: ITGovGRBStatus.CANT_START
+      },
+      governanceRequestFeedbacks: [
+        {
+          __typename: 'GovernanceRequestFeedback',
+          id,
+          sourceAction: GovernanceRequestFeedbackSourceAction.REQUEST_EDITS,
+          targetForm: GovernanceRequestFeedbackTargetForm.INTAKE_REQUEST
+        }
+      ],
+      submittedAt: null,
+      updatedAt: null
+    }
   }
 };

--- a/src/data/mock/govTaskList.ts
+++ b/src/data/mock/govTaskList.ts
@@ -1,4 +1,3 @@
-import { GetGovernanceTaskList } from 'queries/types/GetGovernanceTaskList';
 import {
   ITGovDecisionStatus,
   ITGovDraftBusinessCaseStatus,
@@ -8,12 +7,15 @@ import {
   ITGovGRTStatus,
   ITGovIntakeFormStatus
 } from 'types/graphql-global-types';
+import { GetGovernanceTaskListWithMockData } from 'types/itGov';
 
 const id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 
 /** IT Gov Task List status states */
 // eslint-disable-next-line import/prefer-default-export
-export const taskListState: { [k: string]: GetGovernanceTaskList } = {
+export const taskListState: {
+  [k: string]: GetGovernanceTaskListWithMockData;
+} = {
   /** Event: Intake Request form: Requester starts a new request */
   intakeFormNotStarted: {
     systemIntake: {
@@ -178,6 +180,7 @@ export const taskListState: { [k: string]: GetGovernanceTaskList } = {
         grbMeetingStatus: ITGovGRBStatus.CANT_START
       },
       governanceRequestFeedbacks: [],
+      governanceRequestFeedbackCompletedAt: '2023-07-10T00:30:28Z',
       submittedAt: null,
       updatedAt: null
     }
@@ -202,6 +205,7 @@ export const taskListState: { [k: string]: GetGovernanceTaskList } = {
           id
         }
       ],
+      governanceRequestFeedbackCompletedAt: '2023-07-10T00:30:28Z',
       submittedAt: null,
       updatedAt: null
     }

--- a/src/i18n/en-US/itGov.ts
+++ b/src/i18n/en-US/itGov.ts
@@ -31,7 +31,7 @@ export default {
         reviewInfo:
           'To help with this review, someone from the Governance Team may schedule a phone call with you and Enterprise Architecture (EA).<br/><br/> After that phone call, the Governance Team will decide if you need to go through any additional steps in the governance process.',
         noFeedbackInfo:
-          'The Governance Team had no feedback for your initial Intake Request form. If you have any questions, you may contact them at IT_Governance@cms.hhs.gov.'
+          'The Governance Team had no feedback for your initial Intake Request form. If you have any questions, you may contact them at <a>{{email}}</a>.'
       },
       bizCaseDraft: {
         title: 'Prepare a draft Business Case',

--- a/src/i18n/en-US/itGov.ts
+++ b/src/i18n/en-US/itGov.ts
@@ -28,8 +28,10 @@ export default {
         title: 'Feedback from initial review',
         description:
           'The Governance Team will review your Intake Request form and decide if it needs further governance. If it does, they’ll direct you to go through some or all of the remaining steps.',
-        info:
-          'To help with this review, someone from the Governance Team may schedule a phone call with you and Enterprise Architecture (EA).<br/><br/> After that phone call, the Governance Team will decide if you need to go through any additional steps in the governance process.'
+        reviewInfo:
+          'To help with this review, someone from the Governance Team may schedule a phone call with you and Enterprise Architecture (EA).<br/><br/> After that phone call, the Governance Team will decide if you need to go through any additional steps in the governance process.',
+        noFeedbackInfo:
+          'The Governance Team had no feedback for your initial Intake Request form. If you have any questions, you may contact them at IT_Governance@cms.hhs.gov.'
       },
       bizCaseDraft: {
         title: 'Prepare a draft Business Case',

--- a/src/i18n/en-US/taskList.ts
+++ b/src/i18n/en-US/taskList.ts
@@ -123,8 +123,9 @@ const taskList = {
     SCHEDULED: 'Scheduled'
   },
   taskStatusInfo: {
-    submitted: 'Submitted',
-    lastUpdated: 'Last updated'
+    completed: 'Completed',
+    lastUpdated: 'Last updated',
+    submitted: 'Submitted'
   }
 };
 

--- a/src/queries/GetGovernanceTaskListQuery.ts
+++ b/src/queries/GetGovernanceTaskListQuery.ts
@@ -15,8 +15,6 @@ export default gql`
       }
       governanceRequestFeedbacks {
         id
-        sourceAction
-        targetForm
       }
       submittedAt
       updatedAt

--- a/src/queries/types/GetGovernanceTaskList.ts
+++ b/src/queries/types/GetGovernanceTaskList.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ITGovIntakeFormStatus, ITGovFeedbackStatus, ITGovDecisionStatus, ITGovDraftBusinessCaseStatus, ITGovGRTStatus, ITGovFinalBusinessCaseStatus, ITGovGRBStatus, GovernanceRequestFeedbackSourceAction, GovernanceRequestFeedbackTargetForm } from "./../../types/graphql-global-types";
+import { ITGovIntakeFormStatus, ITGovFeedbackStatus, ITGovDecisionStatus, ITGovDraftBusinessCaseStatus, ITGovGRTStatus, ITGovFinalBusinessCaseStatus, ITGovGRBStatus } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL query operation: GetGovernanceTaskList
@@ -23,8 +23,6 @@ export interface GetGovernanceTaskList_systemIntake_itGovTaskStatuses {
 export interface GetGovernanceTaskList_systemIntake_governanceRequestFeedbacks {
   __typename: "GovernanceRequestFeedback";
   id: UUID;
-  sourceAction: GovernanceRequestFeedbackSourceAction;
-  targetForm: GovernanceRequestFeedbackTargetForm;
 }
 
 export interface GetGovernanceTaskList_systemIntake {

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -66,24 +66,6 @@ export enum GRTFeedbackType {
 }
 
 /**
- * Represents the possible actions that can provide feedback on a governance request
- */
-export enum GovernanceRequestFeedbackSourceAction {
-  PROGRESS_TO_NEW_STEP = "PROGRESS_TO_NEW_STEP",
-  REQUEST_EDITS = "REQUEST_EDITS",
-}
-
-/**
- * Represents the possible forms on a governance request that can receive feedback
- */
-export enum GovernanceRequestFeedbackTargetForm {
-  DRAFT_BUSINESS_CASE = "DRAFT_BUSINESS_CASE",
-  FINAL_BUSINESS_CASE = "FINAL_BUSINESS_CASE",
-  INTAKE_REQUEST = "INTAKE_REQUEST",
-  NO_TARGET_PROVIDED = "NO_TARGET_PROVIDED",
-}
-
-/**
  * The requester view of the IT gov Decision step status
  */
 export enum ITGovDecisionStatus {

--- a/src/types/itGov.ts
+++ b/src/types/itGov.ts
@@ -1,4 +1,18 @@
 /* eslint-disable camelcase */
+import { GetGovernanceTaskList_systemIntake } from 'queries/types/GetGovernanceTaskList';
+
 export type { GetGovernanceTaskList_systemIntake_itGovTaskStatuses as ItGovTaskStatuses } from 'queries/types/GetGovernanceTaskList';
 export type { GetGovernanceTaskList_systemIntake as ItGovTaskSystemIntake } from 'queries/types/GetGovernanceTaskList';
 /* eslint-enable camelcase */
+
+// Mock properties for frontend previews
+// Get rid of this once backend has completed serving the props
+export interface ItGovTaskSystemIntakeWithMockData
+  // eslint-disable-next-line camelcase
+  extends GetGovernanceTaskList_systemIntake {
+  governanceRequestFeedbackCompletedAt?: string | null;
+}
+
+export interface GetGovernanceTaskListWithMockData {
+  systemIntake: ItGovTaskSystemIntakeWithMockData;
+}

--- a/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.test.tsx
+++ b/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render } from '@testing-library/react';
+import i18next from 'i18next';
+
+import { taskListState } from 'data/mock/govTaskList';
+import { ItGovTaskSystemIntake } from 'types/itGov';
+
+import GovTaskFeedbackFromInitialReview from '.';
+
+describe('Gov Task: Feedback from initial review statuses', () => {
+  function renderGovTaskFeedbackFromInitialReview(
+    mockdata: ItGovTaskSystemIntake
+  ) {
+    return render(
+      <MemoryRouter>
+        <GovTaskFeedbackFromInitialReview {...mockdata} />
+      </MemoryRouter>
+    );
+  }
+
+  it('Can’t start', () => {
+    const { getByTestId } = renderGovTaskFeedbackFromInitialReview(
+      taskListState.feedbackFromInitialReviewCantStart.systemIntake!
+    );
+
+    // Cannot yet start
+    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
+      i18next.t<string>('taskList:taskStatus.CANT_START')
+    );
+
+    // Feedback info
+    const reviewInfo = getByTestId('alert');
+    expect(reviewInfo).toHaveClass('usa-alert--info');
+    // expect(reviewInfo).toHaveTextContent(
+    //   i18next.t<string>(
+    //     'itGov:taskList.step.feedbackFromInitialReview.reviewInfo'
+    //   )
+    // );
+  });
+
+  it('In progress', () => {
+    const { getByTestId } = renderGovTaskFeedbackFromInitialReview(
+      taskListState.feedbackFromInitialReviewInProgress.systemIntake!
+    );
+
+    // In review
+    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
+      i18next.t<string>('taskList:taskStatus.IN_REVIEW')
+    );
+
+    // Feedback info
+    const reviewInfo = getByTestId('alert');
+    expect(reviewInfo).toHaveClass('usa-alert--info');
+    // expect(reviewInfo).toHaveTextContent(
+    //   i18next.t<string>(
+    //     'itGov:taskList.step.feedbackFromInitialReview.reviewInfo'
+    //   )
+    // );
+  });
+
+  it('Done - no feedback', () => {
+    const { getByTestId } = renderGovTaskFeedbackFromInitialReview(
+      taskListState.feedbackFromInitialReviewDoneNoFeedback.systemIntake!
+    );
+
+    // Completed
+    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
+      i18next.t<string>('taskList:taskStatus.COMPLETED')
+    );
+
+    // No feedback info
+    const reviewInfo = getByTestId('alert');
+    expect(reviewInfo).toHaveClass('usa-alert--info');
+    // expect(reviewInfo).toHaveTextContent(
+    //   i18next.t<string>(
+    //     'itGov:taskList.step.feedbackFromInitialReview.noFeedbackInfo'
+    //   )
+    // );
+
+    // - completed date
+  });
+
+  it('Done - with feedback', () => {
+    const {
+      getByTestId,
+      getByRole,
+      queryByTestId
+    } = renderGovTaskFeedbackFromInitialReview(
+      taskListState.feedbackFromInitialReviewDoneWithFeedback.systemIntake!
+    );
+
+    // Completed
+    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
+      i18next.t<string>('taskList:taskStatus.COMPLETED')
+    );
+
+    // No alert
+    expect(queryByTestId('alert')).not.toBeInTheDocument();
+
+    // View feedback
+    getByRole('link', {
+      name: i18next.t<string>('itGov:button.viewFeedback')
+    });
+
+    // - completed date
+  });
+
+  it('Re-submitted with feedback', () => {
+    const { getByTestId, getByRole } = renderGovTaskFeedbackFromInitialReview(
+      taskListState.feedbackFromInitialReviewResubmittedWithFeedback
+        .systemIntake!
+    );
+
+    // In review
+    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
+      i18next.t<string>('taskList:taskStatus.IN_REVIEW')
+    );
+
+    // Feedback info
+    const reviewInfo = getByTestId('alert');
+    expect(reviewInfo).toHaveClass('usa-alert--info');
+
+    // View feedback
+    getByRole('link', {
+      name: i18next.t<string>('itGov:button.viewFeedback')
+    });
+  });
+});

--- a/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.test.tsx
+++ b/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.test.tsx
@@ -32,11 +32,11 @@ describe('Gov Task: Feedback from initial review statuses', () => {
     // Feedback info
     const reviewInfo = getByTestId('alert');
     expect(reviewInfo).toHaveClass('usa-alert--info');
-    // expect(reviewInfo).toHaveTextContent(
-    //   i18next.t<string>(
-    //     'itGov:taskList.step.feedbackFromInitialReview.reviewInfo'
-    //   )
-    // );
+    expect(reviewInfo).toContainHTML(
+      i18next.t<string>(
+        'itGov:taskList.step.feedbackFromInitialReview.reviewInfo'
+      )
+    );
   });
 
   it('In progress', () => {
@@ -52,11 +52,11 @@ describe('Gov Task: Feedback from initial review statuses', () => {
     // Feedback info
     const reviewInfo = getByTestId('alert');
     expect(reviewInfo).toHaveClass('usa-alert--info');
-    // expect(reviewInfo).toHaveTextContent(
-    //   i18next.t<string>(
-    //     'itGov:taskList.step.feedbackFromInitialReview.reviewInfo'
-    //   )
-    // );
+    expect(reviewInfo).toContainHTML(
+      i18next.t<string>(
+        'itGov:taskList.step.feedbackFromInitialReview.reviewInfo'
+      )
+    );
   });
 
   it('Done - no feedback', () => {
@@ -72,11 +72,11 @@ describe('Gov Task: Feedback from initial review statuses', () => {
     // No feedback info
     const reviewInfo = getByTestId('alert');
     expect(reviewInfo).toHaveClass('usa-alert--info');
-    // expect(reviewInfo).toHaveTextContent(
-    //   i18next.t<string>(
-    //     'itGov:taskList.step.feedbackFromInitialReview.noFeedbackInfo'
-    //   )
-    // );
+    expect(reviewInfo).toHaveTextContent(
+      i18next.t<string>(
+        'itGov:taskList.step.feedbackFromInitialReview.noFeedbackInfo'
+      )
+    );
 
     // - completed date
   });

--- a/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.test.tsx
+++ b/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.test.tsx
@@ -64,7 +64,7 @@ describe('Gov Task: Feedback from initial review statuses', () => {
   });
 
   it('Done - no feedback', async () => {
-    const { getByTestId } = renderGovTaskFeedbackFromInitialReview(
+    const { getByTestId, getByText } = renderGovTaskFeedbackFromInitialReview(
       taskListState.feedbackFromInitialReviewDoneNoFeedback.systemIntake!
     );
 
@@ -94,13 +94,19 @@ describe('Gov Task: Feedback from initial review statuses', () => {
       within(noFeedbackInfo).getByRole('link', { name: IT_GOV_EMAIL })
     ).toHaveAttribute('href', mailtoItGov);
 
-    // - completed date
+    // Completed date
+    getByText(
+      RegExp(
+        `${i18next.t<string>('taskList:taskStatusInfo.completed')}.*07/10/2023`
+      )
+    );
   });
 
   it('Done - with feedback', () => {
     const {
       getByTestId,
       getByRole,
+      getByText,
       queryByTestId
     } = renderGovTaskFeedbackFromInitialReview(
       taskListState.feedbackFromInitialReviewDoneWithFeedback.systemIntake!
@@ -119,7 +125,12 @@ describe('Gov Task: Feedback from initial review statuses', () => {
       name: i18next.t<string>('itGov:button.viewFeedback')
     });
 
-    // - completed date
+    // Completed date
+    getByText(
+      RegExp(
+        `${i18next.t<string>('taskList:taskStatusInfo.completed')}.*07/10/2023`
+      )
+    );
   });
 
   it('Re-submitted with feedback', () => {

--- a/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.test.tsx
+++ b/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import { Trans } from 'react-i18next';
 import { MemoryRouter } from 'react-router-dom';
-import { render } from '@testing-library/react';
+import { renderToStringWithData } from '@apollo/client/react/ssr';
+import { render, within } from '@testing-library/react';
+import { Link } from '@trussworks/react-uswds';
 import i18next from 'i18next';
 
+import { IT_GOV_EMAIL } from 'constants/externalUrls';
 import { taskListState } from 'data/mock/govTaskList';
 import { ItGovTaskSystemIntake } from 'types/itGov';
 
@@ -59,7 +63,7 @@ describe('Gov Task: Feedback from initial review statuses', () => {
     );
   });
 
-  it('Done - no feedback', () => {
+  it('Done - no feedback', async () => {
     const { getByTestId } = renderGovTaskFeedbackFromInitialReview(
       taskListState.feedbackFromInitialReviewDoneNoFeedback.systemIntake!
     );
@@ -70,13 +74,25 @@ describe('Gov Task: Feedback from initial review statuses', () => {
     );
 
     // No feedback info
-    const reviewInfo = getByTestId('alert');
-    expect(reviewInfo).toHaveClass('usa-alert--info');
-    expect(reviewInfo).toHaveTextContent(
-      i18next.t<string>(
-        'itGov:taskList.step.feedbackFromInitialReview.noFeedbackInfo'
+    const noFeedbackInfo = getByTestId('alert');
+    const mailtoItGov = `mailto:${IT_GOV_EMAIL}`;
+    expect(noFeedbackInfo).toHaveClass('usa-alert--info');
+    expect(noFeedbackInfo).toContainHTML(
+      await renderToStringWithData(
+        <Trans
+          i18nKey="itGov:taskList.step.feedbackFromInitialReview.noFeedbackInfo"
+          components={{
+            a: <Link href={mailtoItGov}> </Link>,
+            email: IT_GOV_EMAIL
+          }}
+        />
       )
     );
+
+    // Email within info
+    expect(
+      within(noFeedbackInfo).getByRole('link', { name: IT_GOV_EMAIL })
+    ).toHaveAttribute('href', mailtoItGov);
 
     // - completed date
   });

--- a/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.tsx
+++ b/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import { Link } from '@trussworks/react-uswds';
 import { kebabCase } from 'lodash';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import Alert from 'components/shared/Alert';
 import TaskListItem, { TaskListDescription } from 'components/TaskList';
+import { IT_GOV_EMAIL } from 'constants/externalUrls';
 import { ITGovFeedbackStatus } from 'types/graphql-global-types';
 import { ItGovTaskSystemIntake } from 'types/itGov';
 
@@ -43,6 +45,10 @@ const GovTaskFeedbackFromInitialReview = ({
               i18nKey={`itGov:taskList.step.${stepKey}.${
                 showReviewInfo ? 'reviewInfo' : 'noFeedbackInfo'
               }`}
+              components={{
+                a: <Link href={`mailto:${IT_GOV_EMAIL}`}> </Link>,
+                email: IT_GOV_EMAIL
+              }}
             />
           </Alert>
         )}

--- a/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.tsx
+++ b/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.tsx
@@ -8,12 +8,13 @@ import Alert from 'components/shared/Alert';
 import TaskListItem, { TaskListDescription } from 'components/TaskList';
 import { IT_GOV_EMAIL } from 'constants/externalUrls';
 import { ITGovFeedbackStatus } from 'types/graphql-global-types';
-import { ItGovTaskSystemIntake } from 'types/itGov';
+import { ItGovTaskSystemIntakeWithMockData } from 'types/itGov';
 
 const GovTaskFeedbackFromInitialReview = ({
   itGovTaskStatuses,
-  governanceRequestFeedbacks
-}: ItGovTaskSystemIntake) => {
+  governanceRequestFeedbacks,
+  governanceRequestFeedbackCompletedAt
+}: ItGovTaskSystemIntakeWithMockData) => {
   const stepKey = 'feedbackFromInitialReview';
   const { t } = useTranslation('itGov');
 
@@ -34,6 +35,9 @@ const GovTaskFeedbackFromInitialReview = ({
       heading={t(`taskList.step.${stepKey}.title`)}
       status={itGovTaskStatuses.feedbackFromInitialReviewStatus}
       testId={kebabCase(t(`taskList.step.${stepKey}.title`))}
+      governanceRequestFeedbackCompletedIso={
+        governanceRequestFeedbackCompletedAt
+      }
     >
       <TaskListDescription>
         <p>{t(`taskList.step.${stepKey}.description`)}</p>

--- a/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.tsx
+++ b/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { kebabCase } from 'lodash';
+
+import UswdsReactLink from 'components/LinkWrapper';
+import Alert from 'components/shared/Alert';
+import TaskListItem, { TaskListDescription } from 'components/TaskList';
+import { ITGovFeedbackStatus } from 'types/graphql-global-types';
+import { ItGovTaskSystemIntake } from 'types/itGov';
+
+const GovTaskFeedbackFromInitialReview = ({
+  itGovTaskStatuses,
+  governanceRequestFeedbacks
+}: ItGovTaskSystemIntake) => {
+  const stepKey = 'feedbackFromInitialReview';
+  const { t } = useTranslation('itGov');
+
+  const hasFeedback = governanceRequestFeedbacks.length > 0;
+
+  const showReviewInfo =
+    itGovTaskStatuses.feedbackFromInitialReviewStatus ===
+      ITGovFeedbackStatus.CANT_START ||
+    itGovTaskStatuses.feedbackFromInitialReviewStatus ===
+      ITGovFeedbackStatus.IN_REVIEW;
+
+  const showNoFeedbackInfo =
+    itGovTaskStatuses.feedbackFromInitialReviewStatus ===
+      ITGovFeedbackStatus.COMPLETED && !hasFeedback;
+
+  return (
+    <TaskListItem
+      heading={t(`taskList.step.${stepKey}.title`)}
+      status={itGovTaskStatuses.feedbackFromInitialReviewStatus}
+      testId={kebabCase(t(`taskList.step.${stepKey}.title`))}
+    >
+      <TaskListDescription>
+        <p>{t(`taskList.step.${stepKey}.description`)}</p>
+
+        {/* Info alert about review or no feedback */}
+        {(showReviewInfo || showNoFeedbackInfo) && (
+          <Alert slim type="info">
+            <Trans
+              i18nKey={`itGov:taskList.step.${stepKey}.${
+                showReviewInfo ? 'reviewInfo' : 'noFeedbackInfo'
+              }`}
+            />
+          </Alert>
+        )}
+
+        {/* Link to view feedback */}
+        {hasFeedback && (
+          <div className="margin-top-2">
+            <UswdsReactLink to="./">{t(`button.viewFeedback`)}</UswdsReactLink>
+          </div>
+        )}
+      </TaskListDescription>
+    </TaskListItem>
+  );
+};
+
+export default GovTaskFeedbackFromInitialReview;

--- a/src/views/GovernanceTaskList/GovTaskIntakeForm/index.tsx
+++ b/src/views/GovernanceTaskList/GovTaskIntakeForm/index.tsx
@@ -5,11 +5,7 @@ import { kebabCase } from 'lodash';
 import UswdsReactLink from 'components/LinkWrapper';
 import Alert from 'components/shared/Alert';
 import TaskListItem, { TaskListDescription } from 'components/TaskList';
-import {
-  GovernanceRequestFeedbackSourceAction,
-  GovernanceRequestFeedbackTargetForm,
-  ITGovIntakeFormStatus
-} from 'types/graphql-global-types';
+import { ITGovIntakeFormStatus } from 'types/graphql-global-types';
 import { ItGovTaskSystemIntake } from 'types/itGov';
 
 const GovTaskIntakeForm = ({
@@ -27,14 +23,7 @@ const GovTaskIntakeForm = ({
     [ITGovIntakeFormStatus.EDITS_REQUESTED, 'editForm']
   ]);
 
-  const hasFeedback =
-    governanceRequestFeedbacks.filter(
-      feedback =>
-        feedback.sourceAction ===
-          GovernanceRequestFeedbackSourceAction.REQUEST_EDITS &&
-        feedback.targetForm ===
-          GovernanceRequestFeedbackTargetForm.INTAKE_REQUEST
-    ).length > 0;
+  const hasFeedback = governanceRequestFeedbacks.length > 0;
 
   return (
     <TaskListItem

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import { Button, Grid, GridContainer } from '@trussworks/react-uswds';
@@ -9,7 +9,6 @@ import UswdsReactLink from 'components/LinkWrapper';
 import MainContent from 'components/MainContent';
 import PageHeading from 'components/PageHeading';
 import PageLoading from 'components/PageLoading';
-import Alert from 'components/shared/Alert';
 import TaskListItem, {
   TaskListContainer,
   TaskListDescription
@@ -22,6 +21,7 @@ import {
 import NotFound from 'views/NotFound';
 import Breadcrumbs from 'views/TechnicalAssistance/Breadcrumbs';
 
+import GovTaskFeedbackFromInitialReview from './GovTaskFeedbackFromInitialReview';
 import GovTaskIntakeForm from './GovTaskIntakeForm';
 
 function GovernanceTaskList() {
@@ -75,24 +75,7 @@ function GovernanceTaskList() {
                   <GovTaskIntakeForm {...systemIntake} />
 
                   {/* 2. Feedback from initial review */}
-                  <TaskListItem
-                    heading={t('taskList.step.feedbackFromInitialReview.title')}
-                    status={itGovTaskStatuses.feedbackFromInitialReviewStatus}
-                    testId={kebabCase(
-                      t('taskList.step.feedbackFromInitialReview.title')
-                    )}
-                  >
-                    <TaskListDescription>
-                      <p>
-                        {t(
-                          'taskList.step.feedbackFromInitialReview.description'
-                        )}
-                      </p>
-                      <Alert type="info" slim className="margin-bottom-0">
-                        <Trans i18nKey="itGov:taskList.step.feedbackFromInitialReview.info" />
-                      </Alert>
-                    </TaskListDescription>
-                  </TaskListItem>
+                  <GovTaskFeedbackFromInitialReview {...systemIntake} />
 
                   {/* 3. Prepare a draft Business Case */}
                   <TaskListItem


### PR DESCRIPTION
# EASI-3060

[Task status states figma](https://www.figma.com/file/ChzAP34A2DVvQUNQwD7lCt/IT-Governance-Next?type=design&node-id=14-23189&mode=design&t=mtbPb6ljoFYmU5Tz-0)

## Changes and Description

- New `GovTaskFeedbackFromInitialReview`
- Mock data type `GetGovernanceTaskListWithMockData` with properties ahead of what the backend provides
  - Mock `governanceRequestFeedbackCompletedAt` for the completed date

## Testing
- Jest tests of the status states
- Preview on local dev
  - Check out the preview branch `NOREF/gov-task-mock-preview` which pulls in mock data for all status states within the parent task list component
  - Turn on the `itGovV2Enabled` flag
  - Seed data or create a new IT Gov request to get to the task list view