### PR TITLE
Add Go linter for exhaustiveness checking of pseudo-enums

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,7 @@ linters:
      - staticcheck
      - gosimple #will be deprecated in golangci-lint v2.0 in favor of staticcheck https://github.com/golangci/golangci-lint/issues/357
      - unused #will be deprecated in golangci-lint v2.0 in favor of staticcheck https://github.com/golangci/golangci-lint/issues/357
+     - exhaustive
   disable:
     - errcheck #requires patching code
 issues:

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -91,6 +91,8 @@ func (e Environment) Deployed() bool {
 		return true
 	case prodEnv:
 		return true
+	case localEnv, testEnv:
+		return false
 	default:
 		return false
 	}

--- a/pkg/email/change_508_status.go
+++ b/pkg/email/change_508_status.go
@@ -29,6 +29,8 @@ func convertStatusToReadableString(status models.AccessibilityRequestStatus) str
 		return "Closed"
 	case models.AccessibilityRequestStatusInRemediation:
 		return "In remediation"
+	case models.AccessibilityRequestStatusDeleted:
+		return ""
 	default:
 		return ""
 	}


### PR DESCRIPTION
No associated ticket; just a thought I had while working on EASI-3058. 

This adds the [exhaustive](https://pkg.go.dev/github.com/nishanths/exhaustive#section-documentation) lint, which checks whether `switch` statements over "enum" constants cover all cases. I think this should be helpful for work on the IT Gov v2 workflow; the queries for status and mutations for handling actions will probably have a lot of `switch`'s over an intake's step, a task's state, or similar; see [this example in Steven's PR for EASI-3048](https://github.com/CMSgov/easi-app/pull/2096/files#diff-f999aa28296603eb0f6d4b0ce0bd05ea2d07103c0419f627373b069ab651e1e7R21). Given that, having a linter to check that all possible values of the step/state are checked seems useful.

The two other changes in this PR are bits of existing code that the `exhaustive` linter warns on; I tested it with `pre-commit run golangci-lint --all-files`.