### PR TITLE
[NOREF] Remove branch name pattern pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
-      - id: no-commit-to-branch
-        args: [
-          '--pattern', '^(?!((feature\/EASI-\d{1,5})|((EASI-\d{1,5}|NOREF|dependabot)\/[a-zA-Z0-9\-\._/]+))$).*',
-        ]
-        name: Enforce branch naming pattern
-        description: Enforces branch naming policy. Allowed branch patterns are 'EASI-#', 'EASI-#/*', 'feature/EASI-#', 'NOREF/*', and 'dependabot/*'. A feature branch like feature/EASI-2020 would have branches like EASI-2020/frontend and EASI-2020/backend merge into it.
       - id: check-yaml
         name: Check YAML formatting
       - id: detect-private-key


### PR DESCRIPTION
# NOREF

## Changes and Description

- Remove branch naming check in favor of using GitHub rules

![image](https://github.com/CMSgov/easi-app/assets/15203744/f29af2f3-5d70-4a28-a056-6ae15730ccbc)

https://github.com/CMSgov/mint-app/pull/634

## How to test this change

- Try to create a branch in GitHub that doesn't match our expected naming patterns!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
