### PR TITLE
[EASI-3081] Generate URLs on demand for documents attached to system intakes

### DIFF
--- a/src/queries/SystemIntakeDocumentQueries.ts
+++ b/src/queries/SystemIntakeDocumentQueries.ts
@@ -37,3 +37,15 @@ export const DeleteSystemIntakeDocumentQuery = gql`
     }
   }
 `;
+
+export const GetSystemIntakeDocumentUrlsQuery = gql`
+  query GetSystemIntakeDocumentUrls($id: UUID!) {
+    systemIntake(id: $id) {
+      id
+      documents {
+        id
+        url
+      }
+    }
+  }
+`;

--- a/src/queries/types/GetSystemIntakeDocumentUrls.ts
+++ b/src/queries/types/GetSystemIntakeDocumentUrls.ts
@@ -1,0 +1,28 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetSystemIntakeDocumentUrls
+// ====================================================
+
+export interface GetSystemIntakeDocumentUrls_systemIntake_documents {
+  __typename: "SystemIntakeDocument";
+  id: UUID;
+  url: string;
+}
+
+export interface GetSystemIntakeDocumentUrls_systemIntake {
+  __typename: "SystemIntake";
+  id: UUID;
+  documents: GetSystemIntakeDocumentUrls_systemIntake_documents[];
+}
+
+export interface GetSystemIntakeDocumentUrls {
+  systemIntake: GetSystemIntakeDocumentUrls_systemIntake | null;
+}
+
+export interface GetSystemIntakeDocumentUrlsVariables {
+  id: UUID;
+}

--- a/src/views/SystemIntake/Documents/DocumentsTable.tsx
+++ b/src/views/SystemIntake/Documents/DocumentsTable.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CellProps, Column, useSortBy, useTable } from 'react-table';
 import { useLazyQuery, useMutation } from '@apollo/client';
-import { Button, Table } from '@trussworks/react-uswds';
+import { Alert, Button, Table } from '@trussworks/react-uswds';
 
 import Modal from 'components/Modal';
 import useMessage from 'hooks/useMessage';
@@ -82,20 +82,18 @@ const DocumentsTable = ({
   });
 
   const columns = useMemo<Column<SystemIntakeDocument>[]>(() => {
-    const getUrlForDocument = (documentId: string) => {
+    const getUrlForDocument = (documentId: string, documentName: string) => {
       getDocumentUrls().then(response => {
         if (response.error || !response.data || !response.data.systemIntake) {
           // if response.data is falsy, that's effectively an error; there's no URL to use to download the file
-          // TODO - error handling
-          /*
+          // similarly, if no systemIntake is returned, there's no URL info to use
           showMessage(
             <Alert type="error" className="margin-top-3">
-              {t('documents.viewFail', {
+              {t('technicalAssistance:documents.viewFail', {
                 documentName
               })}
             </Alert>
           );
-          */
         } else {
           // Download document
           const requestedDocument = response.data.systemIntake.documents.find(
@@ -155,13 +153,14 @@ const DocumentsTable = ({
           if (row.original.status === SystemIntakeDocumentStatus.AVAILABLE) {
             // Show some file actions once it's available
             const documentId = row.original.id;
+            const documentName = row.original.fileName;
             return (
               <>
                 {/* View document */}
                 <Button
                   type="button"
                   unstyled
-                  onClick={() => getUrlForDocument(documentId)}
+                  onClick={() => getUrlForDocument(documentId, documentName)}
                 >
                   {t('technicalAssistance:documents.table.view')}
                 </Button>
@@ -189,7 +188,7 @@ const DocumentsTable = ({
         }
       }
     ];
-  }, [canEdit, setFileToDelete, getDocumentUrls, t]);
+  }, [canEdit, setFileToDelete, getDocumentUrls, showMessage, t]);
 
   const {
     getTableBodyProps,

--- a/src/views/SystemIntake/Documents/DocumentsTable.tsx
+++ b/src/views/SystemIntake/Documents/DocumentsTable.tsx
@@ -1,24 +1,32 @@
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CellProps, Column, useSortBy, useTable } from 'react-table';
-import { useMutation } from '@apollo/client';
-import { Button, Link, Table } from '@trussworks/react-uswds';
+import { useLazyQuery, useMutation } from '@apollo/client';
+import { Button, Table } from '@trussworks/react-uswds';
 
 import Modal from 'components/Modal';
 import useMessage from 'hooks/useMessage';
 import GetSystemIntakeQuery from 'queries/GetSystemIntakeQuery';
-import { DeleteSystemIntakeDocumentQuery } from 'queries/SystemIntakeDocumentQueries';
+import {
+  DeleteSystemIntakeDocumentQuery,
+  GetSystemIntakeDocumentUrlsQuery
+} from 'queries/SystemIntakeDocumentQueries';
 import {
   DeleteSystemIntakeDocument,
   DeleteSystemIntakeDocumentVariables
 } from 'queries/types/DeleteSystemIntakeDocument';
 import { GetSystemIntake_systemIntake as SystemIntake } from 'queries/types/GetSystemIntake';
+import {
+  GetSystemIntakeDocumentUrls,
+  GetSystemIntakeDocumentUrlsVariables
+} from 'queries/types/GetSystemIntakeDocumentUrls';
 import { SystemIntakeDocument } from 'queries/types/SystemIntakeDocument';
 import {
   SystemIntakeDocumentCommonType,
   SystemIntakeDocumentStatus
 } from 'types/graphql-global-types';
 import { formatDateLocal } from 'utils/date';
+import { downloadFileFromURLOnly } from 'utils/downloadFile';
 import { getColumnSortStatus, getHeaderSortIcon } from 'utils/tableSort';
 
 import './index.scss';
@@ -48,7 +56,16 @@ const DocumentsTable = ({
     null
   );
 
-  const { documents } = systemIntake;
+  const { id: systemIntakeID, documents } = systemIntake;
+
+  const [getDocumentUrls] = useLazyQuery<
+    GetSystemIntakeDocumentUrls,
+    GetSystemIntakeDocumentUrlsVariables
+  >(GetSystemIntakeDocumentUrlsQuery, {
+    variables: {
+      id: systemIntakeID
+    }
+  });
 
   const [deleteDocument] = useMutation<
     DeleteSystemIntakeDocument,
@@ -65,6 +82,32 @@ const DocumentsTable = ({
   });
 
   const columns = useMemo<Column<SystemIntakeDocument>[]>(() => {
+    const getUrlForDocument = (documentId: string) => {
+      getDocumentUrls().then(response => {
+        if (response.error || !response.data || !response.data.systemIntake) {
+          // if response.data is falsy, that's effectively an error; there's no URL to use to download the file
+          // TODO - error handling
+          /*
+          showMessage(
+            <Alert type="error" className="margin-top-3">
+              {t('documents.viewFail', {
+                documentName
+              })}
+            </Alert>
+          );
+          */
+        } else {
+          // Download document
+          const requestedDocument = response.data.systemIntake.documents.find(
+            doc => doc.id === documentId
+          )!; // non-null assertion should be safe, this function should only be called with a documentId of a valid document
+          downloadFileFromURLOnly(requestedDocument.url);
+        }
+      });
+      // don't need to call .catch(); apollo-client will always fulfill the promise, even if there's a network error
+      // both network errors and GraphQL errors will set response.error - see https://www.apollographql.com/docs/react/data/error-handling/
+    };
+
     return [
       {
         Header: t<string>(
@@ -109,14 +152,19 @@ const DocumentsTable = ({
               </em>
             );
           // View or Remove
-          if (row.original.status === SystemIntakeDocumentStatus.AVAILABLE)
+          if (row.original.status === SystemIntakeDocumentStatus.AVAILABLE) {
             // Show some file actions once it's available
+            const documentId = row.original.id;
             return (
               <>
                 {/* View document */}
-                <Link target="_blank" href={row.original.url}>
+                <Button
+                  type="button"
+                  unstyled
+                  onClick={() => getUrlForDocument(documentId)}
+                >
                   {t('technicalAssistance:documents.table.view')}
-                </Link>
+                </Button>
 
                 {
                   /* Delete document */
@@ -133,6 +181,7 @@ const DocumentsTable = ({
                 }
               </>
             );
+          }
           // Infected unavailable
           if (row.original.status === SystemIntakeDocumentStatus.UNAVAILABLE)
             return t('technicalAssistance:documents.table.unavailable');
@@ -140,7 +189,7 @@ const DocumentsTable = ({
         }
       }
     ];
-  }, [canEdit, setFileToDelete, t]);
+  }, [canEdit, setFileToDelete, getDocumentUrls, t]);
 
   const {
     getTableBodyProps,


### PR DESCRIPTION
# EASI-3081

## Changes and Description

- Instead of getting the presigned URL from the backend when the page with a <DocumentsTable> is loaded (which runs into issues if the user waits on the page long enough for the presigned URL to expire), have the "View" button query the backend for the URL when clicked, then immediately download the file from it.
- This is very similar to https://github.com/CMSgov/easi-app/pull/2095 (for EASI-3047), but with system intake documents instead of TRB request documents.

## How to test this change

### Testing basic functionality

1. Create a system intake with an attached document.
2. Run `scripts/dev minio:clean` to mark the attachment as clean (virus-free), making it available to view/download.
3. In the admin view for that request, go to the "Uploaded documents" sub-page.
4. Click "View" for the document - you should be able to download the attached document.

### Verifying that this avoids issues with the presigned URL expiring

1. Change the expiration time for presigned URLs - in `pkg/upload/upload.go`, in `NewGetPresignedURL()`, change the call `req.Presign(15 * time.Minute)` to `req.Presign(1 * time.Minute)` to make presigned URLs expire after 1 minute.
2. As above, create an intake request, attach a document, and mark it clean.
3. Go to the "Uploaded documents" sub-page.
4. Wait for more than 1 minute, then click "View" - you should still be able to download the document.

## Notes and Questions
- The error handling is a bit hit-or-miss; the `showMessage()`-based approach only displays an error in the requester view when submitting an take, it doesn't display an error in the admin view or in the requester view of reviewing a form. **I'm not sure if this is sufficient - please let me know what you think. If there's an easy way to display an error message in the admin view, please let me know.**
- There's no loading indicator when fetching a presigned URL; the user clicks "View", the UI doesn't change at all or show any kind of indicator while it's fetching the URL. From testing EASI-3047 in deployed environments, there's a delay of a few hundred milliseconds; it's not too bad, but it's noticeable. I'm not sure if there's anything we can do to make the UX a bit better.
- Is the `setXXX` function returned from `useState()` stable across renders? The `react-hooks/exhaustive-deps` autofix for the `useMemo` callback in `DocumentsTable.tsx` didn't include `setFileToDelete` as a necessary dependency; the [old docs](https://legacy.reactjs.org/docs/hooks-reference.html#usestate) for `useState` specify that the returned setter function is stable across re-renders ("React guarantees that setState function identity is stable and won’t change on re-renders. This is why it’s safe to omit from the useEffect or useCallback dependency list."), but the [newer docs](https://react.dev/reference/react/useState#setstate) don't mention anything like that.