### PR TITLE
Task List Section Status Logic - Prepare a draft business case(3) FE

### DIFF
--- a/src/components/TaskList/index.tsx
+++ b/src/components/TaskList/index.tsx
@@ -10,6 +10,7 @@ import {
   ITGovFeedbackStatus,
   ITGovIntakeFormStatus
 } from 'types/graphql-global-types';
+import { TaskListItemDateInfo } from 'types/taskList';
 import { formatDateLocal } from 'utils/date';
 
 import './index.scss';
@@ -40,6 +41,7 @@ export const TaskListDescription = ({ children }: TaskListDescriptionProps) => {
 type TaskListItemProps = {
   heading: string;
   status: TaskStatus | undefined;
+  statusDateInfo?: TaskListItemDateInfo;
   children?: React.ReactNode;
   testId?: string;
   completedIso?: string | null;
@@ -50,6 +52,7 @@ type TaskListItemProps = {
 const TaskListItem = ({
   heading,
   status,
+  statusDateInfo,
   children,
   testId,
   completedIso,
@@ -97,6 +100,14 @@ const TaskListItem = ({
             {!!status && status in taskStatusClassName && (
               <TaskStatusTag status={status} />
             )}
+
+            {statusDateInfo && (
+              <p className="margin-top-05 margin-bottom-0 text-base">
+                {t(`taskStatusInfo.${statusDateInfo.label}`)}
+                <br /> {statusDateInfo.value}
+              </p>
+            )}
+
             {(completedDate ||
               lastUpdatedDate ||
               governanceRequestFeedbackCompletedDate) && (

--- a/src/components/TaskList/index.tsx
+++ b/src/components/TaskList/index.tsx
@@ -37,6 +37,7 @@ export const TaskListDescription = ({ children }: TaskListDescriptionProps) => {
 type TaskListItemProps = {
   heading: string;
   status: TaskStatus | undefined;
+  statusPercentComplete?: number | false | null | undefined;
   statusDateInfo?: TaskListItemDateInfo;
   children?: React.ReactNode;
   testId?: string;
@@ -45,6 +46,7 @@ type TaskListItemProps = {
 const TaskListItem = ({
   heading,
   status,
+  statusPercentComplete,
   statusDateInfo,
   children,
   testId
@@ -76,10 +78,22 @@ const TaskListItem = ({
               <TaskStatusTag status={status} />
             )}
 
-            {statusDateInfo && (
+            {/* Task status info */}
+            {(Number.isInteger(statusPercentComplete) || statusDateInfo) && (
               <p className="margin-top-05 margin-bottom-0 text-base">
-                {t(`taskStatusInfo.${statusDateInfo.label}`)}
-                <br /> {formatDateLocal(statusDateInfo.value, 'MM/dd/yyyy')}
+                {/* Percent complete */}
+                {Number.isInteger(statusPercentComplete) &&
+                  t('taskStatusInfo.percentComplete', {
+                    percent: statusPercentComplete
+                  })}
+
+                {/* Status dates */}
+                {statusDateInfo && (
+                  <>
+                    {t(`taskStatusInfo.${statusDateInfo.label}`)}
+                    <br /> {formatDateLocal(statusDateInfo.value, 'MM/dd/yyyy')}
+                  </>
+                )}
               </p>
             )}
           </div>

--- a/src/components/TaskList/index.tsx
+++ b/src/components/TaskList/index.tsx
@@ -6,10 +6,6 @@ import TaskStatusTag, {
   TaskStatus,
   taskStatusClassName
 } from 'components/shared/TaskStatusTag';
-import {
-  ITGovFeedbackStatus,
-  ITGovIntakeFormStatus
-} from 'types/graphql-global-types';
 import { TaskListItemDateInfo } from 'types/taskList';
 import { formatDateLocal } from 'utils/date';
 
@@ -44,9 +40,6 @@ type TaskListItemProps = {
   statusDateInfo?: TaskListItemDateInfo;
   children?: React.ReactNode;
   testId?: string;
-  completedIso?: string | null;
-  lastUpdatedIso?: string | null;
-  governanceRequestFeedbackCompletedIso?: string | null;
 };
 
 const TaskListItem = ({
@@ -54,10 +47,7 @@ const TaskListItem = ({
   status,
   statusDateInfo,
   children,
-  testId,
-  completedIso,
-  lastUpdatedIso,
-  governanceRequestFeedbackCompletedIso
+  testId
 }: TaskListItemProps) => {
   const { t } = useTranslation('taskList');
 
@@ -74,21 +64,6 @@ const TaskListItem = ({
     }
   );
 
-  const completedDate =
-    status === ITGovIntakeFormStatus.COMPLETED &&
-    completedIso &&
-    formatDateLocal(completedIso, 'MM/dd/yyyy');
-
-  const lastUpdatedDate =
-    status === ITGovIntakeFormStatus.EDITS_REQUESTED &&
-    lastUpdatedIso &&
-    formatDateLocal(lastUpdatedIso, 'MM/dd/yyyy');
-
-  const governanceRequestFeedbackCompletedDate =
-    status === ITGovFeedbackStatus.COMPLETED &&
-    governanceRequestFeedbackCompletedIso &&
-    formatDateLocal(governanceRequestFeedbackCompletedIso, 'MM/dd/yyyy');
-
   return (
     <li className={taskListItemClasses} data-testid={testId}>
       <div className="task-list__task-content">
@@ -104,32 +79,7 @@ const TaskListItem = ({
             {statusDateInfo && (
               <p className="margin-top-05 margin-bottom-0 text-base">
                 {t(`taskStatusInfo.${statusDateInfo.label}`)}
-                <br /> {statusDateInfo.value}
-              </p>
-            )}
-
-            {(completedDate ||
-              lastUpdatedDate ||
-              governanceRequestFeedbackCompletedDate) && (
-              <p className="margin-top-05 margin-bottom-0 text-base">
-                {completedDate && (
-                  <>
-                    {t('taskStatusInfo.submitted')}
-                    <br /> {completedDate}
-                  </>
-                )}
-                {lastUpdatedDate && (
-                  <>
-                    {t('taskStatusInfo.lastUpdated')}
-                    <br /> {lastUpdatedDate}
-                  </>
-                )}
-                {governanceRequestFeedbackCompletedDate && (
-                  <>
-                    {t('taskStatusInfo.completed')}
-                    <br /> {governanceRequestFeedbackCompletedDate}
-                  </>
-                )}
+                <br /> {formatDateLocal(statusDateInfo.value, 'MM/dd/yyyy')}
               </p>
             )}
           </div>

--- a/src/data/mock/govTaskList.ts
+++ b/src/data/mock/govTaskList.ts
@@ -49,6 +49,7 @@ export const taskListState: {
         bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
         grbMeetingStatus: ITGovGRBStatus.CANT_START
       },
+      intakeFormPctComplete: 22,
       governanceRequestFeedbacks: [],
       submittedAt: null,
       updatedAt: null

--- a/src/data/mock/govTaskList.ts
+++ b/src/data/mock/govTaskList.ts
@@ -16,7 +16,6 @@ const id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 export const taskListState: {
   [k: string]: GetGovernanceTaskListWithMockData;
 } = {
-  /** Event: Intake Request form: Requester starts a new request */
   intakeFormNotStarted: {
     systemIntake: {
       __typename: 'SystemIntake',
@@ -36,7 +35,6 @@ export const taskListState: {
       updatedAt: null
     }
   },
-  /** Event: Intake Request form: Requester starts Intake Request form */
   intakeFormInProgress: {
     systemIntake: {
       __typename: 'SystemIntake',
@@ -56,7 +54,6 @@ export const taskListState: {
       updatedAt: null
     }
   },
-  /** Event: Intake Request form: Requester submits Intake Request form */
   intakeFormSubmitted: {
     systemIntake: {
       __typename: 'SystemIntake',
@@ -76,7 +73,6 @@ export const taskListState: {
       updatedAt: null
     }
   },
-  /** Event: Intake Request form: Admin takes the action to request edits to the Intake Request form */
   intakeFormEditsRequested: {
     systemIntake: {
       __typename: 'SystemIntake',
@@ -101,7 +97,6 @@ export const taskListState: {
       updatedAt: '2023-07-08T00:30:28Z'
     }
   },
-  /** Event: Intake Request form: Requester re- submits Intake Request form */
   intakeFormResubmittedAfterEdits: {
     systemIntake: {
       __typename: 'SystemIntake',
@@ -232,6 +227,182 @@ export const taskListState: {
       ],
       submittedAt: null,
       updatedAt: null
+    }
+  },
+
+  bizCaseDraftCantStart: {
+    systemIntake: {
+      __typename: 'SystemIntake',
+      id,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.IN_REVIEW,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.CANT_START,
+        grtMeetingStatus: ITGovGRTStatus.CANT_START,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
+        grbMeetingStatus: ITGovGRBStatus.CANT_START,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
+      },
+      governanceRequestFeedbacks: [
+        {
+          __typename: 'GovernanceRequestFeedback',
+          id
+        }
+      ],
+      submittedAt: '2023-07-09T00:30:28Z',
+      updatedAt: '2023-07-09T00:30:28Z'
+    }
+  },
+  bizCaseDraftSkipped: {
+    systemIntake: {
+      __typename: 'SystemIntake',
+      id,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.COMPLETED,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.NOT_NEEDED,
+        grtMeetingStatus: ITGovGRTStatus.READY_TO_SCHEDULE,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
+        grbMeetingStatus: ITGovGRBStatus.CANT_START,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
+      },
+      governanceRequestFeedbacks: [
+        {
+          __typename: 'GovernanceRequestFeedback',
+          id
+        }
+      ],
+      submittedAt: '2023-07-09T00:30:28Z',
+      updatedAt: '2023-07-09T00:30:28Z'
+    }
+  },
+  bizCaseDraftNotStarted: {
+    systemIntake: {
+      __typename: 'SystemIntake',
+      id,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.COMPLETED,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.READY,
+        grtMeetingStatus: ITGovGRTStatus.CANT_START,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
+        grbMeetingStatus: ITGovGRBStatus.CANT_START,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
+      },
+      governanceRequestFeedbacks: [
+        {
+          __typename: 'GovernanceRequestFeedback',
+          id
+        }
+      ],
+      submittedAt: '2023-07-09T00:30:28Z',
+      updatedAt: '2023-07-09T00:30:28Z'
+    }
+  },
+  bizCaseDraftInProgress: {
+    systemIntake: {
+      __typename: 'SystemIntake',
+      id,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.COMPLETED,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.IN_PROGRESS,
+        grtMeetingStatus: ITGovGRTStatus.CANT_START,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
+        grbMeetingStatus: ITGovGRBStatus.CANT_START,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
+      },
+      governanceRequestFeedbacks: [
+        {
+          __typename: 'GovernanceRequestFeedback',
+          id
+        }
+      ],
+      submittedAt: '2023-07-09T00:30:28Z',
+      updatedAt: '2023-07-09T00:30:28Z',
+      bizCaseDraftUpdatedAt: '2023-07-12T00:30:28Z'
+    }
+  },
+  bizCaseDraftSubmitted: {
+    systemIntake: {
+      __typename: 'SystemIntake',
+      id,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.COMPLETED,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.COMPLETED,
+        grtMeetingStatus: ITGovGRTStatus.CANT_START,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
+        grbMeetingStatus: ITGovGRBStatus.CANT_START,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
+      },
+      governanceRequestFeedbacks: [
+        {
+          __typename: 'GovernanceRequestFeedback',
+          id
+        }
+      ],
+      submittedAt: '2023-07-09T00:30:28Z',
+      updatedAt: '2023-07-09T00:30:28Z',
+      bizCaseDraftUpdatedAt: '2023-07-13T00:30:28Z',
+      bizCaseDraftSubmittedAt: '2023-07-13T00:30:28Z'
+    }
+  },
+  bizCaseDraftEditsRequestedFromAdmins: {
+    systemIntake: {
+      __typename: 'SystemIntake',
+      id,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.COMPLETED,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.EDITS_REQUESTED,
+        grtMeetingStatus: ITGovGRTStatus.CANT_START,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
+        grbMeetingStatus: ITGovGRBStatus.CANT_START,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
+      },
+      governanceRequestFeedbacks: [
+        {
+          __typename: 'GovernanceRequestFeedback',
+          id
+        }
+      ],
+      submittedAt: '2023-07-09T00:30:28Z',
+      updatedAt: '2023-07-09T00:30:28Z',
+      bizCaseDraftUpdatedAt: '2023-07-14T00:30:28Z',
+      bizCaseDraftSubmittedAt: '2023-07-13T00:30:28Z'
+    }
+  },
+  bizCaseDraftReSubmitted: {
+    systemIntake: {
+      __typename: 'SystemIntake',
+      id,
+      itGovTaskStatuses: {
+        __typename: 'ITGovTaskStatuses',
+        intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
+        feedbackFromInitialReviewStatus: ITGovFeedbackStatus.COMPLETED,
+        bizCaseDraftStatus: ITGovDraftBusinessCaseStatus.COMPLETED,
+        grtMeetingStatus: ITGovGRTStatus.CANT_START,
+        bizCaseFinalStatus: ITGovFinalBusinessCaseStatus.CANT_START,
+        grbMeetingStatus: ITGovGRBStatus.CANT_START,
+        decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
+      },
+      governanceRequestFeedbacks: [
+        {
+          __typename: 'GovernanceRequestFeedback',
+          id
+        }
+      ],
+      submittedAt: '2023-07-09T00:30:28Z',
+      updatedAt: '2023-07-09T00:30:28Z',
+      bizCaseDraftUpdatedAt: '2023-07-15T00:30:28Z',
+      bizCaseDraftSubmittedAt: '2023-07-15T00:30:28Z'
     }
   }
 };

--- a/src/data/mock/govTaskList.ts
+++ b/src/data/mock/govTaskList.ts
@@ -244,12 +244,7 @@ export const taskListState: {
         grbMeetingStatus: ITGovGRBStatus.CANT_START,
         decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
       },
-      governanceRequestFeedbacks: [
-        {
-          __typename: 'GovernanceRequestFeedback',
-          id
-        }
-      ],
+      governanceRequestFeedbacks: [],
       submittedAt: '2023-07-09T00:30:28Z',
       updatedAt: '2023-07-09T00:30:28Z'
     }
@@ -268,12 +263,7 @@ export const taskListState: {
         grbMeetingStatus: ITGovGRBStatus.CANT_START,
         decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
       },
-      governanceRequestFeedbacks: [
-        {
-          __typename: 'GovernanceRequestFeedback',
-          id
-        }
-      ],
+      governanceRequestFeedbacks: [],
       submittedAt: '2023-07-09T00:30:28Z',
       updatedAt: '2023-07-09T00:30:28Z'
     }
@@ -292,12 +282,7 @@ export const taskListState: {
         grbMeetingStatus: ITGovGRBStatus.CANT_START,
         decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
       },
-      governanceRequestFeedbacks: [
-        {
-          __typename: 'GovernanceRequestFeedback',
-          id
-        }
-      ],
+      governanceRequestFeedbacks: [],
       submittedAt: '2023-07-09T00:30:28Z',
       updatedAt: '2023-07-09T00:30:28Z'
     }
@@ -316,12 +301,7 @@ export const taskListState: {
         grbMeetingStatus: ITGovGRBStatus.CANT_START,
         decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
       },
-      governanceRequestFeedbacks: [
-        {
-          __typename: 'GovernanceRequestFeedback',
-          id
-        }
-      ],
+      governanceRequestFeedbacks: [],
       submittedAt: '2023-07-09T00:30:28Z',
       updatedAt: '2023-07-09T00:30:28Z',
       bizCaseDraftUpdatedAt: '2023-07-12T00:30:28Z'
@@ -341,12 +321,7 @@ export const taskListState: {
         grbMeetingStatus: ITGovGRBStatus.CANT_START,
         decisionAndNextStepsStatus: ITGovDecisionStatus.CANT_START
       },
-      governanceRequestFeedbacks: [
-        {
-          __typename: 'GovernanceRequestFeedback',
-          id
-        }
-      ],
+      governanceRequestFeedbacks: [],
       submittedAt: '2023-07-09T00:30:28Z',
       updatedAt: '2023-07-09T00:30:28Z',
       bizCaseDraftUpdatedAt: '2023-07-13T00:30:28Z',

--- a/src/i18n/en-US/itGov.ts
+++ b/src/i18n/en-US/itGov.ts
@@ -36,7 +36,11 @@ export default {
       bizCaseDraft: {
         title: 'Prepare a draft Business Case',
         description:
-          'Draft a business case to communicate your business need, possible solutions and their associated costs. The Governance Team will review it with you and determine whether you are ready for a GRT or GRB meeting.'
+          'Draft a business case to communicate your business need, possible solutions and their associated costs. The Governance Team will review it with you and determine whether you are ready for a GRT or GRB meeting.',
+        viewSubmittedDraftBusinessCase: 'View submitted draft Business Case',
+        submittedInfo: 'Draft Business Case submitted. Waiting for feedback.',
+        editsRequestedWarning:
+          'The Governance Team has requested edits to your draft Business Case. Please make the requested changes and resubmit your form.'
       },
       grtMeeting: {
         title: 'Attend the GRT meeting',

--- a/src/i18n/en-US/taskList.ts
+++ b/src/i18n/en-US/taskList.ts
@@ -123,6 +123,7 @@ const taskList = {
     SCHEDULED: 'Scheduled'
   },
   taskStatusInfo: {
+    percentComplete: '{{percent}}% complete',
     completed: 'Completed',
     lastUpdated: 'Last updated',
     submitted: 'Submitted'

--- a/src/types/itGov.ts
+++ b/src/types/itGov.ts
@@ -10,6 +10,7 @@ export type { GetGovernanceTaskList_systemIntake as ItGovTaskSystemIntake } from
 export interface ItGovTaskSystemIntakeWithMockData
   // eslint-disable-next-line camelcase
   extends GetGovernanceTaskList_systemIntake {
+  intakeFormPctComplete?: number;
   governanceRequestFeedbackCompletedAt?: string | null;
   bizCaseDraftUpdatedAt?: string | null;
   bizCaseDraftSubmittedAt?: string | null;

--- a/src/types/itGov.ts
+++ b/src/types/itGov.ts
@@ -11,6 +11,8 @@ export interface ItGovTaskSystemIntakeWithMockData
   // eslint-disable-next-line camelcase
   extends GetGovernanceTaskList_systemIntake {
   governanceRequestFeedbackCompletedAt?: string | null;
+  bizCaseDraftUpdatedAt?: string | null;
+  bizCaseDraftSubmittedAt?: string | null;
 }
 
 export interface GetGovernanceTaskListWithMockData {

--- a/src/types/taskList.ts
+++ b/src/types/taskList.ts
@@ -1,0 +1,6 @@
+export type TaskListItemDateInfo =
+  | {
+      label: string;
+      value: string;
+    }
+  | undefined;

--- a/src/utils/fnErrorCapture.ts
+++ b/src/utils/fnErrorCapture.ts
@@ -1,0 +1,17 @@
+/**
+ * Wrap a function in a try block which
+ * captures an error stack trace leading up to the call,
+ * and then ignores anything after.
+ */
+export default function fnErrorCapture<T extends (...args: any[]) => any>(
+  fn: T
+): (...args: Parameters<T>) => ReturnType<T> {
+  return function captureFn(...args: Parameters<T>) {
+    try {
+      return fn(...args);
+    } catch (error) {
+      if (error instanceof Error) Error.captureStackTrace(error, captureFn);
+      throw error;
+    }
+  };
+}

--- a/src/utils/testing/helpers.ts
+++ b/src/utils/testing/helpers.ts
@@ -1,0 +1,30 @@
+import { ByRoleMatcher, screen } from '@testing-library/react';
+import i18next from 'i18next';
+
+import { AlertProps } from 'components/shared/Alert';
+import { TaskStatus } from 'components/shared/TaskStatusTag';
+import fnErrorCapture from 'utils/fnErrorCapture';
+
+export const expectTaskStatusTagToHaveTextKey = fnErrorCapture(
+  (taskStatusTextKey: TaskStatus) => {
+    expect(screen.getByTestId('task-list-task-tag')).toHaveTextContent(
+      i18next.t<string>(`taskList:taskStatus.${taskStatusTextKey}`)
+    );
+  }
+);
+
+export const getByRoleWithNameTextKey = fnErrorCapture(
+  (role: ByRoleMatcher, nameTextKey: string) => {
+    return screen.getByRole(role, {
+      name: i18next.t<string>(nameTextKey)
+    });
+  }
+);
+
+export const getExpectedAlertType = fnErrorCapture(
+  (alertType: AlertProps['type']) => {
+    const alert = screen.getByTestId('alert');
+    expect(alert).toHaveClass(`usa-alert--${alertType}`);
+    return alert;
+  }
+);

--- a/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.test.tsx
+++ b/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.test.tsx
@@ -65,7 +65,14 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
     );
     // In progress
     expectTaskStatusTagToHaveStatusText('IN_PROGRESS');
-    // - Last updated date
+    // Last updated date
+    screen.getByText(
+      RegExp(
+        `${i18next.t<string>(
+          'taskList:taskStatusInfo.lastUpdated'
+        )}.*07/12/2023`
+      )
+    );
     // Continue button
     getByRoleWithNameTextKey('link', 'itGov:button.continue');
   });
@@ -78,7 +85,12 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
     // Completed
     expectTaskStatusTagToHaveStatusText('COMPLETED');
 
-    // - Submitted date
+    // Submitted date
+    screen.getByText(
+      RegExp(
+        `${i18next.t<string>('taskList:taskStatusInfo.submitted')}.*07/13/2023`
+      )
+    );
 
     // Submitted & waiting for feedback info
     const submittedInfo = screen.getByTestId('alert');
@@ -92,8 +104,6 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
       'link',
       'itGov:taskList.step.bizCaseDraft.viewSubmittedDraftBusinessCase'
     );
-
-    // - Submitted date
   });
 
   it('Edits requested - from admins', () => {
@@ -104,7 +114,14 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
     // Edits Requested
     expectTaskStatusTagToHaveStatusText('EDITS_REQUESTED');
 
-    // - Last updated date
+    // Last updated date
+    screen.getByText(
+      RegExp(
+        `${i18next.t<string>(
+          'taskList:taskStatusInfo.lastUpdated'
+        )}.*07/14/2023`
+      )
+    );
 
     // Edits requested warning
     const submittedInfo = screen.getByTestId('alert');
@@ -130,7 +147,12 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
     // Completed
     expectTaskStatusTagToHaveStatusText('COMPLETED');
 
-    // - Submitted date
+    // Submitted date
+    screen.getByText(
+      RegExp(
+        `${i18next.t<string>('taskList:taskStatusInfo.submitted')}.*07/15/2023`
+      )
+    );
 
     // Submitted & waiting for feedback info
     const submittedInfo = screen.getByTestId('alert');

--- a/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.test.tsx
+++ b/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.test.tsx
@@ -1,37 +1,17 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { ByRoleMatcher, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import i18next from 'i18next';
 
-import { AlertProps } from 'components/shared/Alert';
-import { TaskStatus } from 'components/shared/TaskStatusTag';
 import { taskListState } from 'data/mock/govTaskList';
 import { ItGovTaskSystemIntake } from 'types/itGov';
-import fnErrorCapture from 'utils/fnErrorCapture';
+import {
+  expectTaskStatusTagToHaveTextKey,
+  getByRoleWithNameTextKey,
+  getExpectedAlertType
+} from 'utils/testing/helpers';
 
 import GovTaskBizCaseDraft from '.';
-
-const expectTaskStatusTagToHaveStatusText = fnErrorCapture(
-  (taskStatus: TaskStatus) => {
-    expect(screen.getByTestId('task-list-task-tag')).toHaveTextContent(
-      i18next.t<string>(`taskList:taskStatus.${taskStatus}`)
-    );
-  }
-);
-
-const getByRoleWithNameTextKey = fnErrorCapture(
-  (role: ByRoleMatcher, nameTextKey: string) => {
-    return screen.getByRole(role, {
-      name: i18next.t<string>(nameTextKey)
-    });
-  }
-);
-
-const getExpectedAlertType = fnErrorCapture((alertType: AlertProps['type']) => {
-  const alert = screen.getByTestId('alert');
-  expect(alert).toHaveClass(`usa-alert--${alertType}`);
-  return alert;
-});
 
 describe('Gov Task: Prepare a draft Business Case statuses', () => {
   function renderGovTaskBizCaseDraft(mockdata: ItGovTaskSystemIntake) {
@@ -47,13 +27,13 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
       taskListState.bizCaseDraftCantStart.systemIntake!
     );
     // Cannot yet start
-    expectTaskStatusTagToHaveStatusText('CANT_START');
+    expectTaskStatusTagToHaveTextKey('CANT_START');
   });
 
   it('Skipped', () => {
     renderGovTaskBizCaseDraft(taskListState.bizCaseDraftSkipped.systemIntake!);
     // Not needed
-    expectTaskStatusTagToHaveStatusText('NOT_NEEDED');
+    expectTaskStatusTagToHaveTextKey('NOT_NEEDED');
   });
 
   it('Not started', () => {
@@ -61,7 +41,7 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
       taskListState.bizCaseDraftNotStarted.systemIntake!
     );
     // Ready to start
-    expectTaskStatusTagToHaveStatusText('READY_TO_START');
+    expectTaskStatusTagToHaveTextKey('READY_TO_START');
     // Start button
     getByRoleWithNameTextKey('link', 'itGov:button.start');
   });
@@ -71,7 +51,7 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
       taskListState.bizCaseDraftInProgress.systemIntake!
     );
     // In progress
-    expectTaskStatusTagToHaveStatusText('IN_PROGRESS');
+    expectTaskStatusTagToHaveTextKey('IN_PROGRESS');
     // Last updated date
     screen.getByText(
       RegExp(
@@ -90,7 +70,7 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
     );
 
     // Completed
-    expectTaskStatusTagToHaveStatusText('COMPLETED');
+    expectTaskStatusTagToHaveTextKey('COMPLETED');
 
     // Submitted date
     screen.getByText(
@@ -117,7 +97,7 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
     );
 
     // Edits Requested
-    expectTaskStatusTagToHaveStatusText('EDITS_REQUESTED');
+    expectTaskStatusTagToHaveTextKey('EDITS_REQUESTED');
 
     // Last updated date
     screen.getByText(
@@ -148,7 +128,7 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
     );
 
     // Completed
-    expectTaskStatusTagToHaveStatusText('COMPLETED');
+    expectTaskStatusTagToHaveTextKey('COMPLETED');
 
     // Submitted date
     screen.getByText(

--- a/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.test.tsx
+++ b/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { ByRoleMatcher, render, screen } from '@testing-library/react';
+import i18next from 'i18next';
+
+import { TaskStatus } from 'components/shared/TaskStatusTag';
+import { taskListState } from 'data/mock/govTaskList';
+import { ItGovTaskSystemIntake } from 'types/itGov';
+import fnErrorCapture from 'utils/fnErrorCapture';
+
+import GovTaskBizCaseDraft from '.';
+
+const expectTaskStatusTagToHaveStatusText = fnErrorCapture(
+  (taskStatus: TaskStatus) => {
+    expect(screen.getByTestId('task-list-task-tag')).toHaveTextContent(
+      i18next.t<string>(`taskList:taskStatus.${taskStatus}`)
+    );
+  }
+);
+
+const getByRoleWithNameTextKey = fnErrorCapture(
+  (role: ByRoleMatcher, nameTextKey: string) => {
+    return screen.getByRole(role, {
+      name: i18next.t<string>(nameTextKey)
+    });
+  }
+);
+
+describe('Gov Task: Prepare a draft Business Case statuses', () => {
+  function renderGovTaskBizCaseDraft(mockdata: ItGovTaskSystemIntake) {
+    return render(
+      <MemoryRouter>
+        <GovTaskBizCaseDraft {...mockdata} />
+      </MemoryRouter>
+    );
+  }
+
+  it('Can’t start', () => {
+    renderGovTaskBizCaseDraft(
+      taskListState.bizCaseDraftCantStart.systemIntake!
+    );
+    // Cannot yet start
+    expectTaskStatusTagToHaveStatusText('CANT_START');
+  });
+
+  it.skip('Skipped', () => {
+    renderGovTaskBizCaseDraft(taskListState.bizCaseDraftSkipped.systemIntake!);
+    // Not needed
+    expectTaskStatusTagToHaveStatusText('NOT_NEEDED');
+  });
+
+  it('Not started', () => {
+    renderGovTaskBizCaseDraft(
+      taskListState.bizCaseDraftNotStarted.systemIntake!
+    );
+    // Ready to start
+    expectTaskStatusTagToHaveStatusText('READY_TO_START');
+    // Start button
+    getByRoleWithNameTextKey('link', 'itGov:button.start');
+  });
+
+  it('In progress', () => {
+    renderGovTaskBizCaseDraft(
+      taskListState.bizCaseDraftInProgress.systemIntake!
+    );
+    // In progress
+    expectTaskStatusTagToHaveStatusText('IN_PROGRESS');
+    // - Last updated date
+    // Continue button
+    getByRoleWithNameTextKey('link', 'itGov:button.continue');
+  });
+
+  it('Submitted', async () => {
+    renderGovTaskBizCaseDraft(
+      taskListState.bizCaseDraftSubmitted.systemIntake!
+    );
+
+    // Completed
+    expectTaskStatusTagToHaveStatusText('COMPLETED');
+
+    // - Submitted date
+
+    // Submitted & waiting for feedback info
+    const submittedInfo = screen.getByTestId('alert');
+    expect(submittedInfo).toHaveClass('usa-alert--info');
+    expect(submittedInfo).toHaveTextContent(
+      i18next.t<string>('itGov:taskList.step.bizCaseDraft.submittedInfo')
+    );
+
+    // View submitted draft biz case link
+    getByRoleWithNameTextKey(
+      'link',
+      'itGov:taskList.step.bizCaseDraft.viewSubmittedDraftBusinessCase'
+    );
+
+    // - Submitted date
+  });
+
+  it('Edits requested - from admins', () => {
+    renderGovTaskBizCaseDraft(
+      taskListState.bizCaseDraftEditsRequestedFromAdmins.systemIntake!
+    );
+
+    // Edits Requested
+    expectTaskStatusTagToHaveStatusText('EDITS_REQUESTED');
+
+    // - Last updated date
+
+    // Edits requested warning
+    const submittedInfo = screen.getByTestId('alert');
+    expect(submittedInfo).toHaveClass('usa-alert--warning');
+    expect(submittedInfo).toHaveTextContent(
+      i18next.t<string>(
+        'itGov:taskList.step.bizCaseDraft.editsRequestedWarning'
+      )
+    );
+
+    // Edit form button
+    getByRoleWithNameTextKey('link', 'itGov:button.editForm');
+
+    // View feedback link
+    getByRoleWithNameTextKey('link', 'itGov:button.viewFeedback');
+  });
+
+  it('Re-submitted', () => {
+    renderGovTaskBizCaseDraft(
+      taskListState.bizCaseDraftReSubmitted.systemIntake!
+    );
+
+    // Completed
+    expectTaskStatusTagToHaveStatusText('COMPLETED');
+
+    // - Submitted date
+
+    // Submitted & waiting for feedback info
+    const submittedInfo = screen.getByTestId('alert');
+    expect(submittedInfo).toHaveClass('usa-alert--info');
+    expect(submittedInfo).toHaveTextContent(
+      i18next.t<string>('itGov:taskList.step.bizCaseDraft.submittedInfo')
+    );
+
+    // View feedback + Submitted draft biz case
+    // todo complete conditions
+    // getByRoleWithNameTextKey('link', 'itGov:button.viewFeedback');
+    getByRoleWithNameTextKey(
+      'link',
+      'itGov:taskList.step.bizCaseDraft.viewSubmittedDraftBusinessCase'
+    );
+  });
+});

--- a/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.test.tsx
+++ b/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.test.tsx
@@ -43,7 +43,7 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
     expectTaskStatusTagToHaveStatusText('CANT_START');
   });
 
-  it.skip('Skipped', () => {
+  it('Skipped', () => {
     renderGovTaskBizCaseDraft(taskListState.bizCaseDraftSkipped.systemIntake!);
     // Not needed
     expectTaskStatusTagToHaveStatusText('NOT_NEEDED');
@@ -162,8 +162,7 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
     );
 
     // View feedback + Submitted draft biz case
-    // todo complete conditions
-    // getByRoleWithNameTextKey('link', 'itGov:button.viewFeedback');
+    getByRoleWithNameTextKey('link', 'itGov:button.viewFeedback');
     getByRoleWithNameTextKey(
       'link',
       'itGov:taskList.step.bizCaseDraft.viewSubmittedDraftBusinessCase'

--- a/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.test.tsx
+++ b/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { ByRoleMatcher, render, screen } from '@testing-library/react';
 import i18next from 'i18next';
 
+import { AlertProps } from 'components/shared/Alert';
 import { TaskStatus } from 'components/shared/TaskStatusTag';
 import { taskListState } from 'data/mock/govTaskList';
 import { ItGovTaskSystemIntake } from 'types/itGov';
@@ -25,6 +26,12 @@ const getByRoleWithNameTextKey = fnErrorCapture(
     });
   }
 );
+
+const getExpectedAlertType = fnErrorCapture((alertType: AlertProps['type']) => {
+  const alert = screen.getByTestId('alert');
+  expect(alert).toHaveClass(`usa-alert--${alertType}`);
+  return alert;
+});
 
 describe('Gov Task: Prepare a draft Business Case statuses', () => {
   function renderGovTaskBizCaseDraft(mockdata: ItGovTaskSystemIntake) {
@@ -93,9 +100,7 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
     );
 
     // Submitted & waiting for feedback info
-    const submittedInfo = screen.getByTestId('alert');
-    expect(submittedInfo).toHaveClass('usa-alert--info');
-    expect(submittedInfo).toHaveTextContent(
+    expect(getExpectedAlertType('info')).toHaveTextContent(
       i18next.t<string>('itGov:taskList.step.bizCaseDraft.submittedInfo')
     );
 
@@ -124,9 +129,7 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
     );
 
     // Edits requested warning
-    const submittedInfo = screen.getByTestId('alert');
-    expect(submittedInfo).toHaveClass('usa-alert--warning');
-    expect(submittedInfo).toHaveTextContent(
+    expect(getExpectedAlertType('warning')).toHaveTextContent(
       i18next.t<string>(
         'itGov:taskList.step.bizCaseDraft.editsRequestedWarning'
       )
@@ -155,9 +158,7 @@ describe('Gov Task: Prepare a draft Business Case statuses', () => {
     );
 
     // Submitted & waiting for feedback info
-    const submittedInfo = screen.getByTestId('alert');
-    expect(submittedInfo).toHaveClass('usa-alert--info');
-    expect(submittedInfo).toHaveTextContent(
+    expect(getExpectedAlertType('info')).toHaveTextContent(
       i18next.t<string>('itGov:taskList.step.bizCaseDraft.submittedInfo')
     );
 

--- a/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.tsx
+++ b/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.tsx
@@ -8,11 +8,13 @@ import TaskListItem, { TaskListDescription } from 'components/TaskList';
 // import { IT_GOV_EMAIL } from 'constants/externalUrls';
 import { ITGovDraftBusinessCaseStatus } from 'types/graphql-global-types';
 import { ItGovTaskSystemIntakeWithMockData } from 'types/itGov';
+import { TaskListItemDateInfo } from 'types/taskList';
+import { formatDateLocal } from 'utils/date';
 
 const GovTaskBizCaseDraft = ({
-  itGovTaskStatuses,
-  governanceRequestFeedbacks,
-  governanceRequestFeedbackCompletedAt
+  itGovTaskStatuses: { bizCaseDraftStatus },
+  bizCaseDraftSubmittedAt,
+  bizCaseDraftUpdatedAt
 }: ItGovTaskSystemIntakeWithMockData) => {
   const stepKey = 'bizCaseDraft';
   const { t } = useTranslation('itGov');
@@ -23,47 +25,64 @@ const GovTaskBizCaseDraft = ({
     [ITGovDraftBusinessCaseStatus.EDITS_REQUESTED, 'editForm']
   ]);
 
+  // Updated and completed at date status info
+  let dateInfo: TaskListItemDateInfo;
+
+  const lastUpdatedDate =
+    (bizCaseDraftStatus === ITGovDraftBusinessCaseStatus.IN_PROGRESS ||
+      bizCaseDraftStatus === ITGovDraftBusinessCaseStatus.EDITS_REQUESTED) &&
+    bizCaseDraftUpdatedAt &&
+    formatDateLocal(bizCaseDraftUpdatedAt, 'MM/dd/yyyy');
+  if (lastUpdatedDate)
+    dateInfo = {
+      label: 'lastUpdated',
+      value: lastUpdatedDate
+    };
+
+  const submittedDate =
+    bizCaseDraftStatus === ITGovDraftBusinessCaseStatus.COMPLETED &&
+    bizCaseDraftSubmittedAt &&
+    formatDateLocal(bizCaseDraftSubmittedAt, 'MM/dd/yyyy');
+  if (!lastUpdatedDate && submittedDate)
+    dateInfo = {
+      label: 'submitted',
+      value: submittedDate
+    };
+
   return (
     <TaskListItem
       heading={t(`taskList.step.${stepKey}.title`)}
-      status={itGovTaskStatuses.bizCaseDraftStatus}
+      status={bizCaseDraftStatus}
+      statusDateInfo={dateInfo}
       testId={kebabCase(t(`taskList.step.${stepKey}.title`))}
-      governanceRequestFeedbackCompletedIso={
-        governanceRequestFeedbackCompletedAt
-      }
     >
       <TaskListDescription>
         <p>{t(`taskList.step.${stepKey}.description`)}</p>
 
         {/* Draft biz case submitted & waiting for feedback */}
-        {itGovTaskStatuses.bizCaseDraftStatus ===
-          ITGovDraftBusinessCaseStatus.COMPLETED && (
+        {bizCaseDraftStatus === ITGovDraftBusinessCaseStatus.COMPLETED && (
           <Alert slim type="info">
             {t(`taskList.step.${stepKey}.submittedInfo`)}
           </Alert>
         )}
 
-        {itGovTaskStatuses.bizCaseDraftStatus ===
+        {bizCaseDraftStatus ===
           ITGovDraftBusinessCaseStatus.EDITS_REQUESTED && (
           <Alert slim type="warning">
             {t(`taskList.step.${stepKey}.editsRequestedWarning`)}
           </Alert>
         )}
 
-        {statusButtonText.has(itGovTaskStatuses.bizCaseDraftStatus) && (
+        {statusButtonText.has(bizCaseDraftStatus) && (
           <div className="margin-top-2">
             <UswdsReactLink variant="unstyled" className="usa-button" to="./">
-              {t(
-                `button.${statusButtonText.get(
-                  itGovTaskStatuses.bizCaseDraftStatus
-                )}`
-              )}
+              {t(`button.${statusButtonText.get(bizCaseDraftStatus)}`)}
             </UswdsReactLink>
           </div>
         )}
 
         {/* Link to view feedback */}
-        {itGovTaskStatuses.bizCaseDraftStatus ===
+        {bizCaseDraftStatus ===
           ITGovDraftBusinessCaseStatus.EDITS_REQUESTED && (
           <div className="margin-top-2">
             <UswdsReactLink to="./">{t(`button.viewFeedback`)}</UswdsReactLink>
@@ -71,8 +90,7 @@ const GovTaskBizCaseDraft = ({
         )}
 
         {/* Link to view submitted draft biz case */}
-        {itGovTaskStatuses.bizCaseDraftStatus ===
-          ITGovDraftBusinessCaseStatus.COMPLETED && (
+        {bizCaseDraftStatus === ITGovDraftBusinessCaseStatus.COMPLETED && (
           <div className="margin-top-2">
             <UswdsReactLink to="./">
               {t(`taskList.step.${stepKey}.viewSubmittedDraftBusinessCase`)}

--- a/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.tsx
+++ b/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.tsx
@@ -14,7 +14,8 @@ import { formatDateLocal } from 'utils/date';
 const GovTaskBizCaseDraft = ({
   itGovTaskStatuses: { bizCaseDraftStatus },
   bizCaseDraftSubmittedAt,
-  bizCaseDraftUpdatedAt
+  bizCaseDraftUpdatedAt,
+  governanceRequestFeedbacks
 }: ItGovTaskSystemIntakeWithMockData) => {
   const stepKey = 'bizCaseDraft';
   const { t } = useTranslation('itGov');
@@ -49,6 +50,8 @@ const GovTaskBizCaseDraft = ({
       value: submittedDate
     };
 
+  const hasFeedback = governanceRequestFeedbacks.length > 0;
+
   return (
     <TaskListItem
       heading={t(`taskList.step.${stepKey}.title`)}
@@ -82,8 +85,7 @@ const GovTaskBizCaseDraft = ({
         )}
 
         {/* Link to view feedback */}
-        {bizCaseDraftStatus ===
-          ITGovDraftBusinessCaseStatus.EDITS_REQUESTED && (
+        {hasFeedback && (
           <div className="margin-top-2">
             <UswdsReactLink to="./">{t(`button.viewFeedback`)}</UswdsReactLink>
           </div>

--- a/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.tsx
+++ b/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.tsx
@@ -9,7 +9,6 @@ import TaskListItem, { TaskListDescription } from 'components/TaskList';
 import { ITGovDraftBusinessCaseStatus } from 'types/graphql-global-types';
 import { ItGovTaskSystemIntakeWithMockData } from 'types/itGov';
 import { TaskListItemDateInfo } from 'types/taskList';
-import { formatDateLocal } from 'utils/date';
 
 const GovTaskBizCaseDraft = ({
   itGovTaskStatuses: { bizCaseDraftStatus },
@@ -26,28 +25,28 @@ const GovTaskBizCaseDraft = ({
     [ITGovDraftBusinessCaseStatus.EDITS_REQUESTED, 'editForm']
   ]);
 
-  // Updated and completed at date status info
   let dateInfo: TaskListItemDateInfo;
 
-  const lastUpdatedDate =
+  // Updated date
+  if (
     (bizCaseDraftStatus === ITGovDraftBusinessCaseStatus.IN_PROGRESS ||
       bizCaseDraftStatus === ITGovDraftBusinessCaseStatus.EDITS_REQUESTED) &&
-    bizCaseDraftUpdatedAt &&
-    formatDateLocal(bizCaseDraftUpdatedAt, 'MM/dd/yyyy');
-  if (lastUpdatedDate)
+    bizCaseDraftUpdatedAt
+  )
     dateInfo = {
       label: 'lastUpdated',
-      value: lastUpdatedDate
+      value: bizCaseDraftUpdatedAt
     };
 
-  const submittedDate =
+  // Submitted date
+  if (
+    !dateInfo &&
     bizCaseDraftStatus === ITGovDraftBusinessCaseStatus.COMPLETED &&
-    bizCaseDraftSubmittedAt &&
-    formatDateLocal(bizCaseDraftSubmittedAt, 'MM/dd/yyyy');
-  if (!lastUpdatedDate && submittedDate)
+    bizCaseDraftSubmittedAt
+  )
     dateInfo = {
       label: 'submitted',
-      value: submittedDate
+      value: bizCaseDraftSubmittedAt
     };
 
   const hasFeedback = governanceRequestFeedbacks.length > 0;

--- a/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.tsx
+++ b/src/views/GovernanceTaskList/GovTaskBizCaseDraft/index.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { kebabCase } from 'lodash';
+
+import UswdsReactLink from 'components/LinkWrapper';
+import Alert from 'components/shared/Alert';
+import TaskListItem, { TaskListDescription } from 'components/TaskList';
+// import { IT_GOV_EMAIL } from 'constants/externalUrls';
+import { ITGovDraftBusinessCaseStatus } from 'types/graphql-global-types';
+import { ItGovTaskSystemIntakeWithMockData } from 'types/itGov';
+
+const GovTaskBizCaseDraft = ({
+  itGovTaskStatuses,
+  governanceRequestFeedbacks,
+  governanceRequestFeedbackCompletedAt
+}: ItGovTaskSystemIntakeWithMockData) => {
+  const stepKey = 'bizCaseDraft';
+  const { t } = useTranslation('itGov');
+
+  const statusButtonText = new Map<ITGovDraftBusinessCaseStatus, string>([
+    [ITGovDraftBusinessCaseStatus.READY, 'start'],
+    [ITGovDraftBusinessCaseStatus.IN_PROGRESS, 'continue'],
+    [ITGovDraftBusinessCaseStatus.EDITS_REQUESTED, 'editForm']
+  ]);
+
+  return (
+    <TaskListItem
+      heading={t(`taskList.step.${stepKey}.title`)}
+      status={itGovTaskStatuses.bizCaseDraftStatus}
+      testId={kebabCase(t(`taskList.step.${stepKey}.title`))}
+      governanceRequestFeedbackCompletedIso={
+        governanceRequestFeedbackCompletedAt
+      }
+    >
+      <TaskListDescription>
+        <p>{t(`taskList.step.${stepKey}.description`)}</p>
+
+        {/* Draft biz case submitted & waiting for feedback */}
+        {itGovTaskStatuses.bizCaseDraftStatus ===
+          ITGovDraftBusinessCaseStatus.COMPLETED && (
+          <Alert slim type="info">
+            {t(`taskList.step.${stepKey}.submittedInfo`)}
+          </Alert>
+        )}
+
+        {itGovTaskStatuses.bizCaseDraftStatus ===
+          ITGovDraftBusinessCaseStatus.EDITS_REQUESTED && (
+          <Alert slim type="warning">
+            {t(`taskList.step.${stepKey}.editsRequestedWarning`)}
+          </Alert>
+        )}
+
+        {statusButtonText.has(itGovTaskStatuses.bizCaseDraftStatus) && (
+          <div className="margin-top-2">
+            <UswdsReactLink variant="unstyled" className="usa-button" to="./">
+              {t(
+                `button.${statusButtonText.get(
+                  itGovTaskStatuses.bizCaseDraftStatus
+                )}`
+              )}
+            </UswdsReactLink>
+          </div>
+        )}
+
+        {/* Link to view feedback */}
+        {itGovTaskStatuses.bizCaseDraftStatus ===
+          ITGovDraftBusinessCaseStatus.EDITS_REQUESTED && (
+          <div className="margin-top-2">
+            <UswdsReactLink to="./">{t(`button.viewFeedback`)}</UswdsReactLink>
+          </div>
+        )}
+
+        {/* Link to view submitted draft biz case */}
+        {itGovTaskStatuses.bizCaseDraftStatus ===
+          ITGovDraftBusinessCaseStatus.COMPLETED && (
+          <div className="margin-top-2">
+            <UswdsReactLink to="./">
+              {t(`taskList.step.${stepKey}.viewSubmittedDraftBusinessCase`)}
+            </UswdsReactLink>
+          </div>
+        )}
+      </TaskListDescription>
+    </TaskListItem>
+  );
+};
+
+export default GovTaskBizCaseDraft;

--- a/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.test.tsx
+++ b/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.test.tsx
@@ -2,13 +2,18 @@ import React from 'react';
 import { Trans } from 'react-i18next';
 import { MemoryRouter } from 'react-router-dom';
 import { renderToStringWithData } from '@apollo/client/react/ssr';
-import { render, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { Link } from '@trussworks/react-uswds';
 import i18next from 'i18next';
 
 import { IT_GOV_EMAIL } from 'constants/externalUrls';
 import { taskListState } from 'data/mock/govTaskList';
 import { ItGovTaskSystemIntake } from 'types/itGov';
+import {
+  expectTaskStatusTagToHaveTextKey,
+  getByRoleWithNameTextKey,
+  getExpectedAlertType
+} from 'utils/testing/helpers';
 
 import GovTaskFeedbackFromInitialReview from '.';
 
@@ -24,19 +29,15 @@ describe('Gov Task: Feedback from initial review statuses', () => {
   }
 
   it('Can’t start', () => {
-    const { getByTestId } = renderGovTaskFeedbackFromInitialReview(
+    renderGovTaskFeedbackFromInitialReview(
       taskListState.feedbackFromInitialReviewCantStart.systemIntake!
     );
 
     // Cannot yet start
-    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
-      i18next.t<string>('taskList:taskStatus.CANT_START')
-    );
+    expectTaskStatusTagToHaveTextKey('CANT_START');
 
     // Feedback info
-    const reviewInfo = getByTestId('alert');
-    expect(reviewInfo).toHaveClass('usa-alert--info');
-    expect(reviewInfo).toContainHTML(
+    expect(getExpectedAlertType('info')).toContainHTML(
       i18next.t<string>(
         'itGov:taskList.step.feedbackFromInitialReview.reviewInfo'
       )
@@ -44,19 +45,15 @@ describe('Gov Task: Feedback from initial review statuses', () => {
   });
 
   it('In progress', () => {
-    const { getByTestId } = renderGovTaskFeedbackFromInitialReview(
+    renderGovTaskFeedbackFromInitialReview(
       taskListState.feedbackFromInitialReviewInProgress.systemIntake!
     );
 
     // In review
-    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
-      i18next.t<string>('taskList:taskStatus.IN_REVIEW')
-    );
+    expectTaskStatusTagToHaveTextKey('IN_REVIEW');
 
     // Feedback info
-    const reviewInfo = getByTestId('alert');
-    expect(reviewInfo).toHaveClass('usa-alert--info');
-    expect(reviewInfo).toContainHTML(
+    expect(getExpectedAlertType('info')).toContainHTML(
       i18next.t<string>(
         'itGov:taskList.step.feedbackFromInitialReview.reviewInfo'
       )
@@ -64,19 +61,16 @@ describe('Gov Task: Feedback from initial review statuses', () => {
   });
 
   it('Done - no feedback', async () => {
-    const { getByTestId, getByText } = renderGovTaskFeedbackFromInitialReview(
+    renderGovTaskFeedbackFromInitialReview(
       taskListState.feedbackFromInitialReviewDoneNoFeedback.systemIntake!
     );
 
     // Completed
-    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
-      i18next.t<string>('taskList:taskStatus.COMPLETED')
-    );
+    expectTaskStatusTagToHaveTextKey('COMPLETED');
 
     // No feedback info
-    const noFeedbackInfo = getByTestId('alert');
+    const noFeedbackInfo = getExpectedAlertType('info');
     const mailtoItGov = `mailto:${IT_GOV_EMAIL}`;
-    expect(noFeedbackInfo).toHaveClass('usa-alert--info');
     expect(noFeedbackInfo).toContainHTML(
       await renderToStringWithData(
         <Trans
@@ -95,7 +89,7 @@ describe('Gov Task: Feedback from initial review statuses', () => {
     ).toHaveAttribute('href', mailtoItGov);
 
     // Completed date
-    getByText(
+    screen.getByText(
       RegExp(
         `${i18next.t<string>('taskList:taskStatusInfo.completed')}.*07/10/2023`
       )
@@ -103,30 +97,21 @@ describe('Gov Task: Feedback from initial review statuses', () => {
   });
 
   it('Done - with feedback', () => {
-    const {
-      getByTestId,
-      getByRole,
-      getByText,
-      queryByTestId
-    } = renderGovTaskFeedbackFromInitialReview(
+    renderGovTaskFeedbackFromInitialReview(
       taskListState.feedbackFromInitialReviewDoneWithFeedback.systemIntake!
     );
 
     // Completed
-    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
-      i18next.t<string>('taskList:taskStatus.COMPLETED')
-    );
+    expectTaskStatusTagToHaveTextKey('COMPLETED');
 
     // No alert
-    expect(queryByTestId('alert')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('alert')).not.toBeInTheDocument();
 
     // View feedback
-    getByRole('link', {
-      name: i18next.t<string>('itGov:button.viewFeedback')
-    });
+    getByRoleWithNameTextKey('link', 'itGov:button.viewFeedback');
 
     // Completed date
-    getByText(
+    screen.getByText(
       RegExp(
         `${i18next.t<string>('taskList:taskStatusInfo.completed')}.*07/10/2023`
       )
@@ -134,23 +119,18 @@ describe('Gov Task: Feedback from initial review statuses', () => {
   });
 
   it('Re-submitted with feedback', () => {
-    const { getByTestId, getByRole } = renderGovTaskFeedbackFromInitialReview(
+    renderGovTaskFeedbackFromInitialReview(
       taskListState.feedbackFromInitialReviewResubmittedWithFeedback
         .systemIntake!
     );
 
     // In review
-    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
-      i18next.t<string>('taskList:taskStatus.IN_REVIEW')
-    );
+    expectTaskStatusTagToHaveTextKey('IN_REVIEW');
 
     // Feedback info
-    const reviewInfo = getByTestId('alert');
-    expect(reviewInfo).toHaveClass('usa-alert--info');
+    getExpectedAlertType('info');
 
     // View feedback
-    getByRole('link', {
-      name: i18next.t<string>('itGov:button.viewFeedback')
-    });
+    getByRoleWithNameTextKey('link', 'itGov:button.viewFeedback');
   });
 });

--- a/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.tsx
+++ b/src/views/GovernanceTaskList/GovTaskFeedbackFromInitialReview/index.tsx
@@ -9,6 +9,7 @@ import TaskListItem, { TaskListDescription } from 'components/TaskList';
 import { IT_GOV_EMAIL } from 'constants/externalUrls';
 import { ITGovFeedbackStatus } from 'types/graphql-global-types';
 import { ItGovTaskSystemIntakeWithMockData } from 'types/itGov';
+import { TaskListItemDateInfo } from 'types/taskList';
 
 const GovTaskFeedbackFromInitialReview = ({
   itGovTaskStatuses,
@@ -17,6 +18,18 @@ const GovTaskFeedbackFromInitialReview = ({
 }: ItGovTaskSystemIntakeWithMockData) => {
   const stepKey = 'feedbackFromInitialReview';
   const { t } = useTranslation('itGov');
+
+  // Completed date
+  let dateInfo: TaskListItemDateInfo;
+  if (
+    itGovTaskStatuses.feedbackFromInitialReviewStatus ===
+      ITGovFeedbackStatus.COMPLETED &&
+    governanceRequestFeedbackCompletedAt
+  )
+    dateInfo = {
+      label: 'completed',
+      value: governanceRequestFeedbackCompletedAt
+    };
 
   const hasFeedback = governanceRequestFeedbacks.length > 0;
 
@@ -34,10 +47,8 @@ const GovTaskFeedbackFromInitialReview = ({
     <TaskListItem
       heading={t(`taskList.step.${stepKey}.title`)}
       status={itGovTaskStatuses.feedbackFromInitialReviewStatus}
+      statusDateInfo={dateInfo}
       testId={kebabCase(t(`taskList.step.${stepKey}.title`))}
-      governanceRequestFeedbackCompletedIso={
-        governanceRequestFeedbackCompletedAt
-      }
     >
       <TaskListDescription>
         <p>{t(`taskList.step.${stepKey}.description`)}</p>

--- a/src/views/GovernanceTaskList/GovTaskIntakeForm/index.test.tsx
+++ b/src/views/GovernanceTaskList/GovTaskIntakeForm/index.test.tsx
@@ -5,6 +5,11 @@ import i18next from 'i18next';
 
 import { taskListState } from 'data/mock/govTaskList';
 import { ItGovTaskSystemIntake } from 'types/itGov';
+import {
+  expectTaskStatusTagToHaveTextKey,
+  getByRoleWithNameTextKey,
+  getExpectedAlertType
+} from 'utils/testing/helpers';
 
 import GovTaskIntakeForm from '.';
 
@@ -18,30 +23,20 @@ describe('Gov Task: Fill out the Intake Request form statuses', () => {
   }
 
   it('not started', () => {
-    const { getByRole, getByTestId } = renderGovTaskIntakeForm(
-      taskListState.intakeFormNotStarted.systemIntake!
-    );
+    renderGovTaskIntakeForm(taskListState.intakeFormNotStarted.systemIntake!);
 
     // Ready to start
-    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
-      i18next.t<string>('taskList:taskStatus.READY')
-    );
+    expectTaskStatusTagToHaveTextKey('READY');
 
     // Start button
-    getByRole('link', {
-      name: i18next.t<string>('itGov:button.start')
-    });
+    getByRoleWithNameTextKey('link', 'itGov:button.start');
   });
 
   it('in progress', () => {
-    const { getByRole, getByTestId } = renderGovTaskIntakeForm(
-      taskListState.intakeFormInProgress.systemIntake!
-    );
+    renderGovTaskIntakeForm(taskListState.intakeFormInProgress.systemIntake!);
 
     // In progress
-    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
-      i18next.t<string>('taskList:taskStatus.IN_PROGRESS')
-    );
+    expectTaskStatusTagToHaveTextKey('IN_PROGRESS');
 
     // % complete
     screen.getByText(
@@ -51,68 +46,51 @@ describe('Gov Task: Fill out the Intake Request form statuses', () => {
     );
 
     // Continue button
-    getByRole('link', {
-      name: i18next.t<string>('itGov:button.continue')
-    });
+    getByRoleWithNameTextKey('link', 'itGov:button.continue');
   });
 
   it('submitted', () => {
-    const { getByRole, getByText, getByTestId } = renderGovTaskIntakeForm(
-      taskListState.intakeFormSubmitted.systemIntake!
-    );
+    renderGovTaskIntakeForm(taskListState.intakeFormSubmitted.systemIntake!);
 
     // Completed
-    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
-      i18next.t<string>('taskList:taskStatus.COMPLETED')
-    );
+    expectTaskStatusTagToHaveTextKey('COMPLETED');
 
     // Submitted MM/DD/YYYY
-    getByText(RegExp(i18next.t<string>('taskList:taskStatusInfo.submitted')));
-    getByText(RegExp('07/07/2023'));
+    screen.getByText(
+      RegExp(
+        `${i18next.t<string>('taskList:taskStatusInfo.submitted')}.*07/07/2023`
+      )
+    );
 
     // View submitted request form
-    getByRole('link', {
-      name: i18next.t<string>(
-        'itGov:taskList.step.intakeForm.viewSubmittedRequestForm'
-      )
-    });
+    getByRoleWithNameTextKey(
+      'link',
+      'itGov:taskList.step.intakeForm.viewSubmittedRequestForm'
+    );
   });
 
   it('edits requested', () => {
-    const {
-      getByRole,
-      getByTestId,
-      getByText,
-      queryByRole
-    } = renderGovTaskIntakeForm(
+    renderGovTaskIntakeForm(
       taskListState.intakeFormEditsRequested.systemIntake!
     );
 
     // Edits requested
-    expect(getByTestId('task-list-task-tag')).toHaveTextContent(
-      i18next.t<string>('taskList:taskStatus.EDITS_REQUESTED')
-    );
+    expectTaskStatusTagToHaveTextKey('EDITS_REQUESTED');
 
     // Edit form button
-    getByRole('link', {
-      name: i18next.t<string>('itGov:button.editForm')
-    });
+    getByRoleWithNameTextKey('link', 'itGov:button.editForm');
 
     // Edits requested warning
-    const alertWarning = getByTestId('alert');
-    expect(alertWarning).toHaveClass('usa-alert--warning');
-    expect(alertWarning).toHaveTextContent(
+    expect(getExpectedAlertType('warning')).toHaveTextContent(
       i18next.t<string>('itGov:taskList.step.intakeForm.editsRequestedWarning')
     );
 
     // View feedback
-    getByRole('link', {
-      name: i18next.t<string>('itGov:button.viewFeedback')
-    });
+    getByRoleWithNameTextKey('link', 'itGov:button.viewFeedback');
 
     // View submitted request form should not exist
     expect(
-      queryByRole('link', {
+      screen.queryByRole('link', {
         name: i18next.t<string>(
           'itGov:taskList.step.intakeForm.viewSubmittedRequestForm'
         )
@@ -120,28 +98,32 @@ describe('Gov Task: Fill out the Intake Request form statuses', () => {
     ).not.toBeInTheDocument();
 
     // Last updated MM/DD/YYYY
-    getByText(RegExp(i18next.t<string>('taskList:taskStatusInfo.lastUpdated')));
-    getByText(RegExp('07/08/2023'));
+    screen.getByText(
+      RegExp(
+        `${i18next.t<string>(
+          'taskList:taskStatusInfo.lastUpdated'
+        )}.*07/08/2023`
+      )
+    );
   });
 
   it('resubmitted after edits', () => {
-    const { getByRole, getByText } = renderGovTaskIntakeForm(
+    renderGovTaskIntakeForm(
       taskListState.intakeFormResubmittedAfterEdits.systemIntake!
     );
 
     // View feedback + View submitted request form
-    getByRole('link', {
-      name: i18next.t<string>('itGov:button.viewFeedback')
-    });
-
-    getByRole('link', {
-      name: i18next.t<string>(
-        'itGov:taskList.step.intakeForm.viewSubmittedRequestForm'
-      )
-    });
+    getByRoleWithNameTextKey('link', 'itGov:button.viewFeedback');
+    getByRoleWithNameTextKey(
+      'link',
+      'itGov:taskList.step.intakeForm.viewSubmittedRequestForm'
+    );
 
     // Submitted MM/DD/YYYY
-    getByText(RegExp(i18next.t<string>('taskList:taskStatusInfo.submitted')));
-    getByText(RegExp('07/09/2023'));
+    screen.getByText(
+      RegExp(
+        `${i18next.t<string>('taskList:taskStatusInfo.submitted')}.*07/09/2023`
+      )
+    );
   });
 });

--- a/src/views/GovernanceTaskList/GovTaskIntakeForm/index.test.tsx
+++ b/src/views/GovernanceTaskList/GovTaskIntakeForm/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import i18next from 'i18next';
 
 import { taskListState } from 'data/mock/govTaskList';
@@ -41,6 +41,13 @@ describe('Gov Task: Fill out the Intake Request form statuses', () => {
     // In progress
     expect(getByTestId('task-list-task-tag')).toHaveTextContent(
       i18next.t<string>('taskList:taskStatus.IN_PROGRESS')
+    );
+
+    // % complete
+    screen.getByText(
+      i18next.t<string>('taskList:taskStatusInfo.percentComplete', {
+        percent: 22
+      })
     );
 
     // Continue button

--- a/src/views/GovernanceTaskList/GovTaskIntakeForm/index.tsx
+++ b/src/views/GovernanceTaskList/GovTaskIntakeForm/index.tsx
@@ -7,6 +7,7 @@ import Alert from 'components/shared/Alert';
 import TaskListItem, { TaskListDescription } from 'components/TaskList';
 import { ITGovIntakeFormStatus } from 'types/graphql-global-types';
 import { ItGovTaskSystemIntake } from 'types/itGov';
+import { TaskListItemDateInfo } from 'types/taskList';
 
 const GovTaskIntakeForm = ({
   itGovTaskStatuses,
@@ -23,15 +24,38 @@ const GovTaskIntakeForm = ({
     [ITGovIntakeFormStatus.EDITS_REQUESTED, 'editForm']
   ]);
 
+  let dateInfo: TaskListItemDateInfo;
+
+  // Updated date
+  if (
+    itGovTaskStatuses.intakeFormStatus ===
+      ITGovIntakeFormStatus.EDITS_REQUESTED &&
+    updatedAt
+  )
+    dateInfo = {
+      label: 'lastUpdated',
+      value: updatedAt
+    };
+
+  // Submitted date
+  if (
+    !dateInfo &&
+    itGovTaskStatuses.intakeFormStatus === ITGovIntakeFormStatus.COMPLETED &&
+    submittedAt
+  )
+    dateInfo = {
+      label: 'submitted',
+      value: submittedAt
+    };
+
   const hasFeedback = governanceRequestFeedbacks.length > 0;
 
   return (
     <TaskListItem
       heading={t(`taskList.step.${stepKey}.title`)}
       status={itGovTaskStatuses.intakeFormStatus}
+      statusDateInfo={dateInfo}
       testId={kebabCase(t(`taskList.step.${stepKey}.title`))}
-      completedIso={submittedAt}
-      lastUpdatedIso={updatedAt}
     >
       <TaskListDescription>
         <p>{t(`taskList.step.${stepKey}.description`)}</p>

--- a/src/views/GovernanceTaskList/GovTaskIntakeForm/index.tsx
+++ b/src/views/GovernanceTaskList/GovTaskIntakeForm/index.tsx
@@ -6,15 +6,16 @@ import UswdsReactLink from 'components/LinkWrapper';
 import Alert from 'components/shared/Alert';
 import TaskListItem, { TaskListDescription } from 'components/TaskList';
 import { ITGovIntakeFormStatus } from 'types/graphql-global-types';
-import { ItGovTaskSystemIntake } from 'types/itGov';
+import { ItGovTaskSystemIntakeWithMockData } from 'types/itGov';
 import { TaskListItemDateInfo } from 'types/taskList';
 
 const GovTaskIntakeForm = ({
   itGovTaskStatuses,
+  intakeFormPctComplete,
   governanceRequestFeedbacks,
   submittedAt,
   updatedAt
-}: ItGovTaskSystemIntake) => {
+}: ItGovTaskSystemIntakeWithMockData) => {
   const stepKey = 'intakeForm';
   const { t } = useTranslation('itGov');
 
@@ -54,6 +55,10 @@ const GovTaskIntakeForm = ({
     <TaskListItem
       heading={t(`taskList.step.${stepKey}.title`)}
       status={itGovTaskStatuses.intakeFormStatus}
+      statusPercentComplete={
+        itGovTaskStatuses.intakeFormStatus ===
+          ITGovIntakeFormStatus.IN_PROGRESS && intakeFormPctComplete
+      }
       statusDateInfo={dateInfo}
       testId={kebabCase(t(`taskList.step.${stepKey}.title`))}
     >

--- a/src/views/GovernanceTaskList/index.test.tsx
+++ b/src/views/GovernanceTaskList/index.test.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import { MemoryRouter, Route } from 'react-router-dom';
-import { render, waitForElementToBeRemoved } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved
+} from '@testing-library/react';
 import i18next from 'i18next';
 
 import { taskListState } from 'data/mock/govTaskList';
 import GetGovernanceTaskListQuery from 'queries/GetGovernanceTaskListQuery';
+import { getByRoleWithNameTextKey } from 'utils/testing/helpers';
 import VerboseMockedProvider from 'utils/testing/VerboseMockedProvider';
 
 import GovernanceTaskList from '.';
@@ -13,7 +18,7 @@ describe('Governance Task List', () => {
   const id = '80950153-4a66-4881-b728-f4cc701ff926';
 
   it('renders a request task list at the initial state', async () => {
-    const { getByRole, getByTestId } = render(
+    render(
       <MemoryRouter initialEntries={[`/governance-task-list/${id}`]}>
         <VerboseMockedProvider
           mocks={[
@@ -42,31 +47,26 @@ describe('Governance Task List', () => {
       </MemoryRouter>
     );
 
-    await waitForElementToBeRemoved(() => getByTestId('page-loading'));
+    await waitForElementToBeRemoved(() => screen.getByTestId('page-loading'));
 
     // Header
-    await getByRole('heading', {
+    await screen.getByRole('heading', {
       level: 1,
       name: i18next.t<string>('itGov:taskList.heading')
     });
 
     // Crumb back to it gov home
     expect(
-      getByRole('link', {
-        name: i18next.t<string>('itGov:itGovernance')
-      })
+      getByRoleWithNameTextKey('link', 'itGov:itGovernance')
     ).toHaveAttribute('href', '/system/making-a-request');
 
     // Sidebar back to home
     expect(
-      getByRole('link', {
-        name: i18next.t<string>('itGov:button.saveAndExit')
-      })
+      getByRoleWithNameTextKey('link', 'itGov:button.saveAndExit')
     ).toHaveAttribute('href', '/system/making-a-request');
 
     // First task list item
-    // errors because of component mock preview setup
-    getByRole('heading', {
+    screen.getByRole('heading', {
       level: 3,
       name: i18next.t<string>('itGov:taskList.step.intakeForm.title')
     });

--- a/src/views/GovernanceTaskList/index.tsx
+++ b/src/views/GovernanceTaskList/index.tsx
@@ -21,6 +21,7 @@ import {
 import NotFound from 'views/NotFound';
 import Breadcrumbs from 'views/TechnicalAssistance/Breadcrumbs';
 
+import GovTaskBizCaseDraft from './GovTaskBizCaseDraft';
 import GovTaskFeedbackFromInitialReview from './GovTaskFeedbackFromInitialReview';
 import GovTaskIntakeForm from './GovTaskIntakeForm';
 
@@ -78,15 +79,7 @@ function GovernanceTaskList() {
                   <GovTaskFeedbackFromInitialReview {...systemIntake} />
 
                   {/* 3. Prepare a draft Business Case */}
-                  <TaskListItem
-                    heading={t('taskList.step.bizCaseDraft.title')}
-                    status={itGovTaskStatuses.bizCaseDraftStatus}
-                    testId={kebabCase(t('taskList.step.bizCaseDraft.title'))}
-                  >
-                    <TaskListDescription>
-                      <p>{t('taskList.step.bizCaseDraft.description')}</p>
-                    </TaskListDescription>
-                  </TaskListItem>
+                  <GovTaskBizCaseDraft {...systemIntake} />
 
                   {/* 4. Attend the GRT meeting */}
                   <TaskListItem


### PR DESCRIPTION
# EASI-3061

[Draft biz case status states in figma](https://www.figma.com/file/ChzAP34A2DVvQUNQwD7lCt/IT-Governance-Next?type=design&node-id=16-23702&mode=design&t=udGDyzTdfuSQYz7z-0)

## Changes and Description

- New `GovTaskBizCaseDraft`
  - [Done statuses are on hold](https://cmsgov.slack.com/archives/CNU2B59UH/p1689279895424799)
- Property param adjustments on `TaskListItem` for status info
- Util function decorator `fnCaptureError()` based on 
https://kentcdodds.com/blog/improve-test-error-messages-of-your-abstractions 
- Test helpers in `src/utils/testing/helpers.ts`

## Testing
- Jest tests of the status states
- Preview on local dev
  - Check out the preview branch `NOREF/gov-task-mock-preview` which pulls in mock data for all status states within the parent task list component
  - Turn on the `itGovV2Enabled` flag
  - Seed data or create a new IT Gov request to get to the task list view