### PR TITLE
[EASI-3105] Ignore certain types of errors in GQL Response Middleware

### DIFF
--- a/pkg/server/gqllogging.go
+++ b/pkg/server/gqllogging.go
@@ -25,10 +25,9 @@ func NewGQLResponseMiddleware() graphql.ResponseMiddleware {
 		duration := time.Since(requestContext.Stats.OperationStart)
 		complexityStats := extension.GetComplexityStats(ctx)
 
-		// Flag the request as an error if there are any errors in the list that aren't ignored
 		numTotalErrors := len(errorList)
 		numIgnoredErrors := countIgnoredErrors(errorList)
-		errored := (numTotalErrors > 0) && (numTotalErrors != numIgnoredErrors)
+		errored := (numTotalErrors > 0) && (numTotalErrors != numIgnoredErrors) // Flag the request as an error if there are any errors in the list that aren't ignored
 		fields := []zap.Field{
 			zap.String("operation", requestContext.OperationName),
 			zap.Duration("duration", duration),


### PR DESCRIPTION
# EASI-3105

## Changes and Description

- Added small function to help identify if errors exist that should be ignored.
- `error: true` in the response qualifies the criteria for our Splunk alerting, so this change just makes that field be `false` in cases where we're only returning errors of an ignored type

## How to test this change

- `scripts/dev up`
- `scripts/dev db:seed`
- Open the GQL Playground, use the following auth headers `{ "Authorization":"Local {\"EUAID\":\"GRTB\",\"favorLocalAuth\":true, \"jobCodes\":[\"EASI_TRB_ADMIN_D\"]}"}`
- Make a query to fetch an intake
```graphql
query bazinga {
  systemIntake(id: "78485ec1-035d-46f6-b524-68616f7f99e4") {
    id
  }
}
```
- Check the logs - make sure `error: false`!
- Try generating other errors to make sure `error: true` in those cases!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
