### PR TITLE
Disable view button when fetching document URLs as a loading indicator

### DIFF
--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -3009,8 +3009,6 @@ func (r *systemIntakeDocumentResolver) UploadedAt(ctx context.Context, obj *mode
 
 // URL is the resolver for the url field.
 func (r *systemIntakeDocumentResolver) URL(ctx context.Context, obj *models.SystemIntakeDocument) (string, error) {
-	time.Sleep(300 * time.Millisecond) // simulate delay in Prod
-
 	return resolvers.GetURLForSystemIntakeDocument(r.s3Client, obj.S3Key)
 }
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -3009,6 +3009,8 @@ func (r *systemIntakeDocumentResolver) UploadedAt(ctx context.Context, obj *mode
 
 // URL is the resolver for the url field.
 func (r *systemIntakeDocumentResolver) URL(ctx context.Context, obj *models.SystemIntakeDocument) (string, error) {
+	time.Sleep(300 * time.Millisecond) // simulate delay in Prod
+
 	return resolvers.GetURLForSystemIntakeDocument(r.s3Client, obj.S3Key)
 }
 

--- a/src/views/SystemIntake/Documents/DocumentsTable.tsx
+++ b/src/views/SystemIntake/Documents/DocumentsTable.tsx
@@ -58,7 +58,7 @@ const DocumentsTable = ({
 
   const { id: systemIntakeID, documents } = systemIntake;
 
-  const [getDocumentUrls, { loading }] = useLazyQuery<
+  const [getDocumentUrls, { loading: documentUrlsLoading }] = useLazyQuery<
     GetSystemIntakeDocumentUrls,
     GetSystemIntakeDocumentUrlsVariables
   >(GetSystemIntakeDocumentUrlsQuery, {
@@ -161,7 +161,7 @@ const DocumentsTable = ({
                   type="button"
                   unstyled
                   onClick={() => getUrlForDocument(documentId, documentName)}
-                  disabled={loading}
+                  disabled={documentUrlsLoading}
                 >
                   {t('technicalAssistance:documents.table.view')}
                 </Button>
@@ -189,7 +189,7 @@ const DocumentsTable = ({
         }
       }
     ];
-  }, [t, getDocumentUrls, showMessage, loading, canEdit]);
+  }, [t, getDocumentUrls, showMessage, documentUrlsLoading, canEdit]);
 
   const {
     getTableBodyProps,

--- a/src/views/SystemIntake/Documents/DocumentsTable.tsx
+++ b/src/views/SystemIntake/Documents/DocumentsTable.tsx
@@ -58,7 +58,7 @@ const DocumentsTable = ({
 
   const { id: systemIntakeID, documents } = systemIntake;
 
-  const [getDocumentUrls] = useLazyQuery<
+  const [getDocumentUrls, { loading }] = useLazyQuery<
     GetSystemIntakeDocumentUrls,
     GetSystemIntakeDocumentUrlsVariables
   >(GetSystemIntakeDocumentUrlsQuery, {
@@ -161,8 +161,12 @@ const DocumentsTable = ({
                   type="button"
                   unstyled
                   onClick={() => getUrlForDocument(documentId, documentName)}
+                  // disabled={loading}
                 >
-                  {t('technicalAssistance:documents.table.view')}
+                  {loading
+                    ? 'Loading...'
+                    : t('technicalAssistance:documents.table.view')}
+                  {/* {t('technicalAssistance:documents.table.view')} */}
                 </Button>
 
                 {
@@ -188,7 +192,7 @@ const DocumentsTable = ({
         }
       }
     ];
-  }, [canEdit, setFileToDelete, getDocumentUrls, showMessage, t]);
+  }, [t, getDocumentUrls, showMessage, loading, canEdit]);
 
   const {
     getTableBodyProps,

--- a/src/views/SystemIntake/Documents/DocumentsTable.tsx
+++ b/src/views/SystemIntake/Documents/DocumentsTable.tsx
@@ -161,12 +161,9 @@ const DocumentsTable = ({
                   type="button"
                   unstyled
                   onClick={() => getUrlForDocument(documentId, documentName)}
-                  // disabled={loading}
+                  disabled={loading}
                 >
-                  {loading
-                    ? 'Loading...'
-                    : t('technicalAssistance:documents.table.view')}
-                  {/* {t('technicalAssistance:documents.table.view')} */}
+                  {t('technicalAssistance:documents.table.view')}
                 </Button>
 
                 {

--- a/src/views/TechnicalAssistance/RequestForm/DocumentsTable.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/DocumentsTable.tsx
@@ -69,7 +69,7 @@ function DocumentsTable({
     variables: { id: trbRequestId }
   });
 
-  const [getDocumentUrls] = useLazyQuery<
+  const [getDocumentUrls, { loading: documentUrlsLoading }] = useLazyQuery<
     GetTrbRequestDocumentUrls,
     GetTrbRequestDocumentsVariables
   >(GetTrbRequestDocumentUrlsQuery, {
@@ -215,6 +215,7 @@ function DocumentsTable({
                 <Button
                   type="button"
                   unstyled
+                  disabled={documentUrlsLoading}
                   onClick={() => getUrlForDocument(documentId, documentName)}
                 >
                   {t('documents.table.view')}
@@ -243,7 +244,7 @@ function DocumentsTable({
         }
       }
     ];
-  }, [t, showMessage, getDocumentUrls, canEdit]);
+  }, [t, getDocumentUrls, showMessage, documentUrlsLoading, canEdit]);
 
   const {
     getTableBodyProps,


### PR DESCRIPTION
No ticket, just a small fix I did following up on https://github.com/CMSgov/easi-app/pull/2109 (for EASI-3081) and https://github.com/CMSgov/easi-app/pull/2095 (for EASI-3047). Those bugfixes introduced a brief delay (~300ms) between clicking "View" in a list of documents and the file dialog opening, without any indicator that anything was happening during the daly. See the video in [this Slack post](https://cmsgov.slack.com/archives/CNU2B59UH/p1689709709125719) for a demonstration.

## Changes and Description

- Set the `disabled` prop on the `<Button>` component in the System Intake and TRB document tables when the query to fetch a document's URL is running, until it returns. This serves as a loading indicator, so users are aware that something's happening, instead of the app appearing unresponsive. See the video in [this Slack post](https://cmsgov.slack.com/archives/CNU2B59UH/p1689709812145329?thread_ts=1689709709.125719&cid=CNU2B59UH) as a demo.

## How to test this change

* Add a manual delay to the backend's resolvers for document URLs to simulate conditions in Prod. To do this, go to `pkg/graph/schema.resolvers.go`, then add `time.Sleep(300 * time.Millisecond)` at the start of the methods `func (r *systemIntakeDocumentResolver) URL` and `func (r *tRBRequestDocumentResolver) URL`.
* Bring the app up locally. 
* To test system intake documents:
    * Create a system intake.
    * As part of the initial request form, upload a document.
    * Run `scripts/dev minio:clean` to mark the document as virus-free.
    * Click the "View" link in the documents table on the page of the request form for uploading documents.
* Testing TRB documents is similar, just create a TRB request instead of a system intake.