### PR TITLE
[NOREF] Added requester name to CEDAR email when changing roles

### DIFF
--- a/cmd/test_email_templates/main.go
+++ b/cmd/test_email_templates/main.go
@@ -140,10 +140,10 @@ func sendTRBEmails(ctx context.Context, client *email.Client) {
 	})
 	noErr(err)
 
-	err = client.SendCedarRolesChangedEmail(ctx, "Johnothan Roleadd", true, false, []string{}, []string{"System API Contact"}, "CMSGovNetSystem", time.Now())
+	err = client.SendCedarRolesChangedEmail(ctx, "Requester Jones", "Johnothan Roleadd", true, false, []string{}, []string{"System API Contact"}, "CMSGovNetSystem", time.Now())
 	noErr(err)
 
-	err = client.SendCedarRolesChangedEmail(ctx, "Johnothan Roledelete", false, true, []string{"System API Contact", "System Manager"}, []string{"System API Contact"}, "CMSGovNetSystem", time.Now())
+	err = client.SendCedarRolesChangedEmail(ctx, "Requester Jones", "Johnothan Roledelete", false, true, []string{"System API Contact", "System Manager"}, []string{"System API Contact"}, "CMSGovNetSystem", time.Now())
 	noErr(err)
 }
 

--- a/pkg/email/cedar_roles_changed.go
+++ b/pkg/email/cedar_roles_changed.go
@@ -13,7 +13,8 @@ import (
 )
 
 type cedarRolesChangedEmailParameters struct {
-	UserFullName        string
+	RequesterFullName   string
+	TargetFullName      string
 	DidAdd              bool
 	DidDelete           bool
 	RoleTypeNamesBefore string
@@ -22,9 +23,10 @@ type cedarRolesChangedEmailParameters struct {
 	Timestamp           string
 }
 
-func (c Client) cedarRolesChangedEmailBody(userFullName string, didAdd bool, didDelete bool, roleTypeNamesBefore []string, roleTypeNamesAfter []string, systemName string, timestamp time.Time) (string, error) {
+func (c Client) cedarRolesChangedEmailBody(requesterFullName string, targetFullName string, didAdd bool, didDelete bool, roleTypeNamesBefore []string, roleTypeNamesAfter []string, systemName string, timestamp time.Time) (string, error) {
 	data := cedarRolesChangedEmailParameters{
-		UserFullName:        userFullName,
+		RequesterFullName:   requesterFullName,
+		TargetFullName:      targetFullName,
 		DidAdd:              didAdd,
 		DidDelete:           didDelete,
 		RoleTypeNamesBefore: strings.Join(roleTypeNamesBefore, ", "),
@@ -49,7 +51,8 @@ func (c Client) cedarRolesChangedEmailBody(userFullName string, didAdd bool, did
 // SendCedarRolesChangedEmail notifies someone that they've been added as an attendee on a TRB request
 func (c Client) SendCedarRolesChangedEmail(
 	ctx context.Context,
-	userFullName string,
+	requesterFullName string,
+	targetFullName string,
 	didAdd bool,
 	didDelete bool,
 	roleTypeNamesBefore []string,
@@ -57,8 +60,8 @@ func (c Client) SendCedarRolesChangedEmail(
 	systemName string,
 	timestamp time.Time,
 ) error {
-	subject := fmt.Sprintf("CEDAR Roles modified for (%v)", userFullName)
-	body, err := c.cedarRolesChangedEmailBody(userFullName, didAdd, didDelete, roleTypeNamesBefore, roleTypeNamesAfter, systemName, timestamp)
+	subject := fmt.Sprintf("CEDAR Roles modified for (%v)", targetFullName)
+	body, err := c.cedarRolesChangedEmailBody(requesterFullName, targetFullName, didAdd, didDelete, roleTypeNamesBefore, roleTypeNamesAfter, systemName, timestamp)
 	if err != nil {
 		return &apperrors.NotificationError{Err: err, DestinationType: apperrors.DestinationTypeEmail}
 	}

--- a/pkg/email/templates/cedar_roles_changed.gohtml
+++ b/pkg/email/templates/cedar_roles_changed.gohtml
@@ -6,7 +6,7 @@
 	<li>Customer: EASi</li>
 	<li>System: {{.SystemName}}</li>
 	<li>API: CEDAR Core</li>
-	<li>Requester {{.RequesterFullName}}</li>
+	<li>Requester: {{.RequesterFullName}}</li>
 	<li>Endpoints:
 		<ul>
 			{{if .DidAdd}}<li>RoleAdd</li>{{end}}

--- a/pkg/email/templates/cedar_roles_changed.gohtml
+++ b/pkg/email/templates/cedar_roles_changed.gohtml
@@ -6,6 +6,7 @@
 	<li>Customer: EASi</li>
 	<li>System: {{.SystemName}}</li>
 	<li>API: CEDAR Core</li>
+	<li>Requester {{.RequesterFullName}}</li>
 	<li>Endpoints:
 		<ul>
 			{{if .DidAdd}}<li>RoleAdd</li>{{end}}
@@ -14,8 +15,8 @@
 	</li>
 	<li>Change:
 		<ul>
-			<li>Before: {{.UserFullName}}; {{if .RoleTypeNamesBefore}}{{.RoleTypeNamesBefore}}{{else}}(No Roles){{end}}</li>
-			<li>After: {{.UserFullName}}; {{if .RoleTypeNamesAfter}}{{.RoleTypeNamesAfter}}{{else}}(No Roles){{end}}</li>
+			<li>Before: {{.TargetFullName}}; {{if .RoleTypeNamesBefore}}{{.RoleTypeNamesBefore}}{{else}}(No Roles){{end}}</li>
+			<li>After: {{.TargetFullName}}; {{if .RoleTypeNamesAfter}}{{.RoleTypeNamesAfter}}{{else}}(No Roles){{end}}</li>
 		</ul>
 	</li>
 </ul>

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -2039,14 +2039,32 @@ func (r *mutationResolver) SetRolesForUserOnSystem(ctx context.Context, input mo
 		// make a new context and copy the logger to it, or else the request will cancel when the parent context cancels
 		emailCtx := appcontext.WithLogger(context.Background(), appcontext.ZLogger(ctx))
 
-		userInfo, err := r.service.FetchUserInfo(emailCtx, input.EuaUserID)
+		// Fetch user info for _both_ the requester _and_ the user whose roles were changed
+		// We're using 2 calls to `FetchUserInfo` rather than 1 call to `FetchUserInfos` since we don't know what order they'll come back in with the latter function
+		g := new(errgroup.Group)
+		var requesterUserInfo *models.UserInfo
+		var errRequester error
+		g.Go(func() error {
+			requesterUserInfo, errRequester = r.service.FetchUserInfo(emailCtx, appcontext.Principal(ctx).ID())
+			return errRequester
+		})
+
+		var targetUserInfo *models.UserInfo
+		var errTarget error
+		g.Go(func() error {
+			targetUserInfo, errTarget = r.service.FetchUserInfo(emailCtx, input.EuaUserID)
+			return errTarget
+		})
+
+		// wait for both calls to complete
+		err := g.Wait()
 		if err != nil {
 			// don't fail the request if the lookup fails, just log and return from the go func
-			appcontext.ZLogger(emailCtx).Error("failed to lookup user info for CEDAR notification email", zap.Error(err))
+			appcontext.ZLogger(emailCtx).Error("failed to lookup user infos for CEDAR notification email", zap.Error(err))
 			return
 		}
 
-		err = r.emailClient.SendCedarRolesChangedEmail(emailCtx, userInfo.CommonName, rs.DidAdd, rs.DidDelete, rs.RoleTypeNamesBefore, rs.RoleTypeNamesAfter, rs.SystemName, time.Now())
+		err = r.emailClient.SendCedarRolesChangedEmail(emailCtx, requesterUserInfo.CommonName, targetUserInfo.CommonName, rs.DidAdd, rs.DidDelete, rs.RoleTypeNamesBefore, rs.RoleTypeNamesAfter, rs.SystemName, time.Now())
 		if err != nil {
 			// don't fail the request if the email fails, just log and return from the go func
 			appcontext.ZLogger(emailCtx).Error("failed to send CEDAR notification email", zap.Error(err))


### PR DESCRIPTION
# NOREF

## Changes and Description

This was an ask from last weeks CEDAR meeting. Again, this is not a permanent auditing solution, but something to hold out while CEDAR builds more robust auditing on their side.

- Adds the full name of the requester to the email sent when changing CEDAR System roles

## How to test this change

- If you just want to validate the email content and templating, `scripts/dev up:backend` followed by `go run cmd/test_email_templates/main.go`, and navigating to http://localhost:1080 to check emails should work
- If you want to test the whole flow:
  - Ensure you're on the VPN
  - Modify [this line](https://github.com/CMSgov/easi-app/blob/b890784582e104ca354032a0e99561f549d1b9c3/pkg/server/routes.go#L107) to be `if !s.environment.Local() || s.environment.Test() {`, to begin using the REAL okta client (as the requester AND the target both need to be in the Okta service)
  - `scripts/dev up`
  - Log in as a real EUA user (use your own, even if it's through local login!)
  - Modify a user's roles in system profile
  - check http://localhost:1080 to see if the email sent with the appropriate content!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
