### PR TITLE
[NOREF] Improve handling of context canceled errors

### DIFF
--- a/pkg/server/gqllogging.go
+++ b/pkg/server/gqllogging.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -53,6 +54,11 @@ func countIgnoredErrors(errorList gqlerror.List) int {
 		if err != nil {
 			// Ignore errors of type apperrors.UnauthorizedError
 			if _, ok := err.Unwrap().(*apperrors.UnauthorizedError); ok {
+				numIgnored++
+			}
+
+			// Ignore errors of type context.Canceled
+			if errors.Is(err, context.Canceled) {
 				numIgnored++
 			}
 		}


### PR DESCRIPTION
# NOREF

## Changes and Description

- Add better error handling in Okta API Client methods
- Ignore any context canceled errors that get forwarded up to the GQL Logging middleware to prevent them from automatically alerting

## How to test this change

- You can force a `return nil, context.Canceled` in this function to test out the logging behavior locally. https://github.com/CMSgov/easi-app/blob/f805ded627e337d8db1094e66665bc38dd63db7b/pkg/local/cedar_ldap.go#L343-L365
  - Seeding the DB and trying to fetch a TRB Request as an admin is a surefire way to trigger this function call, but lots of code calls this.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
