### PR TITLE
EASI-2957: Intake Form Status Implementation

### DIFF
--- a/pkg/apperrors/errors.go
+++ b/pkg/apperrors/errors.go
@@ -270,3 +270,28 @@ type InvalidEUAIDError struct {
 func (e *InvalidEUAIDError) Error() string {
 	return fmt.Sprint("EUAID ", e.EUAID, " does not correspond to a valid EUA user")
 }
+
+// InvalidStateError indicates that a provided enumerated state is not valid. Perhaps it is a string that has been cast as the enum type
+type InvalidStateError struct {
+	Err   error
+	Value string
+	Type  string
+}
+
+// NewInvalidEnumError creates an invalid state error and wraps it as apprpriate
+func NewInvalidEnumError[EnumType ~string](err error, value EnumType, enumType string) InvalidStateError {
+	return InvalidStateError{
+		Err:   err,
+		Value: string(value),
+		Type:  enumType,
+	}
+}
+
+func (e InvalidStateError) Error() string {
+	return fmt.Sprint("Value ", e.Value, " does not correspond to a valid enumeration for type ", e.Type)
+}
+
+// Unwrap returns the underlying error
+func (e InvalidStateError) Unwrap() error {
+	return e.Err
+}

--- a/pkg/apperrors/errors.go
+++ b/pkg/apperrors/errors.go
@@ -271,27 +271,27 @@ func (e *InvalidEUAIDError) Error() string {
 	return fmt.Sprint("EUAID ", e.EUAID, " does not correspond to a valid EUA user")
 }
 
-// InvalidStateError indicates that a provided enumerated state is not valid. Perhaps it is a string that has been cast as the enum type
-type InvalidStateError struct {
+// InvalidEnumError indicates that a provided enumerated state is not valid. Perhaps it is a string that has been cast as the enum type
+type InvalidEnumError struct {
 	Err   error
 	Value string
 	Type  string
 }
 
 // NewInvalidEnumError creates an invalid state error and wraps it as apprpriate
-func NewInvalidEnumError[EnumType ~string](err error, value EnumType, enumType string) InvalidStateError {
-	return InvalidStateError{
+func NewInvalidEnumError[EnumType ~string](err error, value EnumType, enumType string) InvalidEnumError {
+	return InvalidEnumError{
 		Err:   err,
 		Value: string(value),
 		Type:  enumType,
 	}
 }
 
-func (e InvalidStateError) Error() string {
+func (e InvalidEnumError) Error() string {
 	return fmt.Sprint("Value ", e.Value, " does not correspond to a valid enumeration for type ", e.Type)
 }
 
 // Unwrap returns the underlying error
-func (e InvalidStateError) Unwrap() error {
+func (e InvalidEnumError) Unwrap() error {
 	return e.Err
 }

--- a/pkg/graph/resolvers/it_gov_task_statuses.go
+++ b/pkg/graph/resolvers/it_gov_task_statuses.go
@@ -27,7 +27,7 @@ func IntakeFormStatus(intake *models.SystemIntake) (models.ITGovIntakeFormStatus
 	case models.SIRFSSubmitted:
 		return models.ITGISCompleted, nil
 	default: //This is included to be explicit. This should not technically happen in normal use, but it is technically possible as the type is a type alias for string
-		return "", apperrors.NewInvalidEnumError(fmt.Errorf("invalid state provided for the Intake form state"), intake.RequestFormState, "SystemIntakeFormState")
+		return "", apperrors.NewInvalidEnumError(fmt.Errorf("invalid has an invalid value for its intake form state"), intake.RequestFormState, "SystemIntakeFormState")
 	}
 }
 

--- a/pkg/graph/resolvers/it_gov_task_statuses.go
+++ b/pkg/graph/resolvers/it_gov_task_statuses.go
@@ -1,28 +1,33 @@
 package resolvers
 
-import "github.com/cmsgov/easi-app/pkg/models"
+import (
+	"fmt"
+
+	"github.com/cmsgov/easi-app/pkg/apperrors"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
 
 //NOTE these functions are deterministic. Ideally when implementing we should separate the logic which obtains any database information from the methods that calculate the status
 
 // IntakeFormStatus calculates the ITGovTaskListStatus of a system intake for the requester view
-func IntakeFormStatus(intake *models.SystemIntake) models.ITGovIntakeFormStatus {
+func IntakeFormStatus(intake *models.SystemIntake) (models.ITGovIntakeFormStatus, error) {
 	if intake.Step != models.SystemIntakeStepINITIALFORM {
-		return models.ITGISCompleted
+		return models.ITGISCompleted, nil
 	}
 	switch intake.RequestFormState {
 	case models.SIRFSNotStarted:
-		return models.ITGISReady
+		return models.ITGISReady, nil
 
 	case models.SIRFSInProgress:
-		return models.ITGISInProgress
+		return models.ITGISInProgress, nil
 
 	case models.SIRFSEditsRequested:
-		return models.ITGISEditsRequested
+		return models.ITGISEditsRequested, nil
 
 	case models.SIRFSSubmitted:
-		return models.ITGISCompleted
+		return models.ITGISCompleted, nil
 	default: //This is included to be explicit. This should not technically happen in normal use, but it is technically possible as the type is a type alias for string
-		return models.ITGISCompleted
+		return "", apperrors.NewInvalidEnumError(fmt.Errorf("invalid state provided for the Intake form state"), intake.RequestFormState, "SystemIntakeFormState")
 	}
 }
 

--- a/pkg/graph/resolvers/it_gov_task_statuses.go
+++ b/pkg/graph/resolvers/it_gov_task_statuses.go
@@ -6,7 +6,24 @@ import "github.com/cmsgov/easi-app/pkg/models"
 
 // IntakeFormStatus calculates the ITGovTaskListStatus of a system intake for the requester view
 func IntakeFormStatus(intake *models.SystemIntake) models.ITGovIntakeFormStatus {
-	return models.ITGISReady
+	if intake.Step != models.SystemIntakeStepINITIALFORM {
+		return models.ITGISCompleted
+	}
+	switch intake.RequestFormState {
+	case models.SIRFSNotStarted:
+		return models.ITGISReady
+
+	case models.SIRFSInProgress:
+		return models.ITGISInProgress
+
+	case models.SIRFSEditsRequested:
+		return models.ITGISEditsRequested
+
+	case models.SIRFSSubmitted:
+		return models.ITGISCompleted
+	default: //This is included to be explicit. This should not technically happen in normal use, but it is technically possible as the type is a type alias for string
+		return models.ITGISCompleted
+	}
 }
 
 // FeedbackFromInitialReviewStatus calculates the ITGovTaskListStatus for the feedback section of a system intake task list  for the requester view

--- a/pkg/graph/resolvers/it_gov_task_statuses_test.go
+++ b/pkg/graph/resolvers/it_gov_task_statuses_test.go
@@ -12,6 +12,7 @@ type testSystemIntakeFormStatusType struct {
 	testCase       string
 	intake         models.SystemIntake
 	expectedStatus models.ITGovIntakeFormStatus
+	expectError    bool
 }
 
 func TestIntakeFormStatus(t *testing.T) {
@@ -27,6 +28,7 @@ func TestIntakeFormStatus(t *testing.T) {
 				RequestFormState: models.SIRFSNotStarted,
 			},
 			expectedStatus: models.ITGISReady,
+			expectError:    false,
 		},
 		{
 			testCase: "Request form started",
@@ -35,6 +37,7 @@ func TestIntakeFormStatus(t *testing.T) {
 				RequestFormState: models.SIRFSInProgress,
 			},
 			expectedStatus: models.ITGISInProgress,
+			expectError:    false,
 		},
 		{
 			testCase: "Request form edits requested",
@@ -43,6 +46,7 @@ func TestIntakeFormStatus(t *testing.T) {
 				RequestFormState: models.SIRFSEditsRequested,
 			},
 			expectedStatus: models.ITGISEditsRequested,
+			expectError:    false,
 		},
 		{
 			testCase: "Request form submitted",
@@ -51,6 +55,7 @@ func TestIntakeFormStatus(t *testing.T) {
 				RequestFormState: models.SIRFSSubmitted,
 			},
 			expectedStatus: models.ITGISCompleted,
+			expectError:    false,
 		},
 		{
 			testCase: "Request form default case",
@@ -58,7 +63,8 @@ func TestIntakeFormStatus(t *testing.T) {
 				Step:             models.SystemIntakeStepINITIALFORM,
 				RequestFormState: defaultTestState,
 			},
-			expectedStatus: models.ITGISCompleted,
+			expectedStatus: "",
+			expectError:    true,
 		},
 
 		//Tests when the step is not the Intake form
@@ -69,6 +75,7 @@ func TestIntakeFormStatus(t *testing.T) {
 				RequestFormState: models.SIRFSNotStarted,
 			},
 			expectedStatus: models.ITGISCompleted,
+			expectError:    false,
 		},
 		{
 			testCase: "Request form started: not at intake form step",
@@ -77,6 +84,7 @@ func TestIntakeFormStatus(t *testing.T) {
 				RequestFormState: models.SIRFSInProgress,
 			},
 			expectedStatus: models.ITGISCompleted,
+			expectError:    false,
 		},
 		{
 			testCase: "Request form edits requested: not at intake form step",
@@ -85,6 +93,7 @@ func TestIntakeFormStatus(t *testing.T) {
 				RequestFormState: models.SIRFSEditsRequested,
 			},
 			expectedStatus: models.ITGISCompleted,
+			expectError:    false,
 		},
 		{
 			testCase: "Request form submitted: not at intake form step",
@@ -93,21 +102,29 @@ func TestIntakeFormStatus(t *testing.T) {
 				RequestFormState: models.SIRFSSubmitted,
 			},
 			expectedStatus: models.ITGISCompleted,
+			expectError:    false,
 		},
 		{
-			testCase: "Request form default case: not at intake form step",
+			testCase: "Request form default state: not at intake form step, expect complete",
 			intake: models.SystemIntake{
 				Step:             models.SystemIntakeStepGRBMEETING,
 				RequestFormState: defaultTestState,
 			},
 			expectedStatus: models.ITGISCompleted,
+			expectError:    false,
 		},
 	}
 
 	for _, test := range intakeFormTests {
 		t.Run(test.testCase, func(t *testing.T) {
-			status := IntakeFormStatus(&test.intake)
+			status, err := IntakeFormStatus(&test.intake)
 			assert.EqualValues(t, test.expectedStatus, status)
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
 		})
 	}
 

--- a/pkg/graph/resolvers/it_gov_task_statuses_test.go
+++ b/pkg/graph/resolvers/it_gov_task_statuses_test.go
@@ -1,18 +1,119 @@
 package resolvers
 
-import "github.com/cmsgov/easi-app/pkg/models"
+import (
+	"testing"
 
-// TODO: fullly implement the unit tests whent he status calculations have been developed. Store methods should ideally happen on a parent resolver, so the child requests can utilize the same object
-func (suite *ResolverSuite) TestIntakeFormStatus() {
-	intake := models.SystemIntake{
-		Status: models.SystemIntakeStatusCLOSED,
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+type testSystemIntakeFormStatusType struct {
+	testCase       string
+	intake         models.SystemIntake
+	expectedStatus models.ITGovIntakeFormStatus
+}
+
+func TestIntakeFormStatus(t *testing.T) {
+
+	defaultTestState := models.SystemIntakeFormState("Testing Default State")
+
+	intakeFormTests := []testSystemIntakeFormStatusType{
+		//Test cases when the step is the Intake Form
+		{
+			testCase: "Request form not started",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepINITIALFORM,
+				RequestFormState: models.SIRFSNotStarted,
+			},
+			expectedStatus: models.ITGISReady,
+		},
+		{
+			testCase: "Request form started",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepINITIALFORM,
+				RequestFormState: models.SIRFSInProgress,
+			},
+			expectedStatus: models.ITGISInProgress,
+		},
+		{
+			testCase: "Request form edits requested",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepINITIALFORM,
+				RequestFormState: models.SIRFSEditsRequested,
+			},
+			expectedStatus: models.ITGISEditsRequested,
+		},
+		{
+			testCase: "Request form submitted",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepINITIALFORM,
+				RequestFormState: models.SIRFSSubmitted,
+			},
+			expectedStatus: models.ITGISCompleted,
+		},
+		{
+			testCase: "Request form default case",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepINITIALFORM,
+				RequestFormState: defaultTestState,
+			},
+			expectedStatus: models.ITGISCompleted,
+		},
+
+		//Tests when the step is not the Intake form
+		{
+			testCase: "Request form not started: not at intake form step",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepGRBMEETING,
+				RequestFormState: models.SIRFSNotStarted,
+			},
+			expectedStatus: models.ITGISCompleted,
+		},
+		{
+			testCase: "Request form started: not at intake form step",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepGRBMEETING,
+				RequestFormState: models.SIRFSInProgress,
+			},
+			expectedStatus: models.ITGISCompleted,
+		},
+		{
+			testCase: "Request form edits requested: not at intake form step",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepGRBMEETING,
+				RequestFormState: models.SIRFSEditsRequested,
+			},
+			expectedStatus: models.ITGISCompleted,
+		},
+		{
+			testCase: "Request form submitted: not at intake form step",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepGRBMEETING,
+				RequestFormState: models.SIRFSSubmitted,
+			},
+			expectedStatus: models.ITGISCompleted,
+		},
+		{
+			testCase: "Request form default case: not at intake form step",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepGRBMEETING,
+				RequestFormState: defaultTestState,
+			},
+			expectedStatus: models.ITGISCompleted,
+		},
 	}
 
-	status := IntakeFormStatus(&intake)
-	suite.EqualValues(models.ITGISReady, status)
+	for _, test := range intakeFormTests {
+		t.Run(test.testCase, func(t *testing.T) {
+			status := IntakeFormStatus(&test.intake)
+			assert.EqualValues(t, test.expectedStatus, status)
+		})
+	}
 
 }
 
+// TODO: fullly implement the unit tests when the status calculations have been developed. Store methods should ideally happen on a parent resolver, so the child requests can utilize the same object
 func (suite *ResolverSuite) TestFeedbackFromInitialReviewStatus() {
 	intake := models.SystemIntake{
 		Status: models.SystemIntakeStatusCLOSED,

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -716,7 +716,7 @@ func (r *cedarThreatResolver) WeaknessRiskLevel(ctx context.Context, obj *models
 
 // IntakeFormStatus is the resolver for the intakeFormStatus field.
 func (r *iTGovTaskStatusesResolver) IntakeFormStatus(ctx context.Context, obj *models.ITGovTaskStatuses) (models.ITGovIntakeFormStatus, error) {
-	return resolvers.IntakeFormStatus(obj.ParentSystemIntake), nil
+	return resolvers.IntakeFormStatus(obj.ParentSystemIntake)
 }
 
 // FeedbackFromInitialReviewStatus is the resolver for the feedbackFromInitialReviewStatus field.


### PR DESCRIPTION
# EASI-2957

## Changes and Description

- Introduce Status Calculations for the Intake Form Status
   - Note, the function could be simplified, but I favored clarity instead of brevity. Please feel free to note if you disagree with the approach
- Introduce Unit tests for possible permutations of state and status

<!-- Put a description here! -->

## How to test this change
1. Run all the unit tests


If you desire to test this manually, you can use the postman collection to do the following
1. Create a system Intake
2. Retrieve a system intake
3. Use SQL to update the system intakes step and intake form state to verify that the correct status is displayed.
    a. Note, currently the intake form state is not updated by current actions. That functionality will be added  in a future ticket. 

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
