### PR TITLE
[Easi 2958] - feedback from initial review status calculation

### DIFF
--- a/pkg/graph/resolvers/it_gov_task_statuses.go
+++ b/pkg/graph/resolvers/it_gov_task_statuses.go
@@ -33,20 +33,20 @@ func IntakeFormStatus(intake *models.SystemIntake) (models.ITGovIntakeFormStatus
 
 // FeedbackFromInitialReviewStatus calculates the ITGovTaskListStatus for the feedback section of a system intake task list  for the requester view
 func FeedbackFromInitialReviewStatus(intake *models.SystemIntake) (models.ITGovFeedbackStatus, error) {
-	if intake.Step != models.SystemIntakeStepINITIALFORM {
+	if intake.Step != models.SystemIntakeStepINITIALFORM { // If the step is past the initial form, the review is complete
 		return models.ITGFBSCompleted, nil
 	}
 	switch intake.RequestFormState {
-	case models.SIRFSNotStarted, models.SIRFSInProgress:
+	case models.SIRFSNotStarted, models.SIRFSInProgress: // If the form is just in progress, or not started, the review can't start yet
 		return models.ITGFBSCantStart, nil
 
-	case models.SIRFSSubmitted:
+	case models.SIRFSSubmitted: //If the request form has been submitted, it show now show in_review for the feedback step
 		return models.ITGFBSInReview, nil
 
-	case models.SIRFSEditsRequested: // Note, if the state changes back to in_progress, this status will be CANT_START
+	case models.SIRFSEditsRequested: // If the form has edits requested, review has happened and is complete.
 		return models.ITGFBSCompleted, nil
 
-	default: //This is included to be explicit. This should not technically happen in normal use, but it is technically possible as the type is a type alias for string
+	default: // The enum is invalid. This is included to be explicit. This should not technically happen in normal use, but it is technically possible as the type is a type alias for string
 		return "", apperrors.NewInvalidEnumError(fmt.Errorf("intake has an invalid value for its intake form state"), intake.RequestFormState, "SystemIntakeFormState")
 	}
 

--- a/pkg/graph/resolvers/it_gov_task_statuses.go
+++ b/pkg/graph/resolvers/it_gov_task_statuses.go
@@ -27,13 +27,30 @@ func IntakeFormStatus(intake *models.SystemIntake) (models.ITGovIntakeFormStatus
 	case models.SIRFSSubmitted:
 		return models.ITGISCompleted, nil
 	default: //This is included to be explicit. This should not technically happen in normal use, but it is technically possible as the type is a type alias for string
-		return "", apperrors.NewInvalidEnumError(fmt.Errorf("invalid has an invalid value for its intake form state"), intake.RequestFormState, "SystemIntakeFormState")
+		return "", apperrors.NewInvalidEnumError(fmt.Errorf("intake has an invalid value for its intake form state"), intake.RequestFormState, "SystemIntakeFormState")
 	}
 }
 
 // FeedbackFromInitialReviewStatus calculates the ITGovTaskListStatus for the feedback section of a system intake task list  for the requester view
-func FeedbackFromInitialReviewStatus(intake *models.SystemIntake) models.ITGovFeedbackStatus {
-	return models.ITGFBSCantStart
+func FeedbackFromInitialReviewStatus(intake *models.SystemIntake) (models.ITGovFeedbackStatus, error) {
+	if intake.Step != models.SystemIntakeStepINITIALFORM || intake.RequestFormState == models.SIRFSEditsRequested { // If it isn't at the initial form state, or it has
+		return models.ITGFBSCompleted, nil
+	}
+
+	// Step == initial form
+
+	// Form is in progress or not stated
+	if intake.RequestFormState == models.SIRFSInProgress || intake.RequestFormState == models.SIRFSNotStarted {
+		return models.ITGFBSCantStart, nil
+	}
+
+	// Form was been submitted
+	if intake.RequestFormState == models.SIRFSSubmitted {
+		return models.ITGFBSInReview, nil
+	}
+
+	return "", apperrors.NewInvalidEnumError(fmt.Errorf("intake has an invalid value for its intake form state"), intake.RequestFormState, "SystemIntakeFormState")
+
 }
 
 // BizCaseDraftStatus calculates the ITGovDraftBusinessCaseStatus for the BizCaseDraft section for the system intake task list for the requester view

--- a/pkg/graph/resolvers/it_gov_task_statuses_test.go
+++ b/pkg/graph/resolvers/it_gov_task_statuses_test.go
@@ -136,9 +136,10 @@ func (suite *ResolverSuite) TestFeedbackFromInitialReviewStatus() {
 		Status: models.SystemIntakeStatusCLOSED,
 	}
 
-	status := FeedbackFromInitialReviewStatus(&intake)
+	status, err := FeedbackFromInitialReviewStatus(&intake)
 
 	suite.EqualValues(models.ITGFBSCantStart, status)
+	suite.NoError(err)
 
 }
 func (suite *ResolverSuite) TestDecisionAndNextStepsStatus() {

--- a/pkg/graph/resolvers/it_gov_task_statuses_test.go
+++ b/pkg/graph/resolvers/it_gov_task_statuses_test.go
@@ -136,7 +136,6 @@ func TestIntakeFormStatus(t *testing.T) {
 
 }
 
-// TODO: fullly implement the unit tests when the status calculations have been developed. Store methods should ideally happen on a parent resolver, so the child requests can utilize the same object
 func TestFeedbackFromInitialReviewStatus(t *testing.T) {
 	defaultTestState := models.SystemIntakeFormState("Testing Default State")
 

--- a/pkg/graph/resolvers/it_gov_task_statuses_test.go
+++ b/pkg/graph/resolvers/it_gov_task_statuses_test.go
@@ -14,6 +14,12 @@ type testSystemIntakeFormStatusType struct {
 	expectedStatus models.ITGovIntakeFormStatus
 	expectError    bool
 }
+type testSystemIntakeFormFeedbackStatusType struct {
+	testCase       string
+	intake         models.SystemIntake
+	expectedStatus models.ITGovFeedbackStatus
+	expectError    bool
+}
 
 func TestIntakeFormStatus(t *testing.T) {
 
@@ -131,15 +137,118 @@ func TestIntakeFormStatus(t *testing.T) {
 }
 
 // TODO: fullly implement the unit tests when the status calculations have been developed. Store methods should ideally happen on a parent resolver, so the child requests can utilize the same object
-func (suite *ResolverSuite) TestFeedbackFromInitialReviewStatus() {
-	intake := models.SystemIntake{
-		Status: models.SystemIntakeStatusCLOSED,
+func TestFeedbackFromInitialReviewStatus(t *testing.T) {
+	defaultTestState := models.SystemIntakeFormState("Testing Default State")
+
+	intakeFormFeedbackTests := []testSystemIntakeFormFeedbackStatusType{
+		//Test cases when the step is the Intake Form
+		{
+			testCase: "Request form not started",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepINITIALFORM,
+				RequestFormState: models.SIRFSNotStarted,
+			},
+			expectedStatus: models.ITGFBSCantStart,
+			expectError:    false,
+		},
+		{
+			testCase: "Request form started",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepINITIALFORM,
+				RequestFormState: models.SIRFSInProgress,
+			},
+			expectedStatus: models.ITGFBSCantStart,
+			expectError:    false,
+		},
+		{
+			testCase: "Request form Submitted",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepINITIALFORM,
+				RequestFormState: models.SIRFSSubmitted,
+			},
+			expectedStatus: models.ITGFBSInReview,
+			expectError:    false,
+		},
+
+		{
+			testCase: "Request form edits requested",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepINITIALFORM,
+				RequestFormState: models.SIRFSEditsRequested,
+			},
+			expectedStatus: models.ITGFBSCompleted,
+			expectError:    false,
+		},
+		{
+			testCase: "Request form default case",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepINITIALFORM,
+				RequestFormState: defaultTestState,
+			},
+			expectedStatus: "",
+			expectError:    true,
+		},
+
+		//Tests when the step is not the Intake form
+		{
+			testCase: "Request form not started: not at intake form step",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepGRBMEETING,
+				RequestFormState: models.SIRFSNotStarted,
+			},
+			expectedStatus: models.ITGFBSCompleted,
+			expectError:    false,
+		},
+		{
+			testCase: "Request form started: not at intake form step",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepGRBMEETING,
+				RequestFormState: models.SIRFSInProgress,
+			},
+			expectedStatus: models.ITGFBSCompleted,
+			expectError:    false,
+		},
+		{
+			testCase: "Request form edits requested: not at intake form step",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepGRBMEETING,
+				RequestFormState: models.SIRFSEditsRequested,
+			},
+			expectedStatus: models.ITGFBSCompleted,
+			expectError:    false,
+		},
+		{
+			testCase: "Request form submitted: not at intake form step",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepGRBMEETING,
+				RequestFormState: models.SIRFSSubmitted,
+			},
+			expectedStatus: models.ITGFBSCompleted,
+			expectError:    false,
+		},
+		{
+			testCase: "Request form default state: not at intake form step, expect complete",
+			intake: models.SystemIntake{
+				Step:             models.SystemIntakeStepGRBMEETING,
+				RequestFormState: defaultTestState,
+			},
+			expectedStatus: models.ITGFBSCompleted,
+			expectError:    false,
+		},
 	}
 
-	status, err := FeedbackFromInitialReviewStatus(&intake)
+	for _, test := range intakeFormFeedbackTests {
+		t.Run(test.testCase, func(t *testing.T) {
+			status, err := FeedbackFromInitialReviewStatus(&test.intake)
+			assert.EqualValues(t, test.expectedStatus, status)
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 
-	suite.EqualValues(models.ITGFBSCantStart, status)
-	suite.NoError(err)
+		})
+	}
 
 }
 func (suite *ResolverSuite) TestDecisionAndNextStepsStatus() {

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -721,7 +721,7 @@ func (r *iTGovTaskStatusesResolver) IntakeFormStatus(ctx context.Context, obj *m
 
 // FeedbackFromInitialReviewStatus is the resolver for the feedbackFromInitialReviewStatus field.
 func (r *iTGovTaskStatusesResolver) FeedbackFromInitialReviewStatus(ctx context.Context, obj *models.ITGovTaskStatuses) (models.ITGovFeedbackStatus, error) {
-	return resolvers.FeedbackFromInitialReviewStatus(obj.ParentSystemIntake), nil
+	return resolvers.FeedbackFromInitialReviewStatus(obj.ParentSystemIntake)
 }
 
 // BizCaseDraftStatus is the resolver for the bizCaseDraftStatus field.


### PR DESCRIPTION
# EASI-2958

## Changes and Description

- Introduce Status Calculations for the Intake Form Feedback Status
   - Note figma shows a date feedback was submitted, but it was determined that will be a future iteration. As such, the status is solely implemented based on the state of the intake form.
- Introduce Unit tests for possible permutations of state and status

<!-- Put a description here! -->

## How to test this change

If you desire to test this manually, you can use the postman collection to do the following
1. Create a system Intake
2. Retrieve a system intake
3. Use SQL to update the system intakes step and intake form state to verify that the correct status is displayed.
    a. Note, currently the intake form state is not updated by current actions. That functionality will be added  in a future ticket. 


## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
