### PR TITLE
[EASI-2886] - Decision and Next Steps status implementation

### DIFF
--- a/pkg/graph/resolvers/it_gov_task_statuses_test.go
+++ b/pkg/graph/resolvers/it_gov_task_statuses_test.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -12,6 +13,13 @@ type testSystemIntakeFormStatusType struct {
 	testCase       string
 	intake         models.SystemIntake
 	expectedStatus models.ITGovIntakeFormStatus
+	expectError    bool
+}
+
+type testSystemIntakeDecisionStateStatusType struct {
+	testCase       string
+	intake         models.SystemIntake
+	expectedStatus models.ITGovDecisionStatus
 	expectError    bool
 }
 
@@ -141,14 +149,121 @@ func (suite *ResolverSuite) TestFeedbackFromInitialReviewStatus() {
 	suite.EqualValues(models.ITGFBSCantStart, status)
 
 }
-func (suite *ResolverSuite) TestDecisionAndNextStepsStatus() {
-	intake := models.SystemIntake{
-		Status: models.SystemIntakeStatusCLOSED,
+func TestDecisionAndNextStepsStatus(t *testing.T) {
+	yesterday := time.Now().Add(time.Hour * -24)
+	tomorrow := time.Now().Add(time.Hour * 24)
+
+	decisionStateTests := []testSystemIntakeDecisionStateStatusType{
+		{
+			testCase: "Request form not started",
+			intake: models.SystemIntake{
+				Step: models.SystemIntakeStepINITIALFORM,
+			},
+			expectedStatus: models.ITGDSCantStart,
+			expectError:    false,
+		},
+		{
+			testCase: "Draft Business Case",
+			intake: models.SystemIntake{
+				Step: models.SystemIntakeStepDRAFTBIZCASE,
+			},
+			expectedStatus: models.ITGDSCantStart,
+			expectError:    false,
+		},
+		{
+			testCase: "GRT Meeting",
+			intake: models.SystemIntake{
+				Step: models.SystemIntakeStepGRTMEETING,
+			},
+			expectedStatus: models.ITGDSCantStart,
+			expectError:    false,
+		},
+		{
+			testCase: "Final Business Case",
+			intake: models.SystemIntake{
+				Step: models.SystemIntakeStepFINALBIZCASE,
+			},
+			expectedStatus: models.ITGDSCantStart,
+			expectError:    false,
+		},
+		//Testing GRB Meeting States
+		{
+			testCase: "GRB Meeting: no meeting scheduled",
+			intake: models.SystemIntake{
+				Step:    models.SystemIntakeStepGRBMEETING,
+				GRBDate: nil,
+			},
+			expectedStatus: models.ITGDSCantStart,
+			expectError:    false,
+		},
+		{
+			testCase: "GRB Meeting: meeting scheduled, but hasn't happened",
+			intake: models.SystemIntake{
+				Step:    models.SystemIntakeStepGRBMEETING,
+				GRBDate: &tomorrow,
+			},
+			expectedStatus: models.ITGDSCantStart,
+			expectError:    false,
+		},
+		{
+			testCase: "GRB Meeting: meeting scheduled, it already happened",
+			intake: models.SystemIntake{
+				Step:    models.SystemIntakeStepGRBMEETING,
+				GRBDate: &yesterday,
+			},
+			expectedStatus: models.ITGDSInReview,
+			expectError:    false,
+		},
+		{
+			testCase: "Decision issued step: LCID Issued",
+			intake: models.SystemIntake{
+				Step:          models.SystemIntakeStepDECISION,
+				DecisionState: models.SIDSLcidIssued,
+			},
+			expectedStatus: models.ITGDSCompleted,
+			expectError:    false,
+		},
+		{
+			testCase: "Decision issued step: Not Approved",
+			intake: models.SystemIntake{
+				Step:          models.SystemIntakeStepDECISION,
+				DecisionState: models.SIDSNotApproved,
+			},
+			expectedStatus: models.ITGDSCompleted,
+			expectError:    false,
+		},
+		{
+			testCase: "Decision issued step: Not an IT Governance Request",
+			intake: models.SystemIntake{
+				Step:          models.SystemIntakeStepDECISION,
+				DecisionState: models.SIDSNotGovernance,
+			},
+			expectedStatus: models.ITGDSCompleted,
+			expectError:    false,
+		},
+		{
+			testCase: "Decision issued step: No decision issued",
+			intake: models.SystemIntake{
+				Step:          models.SystemIntakeStepDECISION,
+				DecisionState: models.SIDSNoDecision,
+			},
+			expectedStatus: "",
+			expectError:    true,
+		},
 	}
 
-	status := DecisionAndNextStepsStatus(&intake)
+	for _, test := range decisionStateTests {
+		t.Run(test.testCase, func(t *testing.T) {
+			status, err := DecisionAndNextStepsStatus(&test.intake)
+			assert.EqualValues(t, test.expectedStatus, status)
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 
-	suite.EqualValues(models.ITGDSCantStart, status)
+		})
+	}
 
 }
 func (suite *ResolverSuite) TestBizCaseDraftStatus() {

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -746,7 +746,7 @@ func (r *iTGovTaskStatusesResolver) GrbMeetingStatus(ctx context.Context, obj *m
 
 // DecisionAndNextStepsStatus is the resolver for the decisionAndNextStepsStatus field.
 func (r *iTGovTaskStatusesResolver) DecisionAndNextStepsStatus(ctx context.Context, obj *models.ITGovTaskStatuses) (models.ITGovDecisionStatus, error) {
-	return resolvers.DecisionAndNextStepsStatus(obj.ParentSystemIntake), nil
+	return resolvers.DecisionAndNextStepsStatus(obj.ParentSystemIntake)
 }
 
 // AddGRTFeedbackAndKeepBusinessCaseInDraft is the resolver for the addGRTFeedbackAndKeepBusinessCaseInDraft field.


### PR DESCRIPTION

# EASI-2886

## Changes and Description

- Introduce Status Calculations for the Decision and Next Steps Status
   - Technically, this (and the other calculations) doesn't verify that the intake.Step is a valid enum. We could add that additional verification, but I don't think that level of granularity is needed at this level
- Introduce Unit tests for possible permutations of state and status

<!-- Put a description here! -->

## How to test this change

If you desire to test this manually, you can use the postman collection to do the following
1. Create a system Intake
2. Retrieve a system intake
3. Use SQL to update the system intakes step, GRB Date, and decision state to verify that the correct status is displayed.
    a. Note, state is not updated by current actions. That functionality will be added  in a future ticket. 


## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
