### PR TITLE
EASI-3138: Build Frontend Assets in parallel

### DIFF
--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  prepare_deploy:
     runs-on: ubuntu-latest
     environment: ${{ inputs.env }}
     env:
@@ -44,6 +44,38 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-west-2
+      - name: Announce failure
+        if: ${{ failure() }}
+        run: |
+          ./scripts/github-action-announce-broken-branch
+  
+  build_frontend_assets:
+    needs: prepare_deploy
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.env }}
+    env:
+      APP_ENV: ${{ inputs.env }}
+    steps:
+      - name: Build Frontend Assets
+        env:
+          LD_CLIENT_ID: ${{ secrets.LD_CLIENT_ID }}
+          OKTA_CLIENT_ID: ${{ secrets.OKTA_CLIENT_ID }}
+          OKTA_SERVER_ID: ${{ secrets.OKTA_SERVER_ID }}
+          STATIC_S3_BUCKET: ${{ secrets.STATIC_S3_BUCKET }}
+        run: |
+          ./scripts/build_static.sh
+      - name: Announce failure
+        if: ${{ failure() }}
+        run: |
+          ./scripts/github-action-announce-broken-branch
+
+  database_actions:
+    needs: prepare_deploy
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.env }}
+    env:
+      APP_ENV: ${{ inputs.env }}
+    steps:    
       - name: Clean the database
         if: ${{ contains(inputs.env, 'dev') && vars.ENABLE_DEV_DB_CLEAN == '1' }}
         env:
@@ -71,6 +103,18 @@ jobs:
         run: |
           export TASK_REVISION=$(./scripts/update_ecs_task_definition.sh)
           ./scripts/run_ecs_task.sh
+      - name: Announce failure
+        if: ${{ failure() }}
+        run: |
+          ./scripts/github-action-announce-broken-branch
+
+  deploy_backend:
+    needs: [prepare_deploy, database_actions]
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.env }}
+    env:
+      APP_ENV: ${{ inputs.env }}
+    steps:
       - name: Deploy EASI ECS service
         env:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
@@ -88,11 +132,20 @@ jobs:
           NEW_IMAGE_TAG: ${{ env.GIT_HASH }}
         run: |
           ./scripts/healthcheck "$NEW_IMAGE_TAG"
-      - name: Build static assets and release to S3
+      - name: Announce failure
+        if: ${{ failure() }}
+        run: |
+          ./scripts/github-action-announce-broken-branch
+  
+  deploy_frontend:
+    needs: [prepare_deploy, build_frontend_assets]
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.env }}
+    env:
+      APP_ENV: ${{ inputs.env }}
+    steps:
+      - name: Release assets to S3
         env:
-          LD_CLIENT_ID: ${{ secrets.LD_CLIENT_ID }}
-          OKTA_CLIENT_ID: ${{ secrets.OKTA_CLIENT_ID }}
-          OKTA_SERVER_ID: ${{ secrets.OKTA_SERVER_ID }}
           STATIC_S3_BUCKET: ${{ secrets.STATIC_S3_BUCKET }}
         run: |
           ./scripts/release_static

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -148,7 +148,7 @@ jobs:
         env:
           STATIC_S3_BUCKET: ${{ secrets.STATIC_S3_BUCKET }}
         run: |
-          ./scripts/release_static
+          ./scripts/release_static.sh
       - name: Announce failure
         if: ${{ failure() }}
         run: |

--- a/scripts/build_static.sh
+++ b/scripts/build_static.sh
@@ -32,20 +32,11 @@ export REACT_APP_OKTA_REDIRECT_URI="${EASI_URL}/implicit/callback"
 export REACT_APP_API_ADDRESS="${EASI_URL}/api/v1"
 export REACT_APP_GRAPHQL_ADDRESS="${EASI_URL}/api/graph/query"
 
-# Check if we have any access to the s3 bucket
-# Since `s3 ls` returns zero even if the command failed, we assume failure if this command prints anything to stderr
-s3_err="$(aws s3 ls "$STATIC_S3_BUCKET" 1>/dev/null 2>&1)"
-if [[ -z "$s3_err" ]] ; then
-  ( set -x -u ;
-    yarn install --frozen-lockfile
-    yarn run build || exit
-    aws s3 sync --no-progress --delete build/ s3://"$STATIC_S3_BUCKET"/
-  )
-else
-  echo "+ aws s3 ls $STATIC_S3_BUCKET"
-  echo "$s3_err"
-  echo "--"
-  echo "Error reading the S3 bucket. Are you authenticated?" 1>&2
-  exit 1
-fi
+# Build the application
+( 
+  set -x -u ;
+  yarn install --frozen-lockfile
+  yarn run build || exit
+)
+
 

--- a/scripts/release_static.sh
+++ b/scripts/release_static.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+
+set -eu -o pipefail
+
+# Check if we have any access to the s3 bucket
+# Since `s3 ls` returns zero even if the command failed, we assume failure if this command prints anything to stderr
+s3_err="$(aws s3 ls "$STATIC_S3_BUCKET" 1>/dev/null 2>&1)"
+if [[ -z "$s3_err" ]] ; then
+  ( set -x -u ;
+    aws s3 sync --no-progress --delete build/ s3://"$STATIC_S3_BUCKET"/
+  )
+else
+  echo "+ aws s3 ls $STATIC_S3_BUCKET"
+  echo "$s3_err"
+  echo "--"
+  echo "Error reading the S3 bucket. Are you authenticated?" 1>&2
+  exit 1
+fi
+


### PR DESCRIPTION
# EASI-3138

## Changes and Description

- Separate the release_static script into two scripts:
  - build_static.sh and release_static.sh
- Reorganize deployment workflow to leverage being able to build frontend in parallel with DB actions

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
