### PR TITLE
[NOREF] Remove fetchUserInfo from CreateTRBRequest resolver

### DIFF
--- a/cmd/devdata/trb_request.go
+++ b/cmd/devdata/trb_request.go
@@ -373,7 +373,7 @@ func (s *seederConfig) seedTRBWithForm(ctx context.Context, trbName *string, isS
 }
 
 func (s *seederConfig) addTRBRequest(ctx context.Context, rType models.TRBRequestType, name *string) (*models.TRBRequest, error) {
-	trb, err := resolvers.CreateTRBRequest(ctx, rType, mock.FetchUserInfoMock, s.store)
+	trb, err := resolvers.CreateTRBRequest(ctx, rType, s.store)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/graph/resolvers/trb_advice_letter_recommendation_test.go
+++ b/pkg/graph/resolvers/trb_advice_letter_recommendation_test.go
@@ -17,7 +17,7 @@ func (s *ResolverSuite) TestTRBAdviceLetterRecommendationCRUD() {
 	trbRequest := models.NewTRBRequest(anonEua)
 	trbRequest.Type = models.TRBTNeedHelp
 	trbRequest.State = models.TRBRequestStateOpen
-	trbRequest, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, store)
+	trbRequest, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, store)
 	s.NoError(err)
 
 	s.Run("create/update/fetch TRB request feedback", func() {

--- a/pkg/graph/resolvers/trb_request.go
+++ b/pkg/graph/resolvers/trb_request.go
@@ -19,16 +19,9 @@ import (
 func CreateTRBRequest(
 	ctx context.Context,
 	requestType models.TRBRequestType,
-	fetchUserInfo func(context.Context, string) (*models.UserInfo, error),
 	store *storage.Store,
 ) (*models.TRBRequest, error) {
 	princ := appcontext.Principal(ctx)
-
-	// Fetch user info for the "requester" attendee
-	requester, err := fetchUserInfo(ctx, princ.ID())
-	if err != nil {
-		return nil, err
-	}
 
 	trb := models.NewTRBRequest(princ.ID())
 	trb.Type = requestType
@@ -42,11 +35,11 @@ func CreateTRBRequest(
 	// This should probably be a part of a transaction...
 	initialAttendee := &models.TRBRequestAttendee{
 		TRBRequestID: createdTRB.ID,
-		EUAUserID:    requester.EuaUserID,
+		EUAUserID:    princ.ID(),
 		Component:    nil,
 		Role:         nil,
 	}
-	initialAttendee.CreatedBy = appcontext.Principal(ctx).ID()
+	initialAttendee.CreatedBy = princ.ID()
 	_, err = store.CreateTRBRequestAttendee(ctx, initialAttendee)
 	if err != nil {
 		return nil, err

--- a/pkg/graph/resolvers/trb_request_attendee_test.go
+++ b/pkg/graph/resolvers/trb_request_attendee_test.go
@@ -46,7 +46,7 @@ func (s *ResolverSuite) TestCreateTRBRequestAttendee() {
 	trbRequest := models.NewTRBRequest(anonEua)
 	trbRequest.Type = models.TRBTNeedHelp
 	trbRequest.State = models.TRBRequestStateOpen
-	trbRequest, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trbRequest, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 
 	s.Run("fetches TRB request attendees (default attendee should exist)", func() {

--- a/pkg/graph/resolvers/trb_request_document_test.go
+++ b/pkg/graph/resolvers/trb_request_document_test.go
@@ -12,7 +12,7 @@ import (
 
 func (suite *ResolverSuite) TestTRBRequestDocumentResolvers() {
 	// general setup
-	trbRequest, err := CreateTRBRequest(suite.testConfigs.Context, models.TRBTFormalReview, suite.fetchUserInfoStub, suite.testConfigs.Store)
+	trbRequest, err := CreateTRBRequest(suite.testConfigs.Context, models.TRBTFormalReview, suite.testConfigs.Store)
 	suite.NoError(err)
 	suite.NotNil(trbRequest)
 	trbRequestID := trbRequest.ID

--- a/pkg/graph/resolvers/trb_request_feedback_test.go
+++ b/pkg/graph/resolvers/trb_request_feedback_test.go
@@ -67,7 +67,7 @@ func (s *ResolverSuite) TestCreateTRBRequestFeedback() {
 	trbRequest := models.NewTRBRequest(anonEua)
 	trbRequest.Type = models.TRBTNeedHelp
 	trbRequest.State = models.TRBRequestStateOpen
-	trbRequest, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, store)
+	trbRequest, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, store)
 	s.NoError(err)
 
 	form, err := GetTRBRequestFormByTRBRequestID(ctx, store, trbRequest.ID)

--- a/pkg/graph/resolvers/trb_request_form_funding_sources_test.go
+++ b/pkg/graph/resolvers/trb_request_form_funding_sources_test.go
@@ -17,7 +17,7 @@ func (s *ResolverSuite) TestModifyTRBFundingSources() {
 	trbRequest := models.NewTRBRequest(anonEua)
 	trbRequest.Type = models.TRBTNeedHelp
 	trbRequest.State = models.TRBRequestStateOpen
-	trbRequest, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trbRequest, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 
 	s.Run("create/fetch/update/delete TRB request form funding sources", func() {

--- a/pkg/graph/resolvers/trb_request_form_test.go
+++ b/pkg/graph/resolvers/trb_request_form_test.go
@@ -47,7 +47,7 @@ func (s *ResolverSuite) TestCreateTRBRequestForm() {
 	trbRequest := models.NewTRBRequest(anonEua)
 	trbRequest.Type = models.TRBTNeedHelp
 	trbRequest.State = models.TRBRequestStateOpen
-	trbRequest, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trbRequest, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 
 	s.Run("create/update/fetch TRB request forms", func() {

--- a/pkg/graph/resolvers/trb_request_status_test.go
+++ b/pkg/graph/resolvers/trb_request_status_test.go
@@ -67,7 +67,7 @@ func (s *ResolverSuite) TestTRBRequestStatus() {
 	trb := models.NewTRBRequest(anonEua)
 	trb.Type = models.TRBTNeedHelp
 	trb.State = models.TRBRequestStateOpen
-	trb, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trb, err = CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 
 	s.Run("status is correctly calculated as TRB tasks are performed", func() {

--- a/pkg/graph/resolvers/trb_request_system_intake_test.go
+++ b/pkg/graph/resolvers/trb_request_system_intake_test.go
@@ -18,7 +18,7 @@ func (s *ResolverSuite) TestTRBRequestLCID() {
 	trbRequest := models.NewTRBRequest(anonEua)
 	trbRequest.Type = models.TRBTNeedHelp
 	trbRequest.State = models.TRBRequestStateOpen
-	trbRequest, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, store)
+	trbRequest, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, store)
 	s.NoError(err)
 
 	lcids := []string{"111111", "111222", "111333"}

--- a/pkg/graph/resolvers/trb_request_test.go
+++ b/pkg/graph/resolvers/trb_request_test.go
@@ -15,7 +15,7 @@ import (
 // TestCreateTRBRequest makes a new TRB request
 func (s *ResolverSuite) TestCreateTRBRequest() {
 	//TODO get the context in the test configs
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 
@@ -31,7 +31,7 @@ func (s *ResolverSuite) TestCreateTRBRequest() {
 
 // TestUpdateTRBRequest updates a TRB request
 func (s *ResolverSuite) TestUpdateTRBRequest() {
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 
@@ -54,7 +54,7 @@ func (s *ResolverSuite) TestUpdateTRBRequest() {
 
 // TestGetTRBRequestByID returns a TRB request by it's ID
 func (s *ResolverSuite) TestGetTRBRequestByID() {
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 
@@ -78,7 +78,7 @@ func (s *ResolverSuite) TestGetTRBRequests() {
 	ctxABCD = appcontext.WithPrincipal(ctxABCD, principalABCD)
 
 	// Create a TRB request with TEST
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 
@@ -89,7 +89,7 @@ func (s *ResolverSuite) TestGetTRBRequests() {
 	s.EqualValues(trb, col[0])
 
 	// Create a TRB request under ABCD
-	trb2, err := CreateTRBRequest(ctxABCD, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trb2, err := CreateTRBRequest(ctxABCD, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb2)
 	//Check for 2 request
@@ -128,7 +128,7 @@ func (s *ResolverSuite) TestGetMyTRBRequests() {
 	ctxABCD = appcontext.WithPrincipal(ctxABCD, principalABCD)
 
 	// Create a TRB request with TEST
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 
@@ -144,7 +144,7 @@ func (s *ResolverSuite) TestGetMyTRBRequests() {
 	s.Len(col, 0)
 
 	// Create a TRB request under ABCD
-	trb2, err := CreateTRBRequest(ctxABCD, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trb2, err := CreateTRBRequest(ctxABCD, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb2)
 
@@ -183,7 +183,7 @@ func (s *ResolverSuite) TestGetMyTRBRequests() {
 
 // TestUpdateTRBRequestConsultMeetingTime tests the scheduling of consult meeting
 func (s *ResolverSuite) TestUpdateTRBRequestConsultMeetingTime() {
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 
@@ -229,7 +229,7 @@ func (s *ResolverSuite) TestUpdateTRBRequestConsultMeetingTime() {
 
 // TestUpdateTRBRequestTRBLead tests the scheduling of consult meeting
 func (s *ResolverSuite) TestUpdateTRBRequestTRBLead() {
-	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.fetchUserInfoStub, s.testConfigs.Store)
+	trb, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTBrainstorm, s.testConfigs.Store)
 	s.NoError(err)
 	s.NotNil(trb)
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1930,7 +1930,7 @@ func (r *mutationResolver) SendReportAProblemEmail(ctx context.Context, input mo
 
 // CreateTRBRequest is the resolver for the createTRBRequest field.
 func (r *mutationResolver) CreateTRBRequest(ctx context.Context, requestType models.TRBRequestType) (*models.TRBRequest, error) {
-	return resolvers.CreateTRBRequest(ctx, requestType, r.service.FetchUserInfo, r.store)
+	return resolvers.CreateTRBRequest(ctx, requestType, r.store)
 }
 
 // UpdateTRBRequest is the resolver for the updateTRBRequest field.


### PR DESCRIPTION
# NOREF

## Changes and Description

- Remove calls to `fetchUserInfo` when creating TRB Requests
- Remove extra call to fetch principal from context, instead using existing principal object in resolver

## How to test this change

- `scripts/dev up` to start the server
- Log in to the UI
- Create a TRB request
- Ensure that requester information (and default attendee) is correct - check in the DB directly if you want!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
