### PR TITLE
EASI-3160: Use pre-built frontend assets in E2E test step

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,13 @@ jobs:
     uses: ./.github/workflows/build_application_images.yml
     secrets: inherit
 
+  Build_Test_Frontend_Assets:
+    uses: ./.github/workflows/build_frontend_assets.yml
+    secrets: inherit
+    with:
+      env: test
+
   Run_Tests:
     uses: ./.github/workflows/run_tests.yml
-    needs: Build_Application_Images
+    needs: [Build_Application_Images,Build_Test_Frontend_Assets]
     secrets: inherit

--- a/.github/workflows/build_frontend_assets.yml
+++ b/.github/workflows/build_frontend_assets.yml
@@ -38,7 +38,6 @@ jobs:
           LD_CLIENT_ID: ${{ secrets.LD_CLIENT_ID }}
           OKTA_CLIENT_ID: ${{ secrets.OKTA_CLIENT_ID }}
           OKTA_SERVER_ID: ${{ secrets.OKTA_SERVER_ID }}
-          STATIC_S3_BUCKET: ${{ secrets.STATIC_S3_BUCKET }}
         run: |
           ./scripts/build_static.sh
       - name: Upload Frontend assets

--- a/.github/workflows/deploy_pipeline.yml
+++ b/.github/workflows/deploy_pipeline.yml
@@ -20,13 +20,19 @@ jobs:
     with:
       env: ${{ matrix.env }}
 
+  Build_Test_Frontend_Assets:
+    uses: ./.github/workflows/build_frontend_assets.yml
+    secrets: inherit
+    with:
+      env: test
+
   Build_Application_Images:
     uses: ./.github/workflows/build_application_images.yml
     secrets: inherit
 
   Run_Tests:
     uses: ./.github/workflows/run_tests.yml
-    needs: Build_Application_Images
+    needs: [Build_Application_Images,Build_Test_Frontend_Assets]
     secrets: inherit
 
   deploy_dev:

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -37,10 +37,18 @@ jobs:
     secrets: inherit
     with:
       env: ${{ inputs.env }}
+  
+  Build_Test_Frontend_Assets:
+    if: ${{ inputs.skip_tests == false }}
+    uses: ./.github/workflows/build_frontend_assets.yml
+    secrets: inherit
+    with:
+      env: test
+
 
   Run_Tests:
     uses: ./.github/workflows/run_tests.yml
-    needs: Build_Application_Images
+    needs: [Build_Application_Images, Build_Test_Frontend_Assets]
     secrets: inherit
     with:
       skip_tests: ${{ inputs.skip_tests }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -112,25 +112,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ env.GIT_HASH }}
-      - name: Set up node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.EASI_APP_NODE_VERSION }}
-          cache: 'yarn'
-      - name: Install yarn dependencies
-        run: yarn install --frozen-lockfile
-      - name: Build frontend code
-        env:
-          REACT_APP_API_ADDRESS: http://easi:8080/api/v1
-          REACT_APP_GRAPHQL_ADDRESS: http://easi:8080/api/graph/query
-          REACT_APP_APP_ENV: test
-          REACT_APP_OKTA_CLIENT_ID: 0oa2e913coDQeG19S297
-          REACT_APP_OKTA_DOMAIN: https://test.idp.idm.cms.gov
-          REACT_APP_OKTA_SERVER_ID: aus2e96etlbFPnBHt297
-          REACT_APP_OKTA_ISSUER: https://test.idp.idm.cms.gov/oauth2/aus2e96etlbFPnBHt297
-          REACT_APP_OKTA_REDIRECT_URI: http://localhost:3000/implicit/callback
-          REACT_APP_LOCAL_AUTH_ENABLED: true
-        run: yarn run build
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -145,6 +126,11 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+      - name: Download Frontend assets
+        uses: actions/download-artifact@v3
+        with:
+          name: test-frontend-assets
+          path: build/
       - name: Run e2e cypress tests
         env:
           APP_ENV: test

--- a/scripts/build_static.sh
+++ b/scripts/build_static.sh
@@ -4,6 +4,12 @@
 set -eu -o pipefail
 
 case "$APP_ENV" in
+  "test")
+    EASI_URL="http://easi:8080"
+    export REACT_APP_OKTA_DOMAIN="https://test.idp.idm.cms.gov"
+    export REACT_APP_OKTA_REDIRECT_URI="http://localhost:3000/implicit/callback"
+    export REACT_APP_LOCAL_AUTH_ENABLED=true
+    ;;
   "dev")
     EASI_URL="https://dev.easi.cms.gov"
     export REACT_APP_OKTA_DOMAIN="https://test.idp.idm.cms.gov"
@@ -18,7 +24,7 @@ case "$APP_ENV" in
     ;;
   *)
     echo "APP_ENV value not recognized: ${APP_ENV:-unset}"
-    echo "Allowed values: 'dev', 'impl', 'prod'"
+    echo "Allowed values: 'dev','test','impl','prod'"
     exit 1
     ;;
 esac
@@ -28,9 +34,13 @@ export REACT_APP_OKTA_SERVER_ID="$OKTA_SERVER_ID"
 export REACT_APP_LD_CLIENT_ID="$LD_CLIENT_ID"
 export REACT_APP_APP_ENV="$APP_ENV"
 export REACT_APP_OKTA_ISSUER="${REACT_APP_OKTA_DOMAIN}/oauth2/${REACT_APP_OKTA_SERVER_ID}"
-export REACT_APP_OKTA_REDIRECT_URI="${EASI_URL}/implicit/callback"
 export REACT_APP_API_ADDRESS="${EASI_URL}/api/v1"
 export REACT_APP_GRAPHQL_ADDRESS="${EASI_URL}/api/graph/query"
+
+# Only set REACT_APP_OKTA_REDIRECT_URI if APP_ENV is not "test"
+if [ "$APP_ENV" != "test" ]; then
+    export REACT_APP_OKTA_REDIRECT_URI="${EASI_URL}/implicit/callback"
+fi
 
 # Build the application
 ( 

--- a/scripts/build_static.sh
+++ b/scripts/build_static.sh
@@ -24,7 +24,7 @@ case "$APP_ENV" in
     ;;
   *)
     echo "APP_ENV value not recognized: ${APP_ENV:-unset}"
-    echo "Allowed values: 'dev','test','impl','prod'"
+    echo "Allowed values: 'test','dev','impl','prod'"
     exit 1
     ;;
 esac


### PR DESCRIPTION
# EASI-3160

## Changes and Description

- Introduce test APP_ENV case for build_static.sh script, which will build the frontend using test variables
- Build_Test_Frontend_Assets steps will then use the build_static.sh script with test env to build frontend assets and store them as artifacts to be pulled later in E2E testing

## How to test this change

Github Actions pipeline change

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
