### PR TITLE
[EASI-3177] Fix downloaded file names in TRB and IT Gov

### DIFF
--- a/src/queries/GetTrbRequestDocumentUrlsQuery.ts
+++ b/src/queries/GetTrbRequestDocumentUrlsQuery.ts
@@ -7,6 +7,7 @@ export default gql`
       documents {
         id
         url
+        fileName
       }
     }
   }

--- a/src/queries/SystemIntakeDocumentQueries.ts
+++ b/src/queries/SystemIntakeDocumentQueries.ts
@@ -45,6 +45,7 @@ export const GetSystemIntakeDocumentUrlsQuery = gql`
       documents {
         id
         url
+        fileName
       }
     }
   }

--- a/src/queries/types/GetSystemIntakeDocumentUrls.ts
+++ b/src/queries/types/GetSystemIntakeDocumentUrls.ts
@@ -11,6 +11,7 @@ export interface GetSystemIntakeDocumentUrls_systemIntake_documents {
   __typename: "SystemIntakeDocument";
   id: UUID;
   url: string;
+  fileName: string;
 }
 
 export interface GetSystemIntakeDocumentUrls_systemIntake {

--- a/src/queries/types/GetTrbRequestDocumentUrls.ts
+++ b/src/queries/types/GetTrbRequestDocumentUrls.ts
@@ -11,6 +11,7 @@ export interface GetTrbRequestDocumentUrls_trbRequest_documents {
   __typename: "TRBRequestDocument";
   id: UUID;
   url: string;
+  fileName: string;
 }
 
 export interface GetTrbRequestDocumentUrls_trbRequest {

--- a/src/utils/downloadFile.ts
+++ b/src/utils/downloadFile.ts
@@ -1,3 +1,5 @@
+import axios from 'axios';
+
 export function downloadBlob(filename: string, blob: Blob) {
   // This approach to downloading files works fine in the tests I've done in Chrome
   // with PDF files that are < 100kB. For larger files we might need to
@@ -18,12 +20,19 @@ export function downloadBlob(filename: string, blob: Blob) {
   document.body.removeChild(link);
 }
 
-export function downloadFileFromURLOnly(downloadURL: string) {
-  const link = document.createElement('a');
-  link.href = downloadURL;
-
-  // This downloads the file to the user's machine.
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
+export function downloadFileFromURL(downloadURL: string, fileName: string) {
+  return axios
+    .request({
+      url: downloadURL,
+      responseType: 'blob',
+      method: 'GET'
+    })
+    .then(response => {
+      const blob = new Blob([response.data]);
+      downloadBlob(fileName, blob);
+    })
+    .catch(() => {
+      // We don't currently handle errors from this function, but when we do we should update this to pull from i18n
+      throw new Error('Failed to download file');
+    });
 }

--- a/src/views/SystemIntake/Documents/DocumentsTable.tsx
+++ b/src/views/SystemIntake/Documents/DocumentsTable.tsx
@@ -26,7 +26,7 @@ import {
   SystemIntakeDocumentStatus
 } from 'types/graphql-global-types';
 import { formatDateLocal } from 'utils/date';
-import { downloadFileFromURLOnly } from 'utils/downloadFile';
+import { downloadFileFromURL } from 'utils/downloadFile';
 import { getColumnSortStatus, getHeaderSortIcon } from 'utils/tableSort';
 
 import './index.scss';
@@ -99,7 +99,10 @@ const DocumentsTable = ({
           const requestedDocument = response.data.systemIntake.documents.find(
             doc => doc.id === documentId
           )!; // non-null assertion should be safe, this function should only be called with a documentId of a valid document
-          downloadFileFromURLOnly(requestedDocument.url);
+          downloadFileFromURL(
+            requestedDocument.url,
+            requestedDocument.fileName
+          );
         }
       });
       // don't need to call .catch(); apollo-client will always fulfill the promise, even if there's a network error

--- a/src/views/TechnicalAssistance/RequestForm/DocumentsTable.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/DocumentsTable.tsx
@@ -27,7 +27,7 @@ import {
   TRBRequestDocumentStatus
 } from 'types/graphql-global-types';
 import { formatDateLocal } from 'utils/date';
-import { downloadFileFromURLOnly } from 'utils/downloadFile';
+import { downloadFileFromURL } from 'utils/downloadFile';
 import { getColumnSortStatus, getHeaderSortIcon } from 'utils/tableSort';
 
 import { DocumentStatusType } from '../TrbDocuments';
@@ -164,7 +164,10 @@ function DocumentsTable({
           const requestedDocument = response.data.trbRequest.documents.find(
             doc => doc.id === documentId
           )!; // non-null assertion should be safe, this function should only be called with a documentId of a valid document
-          downloadFileFromURLOnly(requestedDocument.url);
+          downloadFileFromURL(
+            requestedDocument.url,
+            requestedDocument.fileName
+          );
         }
       });
       // don't need to call .catch(); apollo-client will always fulfill the promise, even if there's a network error


### PR DESCRIPTION
# EASI-3177

## Changes and Description

- Update GQL queries to fetch file names alongside download URLs
- Update `downloadFileFromURLOnly` to `downloadFileFromURL`, which now takes a `filename`
- Update download code to sue existing `downloadBlob` function, which allows a filename to be passed

## How to test this change

- `scripts/dev up`
- Start a request (TRB, or IT Gov)
- Upload a document
- `scripts/dev minio:clean` to mark it as virus scanned
- Refresh the page that shows the documents table
- Click "view"
- Ensure the downloaded file matches the name as it was uploaded

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
