### PR TITLE
Remove alerts when hasRole returns false

### DIFF
--- a/pkg/server/gqllogging.go
+++ b/pkg/server/gqllogging.go
@@ -52,12 +52,14 @@ func countIgnoredErrors(errorList gqlerror.List) int {
 	numIgnored := 0
 	for _, err := range errorList {
 		if err != nil {
-			// Ignore errors of type apperrors.UnauthorizedError
-			if _, ok := err.Unwrap().(*apperrors.UnauthorizedError); ok {
+			// Ignore any errors that wrap an apperrors.UnauthorizedError somewhere in their chain
+			var unauthorizedError *apperrors.UnauthorizedError
+			if errors.As(err, &unauthorizedError) {
 				numIgnored++
 			}
 
-			// Ignore errors of type context.Canceled
+			// Ignore context.Canceled errors
+			// context.Canceled is a value, not a type, so use errors.Is() instead of errors.As()
 			if errors.Is(err, context.Canceled) {
 				numIgnored++
 			}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -24,6 +23,7 @@ import (
 	"github.com/cmsgov/easi-app/pkg/alerts"
 	"github.com/cmsgov/easi-app/pkg/appconfig"
 	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/apperrors"
 	"github.com/cmsgov/easi-app/pkg/appses"
 	"github.com/cmsgov/easi-app/pkg/appvalidation"
 	"github.com/cmsgov/easi-app/pkg/authorization"
@@ -287,7 +287,10 @@ func (s *Server) routes(
 			return nil, err
 		}
 		if !hasRole {
-			return nil, errors.New("not authorized")
+			// don't need to log here - services.HasRole() handles logging
+			return nil, &apperrors.UnauthorizedError{
+				Err: fmt.Errorf("not authorized: user does not have role %v", role),
+			}
 		}
 		return next(ctx)
 	}}


### PR DESCRIPTION
NOREF PR so that when the `hasRole` directive in our GraphQL schema returns false, it doesn't alert us, similar to how https://github.com/CMSgov/easi-app/pull/2112 addressed issues when a user tried to view a system intake that they're not authorized to view (see EASI-3105). I noticed this about a week ago; [an alert triggered in Prod](https://cmsgov.slack.com/archives/C0486DX6884/p1692731893705289) because a user didn't have the right job code, and thus the `hasRole` check failed when querying TRB requests.

**I'm not 100% positive that we want to stop alerting on these checks.** The alerts might still be valuable if a user has issues with their job code and tries to view something that they should be allowed to view; we'd get an alert instead of having to wait for a user to report an error. On the other hand, this error could come from something like a regular user accidentally using an admin URL, which we should ignore; that lack of authorization is just the system operating as designed. **If we decide we still want to alert on `hasRole` checks returning false, we can close this PR without merging.**

## Changes and Description

- Change the implementation of the `hasRole` GQL directive to return an `apperrors.UnauthorizedError` when a user isn't authorized, instead of just using `errors.New()`. We currently don't trigger alerts on `apperrors.UnauthorizedError`.
- Adjust the code that checks for errors we should ignore to use [`errors.As()`](https://pkg.go.dev/errors@go1.18.3#As), so it ignores errors that have have an `apperrors.UnauthorizedError` _anywhere_ in their error chain, instead of only checking one level of wrapping.

## How to test this change

* To search for logs with `error: true` when running the app locally, run `docker-compose logs --no-log-prefix easi | jq --raw-input 'fromjson?' | jq 'select(.error == true)'`. (If you don't have `jq` installed, you can use `docker-compose logs --no-log-prefix easi | grep "\"error\":true"`)
* To run a query that fails the `hasRole` check, use Postman. In the EASi collection's variables, set the current value for `jobCodes` to `["EASI_USER"]` (removing the other roles), and save the collection. Then query TRB requests: in TRB -> TRB Requests, run the TRBRequestCollection query.
* When running that query on current `main` without the necessary job codes, a message with `error: true` set should be logged. On this branch, the log message for that request should not show as an error due to having `error: false`.

## Notes on Go error handling and `jq` for the curious

<details>
<summary>Checking for apperrors.UnauthorizedError</summary>

- https://goplay.tools/snippet/8_UK7Lu0t-1 demonstrates the difference made by this PR's changes; `currentShouldIgnore()` uses our current logic (though using `errors.Unwrap()` instead of the `Unwrap()` method on `gqlerror.Error`). With one level of wrapping, it finds the `UnauthorizedError` and returns true; with two levels of wrapping, it doesn't check the full error chain, and returns false. `newShouldIgnore()`, using `errors.As()`, works no matter how deeply the `UnauthorizedError` is wrapped.
- The linked docs are for the Go version we currently use; the only change in the [most recent docs](https://pkg.go.dev/errors#As) is that `errors.As()` checks an error's tree instead of its chain, due to Go 1.20 [adding support for wrapping multiple errors](https://go.dev/doc/go1.20).
</details>

<details>
<summary>Using jq with Docker logs</summary>

In the shell pipeline `docker-compose logs --no-log-prefix easi | jq --raw-input 'fromjson?' | jq 'select(.error == true)'`:
* `docker-compose logs --no-log-prefix easi` gets logs from the EASi backend container (the `easi` service in our Docker Compose files), without showing a prefix with the container name
* `jq --raw-input 'fromjson?'` filters out any log lines that aren't valid JSON, such as the `building...` and `running...` logs, or the LaunchDarkly client's logs
* `jq 'select(.error == true)'` filters the JSON log lines for any that have `error` set to `true`.

</details>