### PR TITLE
[EASI-3119] Add hotfix for marshalling HTML scalar types

### DIFF
--- a/pkg/models/html.go
+++ b/pkg/models/html.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"html/template"
 	"io"
 
@@ -15,34 +16,34 @@ import (
 type HTML string
 
 // ToTemplate converts and sanitizes the HTML type to a template.HTML struct
-func (html HTML) ToTemplate() template.HTML {
-	sanitizedHTML := sanitization.SanitizeHTML(html)
+func (h HTML) ToTemplate() template.HTML {
+	sanitizedHTML := sanitization.SanitizeHTML(h)
 	return template.HTML(sanitizedHTML) //nolint //the html is sanitized again on the previous line so we can ignore the warning about
 }
 
 // ValueOrEmptyString returns either the value of the html or an empty string if nil
-func (html *HTML) ValueOrEmptyString() string {
-	if html != nil {
-		return string(*html)
+func (h *HTML) ValueOrEmptyString() string {
+	if h != nil {
+		return string(*h)
 	}
 	return ""
 }
 
 // ValueOrEmptyHTML returns either the value of the html or an empty HTML type if nil
-func (html *HTML) ValueOrEmptyHTML() HTML {
-	if html != nil {
-		return *html
+func (h *HTML) ValueOrEmptyHTML() HTML {
+	if h != nil {
+		return *h
 	}
 	return ""
 }
 
 // StringPointer casts an HTML pointer to a string pointer
-func (html *HTML) StringPointer() *string {
-	return (*string)(html)
+func (h *HTML) StringPointer() *string {
+	return (*string)(h)
 }
 
 // UnmarshalGQLContext unmarshals the data from graphql to the HTML type
-func (html *HTML) UnmarshalGQLContext(ctx context.Context, v interface{}) error {
+func (h *HTML) UnmarshalGQLContext(ctx context.Context, v interface{}) error {
 
 	// Check if the value is a string
 	htmlString, ok := v.(string)
@@ -54,16 +55,20 @@ func (html *HTML) UnmarshalGQLContext(ctx context.Context, v interface{}) error 
 	sanitizedHTMLString := sanitization.SanitizeHTML(htmlString)
 
 	// Set the sanitized HTML value to the receiver
-	*html = HTML(sanitizedHTMLString)
+	*h = HTML(sanitizedHTMLString)
 
 	return nil
 }
 
 // MarshalGQLContext marshals the HTML type to JSON to return to graphQL
-func (html HTML) MarshalGQLContext(ctx context.Context, w io.Writer) error {
+func (h HTML) MarshalGQLContext(ctx context.Context, w io.Writer) error {
+	// TODO: Remove this hotfix taht was introduced as a result of entities being rendered as escaped HTML in non-rich-text views
+	// (Rich Text views handle this escaped data properly, so this hotfix is only needed until we implement rich text views across the board)
+	// Note: We only really need to do this here, instead of ALSO doing it in email code because the encoded HTML is handled cleanly by the html/template package
+	unescapedHTML := html.UnescapeString(string(h))
 
 	// Marshal the HTML value to JSON so that it's properly escaped (wrapped in quotation marks)
-	jsonValue, err := json.Marshal(html)
+	jsonValue, err := json.Marshal(unescapedHTML)
 	if err != nil {
 		return fmt.Errorf("failed to marshal HTML to JSON: %w", err)
 	}

--- a/pkg/models/html.go
+++ b/pkg/models/html.go
@@ -62,7 +62,7 @@ func (h *HTML) UnmarshalGQLContext(ctx context.Context, v interface{}) error {
 
 // MarshalGQLContext marshals the HTML type to JSON to return to graphQL
 func (h HTML) MarshalGQLContext(ctx context.Context, w io.Writer) error {
-	// TODO: Remove this hotfix taht was introduced as a result of entities being rendered as escaped HTML in non-rich-text views
+	// TODO: Remove this hotfix that was introduced as a result of entities being rendered as escaped HTML in non-rich-text views
 	// (Rich Text views handle this escaped data properly, so this hotfix is only needed until we implement rich text views across the board)
 	// Note: We only really need to do this here, instead of ALSO doing it in email code because the encoded HTML is handled cleanly by the html/template package
 	unescapedHTML := html.UnescapeString(string(h))


### PR DESCRIPTION
# EASI-3119

## Changes and Description

- Add code to GQL Marshalling of HTML scalar type that uses `html.UnescapeString()` to ensure that we don't get unexpected characters being rendered in the frontend.

### Before
![image](https://github.com/CMSgov/easi-app/assets/15203744/fae2b38a-a576-4883-bc6d-f6413ace053b)
![image](https://github.com/CMSgov/easi-app/assets/15203744/8019a0b8-5066-4df2-97df-dc53f68f4704)

### After
![image](https://github.com/CMSgov/easi-app/assets/15203744/78388bfc-35f1-4a7c-9608-c14834f2fc42)


## How to test this change

- `scripts/dev up`
- Create and submit a system intake (or seed the DB)
- Create an admin note that has special characters in it (`'`, `<`, or any other [HTML special characters](https://www.html.am/reference/html-special-characters.cfm))
- Ensure the note renders as it was entered

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
