### PR TITLE
[EASI-3119] Fixed last admin notes having escaped characters in REST endpoints

### DIFF
--- a/pkg/handlers/system_intakes.go
+++ b/pkg/handlers/system_intakes.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"html"
 	"net/http"
 	"strings"
 
@@ -41,6 +42,15 @@ func (h SystemIntakesHandler) Handle() http.HandlerFunc {
 			if err != nil {
 				h.WriteErrorResponse(r.Context(), w, err)
 				return
+			}
+
+			// TODO: Hotfix to address escaped HTML in the Last Admin Note
+			for i := range systemIntakes {
+				eachIntake := &systemIntakes[i]
+				if eachIntake.LastAdminNoteContent != nil {
+					escapedNote := html.UnescapeString(eachIntake.LastAdminNoteContent.ValueOrEmptyString())
+					eachIntake.LastAdminNoteContent = models.HTMLPointer(escapedNote)
+				}
 			}
 
 			js, err := json.Marshal(systemIntakes)


### PR DESCRIPTION
# EASI-3119

## Changes and Description

- Manually unescape `LastAdminNoteContent` when fetching system intakes via REST API
![image](https://github.com/CMSgov/easi-app/assets/15203744/33cc0c35-4b28-4776-9ea5-89fa2dc71100)

<!-- Put a description here! -->

## How to test this change

- `scripts/dev up`
- `scripts/dev db:seed`
- Add an admin note containing HTML special characters
- Close the request
- Ensure the `Last Admin Note` renders properly

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
