### PR TITLE
[NOREF] Add `lcidIssuedAt` schema field

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -732,6 +732,7 @@ type ComplexityRoot struct {
 		LastAdminNote               func(childComplexity int) int
 		Lcid                        func(childComplexity int) int
 		LcidCostBaseline            func(childComplexity int) int
+		LcidIssuedAt                func(childComplexity int) int
 		LcidScope                   func(childComplexity int) int
 		LcidStatus                  func(childComplexity int) int
 		LifecycleExpiresAt          func(childComplexity int) int
@@ -1380,6 +1381,7 @@ type SystemIntakeResolver interface {
 
 	Isso(ctx context.Context, obj *models.SystemIntake) (*model.SystemIntakeIsso, error)
 	Lcid(ctx context.Context, obj *models.SystemIntake) (*string, error)
+	LcidIssuedAt(ctx context.Context, obj *models.SystemIntake) (*time.Time, error)
 
 	LcidScope(ctx context.Context, obj *models.SystemIntake) (*models.HTML, error)
 	LcidCostBaseline(ctx context.Context, obj *models.SystemIntake) (*string, error)
@@ -5375,6 +5377,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SystemIntake.LcidCostBaseline(childComplexity), true
 
+	case "SystemIntake.lcidIssuedAt":
+		if e.complexity.SystemIntake.LcidIssuedAt == nil {
+			break
+		}
+
+		return e.complexity.SystemIntake.LcidIssuedAt(childComplexity), true
+
 	case "SystemIntake.lcidScope":
 		if e.complexity.SystemIntake.LcidScope == nil {
 			break
@@ -8270,6 +8279,7 @@ type SystemIntake {
   id: UUID!
   isso: SystemIntakeISSO!
   lcid: String
+  lcidIssuedAt: Time
   lcidExpiresAt: Time
   lcidScope: HTML
   lcidCostBaseline: String
@@ -14905,6 +14915,8 @@ func (ec *executionContext) fieldContext_BusinessCase_systemIntake(ctx context.C
 				return ec.fieldContext_SystemIntake_isso(ctx, field)
 			case "lcid":
 				return ec.fieldContext_SystemIntake_lcid(ctx, field)
+			case "lcidIssuedAt":
+				return ec.fieldContext_SystemIntake_lcidIssuedAt(ctx, field)
 			case "lcidExpiresAt":
 				return ec.fieldContext_SystemIntake_lcidExpiresAt(ctx, field)
 			case "lcidScope":
@@ -23785,6 +23797,8 @@ func (ec *executionContext) fieldContext_CreateSystemIntakeActionExtendLifecycle
 				return ec.fieldContext_SystemIntake_isso(ctx, field)
 			case "lcid":
 				return ec.fieldContext_SystemIntake_lcid(ctx, field)
+			case "lcidIssuedAt":
+				return ec.fieldContext_SystemIntake_lcidIssuedAt(ctx, field)
 			case "lcidExpiresAt":
 				return ec.fieldContext_SystemIntake_lcidExpiresAt(ctx, field)
 			case "lcidScope":
@@ -28690,6 +28704,8 @@ func (ec *executionContext) fieldContext_Mutation_createSystemIntake(ctx context
 				return ec.fieldContext_SystemIntake_isso(ctx, field)
 			case "lcid":
 				return ec.fieldContext_SystemIntake_lcid(ctx, field)
+			case "lcidIssuedAt":
+				return ec.fieldContext_SystemIntake_lcidIssuedAt(ctx, field)
 			case "lcidExpiresAt":
 				return ec.fieldContext_SystemIntake_lcidExpiresAt(ctx, field)
 			case "lcidScope":
@@ -33343,6 +33359,8 @@ func (ec *executionContext) fieldContext_Query_systemIntake(ctx context.Context,
 				return ec.fieldContext_SystemIntake_isso(ctx, field)
 			case "lcid":
 				return ec.fieldContext_SystemIntake_lcid(ctx, field)
+			case "lcidIssuedAt":
+				return ec.fieldContext_SystemIntake_lcidIssuedAt(ctx, field)
 			case "lcidExpiresAt":
 				return ec.fieldContext_SystemIntake_lcidExpiresAt(ctx, field)
 			case "lcidScope":
@@ -33584,6 +33602,8 @@ func (ec *executionContext) fieldContext_Query_systemIntakesWithLcids(ctx contex
 				return ec.fieldContext_SystemIntake_isso(ctx, field)
 			case "lcid":
 				return ec.fieldContext_SystemIntake_lcid(ctx, field)
+			case "lcidIssuedAt":
+				return ec.fieldContext_SystemIntake_lcidIssuedAt(ctx, field)
 			case "lcidExpiresAt":
 				return ec.fieldContext_SystemIntake_lcidExpiresAt(ctx, field)
 			case "lcidScope":
@@ -34785,6 +34805,8 @@ func (ec *executionContext) fieldContext_Query_relatedSystemIntakes(ctx context.
 				return ec.fieldContext_SystemIntake_isso(ctx, field)
 			case "lcid":
 				return ec.fieldContext_SystemIntake_lcid(ctx, field)
+			case "lcidIssuedAt":
+				return ec.fieldContext_SystemIntake_lcidIssuedAt(ctx, field)
 			case "lcidExpiresAt":
 				return ec.fieldContext_SystemIntake_lcidExpiresAt(ctx, field)
 			case "lcidScope":
@@ -37468,6 +37490,47 @@ func (ec *executionContext) fieldContext_SystemIntake_lcid(ctx context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _SystemIntake_lcidIssuedAt(ctx context.Context, field graphql.CollectedField, obj *models.SystemIntake) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SystemIntake_lcidIssuedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.SystemIntake().LcidIssuedAt(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SystemIntake_lcidIssuedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SystemIntake",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SystemIntake_lcidExpiresAt(ctx context.Context, field graphql.CollectedField, obj *models.SystemIntake) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SystemIntake_lcidExpiresAt(ctx, field)
 	if err != nil {
@@ -39283,6 +39346,8 @@ func (ec *executionContext) fieldContext_SystemIntakeAction_systemIntake(ctx con
 				return ec.fieldContext_SystemIntake_isso(ctx, field)
 			case "lcid":
 				return ec.fieldContext_SystemIntake_lcid(ctx, field)
+			case "lcidIssuedAt":
+				return ec.fieldContext_SystemIntake_lcidIssuedAt(ctx, field)
 			case "lcidExpiresAt":
 				return ec.fieldContext_SystemIntake_lcidExpiresAt(ctx, field)
 			case "lcidScope":
@@ -47760,6 +47825,8 @@ func (ec *executionContext) fieldContext_TRBRequestForm_systemIntakes(ctx contex
 				return ec.fieldContext_SystemIntake_isso(ctx, field)
 			case "lcid":
 				return ec.fieldContext_SystemIntake_lcid(ctx, field)
+			case "lcidIssuedAt":
+				return ec.fieldContext_SystemIntake_lcidIssuedAt(ctx, field)
 			case "lcidExpiresAt":
 				return ec.fieldContext_SystemIntake_lcidExpiresAt(ctx, field)
 			case "lcidScope":
@@ -48993,6 +49060,8 @@ func (ec *executionContext) fieldContext_UpdateSystemIntakePayload_systemIntake(
 				return ec.fieldContext_SystemIntake_isso(ctx, field)
 			case "lcid":
 				return ec.fieldContext_SystemIntake_lcid(ctx, field)
+			case "lcidIssuedAt":
+				return ec.fieldContext_SystemIntake_lcidIssuedAt(ctx, field)
 			case "lcidExpiresAt":
 				return ec.fieldContext_SystemIntake_lcidExpiresAt(ctx, field)
 			case "lcidScope":
@@ -63174,6 +63243,39 @@ func (ec *executionContext) _SystemIntake(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._SystemIntake_lcid(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "lcidIssuedAt":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._SystemIntake_lcidIssuedAt(ctx, field, obj)
 				return res
 			}
 

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -1001,6 +1001,7 @@ type SystemIntake {
   id: UUID!
   isso: SystemIntakeISSO!
   lcid: String
+  lcidIssuedAt: Time
   lcidExpiresAt: Time
   lcidScope: HTML
   lcidCostBaseline: String

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -2827,6 +2827,13 @@ func (r *systemIntakeResolver) Lcid(ctx context.Context, obj *models.SystemIntak
 	return obj.LifecycleID.Ptr(), nil
 }
 
+// LcidIssuedAt is the resolver for the lcidIssuedAt field.
+func (r *systemIntakeResolver) LcidIssuedAt(ctx context.Context, obj *models.SystemIntake) (*time.Time, error) {
+	// TODO Implement in https://jiraent.cms.gov/browse/EASI-3319
+	mockDate := time.Date(1989, 8, 18, 12, 0, 0, 0, time.UTC) // this is when Technotronic's "Pump Up The Jam" was released. A very important date for all of humanity.
+	return &mockDate, nil
+}
+
 // LcidScope is the resolver for the lcidScope field.
 func (r *systemIntakeResolver) LcidScope(ctx context.Context, obj *models.SystemIntake) (*models.HTML, error) {
 	return obj.LifecycleScope, nil


### PR DESCRIPTION
# NOREF

## Changes and Description

- Add `lcidIssuedAt` schema field
- Returns a mock date, remainder of the implementation to be done in EASI-3319

## How to test this change

- Create a system intake
- Query the lcidIssuedAt field
- Ensure a date returns (it's mocked, it'll always be the same thing!)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
