### PR TITLE
Replace PrinceXML with Client-side PDF rendering FE

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "i18next": "^19.8.5",
     "i18next-browser-languagedetector": "^5.0.0",
     "istanbul-lib-coverage": "^3.0.0",
-    "js-base64": "^3.6.0",
     "launchdarkly-react-client-sdk": "^3.0.6",
     "lodash": "^4.17.21",
     "luxon": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-router-dom": "^5.1.2",
     "react-select": "^5.4.0",
     "react-table": "^7.5.1",
+    "react-to-print": "^2.14.13",
     "redux": "^4.0.4",
     "redux-actions": "^2.6.5",
     "redux-devtools-extension": "^2.13.8",

--- a/src/components/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/components/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -8,6 +8,11 @@ exports[`The Business Case Review Component > matches the snapshot 1`] = `
     <div
       class="easi-pdf-export"
     >
+      <h1
+        class="easi-only-print"
+      >
+        Business Case
+      </h1>
       <div
         class="grid-container"
       >

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import { useReactToPrint } from 'react-to-print';
 import { IconFileDownload } from '@trussworks/react-uswds';
 import axios from 'axios';
 import classNames from 'classnames';
@@ -37,6 +38,7 @@ function generatePDF(filename: string, content: string) {
     });
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const downloadRefAsPDF = (
   title: string,
   filename: string,
@@ -96,17 +98,29 @@ const PDFExport = ({
   linkPosition = 'bottom',
   disabled
 }: PDFExportProps) => {
-  const divEl = useRef<HTMLDivElement>(null);
+  const printRef = useRef<HTMLDivElement>(null);
+  const handlePrint = useReactToPrint({
+    documentTitle: filename,
+    content: () => printRef.current,
+    // The lib default is to have no margin, which hides window.prints()'s built in pagination
+    // Set auto margins back to show everything the browser renders
+    pageStyle: `
+      @page {
+        margin: auto;
+      }
+    `
+  });
 
-  const IntakeContent: JSX.Element = (
-    <div className="easi-pdf-export" ref={divEl}>
+  const PrintContent: JSX.Element = (
+    <div className="easi-pdf-export" ref={printRef}>
+      <h1 className="easi-only-print">{title}</h1>
       {children}
     </div>
   );
 
   return (
     <>
-      {linkPosition === 'bottom' && IntakeContent}
+      {linkPosition === 'bottom' && PrintContent}
 
       <div
         className={classNames('easi-pdf-export__controls', {
@@ -116,7 +130,7 @@ const PDFExport = ({
         <button
           className="usa-button usa-button--unstyled easi-no-print display-flex flex-align-center"
           type="button"
-          onClick={() => downloadRefAsPDF(title, filename, divEl)}
+          onClick={handlePrint}
           disabled={disabled}
         >
           <IconFileDownload className="margin-right-05" />
@@ -124,7 +138,7 @@ const PDFExport = ({
         </button>
       </div>
 
-      {linkPosition === 'top' && IntakeContent}
+      {linkPosition === 'top' && PrintContent}
     </>
   );
 };

--- a/src/components/PDFExport/index.tsx
+++ b/src/components/PDFExport/index.tsx
@@ -1,12 +1,7 @@
 import React, { useRef } from 'react';
 import { useReactToPrint } from 'react-to-print';
 import { IconFileDownload } from '@trussworks/react-uswds';
-import axios from 'axios';
 import classNames from 'classnames';
-import { Base64 } from 'js-base64';
-import escape from 'lodash';
-
-import { downloadBlob } from 'utils/downloadFile';
 
 type PDFExportProps = {
   filename: string;
@@ -15,76 +10,6 @@ type PDFExportProps = {
   label?: string;
   linkPosition?: 'top' | 'bottom';
   disabled?: boolean;
-};
-
-function generatePDF(filename: string, content: string) {
-  axios
-    .request({
-      url: `${import.meta.env.VITE_API_ADDRESS}/pdf/generate`,
-      responseType: 'blob',
-      method: 'POST',
-      data: {
-        html: Base64.encode(content),
-        filename: 'input.html'
-      }
-    })
-    .then(response => {
-      const blob = new Blob([response.data], { type: 'application/pdf' });
-      downloadBlob(filename, blob);
-    })
-    .catch(e => {
-      // TODO add error handling: display a modal if things fail?
-      console.error(e); // eslint-disable-line
-    });
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const downloadRefAsPDF = (
-  title: string,
-  filename: string,
-  ref: React.RefObject<HTMLDivElement>
-): void => {
-  // Collect any stylesheets that are linked to. These are used in production.
-  const { origin } = document.location;
-  const stylesheetRequests = Array.prototype.slice
-    .apply(document.styleSheets)
-    .filter(
-      // don't load google fonts stylesheets
-      stylesheet => stylesheet.href && stylesheet.href.startsWith(origin)
-    )
-    .map(stylesheet => axios.get(stylesheet.href));
-
-  // Also grab any inline styles, used predominantly in development.
-  const styleBlocks = Array.prototype.slice
-    .apply(document.querySelectorAll('style'))
-    .map(node => node.innerText);
-
-  // Combine external and inline styles
-  Promise.all(stylesheetRequests)
-    .then(stylesheets => {
-      stylesheets.forEach(response => styleBlocks.push(response.data));
-
-      const markupToRender = `<html lang="en">
-        <head>
-          <title>${escape(title)}</title>
-          <style>
-            ${styleBlocks.join('\n\n')}
-          </style>
-        </head>
-        <body>
-          <h1>
-            ${escape(title)}
-          </h1>
-          ${ref && ref.current && ref.current.outerHTML}
-        </body>
-      </html>`;
-
-      generatePDF(filename, markupToRender);
-    })
-    .catch(e => {
-      console.error(e); // eslint-disable-line
-      // TODO add error handling: display a modal if things fail?
-    });
 };
 
 // PDFExport adds a "Download PDF" button to the screen. When this button is clicked,

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -9,6 +9,11 @@ exports[`The GRT business case review > matches the snapshot 1`] = `
       class="easi-pdf-export"
     >
       <h1
+        class="easi-only-print"
+      >
+        System Intake
+      </h1>
+      <h1
         aria-live="polite"
         class="easi-h1 margin-top-0"
         tabindex="-1"

--- a/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/IntakeReview/__snapshots__/index.test.tsx.snap
@@ -15,6 +15,11 @@ exports[`The GRT intake review view > matches the snapshot 1`] = `
     <div
       class="easi-pdf-export"
     >
+      <h1
+        class="easi-only-print"
+      >
+        System Intake
+      </h1>
       <div>
         <dl
           title="System Request"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9796,11 +9796,6 @@ jquery@^3.6.0:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
 
-js-base64@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/js-base64/-/js-base64-3.6.0.tgz"
-  integrity sha512-wVdUBYQeY2gY73RIlPrysvpYx+2vheGo8Y1SNQv/BzHToWpAZzJU7Z6uheKMAe+GLSBig5/Ps2nxg/8tRB73xg==
-
 js-cookie@2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12002,6 +12002,11 @@ react-themeable@^1.1.0:
   dependencies:
     object-assign "^3.0.0"
 
+react-to-print@^2.14.13:
+  version "2.14.13"
+  resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-2.14.13.tgz#cd0349f7ef93c8af5120fac0ef6c4f3d100df490"
+  integrity sha512-PqUGgTRZvkyBzWgaZHVBECWPX2nGEc3HOUy6WNXof6HT4yTFI92wtIkqQtr4jfvHbadqjwTgzgh6vgN8KXlWWw==
+
 react-transition-group@^4.3.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"


### PR DESCRIPTION
# EASI-3267

## Changes and Description

Generate pdfs on the client with react-to-print
- The old generate endpoint `{VITE_API_ADDRESS}/pdf/generate` is no longer used
- `js-base64` is no longer used
- Print page level styles such as timestamp, title, url, pagination, are all defaults of window.print()

<!-- Put a description here! -->

## How to test this change

Download a pdf from a view such as
`http://localhost:3000/governance-review-team/{uuid}/intake-request`