### PR TITLE
[NOREF] Update Postman Env Vars

### DIFF
--- a/EASI.postman_collection.json
+++ b/EASI.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "da6146ac-dee1-4e23-a9d3-042ca132620b",
+		"_postman_id": "e52f7cb3-8387-49f3-9e0a-c791e5ace993",
 		"name": "EASI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "11253221"
@@ -1664,7 +1664,7 @@
 		"apikey": [
 			{
 				"key": "value",
-				"value": "Local {\"EUAID\":\"{{EUAID}}\",\"jobCodes\":{{jobCodes}},\"favorLocalAuth\":true}",
+				"value": "{{authHeader}}",
 				"type": "string"
 			},
 			{
@@ -1706,6 +1706,11 @@
 			"type": "string"
 		},
 		{
+			"key": "authHeader",
+			"value": "Local {\"EUAID\":\"{{EUAID}}\",\"jobCodes\":{{jobCodes}},\"favorLocalAuth\":true}",
+			"type": "string"
+		},
+		{
 			"key": "trbAttendeeID",
 			"value": ""
 		},
@@ -1718,8 +1723,13 @@
 			"value": ""
 		},
 		{
+			"key": "host",
+			"value": "http://localhost:8080",
+			"type": "string"
+		},
+		{
 			"key": "url",
-			"value": "http://localhost:8080/api/graph/query",
+			"value": "{{host}}/api/graph/query",
 			"type": "string"
 		},
 		{
@@ -1732,7 +1742,7 @@
 		},
 		{
 			"key": "apiURL",
-			"value": "http://localhost:8080/api/v1",
+			"value": "{{host}}/api/v1",
 			"type": "string"
 		},
 		{


### PR DESCRIPTION
# NOREF - Update Postman Env Vars

## Changes and Description

Currently, the Postman collection is only really setup for local dev. However, it's useful to be able to quickly test the backend in LLEs. This PR modifies the Postman Env Vars slightly so they can be overridden to target `dev`, `impl`, or `prod` environments.

- Makes the auth header an env var
- Isolates the base URL so it can be replaced with the live URLs.

## How to test this change

1. Import the new collection
2. Click the EASI collection and go to the Variables tab.
3. Replace `EUAID` in the "Current Value" column (do this for all overrides) with your EUA.
4. Replace `host` with https://dev.easi.cms.gov (don't add the trailing slash)
5. Log into `dev` on the real site, then copy the Auth header on GQL queries that starts with "Bearer"
6. Paste the auth header value into `authHeader`.
7. Run some queries against `dev`!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
