### PR TITLE
[NOREF] Issue LCID bug fix

### DIFF
--- a/src/validations/actionSchema.ts
+++ b/src/validations/actionSchema.ts
@@ -148,12 +148,7 @@ const validExpirationDate = () =>
       return DateTime.fromISO(value) >= DateTime.local().startOf('day');
     });
 
-export const issueLcidSchema = Yup.object().shape({
-  useExistingLcid: Yup.boolean().required('Please make a selection'),
-  lcid: Yup.string().when('useExistingLcid', {
-    is: true,
-    then: Yup.string().required('Please select the existing Lifecycle ID')
-  }),
+export const confirmLcidSchema = Yup.object().shape({
   expiresAt: validExpirationDate(),
   scope: Yup.string().required('Please fill in the blank'),
   nextSteps: Yup.string().required('Please fill in the blank'),
@@ -161,3 +156,18 @@ export const issueLcidSchema = Yup.object().shape({
     .oneOf(Object.values(SystemIntakeTRBFollowUp))
     .required('Please make a selection')
 });
+
+export const issueLcidSchema = confirmLcidSchema.shape({
+  useExistingLcid: Yup.boolean().required('Please make a selection'),
+  lcid: Yup.string().when('useExistingLcid', {
+    is: true,
+    then: Yup.string().required('Please select the existing Lifecycle ID')
+  })
+});
+
+export const lcidActionSchema = (type: 'issue' | 'confirm') => {
+  if (type === 'issue') {
+    return issueLcidSchema;
+  }
+  return confirmLcidSchema;
+};

--- a/src/views/GovernanceReviewTeam/Actions/Resolutions/IssueLcid.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/Resolutions/IssueLcid.tsx
@@ -34,7 +34,7 @@ import {
   SystemIntakeTRBFollowUp
 } from 'types/graphql-global-types';
 import { NonNullableProps } from 'types/util';
-import { issueLcidSchema } from 'validations/actionSchema';
+import { lcidActionSchema } from 'validations/actionSchema';
 
 import ActionForm, { SystemIntakeActionFields } from '../components/ActionForm';
 import { EditsRequestedContext } from '..';
@@ -69,6 +69,9 @@ const IssueLcid = ({
   ...defaultValues
 }: IssueLcidProps) => {
   const { t } = useTranslation('action');
+
+  /** Type of LCID action */
+  const actionType = defaultValues.lcid ? 'confirm' : 'issue';
 
   /** Edits requested form key for confirmation modal */
   const editsRequestedKey = useContext(EditsRequestedContext);
@@ -105,16 +108,14 @@ const IssueLcid = ({
   }, [data]);
 
   const form = useForm<IssueLcidFields>({
-    resolver: yupResolver(issueLcidSchema),
+    resolver: yupResolver(lcidActionSchema(actionType)),
     defaultValues: {
       lcid: defaultValues.lcid || '',
       expiresAt: defaultValues.lcidExpiresAt || '',
       nextSteps: defaultValues.decisionNextSteps || '',
       scope: defaultValues.lcidScope || '',
       trbFollowUp: defaultValues.trbFollowUpRecommendation || undefined,
-      costBaseline: defaultValues.lcidCostBaseline || '',
-      // If confirming LCID, set useExistingLcid to true
-      useExistingLcid: defaultValues.lcid ? true : undefined
+      costBaseline: defaultValues.lcidCostBaseline || ''
     }
   });
 
@@ -159,14 +160,11 @@ const IssueLcid = ({
       ...formData
     };
 
-    /**
-     * If default LCID field value is set, returns `confirmLcid`.
-     * Otherwise, returns `issueLcid`.
-     */
-    const mutation = defaultValues.lcid ? confirmLcid : issueLcid;
+    /** Returns `confirmLcid` or `issueLcid` mutation based on form action type */
+    const mutation = actionType === 'confirm' ? confirmLcid : issueLcid;
 
     // If confirming LCID, remove LCID from mutation input
-    if (mutation === confirmLcid) {
+    if (actionType === 'confirm') {
       delete input.lcid;
     }
 

--- a/src/views/GovernanceReviewTeam/Actions/components/ActionForm.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/components/ActionForm.tsx
@@ -94,6 +94,7 @@ const ActionForm = <TFieldValues extends SystemIntakeActionFields>({
   ] = useState<SystemIntakeContactProps | null>(null);
 
   const {
+    control,
     setValue,
     watch,
     reset,
@@ -256,6 +257,7 @@ const ActionForm = <TFieldValues extends SystemIntakeActionFields>({
 
         {/* Additional information */}
         <Controller
+          control={control}
           name="additionalInfo"
           render={({ field, fieldState: { error } }) => (
             <FormGroup error={!!error}>
@@ -288,7 +290,8 @@ const ActionForm = <TFieldValues extends SystemIntakeActionFields>({
 
         {/* Admin note */}
         <Controller
-          name="adminNotes"
+          control={control}
+          name="adminNote"
           render={({ field, fieldState: { error } }) => (
             <FormGroup
               error={!!error}


### PR DESCRIPTION
# NOREF

## Changes and Description

- Fixes two bugs with Issue/Confirm LCID form:
  - Issue LCID mutation
    - LCID value in mutation input was set to empty string even when "use existing LCID" was selected, so new LCID was always generated
  - Confirm LCID form
    - If more than one intake used the same LCID, fields were always showing values from first intake
- Refactored `onSubmit` function in `IssueLcid` component for clarity
- Added comments

<!-- Put a description here! -->

## How to test this change

Log in with `itGovV2Enabled` flag enabled, and go to /governance-review-team/:systemId/actions.

1. Test Issue LCID mutation bug fix
    - Select "Issue a decision or close this request"
    - Select "Issue a Life Cycle ID"
    - Select "Use an existing Life Cycle ID"
    - Select LCID from dropdown
    - Update other LCID fields (important for testing next bug)
    - Ensure LCID in gql mutation response matches selected LCID
      - Can also check LCID in success message at top of next page
2. Test Confirm LCID form bug fix
    - Select "Change decision or re-open this request"
    - Select "Confirm current decision (Issue a Life Cycle ID)"
    - Make sure fields are changed to updated values from previous Issue LCID form

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
