### PR TITLE
[NOREF] - Hard code banner render on landing

### DIFF
--- a/src/components/ServiceAlert/index.tsx
+++ b/src/components/ServiceAlert/index.tsx
@@ -33,7 +33,7 @@ const ServiceAlert = ({
   const { pathname } = useLocation();
   const { serviceAlertEnabled } = useFlags();
 
-  if (!alertPaths.includes(pathname) || !serviceAlertEnabled) {
+  if (!landing && (!alertPaths.includes(pathname) || !serviceAlertEnabled)) {
     return null;
   }
 


### PR DESCRIPTION
# EASI-000

## Changes and Description

Due to deployed Launch Darkly env's having secure mode enabled , initializing the LDWrapper for unauthenticated users is unsuccessful.  We have options to work around this but will require further discussion and architecture.  Because of the the landing page Government shutdown will not be controlled by Launch Darkly.  

**This PR should be deployed as close to the time of the shutdown as possibly, and when we flip the flags in LD.  Additionally there should be a follow up PR to remove this hard coded banner as soon as the shutdown ends**

- Added condition to `<ServiceAlert />` to always render the banner on the landing page

<!-- Put a description here! -->

## How to test this change

Verify the landing page always renders the shutdown banner, independent of LD connection or config

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
