### PR TITLE
[NOREF] remove x net

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.25
-	golang.org/x/net v0.16.0
+	golang.org/x/net v0.16.0 // indirect
 )
 
 require (

--- a/pkg/email/request_edits_test.go
+++ b/pkg/email/request_edits_test.go
@@ -1,10 +1,10 @@
 package email
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/uuid"
-	"golang.org/x/net/context"
 
 	"github.com/cmsgov/easi-app/pkg/models"
 )

--- a/pkg/email/system_intake_close_test.go
+++ b/pkg/email/system_intake_close_test.go
@@ -1,11 +1,11 @@
 package email
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
-	"golang.org/x/net/context"
 
 	"github.com/cmsgov/easi-app/pkg/models"
 )

--- a/pkg/email/system_intake_reopen_test.go
+++ b/pkg/email/system_intake_reopen_test.go
@@ -1,11 +1,11 @@
 package email
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
-	"golang.org/x/net/context"
 
 	"github.com/cmsgov/easi-app/pkg/models"
 )


### PR DESCRIPTION
# NOREF

## Changes and Description

- Remove /x/net package. We only used it for tests for the `context` it provided, and we can just use the base `context` package instead.
- Should make https://github.com/CMSgov/easi-app/pull/2228 no longer needed once merged

## How to test this change

Ensure all unit tests pass in CI! That should be all that's needed

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
