### PR TITLE
[NOREF] Make intake created nullable

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -8320,7 +8320,7 @@ type SystemIntake {
   contract: SystemIntakeContract!
   costs: SystemIntakeCosts
   annualSpending: SystemIntakeAnnualSpending
-  createdAt: Time!
+  createdAt: Time
   currentStage: String
   decisionNextSteps: HTML
   eaCollaborator: String
@@ -37308,14 +37308,11 @@ func (ec *executionContext) _SystemIntake_createdAt(ctx context.Context, field g
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*time.Time)
 	fc.Result = res
-	return ec.marshalNTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SystemIntake_createdAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -63682,9 +63679,6 @@ func (ec *executionContext) _SystemIntake(ctx context.Context, sel ast.Selection
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "createdAt":
 			out.Values[i] = ec._SystemIntake_createdAt(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "currentStage":
 			field := field
 

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -8320,7 +8320,7 @@ type SystemIntake {
   contract: SystemIntakeContract!
   costs: SystemIntakeCosts
   annualSpending: SystemIntakeAnnualSpending
-  createdAt: Time
+  createdAt: Time # TODO - This should probably not be nullable, but some data in IMPL & PROD has it nulled out. We should fix this in the future.
   currentStage: String
   decisionNextSteps: HTML
   eaCollaborator: String

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -985,7 +985,7 @@ type SystemIntake {
   contract: SystemIntakeContract!
   costs: SystemIntakeCosts
   annualSpending: SystemIntakeAnnualSpending
-  createdAt: Time
+  createdAt: Time # TODO - This should probably not be nullable, but some data in IMPL & PROD has it nulled out. We should fix this in the future.
   currentStage: String
   decisionNextSteps: HTML
   eaCollaborator: String

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -985,7 +985,7 @@ type SystemIntake {
   contract: SystemIntakeContract!
   costs: SystemIntakeCosts
   annualSpending: SystemIntakeAnnualSpending
-  createdAt: Time!
+  createdAt: Time
   currentStage: String
   decisionNextSteps: HTML
   eaCollaborator: String

--- a/src/data/systemIntake.ts
+++ b/src/data/systemIntake.ts
@@ -260,7 +260,8 @@ export const convertIntakeToCSV = (intake: SystemIntakeForTable) => {
   }
 
   // Format dates to MM/dd/yyyy
-  const createdAt = formatDateLocal(intake.createdAt, 'MM/dd/yyyy');
+  const createdAt =
+    intake?.createdAt && formatDateLocal(intake.createdAt, 'MM/dd/yyyy');
   const submittedAt =
     intake?.submittedAt && formatDateLocal(intake.submittedAt, 'MM/dd/yyyy');
   const updatedAt =

--- a/src/queries/types/GetSystemIntake.ts
+++ b/src/queries/types/GetSystemIntake.ts
@@ -155,7 +155,7 @@ export interface GetSystemIntake_systemIntake {
   businessCaseId: UUID | null;
   submittedAt: Time | null;
   updatedAt: Time | null;
-  createdAt: Time;
+  createdAt: Time | null;
   archivedAt: Time | null;
   euaUserId: string;
   hasUiChanges: boolean | null;

--- a/src/queries/types/GetSystemIntakesTable.ts
+++ b/src/queries/types/GetSystemIntakesTable.ts
@@ -107,7 +107,7 @@ export interface GetSystemIntakesTable_systemIntakes {
   decidedAt: Time | null;
   submittedAt: Time | null;
   updatedAt: Time | null;
-  createdAt: Time;
+  createdAt: Time | null;
   archivedAt: Time | null;
 }
 

--- a/src/queries/types/SystemIntake.ts
+++ b/src/queries/types/SystemIntake.ts
@@ -155,7 +155,7 @@ export interface SystemIntake {
   businessCaseId: UUID | null;
   submittedAt: Time | null;
   updatedAt: Time | null;
-  createdAt: Time;
+  createdAt: Time | null;
   archivedAt: Time | null;
   euaUserId: string;
   hasUiChanges: boolean | null;


### PR DESCRIPTION
# NOREF

## Changes and Description

- Makes createdAt nullable in the GQL schema. This is because data in IMPL and PROD has nullable CreatedAt's, so rather than trying to fix that, we're going to update the schema to reflect the DB restrictions (which make the column nullable)

The only reason this showed up now is we recently migrated from using REST endpoints on the admin home page to using GQL queries.


## How to test this change

- Start the app locally, make sure nothing breaks
- Seed the DB, use `psql` or a postgres tool to null out an intakes `createdAt` and make sure the app still works as expected.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
