### PR TITLE
[NOREF] Add check to fail PR on presence of 'do not merge' label

### DIFF
--- a/.github/workflows/pr_label_checks.yml
+++ b/.github/workflows/pr_label_checks.yml
@@ -1,0 +1,20 @@
+name: PR Label Checks
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+# This concurrency group exists with cancel-in-progress: true so that only the latest run of the workflow is executed (as its all that should matter).
+concurrency:
+  group: pr-label-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fail_if_label_found:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        if: ${{ contains( github.event.pull_request.labels.*.name, 'do not merge') }}
+        run: |
+          echo "PR has 'do not merge' label, failing."
+          exit 1


### PR DESCRIPTION
# NOREF

## Changes and Description

- Added job that fails a check if `do not merge` is present in the labels

This is (hopefully) useful for cases where approvals exist on a PR, but there's some external reason we don't yet want to merge the changes

## How to test this change

Try adding the `do not merge` label to this PR, see that it fails, try removing it, see that it passes!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
