### PR TITLE
[NOREF] System intakes table loading fix

### DIFF
--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -230,6 +230,15 @@ const RequestRepository = () => {
     data
   );
 
+  /** Returns query loading state based on active table */
+  const resultsLoading = useMemo(() => {
+    if (activeTable === 'closed') {
+      return loadingClosed;
+    }
+
+    return loadingOpen;
+  }, [loadingOpen, loadingClosed, activeTable]);
+
   return (
     <>
       <GridContainer className="margin-top-1 margin-bottom-2">
@@ -454,7 +463,7 @@ const RequestRepository = () => {
           filteredRowLength={page.length}
           rowLength={data.length}
           className="margin-bottom-4"
-          loading={loadingOpen || loadingClosed}
+          loading={resultsLoading}
         />
 
         {/* This is the only table that expands past the USWDS desktop dimensions.  Only convert to scrollable when in tablet/mobile */}


### PR DESCRIPTION
# NOREF

## Changes and Description

The system intakes table on the homepage currently shows "results loading" until both the open and closed queries have completed. This causes the open tab to show "results loading" after the open intake results are already being displayed (there is a significant delay in prod).

This PR updates `RequestRepository` to use the loading state of only the active tab.

<!-- Put a description here! -->

## How to test this change

Make sure the admin home system intakes table only shows "results loading" until the active tab results are displayed.

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
