### PR TITLE
[EASI-2887] Create V1 to V2 migration script

### DIFF
--- a/cmd/migrate_intakes/main.go
+++ b/cmd/migrate_intakes/main.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
+	"gopkg.in/launchdarkly/go-server-sdk.v5/ldcomponents"
+	"gopkg.in/launchdarkly/go-server-sdk.v5/testhelpers/ldtestdata"
+
+	"github.com/cmsgov/easi-app/pkg/appconfig"
+	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/storage"
+	"github.com/cmsgov/easi-app/pkg/testhelpers"
+)
+
+func noErr(err error) {
+	if err != nil {
+		fmt.Println("Error!")
+		fmt.Println(err)
+		panic("Aborting")
+	}
+}
+
+func makeStore(ldClient *ld.LDClient) *storage.Store {
+	config := testhelpers.NewConfig()
+
+	dbConfig := storage.DBConfig{
+		Host:           config.GetString(appconfig.DBHostConfigKey),
+		Port:           config.GetString(appconfig.DBPortConfigKey),
+		Database:       config.GetString(appconfig.DBNameConfigKey),
+		Username:       config.GetString(appconfig.DBUsernameConfigKey),
+		Password:       config.GetString(appconfig.DBPasswordConfigKey),
+		SSLMode:        config.GetString(appconfig.DBSSLModeConfigKey),
+		MaxConnections: config.GetInt(appconfig.DBMaxConnections),
+	}
+
+	store, storeErr := storage.NewStore(dbConfig, ldClient)
+	if storeErr != nil {
+		panic(storeErr)
+	}
+	return store
+}
+
+func migrateIntakes() {
+	zapLogger, err := zap.NewDevelopment()
+	noErr(err)
+
+	ctx := appcontext.WithLogger(context.Background(), zapLogger)
+
+	td := ldtestdata.DataSource()
+	td.Update(td.Flag("emit-to-cedar").BooleanFlag().VariationForAll(true))
+	config := ld.Config{
+		DataSource: td,
+		Events:     ldcomponents.NoEvents(),
+	}
+
+	ldClient, err := ld.MakeCustomClient("fake", config, 0)
+	if err != nil {
+		fmt.Println(err)
+		panic("Error initializing ldClient")
+	}
+
+	store := makeStore(ldClient)
+
+	// Fetch all intakes
+	fmt.Println("Fetching all system intakes")
+	fmt.Println("=======================================")
+	allIntakes, err := store.FetchSystemIntakes(ctx)
+	noErr(err)
+	for _, i := range allIntakes {
+		intake := i // prevent gosec's G601 -- Implicit memory aliasing in for loop.
+		fmt.Println("Preparing to update system intake", intake.ID.String())
+		fmt.Println("Intake Status:", intake.Status)
+		intake.SetV2FieldsBasedOnV1Status(intake.Status)
+		_, err := store.UpdateSystemIntake(ctx, &intake)
+		noErr(err)
+		fmt.Println("Updated system intake", intake.ID.String())
+		fmt.Println("=======================================")
+	}
+}
+
+var submitCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Migrate V1 System Intakes to V2 by setting V2-specific fields",
+	Run: func(cmd *cobra.Command, args []string) {
+		migrateIntakes()
+	},
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "migrate_intakes",
+	Short: "Utility for migrating V1 Intakes to V2",
+}
+
+func init() {
+	rootCmd.AddCommand(submitCmd)
+}
+
+func execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func main() {
+	execute()
+}


### PR DESCRIPTION
# EASI-2887

## Changes and Description

- This PR introduces a script that, for each System Intake, runs `SetV2FieldsBasedOnV1Status`

This should effectively place every Intake in the correct state to migrate to V2, now that https://github.com/CMSgov/easi-app/pull/2270 is in `main` and deployed

## How to test this change

- `scripts/dev up`
- `scripts/dev db:seed` -- This will seed the DB with a _lot_ of V1-specific Intakes
- `go run cmd/migrate_intakes/main.go migrate`
- Check the DB / App UI to see if the V1 intakes look correct in V2
  - Note: This script assumes V1 fields are to be trusted across the board, meaning any V2 intakes that do NOT have V1 fields set will improperly get reset back to the initial task list. This is acceptable, as all intakes in prod should have proper v1 statuses.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
