### PR TITLE
[NOREF] - Default to current form step on request edits action page

### DIFF
--- a/src/views/GovernanceReviewTeam/Actions/RequestEdits.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/RequestEdits.tsx
@@ -16,7 +16,10 @@ import {
   CreateSystemIntakeActionRequestEdits,
   CreateSystemIntakeActionRequestEditsVariables
 } from 'queries/types/CreateSystemIntakeActionRequestEdits';
-import { SystemIntakeFormStep } from 'types/graphql-global-types';
+import {
+  SystemIntakeFormStep,
+  SystemIntakeStep
+} from 'types/graphql-global-types';
 
 import ActionForm, { SystemIntakeActionFields } from './components/ActionForm';
 
@@ -25,7 +28,13 @@ interface RequestEditsFields extends SystemIntakeActionFields {
   emailFeedback: string;
 }
 
-const RequestEdits = ({ systemIntakeId }: { systemIntakeId: string }) => {
+const RequestEdits = ({
+  systemIntakeId,
+  currentStep
+}: {
+  systemIntakeId: string;
+  currentStep: SystemIntakeStep | undefined;
+}) => {
   const { t } = useTranslation(['action', 'form']);
 
   const form = useForm<RequestEditsFields>();
@@ -96,6 +105,7 @@ const RequestEdits = ({ systemIntakeId }: { systemIntakeId: string }) => {
                   data-testid="intakeFormStep"
                   {...field}
                   ref={null}
+                  defaultValue={currentStep}
                 >
                   <option value="">{t('form:dropdownInitialSelect')}</option>
                   {[

--- a/src/views/GovernanceReviewTeam/Actions/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/index.test.tsx
@@ -134,6 +134,55 @@ describe('IT Gov Actions', () => {
       }
     };
 
+    it('target form dropdown selects the current form step by default', async () => {
+      renderActionPage({
+        action: 'request-edits',
+        mocks: [
+          getSystemIntakeQuery(),
+          getSystemIntakeContactsQuery,
+          getGovernanceTaskListQuery({
+            step: SystemIntakeStep.DRAFT_BUSINESS_CASE
+          }),
+          createSystemIntakeActionRequestEditsQuery
+        ]
+      });
+
+      expect(
+        await screen.findByRole('heading', { name: 'Action: request edits' })
+      ).toBeInTheDocument();
+
+      const dropdown = await screen.findByTestId('intakeFormStep');
+      expect(dropdown).toBeInTheDocument();
+      const selectedOption = dropdown.querySelector(
+        'option[selected]'
+      ) as HTMLOptionElement;
+      expect(selectedOption).toBeInTheDocument();
+      expect(selectedOption.value).toBe(SystemIntakeStep.DRAFT_BUSINESS_CASE);
+    });
+
+    it('target form dropdown has no selection when in a non-form step', async () => {
+      renderActionPage({
+        action: 'request-edits',
+        mocks: [
+          getSystemIntakeQuery(),
+          getSystemIntakeContactsQuery,
+          getGovernanceTaskListQuery({
+            step: SystemIntakeStep.GRT_MEETING
+          }),
+          createSystemIntakeActionRequestEditsQuery
+        ]
+      });
+
+      expect(
+        await screen.findByRole('heading', { name: 'Action: request edits' })
+      ).toBeInTheDocument();
+
+      const dropdown = await screen.findByTestId('intakeFormStep');
+      expect(dropdown).toBeInTheDocument();
+      const selectedOption = dropdown.querySelector('option[selected]');
+      expect(selectedOption).not.toBeInTheDocument();
+    });
+
     it('submits the form successfully', async () => {
       renderActionPage({
         action: 'request-edits',

--- a/src/views/GovernanceReviewTeam/Actions/index.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/index.tsx
@@ -157,7 +157,12 @@ const Actions = ({ systemIntake }: ActionsProps) => {
           {/* Request edits */}
           <Route
             path="/governance-review-team/:systemId/actions/request-edits"
-            render={() => <RequestEdits systemIntakeId={systemIntake.id} />}
+            render={() => (
+              <RequestEdits
+                currentStep={step}
+                systemIntakeId={systemIntake.id}
+              />
+            )}
           />
 
           {/* Progress to a new step */}


### PR DESCRIPTION
# NOREF

## Changes and Description

- The admin actions v2 request edits form defaults to the current form step of the intake.
- If the intake is not in a form step, it shows the "Select" option.

I just noticed while manually testing admin actions that the end user doesn't know the current form step when looking at the request edits page, so thought it would be nice for us to default to the current step. It might prevent a user from thinking a business case is in draft when it's really in final or vice versa and unintentionally progressing the intake for example.

## How to test this change

I added some tests to the current Req Edits form file that can be run with:
```sh
scripts/dev test:js
```

The changes can also be tested by creating an intake and setting it to a certain form step and then requesting edits through the UI.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [x] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
