### PR TITLE
Enable Rich text (FE) – TRB Admin notes

### DIFF
--- a/src/views/TechnicalAssistance/AdminHome/AddNote/index.test.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/AddNote/index.test.tsx
@@ -291,13 +291,7 @@ describe('Trb Admin Notes: Add Note', () => {
       );
 
       // Enter note text
-      typeRichText(screen.getByTestId('noteText'), 'My cute note');
-      // userEvent.type(
-      //   getByLabelText(
-      //     RegExp(i18next.t<string>('technicalAssistance:notes.labels.noteText'))
-      //   ),
-      //   'My cute note'
-      // );
+      await typeRichText(await screen.findByTestId('noteText'), 'My cute note');
 
       userEvent.click(submitButton);
     });
@@ -336,13 +330,7 @@ describe('Trb Admin Notes: Add Note', () => {
     );
 
     // Enter note text
-    typeRichText(screen.getByTestId('noteText'), 'My cute note');
-    // userEvent.type(
-    //   getByLabelText(
-    //     RegExp(i18next.t<string>('technicalAssistance:notes.labels.noteText'))
-    //   ),
-    //   'My cute note'
-    // );
+    await typeRichText(await screen.findByTestId('noteText'), 'My cute note');
 
     userEvent.click(
       getByRole('button', {

--- a/src/views/TechnicalAssistance/AdminHome/AddNote/index.test.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/AddNote/index.test.tsx
@@ -42,6 +42,7 @@ import {
 import { MockedQuery } from 'types/util';
 import easiMockStore from 'utils/testing/easiMockStore';
 import { mockTrbRequestId } from 'utils/testing/MockTrbAttendees';
+import typeRichText from 'utils/testing/typeRichText';
 
 import TRBRequestInfoWrapper from '../RequestContext';
 import AdminHome from '..';
@@ -290,12 +291,13 @@ describe('Trb Admin Notes: Add Note', () => {
       );
 
       // Enter note text
-      userEvent.type(
-        getByLabelText(
-          RegExp(i18next.t<string>('technicalAssistance:notes.labels.noteText'))
-        ),
-        'My cute note'
-      );
+      typeRichText(screen.getByTestId('noteText'), 'My cute note');
+      // userEvent.type(
+      //   getByLabelText(
+      //     RegExp(i18next.t<string>('technicalAssistance:notes.labels.noteText'))
+      //   ),
+      //   'My cute note'
+      // );
 
       userEvent.click(submitButton);
     });
@@ -334,12 +336,13 @@ describe('Trb Admin Notes: Add Note', () => {
     );
 
     // Enter note text
-    userEvent.type(
-      getByLabelText(
-        RegExp(i18next.t<string>('technicalAssistance:notes.labels.noteText'))
-      ),
-      'My cute note'
-    );
+    typeRichText(screen.getByTestId('noteText'), 'My cute note');
+    // userEvent.type(
+    //   getByLabelText(
+    //     RegExp(i18next.t<string>('technicalAssistance:notes.labels.noteText'))
+    //   ),
+    //   'My cute note'
+    // );
 
     userEvent.click(
       getByRole('button', {

--- a/src/views/TechnicalAssistance/AdminHome/AddNote/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/AddNote/index.tsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import PageHeading from 'components/PageHeading';
+import RichTextEditor from 'components/RichTextEditor';
 import Alert from 'components/shared/Alert';
 import CheckboxField from 'components/shared/CheckboxField';
 import { ErrorAlertMessage } from 'components/shared/ErrorAlert';
@@ -21,7 +22,6 @@ import HelpText from 'components/shared/HelpText';
 import Label from 'components/shared/Label';
 import MultiSelect from 'components/shared/MultiSelect';
 import RequiredAsterisk from 'components/shared/RequiredAsterisk';
-import TextAreaField from 'components/shared/TextAreaField';
 import Spinner from 'components/Spinner';
 import useCacheQuery from 'hooks/useCacheQuery';
 import useMessage from 'hooks/useMessage';
@@ -421,15 +421,24 @@ const AddNote = ({
               control={control}
               render={({ field, fieldState: { error } }) => (
                 <FormGroup>
-                  <Label htmlFor="noteText" className="text-normal" required>
+                  <Label
+                    id={`${field.name}-label`}
+                    htmlFor="noteText"
+                    className="text-normal"
+                    required
+                  >
                     {t('notes.labels.noteText')}
                   </Label>
-
-                  <TextAreaField
-                    {...field}
-                    ref={null}
-                    id={field.name}
-                    error={!!error}
+                  <RichTextEditor
+                    editableProps={{
+                      id: field.name,
+                      'data-testid': field.name,
+                      'aria-describedby': `${field.name}-hint`,
+                      'aria-labelledby': `${field.name}-label`
+                    }}
+                    field={{ ...field, value: field.value || '' }}
+                    height="300px"
+                    required
                   />
                 </FormGroup>
               )}

--- a/src/views/TechnicalAssistance/AdminHome/__snapshots__/Notes.test.tsx.snap
+++ b/src/views/TechnicalAssistance/AdminHome/__snapshots__/Notes.test.tsx.snap
@@ -87,7 +87,24 @@ exports[`Trb Admin Notes: View Notes > renders successfully  1`] = `
           <dd
             class="margin-left-0 margin-top-2"
           >
-            Initial Request Form Note
+            <div
+              class="easi-toast easi-toast-viewer"
+            >
+              <div>
+                <div
+                  class="toastui-editor-contents"
+                  style="overflow-wrap: break-word;"
+                >
+                  <p
+                    data-nodeid="1"
+                  >
+                    Initial Request Form Note
+                  </p>
+                  
+
+                </div>
+              </div>
+            </div>
           </dd>
         </div>
       </dl>
@@ -142,7 +159,24 @@ exports[`Trb Admin Notes: View Notes > renders successfully  1`] = `
           <dd
             class="margin-left-0 margin-top-2"
           >
-            Supporting Documents Note
+            <div
+              class="easi-toast easi-toast-viewer"
+            >
+              <div>
+                <div
+                  class="toastui-editor-contents"
+                  style="overflow-wrap: break-word;"
+                >
+                  <p
+                    data-nodeid="3"
+                  >
+                    Supporting Documents Note
+                  </p>
+                  
+
+                </div>
+              </div>
+            </div>
           </dd>
         </div>
       </dl>
@@ -197,7 +231,24 @@ exports[`Trb Admin Notes: View Notes > renders successfully  1`] = `
           <dd
             class="margin-left-0 margin-top-2"
           >
-            Advice Letter Note
+            <div
+              class="easi-toast easi-toast-viewer"
+            >
+              <div>
+                <div
+                  class="toastui-editor-contents"
+                  style="overflow-wrap: break-word;"
+                >
+                  <p
+                    data-nodeid="5"
+                  >
+                    Advice Letter Note
+                  </p>
+                  
+
+                </div>
+              </div>
+            </div>
           </dd>
         </div>
       </dl>
@@ -252,7 +303,24 @@ exports[`Trb Admin Notes: View Notes > renders successfully  1`] = `
           <dd
             class="margin-left-0 margin-top-2"
           >
-            General Request Note
+            <div
+              class="easi-toast easi-toast-viewer"
+            >
+              <div>
+                <div
+                  class="toastui-editor-contents"
+                  style="overflow-wrap: break-word;"
+                >
+                  <p
+                    data-nodeid="7"
+                  >
+                    General Request Note
+                  </p>
+                  
+
+                </div>
+              </div>
+            </div>
           </dd>
         </div>
       </dl>
@@ -307,7 +375,24 @@ exports[`Trb Admin Notes: View Notes > renders successfully  1`] = `
           <dd
             class="margin-left-0 margin-top-2"
           >
-            General Request Note
+            <div
+              class="easi-toast easi-toast-viewer"
+            >
+              <div>
+                <div
+                  class="toastui-editor-contents"
+                  style="overflow-wrap: break-word;"
+                >
+                  <p
+                    data-nodeid="9"
+                  >
+                    General Request Note
+                  </p>
+                  
+
+                </div>
+              </div>
+            </div>
           </dd>
         </div>
       </dl>
@@ -362,7 +447,24 @@ exports[`Trb Admin Notes: View Notes > renders successfully  1`] = `
           <dd
             class="margin-left-0 margin-top-2"
           >
-            Hidden note
+            <div
+              class="easi-toast easi-toast-viewer"
+            >
+              <div>
+                <div
+                  class="toastui-editor-contents"
+                  style="overflow-wrap: break-word;"
+                >
+                  <p
+                    data-nodeid="11"
+                  >
+                    Hidden note
+                  </p>
+                  
+
+                </div>
+              </div>
+            </div>
           </dd>
         </div>
       </dl>

--- a/src/views/TechnicalAssistance/AdminHome/components/Note/__snapshots__/index.test.tsx.snap
+++ b/src/views/TechnicalAssistance/AdminHome/components/Note/__snapshots__/index.test.tsx.snap
@@ -53,7 +53,24 @@ exports[`TRB Admin Note > Renders correct note information 1`] = `
       <dd
         class="margin-left-0 margin-top-2"
       >
-        My cute note
+        <div
+          class="easi-toast easi-toast-viewer"
+        >
+          <div>
+            <div
+              class="toastui-editor-contents"
+              style="overflow-wrap: break-word;"
+            >
+              <p
+                data-nodeid="1"
+              >
+                My cute note
+              </p>
+              
+
+            </div>
+          </div>
+        </div>
       </dd>
     </div>
   </dl>

--- a/src/views/TechnicalAssistance/AdminHome/components/Note/index.tsx
+++ b/src/views/TechnicalAssistance/AdminHome/components/Note/index.tsx
@@ -6,6 +6,7 @@ import { Grid } from '@trussworks/react-uswds';
 import classNames from 'classnames';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 
+import { RichTextViewer } from 'components/RichTextEditor';
 import {
   GetTrbAdminNotes_trbRequest_adminNotes as NoteType,
   GetTrbAdminNotes_trbRequest_adminNotes_categorySpecificData_TRBAdminNoteSupportingDocumentsCategoryData_documents as Document
@@ -138,7 +139,9 @@ const Note = ({ note, className, border = true }: NoteProps) => {
           }
         </dd>
 
-        <dd className="margin-left-0 margin-top-2">{note.noteText}</dd>
+        <dd className="margin-left-0 margin-top-2">
+          <RichTextViewer value={note.noteText} />
+        </dd>
       </Grid>
     </dl>
   );


### PR DESCRIPTION
# EASI-3490

## Changes and Description

Similar to the other recent RTE prs. This time for trb admin notes.

## Note
Unit tests pass but a new warning
`Warning: Can't perform a React state update on an unmounted component.`
shows up for
`src/views/TechnicalAssistance/AdminHome/AddNote/index.test.tsx > Trb Admin Notes: Add Note > shows an error notice when submission fails`

This happened when the rich text type test interaction was updated. It may have conflicts with the wrapping act(). Not sure why that would be or why the wrap needed to be in the first place.