### PR TITLE
[NOREF] Fix edits requested default step bug

### DIFF
--- a/src/views/GovernanceReviewTeam/Actions/RequestEdits.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/RequestEdits.tsx
@@ -37,7 +37,21 @@ const RequestEdits = ({
 }) => {
   const { t } = useTranslation(['action', 'form']);
 
-  const form = useForm<RequestEditsFields>();
+  /** Default `intakeFormStep` value
+   *
+   * Converts `currentStep` prop to `SystemIntakeFormStep` type
+   */
+  const defaultIntakeFormStep =
+    currentStep &&
+    SystemIntakeFormStep[
+      SystemIntakeStep[currentStep] as keyof typeof SystemIntakeFormStep
+    ];
+
+  const form = useForm<RequestEditsFields>({
+    defaultValues: {
+      intakeFormStep: defaultIntakeFormStep
+    }
+  });
 
   const { watch, control } = form;
 
@@ -105,7 +119,6 @@ const RequestEdits = ({
                   data-testid="intakeFormStep"
                   {...field}
                   ref={null}
-                  defaultValue={currentStep}
                 >
                   <option value="">{t('form:dropdownInitialSelect')}</option>
                   {[

--- a/src/views/GovernanceReviewTeam/Actions/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/index.test.tsx
@@ -153,12 +153,9 @@ describe('IT Gov Actions', () => {
       ).toBeInTheDocument();
 
       const dropdown = await screen.findByTestId('intakeFormStep');
+
       expect(dropdown).toBeInTheDocument();
-      const selectedOption = dropdown.querySelector(
-        'option[selected]'
-      ) as HTMLOptionElement;
-      expect(selectedOption).toBeInTheDocument();
-      expect(selectedOption.value).toBe(SystemIntakeStep.DRAFT_BUSINESS_CASE);
+      expect(dropdown).toHaveValue(SystemIntakeFormStep.DRAFT_BUSINESS_CASE);
     });
 
     it('target form dropdown has no selection when in a non-form step', async () => {

--- a/src/views/GovernanceReviewTeam/Actions/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/index.test.tsx
@@ -229,7 +229,7 @@ describe('IT Gov Actions', () => {
         mocks: [
           getSystemIntakeQuery(),
           getSystemIntakeContactsQuery,
-          getGovernanceTaskListQuery()
+          getGovernanceTaskListQuery({ step: SystemIntakeStep.GRB_MEETING })
         ]
       });
 


### PR DESCRIPTION
# NOREF

## Changes and Description

In the edits requested action form, the default value for "Which form needs edits" was being set in the field component but not in the actual field values object. This resulted in a field error if you tried submitting the form without touching that field, because the 'intakeFormStep' value was still undefined.

**Changes:**
- Converted the `currentStep` prop from the `SystemIntakeStep` type to `SystemIntakeFormStep`
- Moved setting  the default value from the field component to the form's `defaultValues` prop
- Updated unit tests

<!-- Put a description here! -->

## How to test this change

- Complete Request Edits form and make sure existing step is set as default
  - Default value should be set for initial request form, draft business case, and final business case steps. If request is in GRB or GRT meeting steps, field should default to `- Select -` with no value set.

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
