### PR TITLE
[EASI-3656] Remove intake request functionality

### DIFF
--- a/src/data/mock/govTaskList.ts
+++ b/src/data/mock/govTaskList.ts
@@ -22,6 +22,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.READY,
@@ -45,6 +46,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.IN_PROGRESS,
@@ -69,6 +71,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -92,6 +95,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.EDITS_REQUESTED,
@@ -121,6 +125,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -151,6 +156,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.IN_PROGRESS,
@@ -174,6 +180,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -197,6 +204,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -221,6 +229,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -251,6 +260,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -281,6 +291,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -304,6 +315,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -327,6 +339,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -350,6 +363,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -377,6 +391,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -405,6 +420,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -439,6 +455,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -473,6 +490,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -507,6 +525,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -536,6 +555,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -564,6 +584,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -592,6 +613,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -620,6 +642,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -648,6 +671,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -676,6 +700,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -710,6 +735,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -739,6 +765,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -767,6 +794,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -791,6 +819,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -819,6 +848,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -848,6 +878,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -877,6 +908,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -913,6 +945,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -949,6 +982,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -985,6 +1019,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -1016,6 +1051,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -1044,6 +1080,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -1072,6 +1109,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -1100,6 +1138,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -1128,6 +1167,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -1157,6 +1197,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -1185,6 +1226,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,
@@ -1213,6 +1255,7 @@ export const taskListState: {
     systemIntake: {
       __typename: 'SystemIntake',
       id,
+      requestName: 'Mock intake request',
       itGovTaskStatuses: {
         __typename: 'ITGovTaskStatuses',
         intakeFormStatus: ITGovIntakeFormStatus.COMPLETED,

--- a/src/data/mock/systemIntake.ts
+++ b/src/data/mock/systemIntake.ts
@@ -426,6 +426,7 @@ export const getGovernanceTaskListQuery = (
       systemIntake: {
         __typename: 'SystemIntake',
         id: systemIntakeId,
+        requestName: 'Mock system intake',
         itGovTaskStatuses: {
           __typename: 'ITGovTaskStatuses',
           intakeFormStatus: ITGovIntakeFormStatus.READY,

--- a/src/queries/GetGovernanceTaskListQuery.ts
+++ b/src/queries/GetGovernanceTaskListQuery.ts
@@ -4,6 +4,8 @@ export default gql`
   query GetGovernanceTaskList($id: UUID!) {
     systemIntake(id: $id) {
       id
+      requestName
+
       itGovTaskStatuses {
         intakeFormStatus
         feedbackFromInitialReviewStatus
@@ -13,10 +15,12 @@ export default gql`
         grbMeetingStatus
         decisionAndNextStepsStatus
       }
+
       governanceRequestFeedbacks {
         id
         targetForm
       }
+
       submittedAt
       updatedAt
       grtDate

--- a/src/queries/types/GetGovernanceTaskList.ts
+++ b/src/queries/types/GetGovernanceTaskList.ts
@@ -34,6 +34,7 @@ export interface GetGovernanceTaskList_systemIntake_businessCase {
 export interface GetGovernanceTaskList_systemIntake {
   __typename: "SystemIntake";
   id: UUID;
+  requestName: string | null;
   itGovTaskStatuses: GetGovernanceTaskList_systemIntake_itGovTaskStatuses;
   governanceRequestFeedbacks: GetGovernanceTaskList_systemIntake_governanceRequestFeedbacks[];
   submittedAt: Time | null;

--- a/src/views/GovernanceTaskList/index.test.tsx
+++ b/src/views/GovernanceTaskList/index.test.tsx
@@ -83,9 +83,13 @@ describe('Governance Task List', () => {
             })
           ]}
         >
-          <Route path="/governance-task-list/:systemId">
-            <GovernanceTaskList />
-          </Route>
+          <Provider store={store}>
+            <MessageProvider>
+              <Route path="/governance-task-list/:systemId">
+                <GovernanceTaskList />
+              </Route>
+            </MessageProvider>
+          </Provider>
         </VerboseMockedProvider>
       </MemoryRouter>
     );
@@ -107,9 +111,13 @@ describe('Governance Task List', () => {
             )
           ]}
         >
-          <Route path="/governance-task-list/:systemId">
-            <GovernanceTaskList />
-          </Route>
+          <Provider store={store}>
+            <MessageProvider>
+              <Route path="/governance-task-list/:systemId">
+                <GovernanceTaskList />
+              </Route>
+            </MessageProvider>
+          </Provider>
         </VerboseMockedProvider>
       </MemoryRouter>
     );

--- a/src/views/GovernanceTaskList/index.test.tsx
+++ b/src/views/GovernanceTaskList/index.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
 import {
   render,
@@ -8,7 +9,9 @@ import {
 import i18next from 'i18next';
 
 import { taskListState } from 'data/mock/govTaskList';
+import { MessageProvider } from 'hooks/useMessage';
 import GetGovernanceTaskListQuery from 'queries/GetGovernanceTaskListQuery';
+import easiMockStore from 'utils/testing/easiMockStore';
 import { getByRoleWithNameTextKey } from 'utils/testing/helpers';
 import VerboseMockedProvider from 'utils/testing/VerboseMockedProvider';
 
@@ -16,6 +19,8 @@ import GovernanceTaskList from '.';
 
 describe('Governance Task List', () => {
   const id = '80950153-4a66-4881-b728-f4cc701ff926';
+
+  const store = easiMockStore();
 
   it('renders a request task list at the initial state', async () => {
     render(
@@ -40,9 +45,13 @@ describe('Governance Task List', () => {
             }
           ]}
         >
-          <Route path="/governance-task-list/:systemId">
-            <GovernanceTaskList />
-          </Route>
+          <Provider store={store}>
+            <MessageProvider>
+              <Route path="/governance-task-list/:systemId">
+                <GovernanceTaskList />
+              </Route>
+            </MessageProvider>
+          </Provider>
         </VerboseMockedProvider>
       </MemoryRouter>
     );


### PR DESCRIPTION
# EASI-3656

## Changes and Description

- Fixed "Remove your request" link in sidebar of v2 task list
  - Link triggers modal and archives request (same as v1)

<!-- Put a description here! -->

## How to test this change

1. Create new intake request
2. Go to task list
3. Click "Remove your request" link in sidebar
4. Click "Remove request" button in modal
5. Confirm that request shows up in "closed requests" tab of system intakes table

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
