### PR TITLE
[EASI-3715] Filter out archived intakes from fetch queries

### DIFF
--- a/EASI.postman_collection.json
+++ b/EASI.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "de661b7b-cb82-4fcd-bfb6-2d4724f7e261",
+		"_postman_id": "4964f9c7-75e0-4405-9373-569ba488d5e4",
 		"name": "EASI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "11253221"
@@ -695,6 +695,35 @@
 							"response": []
 						},
 						{
+							"name": "SystemIntake Delete (archive)",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{apiURL}}/system_intake/{{systemIntakeID}}",
+									"host": [
+										"{{apiURL}}"
+									],
+									"path": [
+										"system_intake",
+										"{{systemIntakeID}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "CreateSystemIntakeContact (FORM1)",
 							"event": [
 								{
@@ -1116,7 +1145,39 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query systemIntake {\n  systemIntake(id:\"{{systemIntakeID}}\") {\n    step\n    requestFormState\n    draftBusinessCaseState\n    grtMeetingState\n    finalBusinessCaseState\n    grbMeetingState\n    decisionState\n    itGovTaskStatuses {      \n        intakeFormStatus\n        feedbackFromInitialReviewStatus\n        decisionAndNextStepsStatus\n        bizCaseDraftStatus\n        grtMeetingStatus\n        bizCaseFinalStatus\n        grbMeetingStatus\n    }\n    id\n    actions {\n        type\n        actor {\n            name\n        }\n        step\n        feedback\n    }\n#   adminLead\n#   archivedAt\n# #   businessCase\n#   businessNeed\n# #   businessOwner\n#   businessSolution\n# #   contract\n# #   costs\n#   createdAt\n#   currentStage\n#   decisionNextSteps\n#   eaCollaborator\n#   eaCollaboratorName\n#   euaUserId\n#   existingFunding\n# #   fundingSources\n# #   governanceTeams\n#   grbDate\n#   grtDate\n# #   grtFeedbacks\n#   id\n# #   isso\n#   lcid\n#   lcidExpiresAt\n#   lcidScope\n#   lcidCostBaseline\n#   needsEaSupport\n# #   notes\n#   oitSecurityCollaborator\n#   oitSecurityCollaboratorName\n# #   productManager\n#   projectAcronym\n#   rejectionReason\n#   requestName\n#   requestType\n# #   requester\n#   status\n#   submittedAt\n#   trbCollaborator\n#   trbCollaboratorName\n#   updatedAt\n#   grtReviewEmailBody\n#   decidedAt\n#   businessCaseId\n# #   lastAdminNote\n#   cedarSystemId\n# #   documents\n#   hasUiChanges\n    \n    \n  }\n  \n  \n}",
+								"query": "query systemIntake {\n  systemIntake(id:\"{{systemIntakeID}}\") {\n    step\n    state\n    status\n    archivedAt\n    requestFormState\n    draftBusinessCaseState\n    grtMeetingState\n    finalBusinessCaseState\n    grbMeetingState\n    decisionState\n    itGovTaskStatuses {      \n        intakeFormStatus\n        feedbackFromInitialReviewStatus\n        decisionAndNextStepsStatus\n        bizCaseDraftStatus\n        grtMeetingStatus\n        bizCaseFinalStatus\n        grbMeetingStatus\n    }\n    id\n    actions {\n        type\n        actor {\n            name\n        }\n        step\n        feedback\n    }\n#   adminLead\n# #   businessCase\n#   businessNeed\n# #   businessOwner\n#   businessSolution\n# #   contract\n# #   costs\n#   createdAt\n#   currentStage\n#   decisionNextSteps\n#   eaCollaborator\n#   eaCollaboratorName\n#   euaUserId\n#   existingFunding\n# #   fundingSources\n# #   governanceTeams\n#   grbDate\n#   grtDate\n# #   grtFeedbacks\n#   id\n# #   isso\n#   lcid\n#   lcidExpiresAt\n#   lcidScope\n#   lcidCostBaseline\n#   needsEaSupport\n# #   notes\n#   oitSecurityCollaborator\n#   oitSecurityCollaboratorName\n# #   productManager\n#   projectAcronym\n#   rejectionReason\n#   requestName\n#   requestType\n# #   requester\n#   status\n#   submittedAt\n#   trbCollaborator\n#   trbCollaboratorName\n#   updatedAt\n#   grtReviewEmailBody\n#   decidedAt\n#   businessCaseId\n# #   lastAdminNote\n#   cedarSystemId\n# #   documents\n#   hasUiChanges\n    \n    \n  }\n  \n  \n}",
+								"variables": ""
+							}
+						},
+						"url": {
+							"raw": "{{url}}",
+							"host": [
+								"{{url}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "SystemIntake Get Homepage Admin Table",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "graphql",
+							"graphql": {
+								"query": "query systemIntake {\n  systemIntake(id:\"{{systemIntakeID}}\") {\n    step\n    state\n    status\n    archivedAt\n    requestFormState\n    draftBusinessCaseState\n    grtMeetingState\n    finalBusinessCaseState\n    grbMeetingState\n    decisionState\n    itGovTaskStatuses {      \n        intakeFormStatus\n        feedbackFromInitialReviewStatus\n        decisionAndNextStepsStatus\n        bizCaseDraftStatus\n        grtMeetingStatus\n        bizCaseFinalStatus\n        grbMeetingStatus\n    }\n    id\n    actions {\n        type\n        actor {\n            name\n        }\n        step\n        feedback\n    }\n#   adminLead\n# #   businessCase\n#   businessNeed\n# #   businessOwner\n#   businessSolution\n# #   contract\n# #   costs\n#   createdAt\n#   currentStage\n#   decisionNextSteps\n#   eaCollaborator\n#   eaCollaboratorName\n#   euaUserId\n#   existingFunding\n# #   fundingSources\n# #   governanceTeams\n#   grbDate\n#   grtDate\n# #   grtFeedbacks\n#   id\n# #   isso\n#   lcid\n#   lcidExpiresAt\n#   lcidScope\n#   lcidCostBaseline\n#   needsEaSupport\n# #   notes\n#   oitSecurityCollaborator\n#   oitSecurityCollaboratorName\n# #   productManager\n#   projectAcronym\n#   rejectionReason\n#   requestName\n#   requestType\n# #   requester\n#   status\n#   submittedAt\n#   trbCollaborator\n#   trbCollaboratorName\n#   updatedAt\n#   grtReviewEmailBody\n#   decidedAt\n#   businessCaseId\n# #   lastAdminNote\n#   cedarSystemId\n# #   documents\n#   hasUiChanges\n    \n    \n  }\n  \n  \n}",
 								"variables": ""
 							}
 						},

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -218,7 +218,8 @@ func GetStatusesByFilter(filter SystemIntakeStatusFilter) ([]SystemIntakeStatus,
 	case SystemIntakeStatusFilterCLOSED:
 		return []SystemIntakeStatus{
 			SystemIntakeStatusLCIDISSUED,
-			SystemIntakeStatusWITHDRAWN,
+			// prevents withdrawn intakes from appearing in "CLOSED" tab of admin view
+			// SystemIntakeStatusWITHDRAWN,
 			SystemIntakeStatusNOTITREQUEST,
 			SystemIntakeStatusNOTAPPROVED,
 			SystemIntakeStatusNOGOVERNANCE,

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -409,6 +409,7 @@ func (s *Store) FetchSystemIntakes(ctx context.Context) (models.SystemIntakes, e
 // This is a bit of a hold-over, and should be simplified when we start to filter based on IT Gov v2 states, which should be
 // much simpler to use
 // TODO: Modify with https://jiraent.cms.gov/browse/EASI-3440
+// TODO: This method is not currently in use.
 func (s *Store) FetchIntakesForAdmins(ctx context.Context) ([]*models.SystemIntake, error) {
 	intakes := []*models.SystemIntake{}
 	err := s.db.Select(&intakes, `

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -269,20 +269,21 @@ func (s *Store) UpdateSystemIntake(ctx context.Context, intake *models.SystemInt
 
 const fetchSystemIntakeSQL = `
 		SELECT
-		       system_intakes.*,
-		       business_cases.id as business_case_id
+			system_intakes.*,
+		    business_cases.id as business_case_id
 		FROM
-		     system_intakes
-		     LEFT JOIN business_cases ON business_cases.system_intake = system_intakes.id
+		    system_intakes
+		    LEFT JOIN business_cases ON business_cases.system_intake = system_intakes.id
 `
 
 // FetchSystemIntakeByID queries the DB for a system intake matching the given ID
 func (s *Store) FetchSystemIntakeByID(ctx context.Context, id uuid.UUID) (*models.SystemIntake, error) {
 	intake := models.SystemIntake{}
-	const idMatchClause = `
+	const whereClause = `
 		WHERE system_intakes.id=$1
+			AND system_intakes.archived_at IS NULL AND system_intakes.status != 'WITHDRAWN'
 `
-	err := s.db.Get(&intake, fetchSystemIntakeSQL+idMatchClause, id)
+	err := s.db.Get(&intake, fetchSystemIntakeSQL+whereClause, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			appcontext.ZLogger(ctx).Info(
@@ -345,6 +346,7 @@ func (s *Store) FetchSystemIntakeByLifecycleID(ctx context.Context, lifecycleID 
 	intakes := []models.SystemIntake{}
 	const matchClause = `
 		WHERE system_intakes.lcid=$1
+			AND system_intakes.archived_at IS NULL AND system_intakes.status != 'WITHDRAWN'
 	`
 	err := s.db.Select(&intakes, fetchSystemIntakeSQL+matchClause, lifecycleID)
 	if err != nil {
@@ -409,7 +411,10 @@ func (s *Store) FetchSystemIntakes(ctx context.Context) (models.SystemIntakes, e
 // TODO: Modify with https://jiraent.cms.gov/browse/EASI-3440
 func (s *Store) FetchIntakesForAdmins(ctx context.Context) ([]*models.SystemIntake, error) {
 	intakes := []*models.SystemIntake{}
-	err := s.db.Select(&intakes, "SELECT * FROM system_intakes WHERE status NOT IN ('INTAKE_DRAFT','APPROVED','CLOSED')")
+	err := s.db.Select(&intakes, `
+		SELECT * FROM system_intakes WHERE status NOT IN ('INTAKE_DRAFT','APPROVED','CLOSED')
+		AND archived_at IS NULL AND status != 'WITHDRAWN'
+	`)
 	if err != nil {
 		appcontext.ZLogger(ctx).Error(fmt.Sprintf("Failed to fetch system intakes %s", err))
 		return []*models.SystemIntake{}, err
@@ -418,6 +423,7 @@ func (s *Store) FetchIntakesForAdmins(ctx context.Context) ([]*models.SystemInta
 }
 
 // FetchSystemIntakesByStatuses queries the DB for all system intakes matching a status filter
+// Is this in use? It should be removed post admin actions v2 launch or modified
 func (s *Store) FetchSystemIntakesByStatuses(ctx context.Context, allowedStatuses []models.SystemIntakeStatus) (models.SystemIntakes, error) {
 	var intakes models.SystemIntakes
 	query := `

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -281,8 +281,8 @@ func (s *Store) FetchSystemIntakeByID(ctx context.Context, id uuid.UUID) (*model
 	intake := models.SystemIntake{}
 	const whereClause = `
 		WHERE system_intakes.id=$1
-			AND system_intakes.archived_at IS NULL AND system_intakes.status != 'WITHDRAWN'
-`
+	`
+	// should not filter for archived because the update method relies on this method to return the archived intake
 	err := s.db.Get(&intake, fetchSystemIntakeSQL+whereClause, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
# EASI-3715

## Changes and Description

- This changes filters out `WITHDRAWN` status intakes from the table views of requesters and admins.
- Postman collection updated.
- After launch, we should run a migration to delete the intakes with this status or timestamp, modify the delete methods to truly delete the intakes, and remove these filters from the queries.

## How to test this change

Use Postman to create/delete (archive) requests. Postman request for the admin home page table view of requests also added.

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
