### PR TITLE
[EASI-3716] Decision actions edits requested modal

### DIFF
--- a/src/views/GovernanceReviewTeam/Actions/RequestEdits.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/RequestEdits.tsx
@@ -37,6 +37,13 @@ const RequestEdits = ({
 }) => {
   const { t } = useTranslation(['action', 'form']);
 
+  const [mutate] = useMutation<
+    CreateSystemIntakeActionRequestEdits,
+    CreateSystemIntakeActionRequestEditsVariables
+  >(CreateSystemIntakeActionRequestEditsQuery, {
+    refetchQueries: ['GetGovernanceTaskList']
+  });
+
   /** Default `intakeFormStep` value
    *
    * Converts `currentStep` prop to `SystemIntakeFormStep` type
@@ -60,11 +67,6 @@ const RequestEdits = ({
       variables: { input: { systemIntakeID: systemIntakeId, ...formData } }
     });
   };
-
-  const [mutate] = useMutation<
-    CreateSystemIntakeActionRequestEdits,
-    CreateSystemIntakeActionRequestEditsVariables
-  >(CreateSystemIntakeActionRequestEditsQuery);
 
   const intakeFormStepName = t(
     `requestEdits.option.intakeFormStep.${watch('intakeFormStep')}`


### PR DESCRIPTION
# EASI-3716

## Changes and Description

From UX QA doc
- [Decision warning modal not appearing](https://docs.google.com/document/d/1oZBAphS7VgoFIjcTXMSyXfb6LbAQMylTqPxMxlzHnyU/edit#heading=h.9td6b9f0towf)
  - Modal was not showing up because forms were using cached `taskStatuses` to determine if edits had been requested
  - Updated Edits Requested component to refetch `GetGovernanceTaskList` after mutation

<!-- Put a description here! -->

## How to test this change

- Request edits to a form
- Test decision action forms to confirm modal appears after clicking submit button
  - Not approved by GRB 
  - Issue a Life Cycle ID
  - Not an IT Governance request

**Note:** submitting the decision action forms removes the "edits requested" status. To test on all three forms without having to go through additional steps, don't submit the form after confirming the modal appears.

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
