### PR TITLE
[EASI-3176] Fix Manage LCID action form rich text fields

### DIFF
--- a/src/views/GovernanceReviewTeam/Actions/ManageLcid/ExpireLcid.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ManageLcid/ExpireLcid.tsx
@@ -81,7 +81,7 @@ const ExpireLcid = ({ systemIntakeId, lcidStatus, lcid }: ExpireLcidProps) => {
         <Controller
           name="reason"
           control={control}
-          render={({ field: { ref, ...field }, fieldState: { error } }) => (
+          render={({ field, fieldState: { error } }) => (
             <FormGroup error={!!error}>
               <Label
                 htmlFor={field.name}
@@ -98,7 +98,7 @@ const ExpireLcid = ({ systemIntakeId, lcidStatus, lcid }: ExpireLcidProps) => {
                 <FieldErrorMsg>{t(error.message)}</FieldErrorMsg>
               )}
               <RichTextEditor
-                {...field}
+                field={field}
                 editableProps={{
                   id: field.name,
                   'data-testid': field.name,
@@ -112,7 +112,7 @@ const ExpireLcid = ({ systemIntakeId, lcidStatus, lcid }: ExpireLcidProps) => {
         <Controller
           name="nextSteps"
           control={control}
-          render={({ field: { ref, ...field } }) => (
+          render={({ field }) => (
             <FormGroup>
               <Label
                 htmlFor={field.name}
@@ -125,7 +125,7 @@ const ExpireLcid = ({ systemIntakeId, lcidStatus, lcid }: ExpireLcidProps) => {
                 {t('expireLcid.nextStepsHelpText')}
               </HelpText>
               <RichTextEditor
-                {...field}
+                field={field}
                 editableProps={{
                   id: field.name,
                   'data-testid': field.name,

--- a/src/views/GovernanceReviewTeam/Actions/ManageLcid/RetireLcid.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ManageLcid/RetireLcid.tsx
@@ -151,7 +151,7 @@ const RetireLcid = ({
             <Controller
               control={control}
               name="reason"
-              render={({ field: { ref, ...field } }) => (
+              render={({ field }) => (
                 <FormGroup>
                   <Label
                     htmlFor={field.name}
@@ -164,7 +164,7 @@ const RetireLcid = ({
                     {t('retireLcid.reasonHelpText')}
                   </HelpText>
                   <RichTextEditor
-                    {...field}
+                    field={field}
                     editableProps={{
                       id: field.name,
                       'data-testid': field.name,

--- a/src/views/GovernanceReviewTeam/Actions/ManageLcid/UpdateLcid.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ManageLcid/UpdateLcid.tsx
@@ -159,7 +159,7 @@ const UpdateLcid = ({
         <Controller
           name="scope"
           control={control}
-          render={({ field: { ref, ...field }, fieldState: { error } }) => (
+          render={({ field, fieldState: { error } }) => (
             <FormGroup error={!!error}>
               <Label
                 htmlFor={field.name}
@@ -175,7 +175,7 @@ const UpdateLcid = ({
                 <FieldErrorMsg>{t(error.message)}</FieldErrorMsg>
               )}
               <RichTextEditor
-                {...field}
+                field={field}
                 editableProps={{
                   id: field.name,
                   'data-testid': field.name,
@@ -190,7 +190,7 @@ const UpdateLcid = ({
         <Controller
           name="nextSteps"
           control={control}
-          render={({ field: { ref, ...field }, fieldState: { error } }) => (
+          render={({ field, fieldState: { error } }) => (
             <FormGroup error={!!error}>
               <Label
                 htmlFor={field.name}
@@ -206,7 +206,7 @@ const UpdateLcid = ({
                 <FieldErrorMsg>{t(error.message)}</FieldErrorMsg>
               )}
               <RichTextEditor
-                {...field}
+                field={field}
                 editableProps={{
                   id: field.name,
                   'data-testid': field.name,
@@ -244,7 +244,7 @@ const UpdateLcid = ({
         <Controller
           name="reason"
           control={control}
-          render={({ field: { ref, ...field }, fieldState: { error } }) => (
+          render={({ field, fieldState: { error } }) => (
             <FormGroup error={!!error}>
               <Label
                 htmlFor={field.name}
@@ -257,7 +257,7 @@ const UpdateLcid = ({
                 {t('updateLcid.reasonHelpText')}
               </HelpText>
               <RichTextEditor
-                {...field}
+                field={field}
                 editableProps={{
                   id: field.name,
                   'data-testid': field.name,


### PR DESCRIPTION
# EASI-3716

## Changes and Description

Manage LCID action forms rich text fields were returning `wysiwyg` as the field value. See [Slack thread](https://cmsgov.slack.com/archives/CNU2B59UH/p1702316265976989) for details.

- Updated `RichTextEditor` component `field` props in Manage LCID action forms

<!-- Put a description here! -->

## How to test this change

- Issue LCID to intake request
- Complete Update LCID form with all fields filled
- Ensure correct new field values are showing on Lifecycle ID admin page

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
