### PR TITLE
[NOREF] Store reason for rejection from Not IT Gov decision

### DIFF
--- a/pkg/graph/resolvers/system_intake_actions.go
+++ b/pkg/graph/resolvers/system_intake_actions.go
@@ -720,8 +720,7 @@ func CreateSystemIntakeActionNotITGovRequest(
 	if err != nil {
 		return nil, err
 	}
-	// TODO: Send Notification Email (EASI-3109)
-	// input.Reason is currently not persisted and only sent in the notification email
+
 	_, err = store.CreateAction(ctx, &models.Action{
 		ActionType:     models.ActionTypeNOTITGOVREQUEST,
 		ActorName:      adminTakingAction.CommonName,

--- a/pkg/graph/resolvers/system_intake_actions.go
+++ b/pkg/graph/resolvers/system_intake_actions.go
@@ -707,6 +707,7 @@ func CreateSystemIntakeActionNotITGovRequest(
 	}
 	intake.State = models.SystemIntakeStateCLOSED
 	intake.Step = models.SystemIntakeStepDECISION
+	intake.RejectionReason = input.Reason
 	intake.DecisionState = models.SIDSNotGovernance
 
 	updatedTime := time.Now()

--- a/pkg/graph/resolvers/system_intake_actions_test.go
+++ b/pkg/graph/resolvers/system_intake_actions_test.go
@@ -909,6 +909,7 @@ func (s *ResolverSuite) TestSystemIntakeNotITGovRequestAction() {
 				s.NoError(err)
 				additionalInfo := models.HTMLPointer("banana")
 				adminNote := models.HTMLPointer("apple")
+				reason := models.HTMLPointer("meatloaf")
 				actionedIntake, err := CreateSystemIntakeActionNotITGovRequest(
 					ctx,
 					s.testConfigs.Store,
@@ -921,7 +922,7 @@ func (s *ResolverSuite) TestSystemIntakeNotITGovRequestAction() {
 							ShouldNotifyITGovernance: false,
 							ShouldNotifyITInvestment: false,
 						},
-						Reason:         models.HTMLPointer("meatloaf"),
+						Reason:         reason,
 						AdditionalInfo: additionalInfo,
 						AdminNote:      adminNote,
 					},
@@ -935,6 +936,8 @@ func (s *ResolverSuite) TestSystemIntakeNotITGovRequestAction() {
 				s.Equal(models.SystemIntakeStepDECISION, actionedIntake.Step)
 				// Decision state should be NOT_GOVERNANCE
 				s.Equal(models.SIDSNotGovernance, actionedIntake.DecisionState)
+				// Rejection Reason should be stored
+				s.Equal(reason, actionedIntake.RejectionReason)
 			})
 		}
 	}


### PR DESCRIPTION
# NOREF

## Changes and Description

- Stores the `reason` input from the "Not an IT Gov Request" decision action under `RejectionReason` on intakes.

## How to test this change

Create an intake, close it as "Not an IT Gov Request", retrieve the intake using GQL to verify the reason is retrieved as `rejectionReason`.

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
