### PR TITLE
EASI-3716 Different email section alert for certain action UIs

### DIFF
--- a/src/views/GovernanceReviewTeam/Actions/ManageLcid/ExpireLcid.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ManageLcid/ExpireLcid.tsx
@@ -77,6 +77,7 @@ const ExpireLcid = ({ systemIntakeId, lcidStatus, lcid }: ExpireLcidProps) => {
             title={t('manageLcid.expire', { context: lcidStatus })}
           />
         }
+        notificationAlertWarn
       >
         <Controller
           name="reason"

--- a/src/views/GovernanceReviewTeam/Actions/ManageLcid/RetireLcid.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ManageLcid/RetireLcid.tsx
@@ -113,6 +113,7 @@ const RetireLcid = ({
             })}
           />
         }
+        notificationAlertWarn
       >
         <Controller
           control={control}

--- a/src/views/GovernanceReviewTeam/Actions/ManageLcid/UpdateLcid.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/ManageLcid/UpdateLcid.tsx
@@ -110,6 +110,7 @@ const UpdateLcid = ({
             />
           </LcidTitleBox>
         }
+        notificationAlertWarn
       >
         <h3 className="margin-bottom-1">{t('updateLcid.title')}</h3>
         <HelpText className="line-height-body-5">

--- a/src/views/GovernanceReviewTeam/Actions/Resolutions/CloseRequest.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/Resolutions/CloseRequest.tsx
@@ -108,6 +108,7 @@ const CloseRequest = ({
           />
         }
         modal={modal}
+        notificationAlertWarn
       >
         <Controller
           name="reason"

--- a/src/views/GovernanceReviewTeam/Actions/Resolutions/ReopenRequest.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/Resolutions/ReopenRequest.tsx
@@ -72,6 +72,7 @@ const ReopenRequest = ({
             decisionState={decisionState}
           />
         }
+        notificationAlertWarn
       >
         <Controller
           name="reason"

--- a/src/views/GovernanceReviewTeam/Actions/components/ActionForm.tsx
+++ b/src/views/GovernanceReviewTeam/Actions/components/ActionForm.tsx
@@ -69,6 +69,8 @@ export type ActionFormProps<TFieldValues extends SystemIntakeActionFields> = {
   errorKeyContext?: string;
   children?: React.ReactNode;
   className?: string;
+  // Switch notification type to warning instead of info default
+  notificationAlertWarn?: boolean;
 } & Omit<JSX.IntrinsicElements['form'], 'onSubmit' | 'title'>;
 
 /**
@@ -94,6 +96,7 @@ const ActionForm = <TFieldValues extends SystemIntakeActionFields>({
   errorKeyContext,
   children,
   className,
+  notificationAlertWarn = false,
   ...formProps
 }: ActionFormProps<TFieldValues>) => {
   const { t } = useTranslation('action');
@@ -305,7 +308,7 @@ const ActionForm = <TFieldValues extends SystemIntakeActionFields>({
           <h3 className="margin-bottom-0 margin-top-6">
             {t('notification.heading')}
           </h3>
-          <Alert type="info" slim>
+          <Alert type={notificationAlertWarn ? 'warning' : 'info'} slim>
             {t('notification.alert')}
           </Alert>
           <Trans


### PR DESCRIPTION
# EASI-3716

"Different email section alert/banner for certain action UIs" from [the ux qa doc](https://docs.google.com/document/d/1oZBAphS7VgoFIjcTXMSyXfb6LbAQMylTqPxMxlzHnyU/edit)

## Changes and Description

- ActionForm `notificationAlertWarn` property set on the actions forms for
  - expire
  - retire
  - update LCID
  - close
  - and re-open

<!-- Put a description here! -->

## How to test this change

Go through the request actions and make sure that only the forms from the above list have the Notification email section's alert box as the warning type.