### PR TITLE
EASI-3438 Various search fixes (EASi)

### DIFF
--- a/src/components/AccessibilityDocumentsList/index.tsx
+++ b/src/components/AccessibilityDocumentsList/index.tsx
@@ -175,7 +175,7 @@ const AccessibilityDocumentsList = ({
       data,
       documents,
       autoResetSortBy: false,
-      autoResetPage: false,
+      autoResetPage: true,
       initialState: {
         sortBy: useMemo(() => [{ id: 'uploadedAt', desc: true }], [])
       }

--- a/src/components/AccessibilityRequestsTable/index.tsx
+++ b/src/components/AccessibilityRequestsTable/index.tsx
@@ -169,7 +169,7 @@ const AccessibilityRequestsTable: FunctionComponent<AccessibilityRequestsTablePr
       globalFilter: useMemo(() => globalFilterCellText, []),
       requests,
       autoResetSortBy: false,
-      autoResetPage: false,
+      autoResetPage: true,
       initialState: {
         sortBy: useMemo(() => [{ id: 'submittedAt', desc: true }], []),
         pageIndex: 0

--- a/src/components/RequestRepository/index.tsx
+++ b/src/components/RequestRepository/index.tsx
@@ -205,7 +205,7 @@ const RequestRepository = () => {
       globalFilter: useMemo(() => globalFilterCellText, []),
       data,
       autoResetSortBy: false,
-      autoResetPage: false,
+      autoResetPage: true,
       initialState: {
         sortBy: useMemo(() => lastSort[activeTable], [lastSort, activeTable]),
         pageSize: defaultPageSize

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -196,7 +196,7 @@ const Table = ({
       },
       globalFilter: useMemo(() => globalFilterCellText, []),
       autoResetSortBy: false,
-      autoResetPage: false,
+      autoResetPage: true,
       initialState: {
         sortBy: useMemo(() => [{ id: 'submittedAt', desc: true }], []),
         pageIndex: 0,

--- a/src/views/SystemIntake/Documents/DocumentsTable.tsx
+++ b/src/views/SystemIntake/Documents/DocumentsTable.tsx
@@ -205,7 +205,7 @@ const DocumentsTable = ({
       columns,
       data: documents,
       autoResetSortBy: false,
-      autoResetPage: false,
+      autoResetPage: true,
       initialState: {
         sortBy: useMemo(() => [{ id: 'uploadedAt', desc: true }], [])
       }

--- a/src/views/SystemList/Table.tsx
+++ b/src/views/SystemList/Table.tsx
@@ -192,7 +192,7 @@ export const Table = ({
       data: systems as CedarSystem[],
       globalFilter: useMemo(() => globalFilterCellText, []),
       autoResetSortBy: false,
-      autoResetPage: false,
+      autoResetPage: true,
       initialState: {
         sortBy: useMemo(() => [{ id: 'systemName', desc: false }], []),
         pageIndex: 0,

--- a/src/views/TechnicalAssistance/Homepage.tsx
+++ b/src/views/TechnicalAssistance/Homepage.tsx
@@ -133,7 +133,7 @@ function Homepage() {
       globalFilter: useMemo(() => globalFilterCellText, []),
       data: useMemo(() => data?.myTrbRequests || [], [data?.myTrbRequests]),
       autoResetSortBy: false,
-      autoResetPage: false,
+      autoResetPage: true,
       initialState: {
         sortBy: useMemo(() => [{ id: 'form.submittedAt', desc: true }], []),
         pageIndex: 0,

--- a/src/views/TechnicalAssistance/RequestForm/DocumentsTable.tsx
+++ b/src/views/TechnicalAssistance/RequestForm/DocumentsTable.tsx
@@ -260,7 +260,7 @@ function DocumentsTable({
       columns,
       data: documents,
       autoResetSortBy: false,
-      autoResetPage: false,
+      autoResetPage: true,
       initialState: {
         sortBy: useMemo(() => [{ id: 'uploadedAt', desc: true }], [])
       }

--- a/src/views/TechnicalAssistance/TrbAdminTeamHome.tsx
+++ b/src/views/TechnicalAssistance/TrbAdminTeamHome.tsx
@@ -205,7 +205,7 @@ function TrbNewRequestsTable({ requests, className }: TrbRequestsTableProps) {
       globalFilter: useMemo(() => globalFilterCellText, []),
       data: requests,
       autoResetSortBy: false,
-      autoResetPage: false,
+      autoResetPage: true,
       initialState: {
         sortBy: useMemo(() => [{ id: 'form.submittedAt', desc: true }], []),
         pageIndex: 0,
@@ -423,7 +423,7 @@ function TrbExistingRequestsTable({ requests }: TrbRequestsTableProps) {
         [activeTable, requests]
       ),
       autoResetSortBy: false,
-      autoResetPage: false,
+      autoResetPage: true,
       initialState: {
         sortBy: useMemo(() => [{ id: 'form.submittedAt', desc: true }], []),
         pageIndex: 0,


### PR DESCRIPTION
# EASI-3438

## Changes and Description

useTable autoResetPage set to true (fix method copied from mint)

<!-- Put a description here! -->

## How to test this change

Follow reproduction steps in the ticket to make sure that what is described is no longer the case

1. Go to Systems tab in IMPL
2. Navigate to page 2 of the results
3. Search for "ACO"
4. See that pagination resets to page 1, where the ACO result shows up

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
