### PR TITLE
[NOREF] Disable NPM major upgrades from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,11 +44,13 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 1
     groups:
-      major:
-        patterns:
-          - "*"
-        update-types:
-          - "major"
+      # We currently have far too many major NPM packages to upgrade reasonably with dependabot.
+      # Let's uncomment this when we're ready to start upgrading them.
+      # major:
+      #   patterns:
+      #     - "*"
+      #   update-types:
+      #     - "major"
       other:
         patterns:
           - "*"


### PR DESCRIPTION
# NOREF

## Changes and Description

- This PR aims to disable major NPM upgrades being suggested from dependabot, as it was often suggesting PRs with 40+ package upgrades, which is unreasonable for a single PR.

https://github.com/CMSgov/easi-app/pull/2324 is an example of one of those PRs!

## How to test this change

- Just ensure that this is still a valid dependabot file!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
