### PR TITLE
EASI-3782 Cleanup v1 references on Admin home page (table)

### DIFF
--- a/src/components/RequestRepository/tableMap.ts
+++ b/src/components/RequestRepository/tableMap.ts
@@ -1,4 +1,4 @@
-import { TFunction } from 'i18next';
+import i18next, { TFunction } from 'i18next';
 import { sortBy } from 'lodash';
 
 import contractStatus from 'constants/enums/contractStatus';
@@ -8,7 +8,6 @@ import {
 } from 'queries/types/GetSystemIntakesTable';
 import { formatContractDate } from 'utils/date';
 import { getPersonNameAndComponentAcronym } from 'utils/getPersonNameAndComponent';
-import { translateStatus } from 'utils/systemIntake';
 
 // Here is where the data can be modified and used appropriately for sorting.
 // Modifed data can then be configured with JSX components in column cell configuration
@@ -128,7 +127,12 @@ const tableMap = (
         startDate: contractStartDate,
         endDate: contractEndDate
       },
-      status: translateStatus(intake.status, intake.lcid),
+      status: i18next.t(
+        `governanceReviewTeam:systemIntakeStatusAdmin.${intake.statusAdmin}`,
+        {
+          lcid: intake.lcid
+        }
+      ),
       lastAdminNote,
       filterDate
     };

--- a/src/components/RequestRepository/useRequestTableColumns.tsx
+++ b/src/components/RequestRepository/useRequestTableColumns.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { CellProps, Column, Row } from 'react-table';
 import { IconError } from '@trussworks/react-uswds';
-import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import TruncatedText from 'components/shared/TruncatedText';
@@ -20,7 +19,6 @@ const useRequestTableColumns = (
   activeTable: 'open' | 'closed'
 ): Array<Column<SystemIntakeForTable>> => {
   const { t } = useTranslation('governanceReviewTeam');
-  const flags = useFlags();
 
   // Character limit for length of free text (Admin Note, LCID Scope, etc.), any
   // text longer then this limit will be displayed with a button to allow users
@@ -125,36 +123,6 @@ const useRequestTableColumns = (
     }
   };
 
-  const statusV1Column: Column<SystemIntakeForTable> = {
-    Header: t<string>('intake:fields.status'),
-    accessor: 'status',
-    Cell: ({
-      row,
-      value
-    }: CellProps<SystemIntakeForTable, SystemIntakeForTable['status']>) => {
-      // If LCID_ISSUED append LCID Scope to status
-      if (value === `LCID: ${row.original.lcid}`) {
-        return (
-          <>
-            {value}
-            <br />
-            <TruncatedText
-              id="lcid-scope"
-              label="less"
-              closeLabel="more"
-              text={`Scope: ${row.original.lcidScope}`}
-              charLimit={freeFormTextCharLimit}
-              className="margin-top-2"
-            />
-          </>
-        );
-      }
-
-      // If any other value just display status
-      return value;
-    }
-  };
-
   const statusColumn: Column<SystemIntakeForTable> = {
     Header: t<string>('intake:fields.status'),
     accessor: 'statusAdmin',
@@ -221,7 +189,7 @@ const useRequestTableColumns = (
         requestNameColumn,
         requesterColumn,
         adminLeadColumn,
-        flags.itGovV2Enabled ? statusColumn : statusV1Column,
+        statusColumn,
         grtDateColumn,
         grbDateColumn
       ];
@@ -232,7 +200,7 @@ const useRequestTableColumns = (
         requestNameColumn,
         requesterColumn,
         lcidExpirationDateColumn,
-        flags.itGovV2Enabled ? statusColumn : statusV1Column,
+        statusColumn,
         lastAdminNoteColumn
       ];
     }

--- a/src/data/mock/systemIntake.ts
+++ b/src/data/mock/systemIntake.ts
@@ -301,7 +301,6 @@ export const systemIntakeForTable: TableSystemIntake = {
   id: '1',
   euaUserId: '',
   requestName: '',
-  status: SystemIntakeStatus.INTAKE_SUBMITTED,
   statusAdmin: SystemIntakeStatusAdmin.INITIAL_REQUEST_FORM_IN_PROGRESS,
   state: SystemIntakeState.OPEN,
   requesterName: systemIntake.requester.name,

--- a/src/queries/GetSystemIntakesTableQuery.ts
+++ b/src/queries/GetSystemIntakesTableQuery.ts
@@ -11,7 +11,6 @@ export default gql`
       id
       euaUserId
       requestName
-      status
       statusAdmin
       state
 

--- a/src/queries/types/GetSystemIntakesTable.ts
+++ b/src/queries/types/GetSystemIntakesTable.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { SystemIntakeStatus, SystemIntakeStatusAdmin, SystemIntakeState } from "./../../types/graphql-global-types";
+import { SystemIntakeStatusAdmin, SystemIntakeState } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL query operation: GetSystemIntakesTable
@@ -80,7 +80,6 @@ export interface GetSystemIntakesTable_systemIntakes {
   id: UUID;
   euaUserId: string;
   requestName: string | null;
-  status: SystemIntakeStatus;
   statusAdmin: SystemIntakeStatusAdmin;
   state: SystemIntakeState;
   requesterName: string | null;


### PR DESCRIPTION
# [EASI-3782](https://jiraent.cms.gov/browse/EASI-3782)

## Changes and Description

- `useRequestTableColumns` renders the status column from `statusAdmin`
- Removes `GetSystemIntakesQuery` `systemIntakes.status` property
- `tableMap` uses `statusAdmin`

- `translateStatus()` is no longer used and can be removed from this pr after another ref removal here https://github.com/CMSgov/easi-app/pull/2342 is in main

<!-- Put a description here! -->

## How to test this change

Make sure the admin table renders the vs statuses as expected