### PR TITLE
[EASI-3718] Update retirement date test fix

### DIFF
--- a/cypress/e2e/governanceReviewTeam.cy.js
+++ b/cypress/e2e/governanceReviewTeam.cy.js
@@ -13,8 +13,8 @@ describe('Governance Review Team', () => {
       if (req.body.operationName === 'GetSystemIntake') {
         req.alias = 'getSystemIntake';
       }
-      if (req.body.operationName === 'GetSystemIntakeContactsQuery') {
-        req.alias = 'getSystemIntakeContacts';
+      if (req.body.operationName === 'GetGovernanceTaskList') {
+        req.alias = 'getGovernanceTaskList';
       }
     });
 
@@ -306,7 +306,6 @@ describe('Governance Review Team', () => {
     cy.contains('button', 'Complete action').should('not.be.disabled').click();
 
     // Check form submit was successful
-
     cy.get('div[data-testid="alert"]').contains(
       /Life Cycle ID [0-9]{6} has been updated./
     );
@@ -314,6 +313,11 @@ describe('Governance Review Team', () => {
     // Check updated values are displayed on Life Cycle ID page
 
     cy.get('[data-testid="grt-nav-lifecycleID.title-link"]').click();
+
+    // Wait for task list query to complete
+    cy.wait('@getGovernanceTaskList')
+      .its('response.statusCode')
+      .should('eq', 200);
 
     cy.get('dd').contains(expirationDate.toFormat('MMMM d, yyyy'));
     cy.get('dd').contains(scope);
@@ -343,7 +347,6 @@ describe('Governance Review Team', () => {
     cy.contains('button', 'Complete action').should('not.be.disabled').click();
 
     // Check form submit was successful
-
     cy.get('div[data-testid="alert"]').contains(
       'Life Cycle ID 000009 is now expired.'
     );
@@ -373,7 +376,6 @@ describe('Governance Review Team', () => {
     cy.contains('button', 'Complete action').should('not.be.disabled').click();
 
     // Check form submit was successful
-
     cy.get('div[data-testid="alert"]').contains(
       'Life Cycle ID 000010 is now retired.'
     );
@@ -414,12 +416,18 @@ describe('Governance Review Team', () => {
     cy.contains('button', 'Complete action').should('not.be.disabled').click();
 
     // Check form submit was successful
-
     cy.get('div[data-testid="alert"]').contains(
       'Life Cycle ID 000006 is now retired.'
     );
 
     // Check retirement date updated
+
+    cy.get('[data-testid="grt-nav-actions-link"]').click();
+
+    // Wait for task list query to complete
+    cy.wait('@getGovernanceTaskList')
+      .its('response.statusCode')
+      .should('eq', 200);
 
     cy.get('#grt-action__manage-lcid').check({ force: true });
 
@@ -432,7 +440,7 @@ describe('Governance Review Team', () => {
     cy.get('#retiresAt').should('have.value', updatedRetirementDate);
   });
 
-  it('can close a request', () => {
+  it.skip('can close a request', () => {
     // Selecting name based on pre-seeded data
     // Closable Request - 20cbcfbf-6459-4c96-943b-e76b83122dbf
     cy.governanceReviewTeam.grtActions.selectAction({
@@ -458,7 +466,7 @@ describe('Governance Review Team', () => {
     );
   });
 
-  it('can add additional contact as email recipient', () => {
+  it.skip('can add additional contact as email recipient', () => {
     cy.contains('a', 'Ready for business case').should('be.visible').click();
     cy.get('[data-testid="grt-nav-actions-link"]').click();
 

--- a/cypress/e2e/governanceReviewTeam.cy.js
+++ b/cypress/e2e/governanceReviewTeam.cy.js
@@ -3,7 +3,10 @@ import { DateTime } from 'luxon';
 import governaceReviewTeam from '../../src/i18n/en-US/articles/governanceReviewTeam';
 
 describe('Governance Review Team', () => {
-  const futureDate = DateTime.local().plus({ year: 1 });
+  // Expiration and retirement dates
+  // Matches pattern set in seed data: +1 year for expiration, +2 years for retirement
+  const expirationDate = DateTime.local().plus({ year: 1 });
+  const retirementDate = expirationDate.plus({ year: 1 });
 
   beforeEach(() => {
     cy.intercept('POST', '/api/graph/query', req => {
@@ -190,7 +193,7 @@ describe('Governance Review Team', () => {
 
     cy.get('#useExistingLcid_false').check({ force: true });
 
-    cy.get('#expiresAt').type(futureDate.toFormat('MM/dd/yyyy'));
+    cy.get('#expiresAt').type(expirationDate.toFormat('MM/dd/yyyy'));
     cy.get('div#scope').type(scope);
     cy.get('div#nextSteps').type(nextSteps);
     cy.get('#stronglyRecommended').check({ force: true });
@@ -209,7 +212,7 @@ describe('Governance Review Team', () => {
 
     cy.get('[data-testid="grt-nav-lifecycleID.title-link"]').click();
 
-    cy.get('dd').contains(futureDate.toFormat('MMMM d, yyyy'));
+    cy.get('dd').contains(expirationDate.toFormat('MMMM d, yyyy'));
     cy.get('dd').contains(scope);
     cy.get('dd').contains(nextSteps);
     cy.get('dd').contains('Yes, strongly recommend');
@@ -240,7 +243,7 @@ describe('Governance Review Team', () => {
     cy.get('#useExistingLcid').select(lcid).should('have.value', lcid);
 
     cy.get('#expiresAt').clear();
-    cy.get('#expiresAt').type(futureDate.toFormat('MM/dd/yyyy'));
+    cy.get('#expiresAt').type(expirationDate.toFormat('MM/dd/yyyy'));
 
     cy.get('div#scope').clear();
     cy.get('div#scope').type(scope);
@@ -267,7 +270,7 @@ describe('Governance Review Team', () => {
     cy.get('[data-testid="grt-nav-lifecycleID.title-link"]').click();
 
     cy.get('dd').contains(lcid);
-    cy.get('dd').contains(futureDate.toFormat('MMMM d, yyyy'));
+    cy.get('dd').contains(expirationDate.toFormat('MMMM d, yyyy'));
     cy.get('dd').contains(scope);
     cy.get('dd').contains(nextSteps);
     cy.get('dd').contains('Yes, strongly recommend');
@@ -295,7 +298,7 @@ describe('Governance Review Team', () => {
     const nextSteps = 'Updated test next steps for issuing LCID';
     const costBaseline = 'Updated test cost baseline for issuing LCID';
 
-    cy.get('#expiresAt').type(futureDate.toFormat('MM/dd/yyyy'));
+    cy.get('#expiresAt').type(expirationDate.toFormat('MM/dd/yyyy'));
     cy.get('div#scope').type(scope);
     cy.get('div#nextSteps').type(nextSteps);
     cy.get('#costBaseline').type(costBaseline);
@@ -312,7 +315,7 @@ describe('Governance Review Team', () => {
 
     cy.get('[data-testid="grt-nav-lifecycleID.title-link"]').click();
 
-    cy.get('dd').contains(futureDate.toFormat('MMMM d, yyyy'));
+    cy.get('dd').contains(expirationDate.toFormat('MMMM d, yyyy'));
     cy.get('dd').contains(scope);
     cy.get('dd').contains(nextSteps);
     cy.get('dd').contains(costBaseline);
@@ -365,7 +368,7 @@ describe('Governance Review Team', () => {
 
     // Complete action form
 
-    cy.get('#retiresAt').type(futureDate.toFormat('MM/dd/yyyy'));
+    cy.get('#retiresAt').type(retirementDate.toFormat('MM/dd/yyyy'));
 
     cy.contains('button', 'Complete action').should('not.be.disabled').click();
 
@@ -396,12 +399,12 @@ describe('Governance Review Team', () => {
     // Check initial retirement date
     cy.get('#retiresAt').should(
       'have.value',
-      futureDate.toFormat('MM/dd/yyyy')
+      retirementDate.toFormat('MM/dd/yyyy')
     );
 
     // Complete action form
 
-    const updatedRetirementDate = futureDate
+    const updatedRetirementDate = retirementDate
       .plus({ month: 1 })
       .toFormat('MM/dd/yyyy');
 
@@ -429,7 +432,7 @@ describe('Governance Review Team', () => {
     cy.get('#retiresAt').should('have.value', updatedRetirementDate);
   });
 
-  it.skip('can close a request', () => {
+  it('can close a request', () => {
     // Selecting name based on pre-seeded data
     // Closable Request - 20cbcfbf-6459-4c96-943b-e76b83122dbf
     cy.governanceReviewTeam.grtActions.selectAction({
@@ -455,7 +458,7 @@ describe('Governance Review Team', () => {
     );
   });
 
-  it.skip('can add additional contact as email recipient', () => {
+  it('can add additional contact as email recipient', () => {
     cy.contains('a', 'Ready for business case').should('be.visible').click();
     cy.get('[data-testid="grt-nav-actions-link"]').click();
 

--- a/cypress/e2e/governanceReviewTeam.cy.js
+++ b/cypress/e2e/governanceReviewTeam.cy.js
@@ -378,7 +378,7 @@ describe('Governance Review Team', () => {
     );
   });
 
-  it.skip('can update a Life Cycle ID retirement date', () => {
+  it('can update a Life Cycle ID retirement date', () => {
     cy.contains('button', 'Closed requests').click();
 
     cy.contains('a', 'Retired LCID').should('be.visible').click();

--- a/cypress/e2e/governanceReviewTeam.cy.js
+++ b/cypress/e2e/governanceReviewTeam.cy.js
@@ -417,8 +417,6 @@ describe('Governance Review Team', () => {
 
     // Check retirement date updated
 
-    cy.get('[data-testid="grt-nav-actions-link"]').click();
-
     cy.get('#grt-action__manage-lcid').check({ force: true });
 
     cy.contains('button', 'Continue').click();

--- a/cypress/e2e/governanceReviewTeam.cy.js
+++ b/cypress/e2e/governanceReviewTeam.cy.js
@@ -3,6 +3,8 @@ import { DateTime } from 'luxon';
 import governaceReviewTeam from '../../src/i18n/en-US/articles/governanceReviewTeam';
 
 describe('Governance Review Team', () => {
+  const futureDate = DateTime.local().plus({ year: 1 });
+
   beforeEach(() => {
     cy.intercept('POST', '/api/graph/query', req => {
       if (req.body.operationName === 'GetSystemIntake') {
@@ -182,14 +184,13 @@ describe('Governance Review Team', () => {
 
     // Complete action form
 
-    const expirationDate = DateTime.local().plus({ year: 1 });
     const scope = 'Test scope for issuing new LCID';
     const nextSteps = 'Test next steps for issuing new LCID';
     const costBaseline = 'Test next steps for issuing new LCID';
 
     cy.get('#useExistingLcid_false').check({ force: true });
 
-    cy.get('#expiresAt').type(expirationDate.toFormat('MM/dd/yyyy'));
+    cy.get('#expiresAt').type(futureDate.toFormat('MM/dd/yyyy'));
     cy.get('div#scope').type(scope);
     cy.get('div#nextSteps').type(nextSteps);
     cy.get('#stronglyRecommended').check({ force: true });
@@ -208,7 +209,7 @@ describe('Governance Review Team', () => {
 
     cy.get('[data-testid="grt-nav-lifecycleID.title-link"]').click();
 
-    cy.get('dd').contains(expirationDate.toFormat('MMMM d, yyyy'));
+    cy.get('dd').contains(futureDate.toFormat('MMMM d, yyyy'));
     cy.get('dd').contains(scope);
     cy.get('dd').contains(nextSteps);
     cy.get('dd').contains('Yes, strongly recommend');
@@ -231,7 +232,6 @@ describe('Governance Review Team', () => {
     // Complete action form
 
     const lcid = '000001';
-    const expirationDate = DateTime.local().plus({ year: 1 });
     const scope = 'Test scope for issuing existing LCID';
     const nextSteps = 'Test next steps for issuing existing LCID';
     const costBaseline = 'Test next steps for issuing existing LCID';
@@ -240,7 +240,7 @@ describe('Governance Review Team', () => {
     cy.get('#useExistingLcid').select(lcid).should('have.value', lcid);
 
     cy.get('#expiresAt').clear();
-    cy.get('#expiresAt').type(expirationDate.toFormat('MM/dd/yyyy'));
+    cy.get('#expiresAt').type(futureDate.toFormat('MM/dd/yyyy'));
 
     cy.get('div#scope').clear();
     cy.get('div#scope').type(scope);
@@ -267,7 +267,7 @@ describe('Governance Review Team', () => {
     cy.get('[data-testid="grt-nav-lifecycleID.title-link"]').click();
 
     cy.get('dd').contains(lcid);
-    cy.get('dd').contains(expirationDate.toFormat('MMMM d, yyyy'));
+    cy.get('dd').contains(futureDate.toFormat('MMMM d, yyyy'));
     cy.get('dd').contains(scope);
     cy.get('dd').contains(nextSteps);
     cy.get('dd').contains('Yes, strongly recommend');
@@ -291,12 +291,11 @@ describe('Governance Review Team', () => {
 
     // Complete action form
 
-    const expirationDate = DateTime.local().plus({ year: 2 });
     const scope = 'Updated test scope for issuing LCID';
     const nextSteps = 'Updated test next steps for issuing LCID';
     const costBaseline = 'Updated test cost baseline for issuing LCID';
 
-    cy.get('#expiresAt').type(expirationDate.toFormat('MM/dd/yyyy'));
+    cy.get('#expiresAt').type(futureDate.toFormat('MM/dd/yyyy'));
     cy.get('div#scope').type(scope);
     cy.get('div#nextSteps').type(nextSteps);
     cy.get('#costBaseline').type(costBaseline);
@@ -313,7 +312,7 @@ describe('Governance Review Team', () => {
 
     cy.get('[data-testid="grt-nav-lifecycleID.title-link"]').click();
 
-    cy.get('dd').contains(expirationDate.toFormat('MMMM d, yyyy'));
+    cy.get('dd').contains(futureDate.toFormat('MMMM d, yyyy'));
     cy.get('dd').contains(scope);
     cy.get('dd').contains(nextSteps);
     cy.get('dd').contains(costBaseline);
@@ -366,8 +365,7 @@ describe('Governance Review Team', () => {
 
     // Complete action form
 
-    const retirementDate = DateTime.local().plus({ year: 2 });
-    cy.get('#retiresAt').type(retirementDate.toFormat('MM/dd/yyyy'));
+    cy.get('#retiresAt').type(futureDate.toFormat('MM/dd/yyyy'));
 
     cy.contains('button', 'Complete action').should('not.be.disabled').click();
 
@@ -396,16 +394,19 @@ describe('Governance Review Team', () => {
     cy.contains('h3', 'Change retirement date');
 
     // Check initial retirement date
-    cy.get('#retiresAt').should('have.value', '01/05/2026');
+    cy.get('#retiresAt').should(
+      'have.value',
+      futureDate.toFormat('MM/dd/yyyy')
+    );
 
     // Complete action form
 
-    const retirementDate = DateTime.local()
-      .plus({ month: 1, year: 2 })
+    const updatedRetirementDate = futureDate
+      .plus({ month: 1 })
       .toFormat('MM/dd/yyyy');
 
     cy.get('#retiresAt').clear();
-    cy.get('#retiresAt').type(retirementDate);
+    cy.get('#retiresAt').type(updatedRetirementDate);
 
     cy.contains('button', 'Complete action').should('not.be.disabled').click();
 
@@ -425,7 +426,7 @@ describe('Governance Review Team', () => {
 
     cy.contains('button', 'Next').should('not.be.disabled').click();
 
-    cy.get('#retiresAt').should('have.value', retirementDate);
+    cy.get('#retiresAt').should('have.value', updatedRetirementDate);
   });
 
   it.skip('can close a request', () => {


### PR DESCRIPTION
# EASI-3718

## Changes and Description

- Fixes failing e2e test for updating an LCID retirement date
- "Manage a Life Cycle ID" action was selected before page was done loading, so options were resetting and Continue button was disabled
  - Removed unnecessary step to navigate to actions page - test is already on page after initial form is submitted

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
