### PR TITLE
EASI-3483: k8s manifests for local development

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     hooks:
       - id: check-yaml
         name: Check YAML formatting
+        args: [--allow-multiple-documents]
       - id: detect-private-key
         name: Check for private keys
       - id: end-of-file-fixer

--- a/.spelling
+++ b/.spelling
@@ -201,6 +201,11 @@ Sprague
 Shoup
 TinyMCE
 Vite
+Kubernetes
+k8s_dev.sh
+Kustomize
+namespace
+create-local-development-k8s-manifests
 
 # Jira ticket numbers
 # The underlying spellchecking package doesn't currently support patterns; see https://github.com/lukeapage/node-markdown-spellcheck/issues/49
@@ -214,3 +219,4 @@ EASI-3224
 EASI-2888
 EASI-3019
 EASI-3082
+EASI-3483

--- a/Dockerfile.backend_k8s
+++ b/Dockerfile.backend_k8s
@@ -1,0 +1,37 @@
+FROM golang:1.21 AS base
+
+WORKDIR /easi/
+
+COPY config/tls/*.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+FROM base AS build
+
+COPY cmd/ ./cmd/
+COPY pkg/ ./pkg/
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin/easi ./cmd/easi
+
+FROM gcr.io/distroless/base:latest
+
+WORKDIR /easi/
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /easi/pkg/email/templates ./templates
+COPY --from=build /easi/bin/easi ./
+
+ARG ARG_APPLICATION_VERSION
+ARG ARG_APPLICATION_DATETIME
+ARG ARG_APPLICATION_TS
+ENV APPLICATION_VERSION=${ARG_APPLICATION_VERSION} \
+    APPLICATION_DATETIME=${ARG_APPLICATION_DATETIME} \
+    APPLICATION_TS=${ARG_APPLICATION_TS} \
+    EMAIL_TEMPLATE_DIR=/easi/templates
+
+USER 1000
+
+ENTRYPOINT ["/easi/easi"]
+
+CMD ["serve"]

--- a/Dockerfile.client_k8s
+++ b/Dockerfile.client_k8s
@@ -1,0 +1,22 @@
+FROM node:16.14.0 AS base
+
+WORKDIR /app
+
+ENV PATH /app/node_modules/.bin:$PATH
+
+FROM base AS modules
+
+COPY package.json yarn.lock ./
+
+RUN yarn install --frozen-lockfile
+
+FROM modules AS src
+
+COPY tsconfig.json .eslintrc vite.config.ts apollo.config.js index.html ./
+COPY public ./public
+COPY src ./src
+
+RUN yarn run build
+RUN yarn global add serve
+
+ENTRYPOINT [ "yarn", "start" ]

--- a/deploy/base/db-migrate.yaml
+++ b/deploy/base/db-migrate.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: db-migrate
+  name: db-migrate
+  namespace: easi
+spec:
+  template:
+    metadata:
+      labels:
+        app: db-migrate
+    spec:
+      containers:
+        - env:
+            - name: FLYWAY_PASSWORD
+              value: mysecretpassword
+            - name: FLYWAY_PLACEHOLDERS_APP_USER_PASSWORD
+              value: supersecretapp
+            - name: FLYWAY_URL
+              value: jdbc:postgresql://db/postgres
+            - name: FLYWAY_USER
+              value: postgres
+          image: db-migrate:latest
+          imagePullPolicy: Never
+          name: db-migrate
+          resources: {}
+      restartPolicy: Never
+  backoffLimit: 4
+  completions: 1
+  parallelism: 1

--- a/deploy/base/db.yaml
+++ b/deploy/base/db.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-configmap
+  namespace: easi
+data:
+  POSTGRES_PASSWORD: mysecretpassword
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: easi
+  name: db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: db
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+        - args:
+            - postgres
+            - -c
+            - log_statement=all
+            - -c
+            - max_connections=25
+          envFrom:
+            - configMapRef:
+                name: db-configmap        
+          image: postgres:14.7
+          name: db
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          resources: {}
+      restartPolicy: Always
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: easi
+  name: db
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: db

--- a/deploy/base/easi-client.yaml
+++ b/deploy/base/easi-client.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: easi-client-configmap
+  namespace: easi
+data:
+  VITE_APP_ENV: local
+  VITE_API_ADDRESS: http://easi-backend.localdev.me/api/v1
+  VITE_GRAPHQL_ADDRESS: http://easi-backend.localdev.me/api/graph/query
+  VITE_OKTA_CLIENT_ID: 0oa2e913coDQeG19S297
+  VITE_OKTA_DOMAIN: https://test.idp.idm.cms.gov
+  VITE_OKTA_ISSUER: https://test.idp.idm.cms.gov/oauth2/aus2e96etlbFPnBHt297
+  VITE_OKTA_REDIRECT_URI: http://easi-client:3000/implicit/callback
+  VITE_OKTA_SERVER_ID: aus2e96etlbFPnBHt297
+  VITE_LD_ENV_USER: ''
+  VITE_LD_USER_HASH: ''
+  VITE_LD_CLIENT_ID: 63231d448bd05a111f06195b
+  VITE_LOCAL_AUTH_ENABLED: 'true'
+  CHOKIDAR_USEPOLLING: 'true'
+  ESLINT_NO_DEV_ERRORS: 'true'
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: easi-client
+  name: easi-client
+  namespace: easi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: easi-client
+  template:
+    metadata:
+      labels:
+        app: easi-client
+    spec:
+      containers:
+        - name: easi-client
+          image: easi-client:latest
+          imagePullPolicy: Never
+          envFrom:
+            - configMapRef:
+                name: easi-client-configmap
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          resources: {}
+      restartPolicy: Always
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: easi
+  name: easi-client
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+  selector:
+    app: easi-client
+
+--- 
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: easi-client-ingress
+  namespace: easi
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+    - host: easi.localdev.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: easi-client
+                port:
+                  number: 3000

--- a/deploy/base/easi.yaml
+++ b/deploy/base/easi.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: easi-backend-configmap
+  namespace: easi
+data:
+  CEDAR_ENV: dev
+  CEDAR_API_KEY: ''
+  CEDAR_API_URL: "webmethods-apigw.cedardev.cms.gov"
+  CEDAR_CORE_API_VERSION: "2.0.0"
+  CEDAR_CACHE_INTERVAL: "30m"
+  CEDAR_EMAIL_ADDRESS: "EnterpriseArchitecture@notCMS.gov"
+  APP_ENV: local
+  CLIENT_PROTOCOL: http
+  CLIENT_DOMAIN: easi.localdev.me
+  CLIENT_PORT: '80'
+  CLIENT_HOSTNAME: easi.localdev.me:80
+  CLIENT_ADDRESS: http://easi.localdev.me
+  API_PORT: '8080'
+  OKTA_CLIENT_ID: 0oa2e913coDQeG19S297
+  OKTA_ISSUER: https://test.idp.idm.cms.gov/oauth2/aus2e96etlbFPnBHt297
+  GRT_EMAIL: success@simulator.amazonses.com
+  IT_INVESTMENT_EMAIL: success@simulator.amazonses.com
+  ACCESSIBILITY_TEAM_EMAIL: success@simulator.amazonses.com
+  EASI_HELP_EMAIL: success@simulator.amazonses.com
+  TRB_EMAIL: success@simulator.amazonses.com
+  EMAIL_TEMPLATE_DIR: /easi/pkg/email/templates
+  AWS_REGION: us-west-2
+  AWS_SES_SOURCE: '\"EASi Local\" <no-reply-local@info.easi.cms.gov>'
+  AWS_SES_SOURCE_ARN: ses-arn
+  AWS_S3_FILE_UPLOAD_BUCKET: easiappfileuploads
+  AWS_ACCESS_KEY_ID: '1'
+  AWS_SECRET_ACCESS_KEY: '1'
+  PGHOST: db
+  PGPORT: '5432'
+  PGDATABASE: postgres
+  PGUSER: postgres
+  PGPASS: mysecretpassword
+  PGSSLMODE: disable
+  DB_MAX_CONNECTIONS: '20'
+  FLAG_SOURCE: LOCAL
+  FLAGDATA_FILE: "./cypress/fixtures/flagdata.json"
+  LD_SDK_KEY: ''
+  LD_TIMEOUT_SECONDS: '30'
+  LD_ENV_USER: ''
+  MINIO_ACCESS_KEY: minioadmin
+  MINIO_SECRET_KEY: minioadmin
+  MINIO_ADDRESS: http://minio:9000
+  SERVER_CERT: ''
+  SERVER_KEY: ''
+  USE_TLS: 'false'
+  ALT_JOB_CODES: 'true'
+  OKTA_API_URL: https://test.idp.idm.cms.gov
+  OKTA_API_TOKEN: ''
+  USE_OKTA_API: 'true'
+  LOCAL_AUTH_ENABLED: 'true'
+
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: easi-backend
+  namespace: easi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: easi-backend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: easi-backend
+    spec:
+      containers:
+        - name: easi-backend
+          image: easi-backend:latest
+          imagePullPolicy: Never
+          envFrom:
+            - configMapRef:
+                name: easi-backend-configmap
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources: {}
+          command:
+             - ./bin/easi
+             - serve
+      restartPolicy: Always
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: easi-backend
+  namespace: easi
+spec:
+  ports:
+    - name: "8080"
+      port: 8080
+      targetPort: 8080
+    - name: "2345"
+      port: 2345
+      targetPort: 2345
+  selector:
+    app: easi-backend
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: easi-backend-ingress
+  namespace: easi
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+    - host: easi-backend.localdev.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: easi-backend
+                port:
+                  number: 8080

--- a/deploy/base/email.yaml
+++ b/deploy/base/email.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: email
+  name: email
+  namespace: easi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: email
+  template:
+    metadata:
+      labels:
+        app: email
+    spec:
+      containers:
+        - image: dockage/mailcatcher:latest
+          name: email
+          ports:
+            - containerPort: 1025
+              protocol: TCP
+            - containerPort: 1080
+              protocol: TCP
+          resources: {}
+      restartPolicy: Always
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: email
+  namespace: easi
+spec:
+  ports:
+    - name: "smtp"
+      port: 1025
+      targetPort: 1025
+    - name: "http"
+      port: 1080
+      targetPort: 1080
+  selector:
+    app: email
+
+--- 
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: email-ingress
+  namespace: easi
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+    - host: email.localdev.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: email
+                port:
+                  number: 1080

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - db-migrate.yaml
+  - db.yaml
+  - easi-client.yaml
+  - easi.yaml
+  - email.yaml

--- a/deploy/base/namespace.yaml
+++ b/deploy/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: easi

--- a/docs/k8s_dev_script_usage.md
+++ b/docs/k8s_dev_script_usage.md
@@ -1,0 +1,116 @@
+# k8s_dev.sh - Script for easy EASi Deployment to a local Kubernetes Cluster for easy local development 😉
+
+`k8s_dev.sh` is used to deploy the EASi application to a Kubernetes cluster.
+
+## Prerequisites
+
+#### `kubectl`
+
+You will need to have `kubectl` installed somewhere in your PATH directories in order to interact with a Kubernetes cluster.  
+See https://kubernetes.io/docs/tasks/tools/ for installation instructions.
+
+#### Kubernetes Cluster
+
+You will obviously need a cluster to deploy to. This cluster needs to be configured as your current `kubectl` context, as the current functionality of this script does not let you define contexts during runtime.
+
+#### Kustomize
+
+`kustomize` is a Kubernetes configuration transformation tool that enables you to customize base YAML manifests, leaving the original files untouched.
+`kustomize` will need to be installed somewhere in your PATH directories.  
+See https://kubectl.docs.kubernetes.io/installation/kustomize/ for installation instructions.
+
+## What does it do?
+
+1. Prerequisite check: looking for `kubectl` and `kustomize`
+1. Clears given branch namespace to remove any previous deployment
+1. Builds `easi-client`, `easi-backend`, and `db-migrate` images and tags with branch/namespace name
+1. Using `kustomize`, deploys EASi into given branch namespace
+1. Prints output for EASi and MailCatcher URLs for easy (😉) access
+
+## Usage
+
+`./k8s_dev.sh [OPTIONS]`
+
+By default, this script will create a new namespace with the branch name.  
+For example: I have checked out a git branch named `EASI-3486/create-local-development-k8s-manifests`. The script will strip the relevant `easi-3486` and use this as the namespace throughout runtime.
+
+#### Options
+
+| OPTION 	|              ACTION              	|
+|--------	|:--------------------------------:	|
+|   -n   	| Create a custom namespace 	|
+
+## Examples
+
+### Default Namespace (checked out EASI-3483/create-local-development-k8s-manifests)
+```bash
+./scripts/k8s_dev.sh
+❄️  Clear easi-3483 namespace ❄️
+Warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
+namespace "easi-3483" force deleted
+🐋 Building easi-client:easi-3483 image 🐋
+[+] Building 2.1s (14/14) FINISHED
+::: DOCKER BUILD OUTPUT :::
+🐋 Building easi-backend:easi-3483 image 🐋
+[+] Building 5.1s (14/14) FINISHED
+::: DOCKER BUILD OUTPUT :::
+🐋 Building db-migrate:easi-3483 image 🐋
+[+] Building 2.1s (7/7) FINISHED
+::: DOCKER BUILD OUTPUT :::
+❄️  Deploying EASi via Kustomize  ❄️
+namespace/easi-3483 created
+configmap/db-configmap created
+configmap/easi-backend-configmap created
+configmap/easi-client-configmap created
+service/db created
+service/easi-backend created
+service/easi-client created
+service/email created
+deployment.apps/db created
+deployment.apps/easi-backend created
+deployment.apps/easi-client created
+deployment.apps/email created
+job.batch/db-migrate created
+ingress.networking.k8s.io/easi-backend-ingress created
+ingress.networking.k8s.io/easi-client-ingress created
+ingress.networking.k8s.io/email-ingress created
+❄️  EASi: http://easi-3483.localdev.me ❄️
+❄️  Mailcatcher: http://easi-3483-email.localdev.me ❄️
+```
+
+### Custom Branch Namespace
+```bash
+./scripts/k8s_dev.sh -n easi
+
+❄️  Clear easi namespace ❄️
+Warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
+namespace "easi" force deleted
+🐋 Building easi-client:easi image 🐋
+[+] Building 72.8s (15/15) FINISHED
+::: DOCKER BUILD OUTPUT :::
+🐋 Building easi-backend:easi image 🐋
+[+] Building 20.6s (15/15) FINISHED
+::: DOCKER BUILD OUTPUT :::
+🐋 Building db-migrate:easi image 🐋
+[+] Building 2.2s (8/8) FINISHED
+::: DOCKER BUILD OUTPUT :::
+❄️  Deploying EASi via Kustomize  ❄️
+namespace/easi created
+configmap/db-configmap created
+configmap/easi-backend-configmap created
+configmap/easi-client-configmap created
+service/db created
+service/easi-backend created
+service/easi-client created
+service/email created
+deployment.apps/db created
+deployment.apps/easi-backend created
+deployment.apps/easi-client created
+deployment.apps/email created
+job.batch/db-migrate created
+ingress.networking.k8s.io/easi-backend-ingress created
+ingress.networking.k8s.io/easi-client-ingress created
+ingress.networking.k8s.io/email-ingress created
+❄️  EASi: http://easi.localdev.me ❄️
+❄️  Mailcatcher: http://easi-email.localdev.me ❄️
+```

--- a/scripts/k8s_dev.sh
+++ b/scripts/k8s_dev.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+# Exit on any error
+set -e
+
+# Function to show usage
+usage() {
+  echo "Usage: $0 [-n namespace]"
+  echo "  -n  Set the namespace. If not provided, it will be inferred from the current Git branch."
+  echo "      Must be a valid Kubernetes namespace name (lowercase alpha characters, numbers, or hyphens)."
+  echo "      See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+  exit 1
+}
+
+# Parent path magic to always set the correct relative paths when running this script
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )
+cd "$parent_path" || exit
+
+# PREREQ CHECKS!
+# Check if kustomize is installed
+if ! command -v kustomize &> /dev/null; then
+  echo "kustomize is not installed in user PATH directories. Please install kustomize and try again."
+  echo "See https://kubectl.docs.kubernetes.io/installation/kustomize/ for installation instructions."
+  exit 1
+fi
+# Check if kubectl is installed
+if ! command -v kubectl &> /dev/null; then
+  echo "kubectl is not installed in user PATH directories. Please install kubectl and try again."
+  echo "See https://kubernetes.io/docs/tasks/tools/ for installation instructions."
+  exit 1
+fi
+
+# Function to validate the namespace string
+validate_namespace() {
+  local namespace=$1
+
+  # Check if the branch name is empty
+  if [ -z "$namespace" ]; then
+    echo "Error: namespace string is empty"
+    usage
+  fi
+
+  # Regex for valid namespace strings (modify as needed)
+  local valid_namespace_regex='^[a-z0-9-]+$'
+  local blacklisted_namespace_regex='^(default|kube-public|kube-system|kube-node-lease)$'
+
+  if ! [[ $namespace =~ $valid_namespace_regex ]] ; then
+    echo "Error: Invalid namespace. Per Kubernetes, namespaces must consist of lowercase alpha characters, numbers, or hyphens."
+  fi
+
+  if [[ $namespace =~ $blacklisted_namespace_regex ]] ; then
+    echo "Error: Invalid namespace. Per Kubernetes, the following namespaces are reserved and cannot be used: default, kube-public, kube-system, kube-node-lease."
+  fi
+
+}
+
+# Parse command line options
+while getopts ":n:" opt; do
+  case ${opt} in
+    n )
+      NAMESPACE=$OPTARG
+      ;;
+    \? )
+      echo "Invalid Option: -$OPTARG" 1>&2
+      usage
+      ;;
+    : )
+      echo "Invalid Option: -$OPTARG requires an argument" 1>&2
+      usage
+      ;;
+  esac
+done
+
+# Set NAMESPACE from Git if not provided
+if [ -z "$NAMESPACE" ]; then
+    NAMESPACE=$(git rev-parse --abbrev-ref HEAD | sed -E 's/^(EASI-[0-9]*|NOREF).*/\1/' | tr '[:upper:]' '[:lower:]')
+fi
+
+# Run validate_namespace
+validate_namespace "$NAMESPACE"
+
+# Delete namespace if it exists
+if kubectl get ns "$NAMESPACE" > /dev/null 2>&1; then
+    echo "❄️  Clear ${NAMESPACE} namespace ❄️"
+    kubectl delete ns "$NAMESPACE" || {
+        echo "Failed to delete namespace ${NAMESPACE}"
+        exit 1
+    }
+fi
+
+# Build Docker images
+(
+    echo "🐋 Building easi-client:${NAMESPACE} image 🐋"
+    docker build -f ../Dockerfile.client_k8s -t easi-client:"$NAMESPACE" ../.
+
+    # APPLICATION_VERSION=$(git rev-parse HEAD)
+    # APPLICATION_DATETIME="$(date --rfc-3339='seconds' --utc)"
+    # APPLICATION_TS="$(date --date="$APPLICATION_DATETIME" '+%s')"
+    # echo "APPLICATION_DATETIME=${APPLICATION_DATETIME}"
+    # echo "APPLICATION_TS=${APPLICATION_TS}"
+    # echo "APPLICATION_VERSION=${APPLICATION_VERSION}"
+
+    echo "🐋 Building easi-backend:${NAMESPACE} image 🐋"
+    # docker build -f ../Dockerfile --build-arg APPLICATION_DATETIME="${APPLICATION_DATETIME}" --build-arg APPLICATION_TS="${APPLICATION_TS}" --build-arg APPLICATION_VERSION="${APPLICATION_VERSION}" -t easi-backend:latest ../.
+    docker build -f ../Dockerfile.backend_k8s --target build -t easi-backend:"$NAMESPACE" ../.
+
+    echo "🐋 Building db-migrate:${NAMESPACE} image 🐋"
+    docker build -f ../Dockerfile.db_migrations --build-arg TAG=9.10-alpine -t db-migrate:"$NAMESPACE" ../.
+)
+
+echo "❄️  Deploying EASi via Kustomize  ❄️"
+TEMPDIR=$(mktemp -d ../tmp.k8s.XXXXX)
+delete_temp_dir() {
+    if [ -d "$TEMPDIR" ]; then
+        rm -r "$TEMPDIR"
+    fi
+}
+(
+    cd "$TEMPDIR" || exit
+    kustomize create --resources ../deploy/base
+    kustomize edit set namespace "$NAMESPACE"
+    kustomize build > manifest.yaml
+    sed -i'' -E "s/easi-client:latest/easi-client:${NAMESPACE}/" manifest.yaml
+    sed -i'' -E "s/easi-backend:latest/easi-backend:${NAMESPACE}/" manifest.yaml
+    sed -i'' -E "s/db-migrate:latest/db-migrate:${NAMESPACE}/" manifest.yaml
+    sed -i'' -E "s/easi-backend.localdev.me/${NAMESPACE}-backend.localdev.me/" manifest.yaml
+    sed -i'' -E "s/easi.localdev.me/${NAMESPACE}.localdev.me/" manifest.yaml
+    sed -i'' -E "s/email.localdev.me/${NAMESPACE}-email.localdev.me/" manifest.yaml
+    kubectl apply -f manifest.yaml
+    trap delete_temp_dir EXIT
+)
+
+echo "❄️  EASi: http://${NAMESPACE}.localdev.me ❄️"
+echo "❄️  Mailcatcher: http://${NAMESPACE}-email.localdev.me ❄️"
+


### PR DESCRIPTION
# EASI-3483

## Changes and Description

This pull request includes updates to the Kubernetes manifests and development script. The changes include:

1. kustomize base manifests for:

- db-migrate job
- postgres db
- easi-client (frontend)
- easi (backend)
- mailcatcher
- **MINIO IS CURRENTLY NOT FUNCTIONAL** still working on implementation

2. 2 new dockerfiles for easi and easi-client to help with k8s local development

3. first iteration of the k8s_dev.sh script to ease deploying EASi to your local k8s cluster

## How to test this change

1. see `k8s_dev_script_usage.md` in the docs folder for further instructions - reach out @Jdwoodson for any assistance needed
1. **Rancher Desktop** is recommended at this time for ease of understanding Kubernetes Ingress!
1. Functionality that requires MINIO will NOT work as I will still need to work thru implementation. 

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
