### PR TITLE
EASI-3783 v1 references on Requester home page

### DIFF
--- a/src/i18n/en-US/intake.ts
+++ b/src/i18n/en-US/intake.ts
@@ -54,25 +54,6 @@ const intake = {
     }
   },
   lifecycleId: 'Life Cycle ID',
-  statusMap: {
-    INTAKE_DRAFT: 'Intake draft',
-    INTAKE_SUBMITTED: 'Intake request received',
-    NEED_BIZ_CASE: 'Waiting for draft business case',
-    BIZ_CASE_DRAFT: 'Waiting for draft business case',
-    BIZ_CASE_DRAFT_SUBMITTED: 'Draft business case received',
-    BIZ_CASE_CHANGES_NEEDED: 'Waiting for draft business case',
-    BIZ_CASE_FINAL_NEEDED: 'Waiting for final business case',
-    BIZ_CASE_FINAL_SUBMITTED: 'Final business case received',
-    READY_FOR_GRT: 'Ready for GRT meeting',
-    READY_FOR_GRB: 'Ready for GRB meeting',
-    LCID_ISSUED: 'Life Cycle ID issued',
-    WITHDRAWN: 'Withdrawn',
-    NOT_IT_REQUEST: 'Closed',
-    NOT_APPROVED: 'Business case not approved',
-    NO_GOVERNANCE: 'Closed',
-    SHUTDOWN_IN_PROGRESS: 'Decomission in progress',
-    SHUTDOWN_COMPLETE: 'Decommissioned'
-  },
   banner: {
     title: {
       intakeIncomplete: 'Intake request incomplete',

--- a/src/utils/systemIntake.ts
+++ b/src/utils/systemIntake.ts
@@ -4,8 +4,7 @@ import cmsDivisionsAndOffices from 'constants/enums/cmsDivisionsAndOffices';
 import {
   closedIntakeStatusesV1,
   openIntakeStatusesV1,
-  RequestType,
-  SystemIntakeStatusV1
+  RequestType
 } from 'types/systemIntake';
 
 // NOTE: these utility functions take strings rather than more restricted types so they can operate on values coming from GraphQL queries,
@@ -71,28 +70,4 @@ export const getAcronymForComponent = (componentToTranslate: string) => {
 
   // TODO: what do we return if not found? (should be impossible)
   return component ? component.acronym : 'Other';
-};
-
-/**
- * Translate the API status enum to a human readable string
- * @param statusEnum - intake status represented by enum value
- */
-export const translateStatus = (
-  statusEnum: SystemIntakeStatusV1,
-  lcid: string | null
-) => {
-  let statusTranslation = '';
-
-  if (statusEnum === 'LCID_ISSUED') {
-    // if status is LCID_ISSUED, translate from enum to i18n and append LCID
-    // Display not available message if LCID is null (usually due to bad SharePoint data migration)
-    statusTranslation = `${i18next.t(`intake:statusMap.${statusEnum}`)}: ${
-      lcid || 'ID Not Available'
-    }`;
-  } else {
-    // if not just translate from enum to i18n
-    statusTranslation = i18next.t(`intake:statusMap.${statusEnum}`);
-  }
-
-  return statusTranslation;
 };

--- a/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
+++ b/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
@@ -325,7 +325,6 @@ exports[`My Requests Table > when there are requests > matches snapshot 1`] = `
               style="width: 200px; padding-left: 0px;"
             >
               <span>
-                Open
                 <span
                   class="text-base-dark font-body-3xs"
                 >
@@ -372,7 +371,6 @@ exports[`My Requests Table > when there are requests > matches snapshot 1`] = `
               style="width: 200px; padding-left: 0px;"
             >
               <span>
-                In remediation
                 <span
                   class="text-base-dark font-body-3xs"
                 >
@@ -418,7 +416,7 @@ exports[`My Requests Table > when there are requests > matches snapshot 1`] = `
               role="cell"
               style="width: 200px; padding-left: 0px;"
             >
-              Intake draft
+              Intake Request in progress
             </td>
             <td
               role="cell"
@@ -458,7 +456,7 @@ exports[`My Requests Table > when there are requests > matches snapshot 1`] = `
               role="cell"
               style="width: 200px; padding-left: 0px;"
             >
-              Life Cycle ID issued: A123456: A123456
+              LCID issued: A123456
             </td>
             <td
               role="cell"

--- a/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
+++ b/src/views/MyRequests/Table/__snapshots__/index.test.tsx.snap
@@ -325,6 +325,7 @@ exports[`My Requests Table > when there are requests > matches snapshot 1`] = `
               style="width: 200px; padding-left: 0px;"
             >
               <span>
+                Open
                 <span
                   class="text-base-dark font-body-3xs"
                 >
@@ -371,6 +372,7 @@ exports[`My Requests Table > when there are requests > matches snapshot 1`] = `
               style="width: 200px; padding-left: 0px;"
             >
               <span>
+                In remediation
                 <span
                   class="text-base-dark font-body-3xs"
                 >

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -103,6 +103,8 @@ const Table = ({
       },
       {
         Header: t('requestsTable.headers.status'),
+        // The status property is just a generic property available on all request types
+        // See cases below for details on how statuses are determined by type
         accessor: 'status',
         Cell: ({ row, value }: any) => {
           switch (row.original.type) {

--- a/src/views/MyRequests/Table/index.tsx
+++ b/src/views/MyRequests/Table/index.tsx
@@ -9,7 +9,6 @@ import {
 } from 'react-table';
 import { useQuery } from '@apollo/client';
 import { Table as UswdsTable } from '@trussworks/react-uswds';
-import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import Spinner from 'components/Spinner';
@@ -59,8 +58,6 @@ const Table = ({
     variables: { first: 20 },
     fetchPolicy: 'cache-and-network'
   });
-
-  const flags = useFlags();
 
   const columns: any = useMemo(() => {
     return [
@@ -125,16 +122,10 @@ const Table = ({
                 </span>
               );
             case t(`requestsTable.types.GOVERNANCE_REQUEST`):
-              if (flags.itGovV2Enabled) {
-                return t(
-                  `governanceReviewTeam:systemIntakeStatusRequester.${row.original.statusRequester}`,
-                  { lcid: row.original.lcid }
-                );
-              }
-              if (row.original.lcid) {
-                return `${value}: ${row.original.lcid}`;
-              }
-              return value;
+              return t(
+                `governanceReviewTeam:systemIntakeStatusRequester.${row.original.statusRequester}`,
+                { lcid: row.original.lcid }
+              );
             case t(`requestsTable.types.TRB`):
               return value;
             default:

--- a/src/views/MyRequests/Table/tableMap.ts
+++ b/src/views/MyRequests/Table/tableMap.ts
@@ -63,12 +63,6 @@ const tableMap = (
             }
             status = accessibilityRequestStatusMap[request.status];
             break;
-          case RequestType.GOVERNANCE_REQUEST:
-            status = t(`intake:statusMap.${request.status}`);
-            if (request.lcid) {
-              status = `${status}: ${request.lcid}`;
-            }
-            break;
           default:
             status = '';
             break;


### PR DESCRIPTION
# EASI-3783

## Changes and Description
- Only reference it gov v2 statuses in the requester table, remove flag switches and other references to old v1 statuses
- `GetRequests.status` is left in since it is a generic property that still has references to the Accessibility request type
- Removed the Governance Request status case switch from tableMap, since it looked redundant with what the Table Column Cell definition has. Searching seems to work fine. @patrickseguraoddball Since this might have been your original code can you check that this edit is ok?

## Test
Take a look at the requester home page table after seeding data
- Make sure the status columns are ok
- Make sure table features like searching and sorting are ok

Unit test snapshots are updated