### PR TITLE
[EASI-3090] - Send LCID expiration emails even if no EUA is stored

### DIFF
--- a/cmd/devdata/main.go
+++ b/cmd/devdata/main.go
@@ -158,6 +158,20 @@ func main() {
 	intake = makeSystemIntakeAndSubmit("LCID issued after initial form submitted", &intakeID, requesterEUA, logger, store)
 	issueLCID(logger, store, intake, time.Now().AddDate(1, 0, 0), models.TRBFRStronglyRecommended)
 
+	intakeID = uuid.MustParse("98edbd5a-f97d-47f2-9ea1-9369509da398")
+	intake = makeSystemIntakeAndIssueLCID("Intake with Expiring LCID and no EUA ID", &intakeID, "", logger, store)
+	modifySystemIntake(logger, store, intake, func(i *models.SystemIntake) {
+		expireTime := time.Now().AddDate(0, 0, 30) // expires in 30 days
+		i.LifecycleExpiresAt = &expireTime
+	})
+
+	intakeID = uuid.MustParse("1fecf78f-e309-4540-9f44-6e41ea686c56")
+	intake = makeSystemIntakeAndIssueLCID("Intake with Expiring LCID", &intakeID, requesterEUA, logger, store)
+	modifySystemIntake(logger, store, intake, func(i *models.SystemIntake) {
+		expireTime := time.Now().AddDate(0, 0, 30) // expires in 30 days
+		i.LifecycleExpiresAt = &expireTime
+	})
+
 	intakeID = uuid.MustParse("9ab475a8-a691-45e9-b55d-648b6e752efa")
 	makeSystemIntakeAndIssueLCID("LCID issued", &intakeID, requesterEUA, logger, store)
 

--- a/cmd/devdata/system_intake_decision_actions.go
+++ b/cmd/devdata/system_intake_decision_actions.go
@@ -22,18 +22,32 @@ func makeSystemIntakeAndIssueLCID(
 	store *storage.Store,
 ) *models.SystemIntake {
 	pastMeetingDate := time.Now().AddDate(0, -1, 0)
-	intake := makeSystemIntakeAndProgressToStep(
-		requestName,
-		intakeID,
-		requesterEUA,
-		logger,
-		store,
-		model.SystemIntakeStepToProgressToGrbMeeting,
-		&progressOptions{
-			completeOtherSteps: true,
-			meetingDate:        &pastMeetingDate,
-		},
-	)
+	var intake *models.SystemIntake
+	// business cases require EUA ID to be set in DB constraint
+	if requesterEUA == "" {
+		intake = makeSystemIntakeAndProgressToStep(
+			requestName,
+			intakeID,
+			requesterEUA,
+			logger,
+			store,
+			model.SystemIntakeStepToProgressToDraftBusinessCase,
+			nil,
+		)
+	} else {
+		intake = makeSystemIntakeAndProgressToStep(
+			requestName,
+			intakeID,
+			requesterEUA,
+			logger,
+			store,
+			model.SystemIntakeStepToProgressToGrbMeeting,
+			&progressOptions{
+				completeOtherSteps: true,
+				meetingDate:        &pastMeetingDate,
+			},
+		)
+	}
 	intake = issueLCID(
 		logger,
 		store,


### PR DESCRIPTION
# EASI-3090

## Changes and Description

- This allows LCID expiration emails for intakes to send even when no EUA ID is stored on the intake. I had thought the code for this was already implemented in the `getAlertRecipients` function, but it turns out an if statement skipped intakes with no EUA already.

## How to test this change

To see the emails in mailcatcher using seed data:
```sh
scripts/dev up:backend && scripts/dev db:seed && docker-compose restart easi
```
To run the expiration tests:
```sh
go test ./pkg/alerts
```
or all tests:
```sh
scripts/dev test:go
```


## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
