### PR TITLE
[EASI-2101] Help center back button

### DIFF
--- a/src/components/HelpBreadcrumb/__snapshots__/index.test.tsx.snap
+++ b/src/components/HelpBreadcrumb/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`HelpBreadcrumb > matches the snapshot 1`] = `
         d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
       />
     </svg>
-    Back
+    Back to help center
   </button>
 </DocumentFragment>
 `;

--- a/src/components/HelpBreadcrumb/index.test.tsx
+++ b/src/components/HelpBreadcrumb/index.test.tsx
@@ -5,7 +5,7 @@ import HelpBreadcrumb from './index';
 
 describe('HelpBreadcrumb', () => {
   it('matches the snapshot', () => {
-    const { asFragment } = render(<HelpBreadcrumb type="Back" />);
+    const { asFragment } = render(<HelpBreadcrumb />);
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/components/HelpBreadcrumb/index.tsx
+++ b/src/components/HelpBreadcrumb/index.tsx
@@ -5,25 +5,26 @@ import { Button, IconArrowBack, IconClose } from '@trussworks/react-uswds';
 import classNames from 'classnames';
 
 type HelpBreadcrumbProps = {
-  type: 'Back' | 'Close tab';
+  type?: 'back' | 'close';
   className?: string;
   text?: string;
 };
 
 export default function HelpBreadcrumb({
-  type = 'Back',
+  type = 'back',
   className,
   text
 }: HelpBreadcrumbProps) {
   const history = useHistory();
-  const { t } = useTranslation();
+  const { t } = useTranslation('help');
   const handleClick = () => {
-    if (type === 'Close tab') {
+    if (type === 'close') {
       window.close();
     } else {
       history.goBack();
     }
   };
+
   return (
     <Button
       type="button"
@@ -31,7 +32,7 @@ export default function HelpBreadcrumb({
       onClick={() => handleClick()}
       className={classNames('margin-top-6', className)}
     >
-      {type === 'Close tab' ? (
+      {type === 'close' ? (
         <IconClose className="margin-right-05 margin-top-3px text-tbottom" />
       ) : (
         <IconArrowBack className="margin-right-05 margin-top-3px text-tbottom" />

--- a/src/components/HelpBreadcrumb/index.tsx
+++ b/src/components/HelpBreadcrumb/index.tsx
@@ -21,7 +21,7 @@ export default function HelpBreadcrumb({
     if (type === 'close') {
       window.close();
     } else {
-      history.goBack();
+      history.push('/help');
     }
   };
 

--- a/src/i18n/en-US/help.ts
+++ b/src/i18n/en-US/help.ts
@@ -28,7 +28,8 @@ const help = {
     content: 'Contact the Governance team:',
     email: 'IT_Governance@cms.hhs.gov'
   },
-  back: 'Back',
+  back: 'Back to help center',
+  close: 'Close tab',
   allHelpArticles: 'All help articles',
   itGovernance: {
     heading: 'IT Governance',

--- a/src/views/Help/All/__snapshots__/index.test.tsx.snap
+++ b/src/views/Help/All/__snapshots__/index.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`All help articles > matches the snapshot 1`] = `
           d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
         />
       </svg>
-      Back
+      Back to help center
     </button>
     <div
       class="help-page-intro margin-bottom-4"

--- a/src/views/Help/All/index.tsx
+++ b/src/views/Help/All/index.tsx
@@ -17,7 +17,7 @@ const AllHelp = () => {
 
   return (
     <MainContent className="grid-container margin-bottom-10">
-      <HelpBreadcrumb type="Back" />
+      <HelpBreadcrumb />
       <HelpPageIntro heading={t('allHelpArticles')} />
       <CardGroup className="margin-y-2">
         {allArticles.map(article => (

--- a/src/views/Help/ITGovernance/NewSystem/index.tsx
+++ b/src/views/Help/ITGovernance/NewSystem/index.tsx
@@ -11,7 +11,7 @@ const NewSystem = () => {
   return (
     <>
       <div className="grid-container">
-        <HelpBreadcrumb type="Close tab" />
+        <HelpBreadcrumb type="close" />
         <HelpPageIntro
           heading={t('newSystem:title')}
           subheading={t('newSystem:description')}

--- a/src/views/Help/ITGovernance/PrepareForGRB/index.tsx
+++ b/src/views/Help/ITGovernance/PrepareForGRB/index.tsx
@@ -9,7 +9,7 @@ const PrepareForGRB = () => {
   return (
     <>
       <MainContent className="grid-container">
-        <HelpBreadcrumb type="Close tab" />
+        <HelpBreadcrumb type="close" />
         <PrepareForGRBBase helpArticle />
       </MainContent>
       <div className="margin-top-7">

--- a/src/views/Help/ITGovernance/PrepareForGRT/index.tsx
+++ b/src/views/Help/ITGovernance/PrepareForGRT/index.tsx
@@ -9,7 +9,7 @@ const PrepareForGRT = () => {
   return (
     <>
       <MainContent className="grid-container">
-        <HelpBreadcrumb type="Close tab" />
+        <HelpBreadcrumb type="close" />
         <PrepareForGRTBase helpArticle />
       </MainContent>
       <div className="margin-top-7">

--- a/src/views/Help/ITGovernance/SampleBusinessCase/index.tsx
+++ b/src/views/Help/ITGovernance/SampleBusinessCase/index.tsx
@@ -10,7 +10,7 @@ import sampleBusinessCaseData from './sampleBusinessCaseData';
 export default function SampleBusinessCase() {
   return (
     <MainContent className="grid-container">
-      <HelpBreadcrumb type="Close tab" />
+      <HelpBreadcrumb type="close" />
       <HelpPageIntro
         heading="Sample Business Case"
         subheading="This sample Business Case can help you as you fill out your own Business Case. The content here is an example of how complete and precise to be when completing your Business Case."

--- a/src/views/Help/ITGovernance/__snapshots__/index.test.tsx.snap
+++ b/src/views/Help/ITGovernance/__snapshots__/index.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`IT Governance Help > matches the snapshot 1`] = `
           d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
         />
       </svg>
-      Back
+      Back to help center
     </button>
     <div
       class="help-page-intro margin-bottom-4"

--- a/src/views/Help/ITGovernance/index.tsx
+++ b/src/views/Help/ITGovernance/index.tsx
@@ -15,7 +15,7 @@ const ITGovernance = () => {
   const { t } = useTranslation('help');
   return (
     <MainContent className="grid-container">
-      <HelpBreadcrumb type="Back" />
+      <HelpBreadcrumb />
       <HelpPageIntro
         heading={t('itGovernance.heading')}
         subheading={t('itGovernance.subheading')}

--- a/src/views/Help/SendFeedback/index.tsx
+++ b/src/views/Help/SendFeedback/index.tsx
@@ -397,7 +397,7 @@ export const HelpFormHeading = ({
   return (
     <>
       <HelpBreadcrumb
-        type="Close tab"
+        type="close"
         text={!isDone ? t('sendFeedback.closeTab') : undefined}
       />
       <h1 className="margin-top-2 margin-bottom-1">

--- a/src/views/Help/TechnicalReviewBoard/PrepareTrbConsultMeeting.tsx
+++ b/src/views/Help/TechnicalReviewBoard/PrepareTrbConsultMeeting.tsx
@@ -19,7 +19,7 @@ function PrepareTrbConsultMeeting() {
   return (
     <>
       <MainContent className="grid-container margin-bottom-7">
-        <HelpBreadcrumb type="Close tab" />
+        <HelpBreadcrumb type="close" />
         <HelpPageIntro
           type="Technical Review Board"
           heading={t('title')}

--- a/src/views/Help/TechnicalReviewBoard/StepsInProcess.tsx
+++ b/src/views/Help/TechnicalReviewBoard/StepsInProcess.tsx
@@ -20,7 +20,7 @@ const StepsInProcess = () => {
   return (
     <>
       <MainContent className="grid-container margin-bottom-7">
-        <HelpBreadcrumb type="Close tab" />
+        <HelpBreadcrumb type="close" />
         <HelpPageIntro
           type="Technical Review Board"
           heading={t('title')}

--- a/src/views/Help/TechnicalReviewBoard/index.tsx
+++ b/src/views/Help/TechnicalReviewBoard/index.tsx
@@ -16,7 +16,7 @@ const TechnicalReviewBoard = () => {
 
   return (
     <MainContent className="grid-container">
-      <HelpBreadcrumb type="Back" />
+      <HelpBreadcrumb />
       <HelpPageIntro
         heading={t('technicalReviewBoard.heading')}
         subheading={t('technicalReviewBoard.subheading')}


### PR DESCRIPTION
# EASI-2102

## Changes and Description

- Updated help center back button text to "Back to help center"
- Back button returns to main help center instead of previous page

<!-- Put a description here! -->

## How to test this change

- Go to /help/all-articles
- Check back button text
- Button click should take you to /help

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
