### PR TITLE
[NOREF] Ignore query for gov task list if there's no system intake ID

### DIFF
--- a/src/data/businessCase.ts
+++ b/src/data/businessCase.ts
@@ -95,7 +95,7 @@ export const defaultProposedSolution = {
 
 export const businessCaseInitialData: BusinessCaseModel = {
   status: 'OPEN',
-  systemIntakeId: '',
+  systemIntakeId: '34ded286-02fa-4457-b1a5-0fc6ec00ecf5', // just a random UUID. All business cases should have a systemIntakeId
   systemIntakeStatus: '',
   requestName: '',
   requester: {

--- a/src/views/BusinessCase/index.tsx
+++ b/src/views/BusinessCase/index.tsx
@@ -86,7 +86,8 @@ export const BusinessCase = () => {
   >(GetGovernanceTaskListQuery, {
     variables: {
       id: businessCase.systemIntakeId
-    }
+    },
+    skip: !businessCase?.systemIntakeId
   });
 
   const isFinal: boolean =

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -474,7 +474,7 @@ exports[`The GRT business case review > matches the snapshot 1`] = `
     </div>
     <a
       class="usa-button margin-top-5"
-      href="/governance-review-team//actions"
+      href="/governance-review-team/34ded286-02fa-4457-b1a5-0fc6ec00ecf5/actions"
     >
       Take an action
     </a>


### PR DESCRIPTION
# NOREF
## Changes and Description

- Prevents queries from being made to fetch the Governance Task List when we don't have the ID of the intake to query by, yet.

This helps prevent an accidental query with `"id":""` when the page is loading the business case.

https://cmsgov.slack.com/archives/C0486DX6884/p1706300155882699

## How to test this change

- Seed the DB
- Visit the requester task list for `Edits requested on draft biz case` (Signed in as `USR1`)
- Ensure that when you edit the form, the network tab only shows valid requests with ID's (pictures below of valid and not valid)

![image](https://github.com/CMSgov/easi-app/assets/15203744/5888eb23-eebb-4ed0-998d-05db949d1e52)
![image](https://github.com/CMSgov/easi-app/assets/15203744/af267cb6-9190-4152-87a4-b12177e790eb)


## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
