### PR TITLE
[EASI-3755] [EASI-3872] Add new "ContractName" field and partially implement resolver

### DIFF
--- a/EASI.postman_collection.json
+++ b/EASI.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "960f5a31-db36-4e16-be6d-7a0e8ee48a86",
+		"_postman_id": "58c4718f-c2b8-4800-afb9-b71f6f2edb93",
 		"name": "EASI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "12341016"
@@ -1130,6 +1130,27 @@
 					"name": "Set Intake Relations",
 					"item": [
 						{
+							"name": "Set New System",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "graphql",
+									"graphql": {
+										"query": "mutation SetSystemIntakeRelationNewSystem ($input: SetSystemIntakeRelationNewSystemInput!) {\r\n    setSystemIntakeRelationNewSystem(input:$input) {\r\n        userErrors {\r\n            message\r\n            path\r\n        }\r\n        systemIntake {\r\n            id\r\n            step\r\n            state\r\n            contractName\r\n        }\r\n    }\r\n}",
+										"variables": "{\r\n    \"input\": {\r\n        \"systemIntakeID\": \"{{systemIntakeID}}\",\r\n        \"contractNumbers\": []\r\n    }\r\n}"
+									}
+								},
+								"url": {
+									"raw": "{{url}}",
+									"host": [
+										"{{url}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "Set Existing Service/Contract",
 							"request": {
 								"method": "POST",
@@ -1139,6 +1160,27 @@
 									"graphql": {
 										"query": "mutation SetSystemIntakeRelationExistingService ($input: SetSystemIntakeRelationExistingServiceInput!) {\r\n    setSystemIntakeRelationExistingService(input:$input) {\r\n        userErrors {\r\n            message\r\n            path\r\n        }\r\n        systemIntake {\r\n            id\r\n            step\r\n            state\r\n            contractName\r\n        }\r\n    }\r\n}",
 										"variables": "{\r\n    \"input\": {\r\n        \"systemIntakeID\": \"{{systemIntakeID}}\",\r\n        \"contractName\": \"New name!\",\r\n        \"contractNumbers\": []\r\n    }\r\n}"
+									}
+								},
+								"url": {
+									"raw": "{{url}}",
+									"host": [
+										"{{url}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Set Existing System",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "graphql",
+									"graphql": {
+										"query": "mutation SetSystemIntakeRelationExistingSystem ($input: SetSystemIntakeRelationExistingSystemInput!) {\r\n    setSystemIntakeRelationExistingSystem(input:$input) {\r\n        userErrors {\r\n            message\r\n            path\r\n        }\r\n        systemIntake {\r\n            id\r\n            step\r\n            state\r\n            contractName\r\n        }\r\n    }\r\n}",
+										"variables": "{\r\n    \"input\": {\r\n        \"systemIntakeID\": \"{{systemIntakeID}}\",\r\n        \"contractNumbers\": [],\r\n        \"cedarSystemIDs\": []\r\n    }\r\n}"
 									}
 								},
 								"url": {

--- a/EASI.postman_collection.json
+++ b/EASI.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "998f6166-79d0-4776-a76a-dbaae2f1bb06",
+		"_postman_id": "960f5a31-db36-4e16-be6d-7a0e8ee48a86",
 		"name": "EASI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "20320964"
+		"_exporter_id": "12341016"
 	},
 	"item": [
 		{
@@ -1127,6 +1127,32 @@
 					]
 				},
 				{
+					"name": "Set Intake Relations",
+					"item": [
+						{
+							"name": "Set Existing Service/Contract",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "graphql",
+									"graphql": {
+										"query": "mutation SetSystemIntakeRelationExistingService ($input: SetSystemIntakeRelationExistingServiceInput!) {\r\n    setSystemIntakeRelationExistingService(input:$input) {\r\n        userErrors {\r\n            message\r\n            path\r\n        }\r\n        systemIntake {\r\n            id\r\n            step\r\n            state\r\n            contractName\r\n        }\r\n    }\r\n}",
+										"variables": "{\r\n    \"input\": {\r\n        \"systemIntakeID\": \"{{systemIntakeID}}\",\r\n        \"contractName\": \"New name!\",\r\n        \"contractNumbers\": []\r\n    }\r\n}"
+									}
+								},
+								"url": {
+									"raw": "{{url}}",
+									"host": [
+										"{{url}}"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
 					"name": "SystemIntake Get",
 					"event": [
 						{
@@ -1145,7 +1171,7 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query systemIntake {\n  systemIntake(id:\"{{systemIntakeID}}\") {\n    step\n    state\n    status\n    archivedAt\n    requestFormState\n    draftBusinessCaseState\n    grtMeetingState\n    finalBusinessCaseState\n    grbMeetingState\n    decisionState\n    itGovTaskStatuses {      \n        intakeFormStatus\n        feedbackFromInitialReviewStatus\n        decisionAndNextStepsStatus\n        bizCaseDraftStatus\n        grtMeetingStatus\n        bizCaseFinalStatus\n        grbMeetingStatus\n    }\n    id\n    actions {\n        type\n        actor {\n            name\n        }\n        step\n        feedback\n    }\n#   adminLead\n# #   businessCase\n#   businessNeed\n# #   businessOwner\n#   businessSolution\n# #   contract\n# #   costs\n#   createdAt\n#   currentStage\n#   decisionNextSteps\n#   eaCollaborator\n#   eaCollaboratorName\n#   euaUserId\n#   existingFunding\n# #   fundingSources\n# #   governanceTeams\n#   grbDate\n#   grtDate\n# #   grtFeedbacks\n#   id\n# #   isso\n#   lcid\n#   lcidExpiresAt\n#   lcidScope\n#   lcidCostBaseline\n#   needsEaSupport\n# #   notes\n#   oitSecurityCollaborator\n#   oitSecurityCollaboratorName\n# #   productManager\n#   projectAcronym\n#   rejectionReason\n#   requestName\n#   requestType\n# #   requester\n#   status\n#   submittedAt\n#   trbCollaborator\n#   trbCollaboratorName\n#   updatedAt\n#   grtReviewEmailBody\n#   decidedAt\n#   businessCaseId\n# #   lastAdminNote\n#   cedarSystemId\n# #   documents\n#   hasUiChanges\n    \n    \n  }\n  \n  \n}",
+								"query": "query systemIntake {\n  systemIntake(id:\"{{systemIntakeID}}\") {\n    step\n    state\n    status\n    archivedAt\n    requestFormState\n    draftBusinessCaseState\n    grtMeetingState\n    finalBusinessCaseState\n    grbMeetingState\n    decisionState\n    itGovTaskStatuses {      \n        intakeFormStatus\n        feedbackFromInitialReviewStatus\n        decisionAndNextStepsStatus\n        bizCaseDraftStatus\n        grtMeetingStatus\n        bizCaseFinalStatus\n        grbMeetingStatus\n    }\n    id\n    actions {\n        type\n        actor {\n            name\n        }\n        step\n        feedback\n    }\n    contractName\n#   adminLead\n# #   businessCase\n#   businessNeed\n# #   businessOwner\n#   businessSolution\n# #   contract\n# #   costs\n#   createdAt\n#   currentStage\n#   decisionNextSteps\n#   eaCollaborator\n#   eaCollaboratorName\n#   euaUserId\n#   existingFunding\n# #   fundingSources\n# #   governanceTeams\n#   grbDate\n#   grtDate\n# #   grtFeedbacks\n#   id\n# #   isso\n#   lcid\n#   lcidExpiresAt\n#   lcidScope\n#   lcidCostBaseline\n#   needsEaSupport\n# #   notes\n#   oitSecurityCollaborator\n#   oitSecurityCollaboratorName\n# #   productManager\n#   projectAcronym\n#   rejectionReason\n#   requestName\n#   requestType\n# #   requester\n#   status\n#   submittedAt\n#   trbCollaborator\n#   trbCollaboratorName\n#   updatedAt\n#   grtReviewEmailBody\n#   decidedAt\n#   businessCaseId\n# #   lastAdminNote\n#   cedarSystemId\n# #   documents\n#   hasUiChanges\n    \n    \n  }\n  \n  \n}",
 								"variables": ""
 							}
 						},

--- a/cmd/devdata/main.go
+++ b/cmd/devdata/main.go
@@ -632,6 +632,18 @@ func main() {
 			completeOtherSteps: true,
 		},
 	)
+
+	// Intakes with Relation data
+	// 1. Intake with no related systems/services
+	// TODO
+
+	// 2. Intake related to CEDAR System(s)
+	// TODO
+
+	// 3. Intake related to an existing contract/service
+	intakeID = uuid.MustParse("b8e3fbf3-73af-4bac-bac3-fd6167a36166")
+	intake = makeSystemIntakeAndSubmit("System Intake Relation (Existing Contract/Service)", &intakeID, requesterEUA, logger, store)
+	setSystemIntakeRelationExistingService(logger, store, intake, "My Cool Existing Contract/Service")
 }
 
 func date(year, month, day int) *time.Time {

--- a/cmd/devdata/system_intake.go
+++ b/cmd/devdata/system_intake.go
@@ -257,6 +257,24 @@ func updateSystemIntakeContact(
 	}
 }
 
+func setSystemIntakeRelationExistingService(
+	logger *zap.Logger,
+	store *storage.Store,
+	intake *models.SystemIntake,
+	contractName string,
+) {
+	ctx := mock.CtxWithLoggerAndPrincipal(logger, intake.EUAUserID.ValueOrZero())
+	input := &model.SetSystemIntakeRelationExistingServiceInput{
+		SystemIntakeID: intake.ID,
+		ContractName:   contractName,
+		// ContractNumbers: []string{"1234567890"},
+	}
+	_, err := resolvers.SetSystemIntakeRelationExistingService(ctx, store, input)
+	if err != nil {
+		panic(err)
+	}
+}
+
 func updateSystemIntakeContactDetails(
 	logger *zap.Logger,
 	store *storage.Store,

--- a/migrations/V171__Add_Contract_Name.sql
+++ b/migrations/V171__Add_Contract_Name.sql
@@ -1,0 +1,3 @@
+-- Using a NULLable ZERO_STRING here so that you either have a valid non-empty string
+-- or an explicitly NULL value (i.e. not "")
+ALTER TABLE system_intakes ADD COLUMN contract_name ZERO_STRING;

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -709,6 +709,7 @@ type ComplexityRoot struct {
 		BusinessSolution            func(childComplexity int) int
 		CedarSystemID               func(childComplexity int) int
 		Contract                    func(childComplexity int) int
+		ContractName                func(childComplexity int) int
 		Costs                       func(childComplexity int) int
 		CreatedAt                   func(childComplexity int) int
 		CurrentStage                func(childComplexity int) int
@@ -1474,6 +1475,7 @@ type SystemIntakeResolver interface {
 	StatusAdmin(ctx context.Context, obj *models.SystemIntake) (models.SystemIntakeStatusAdmin, error)
 	LcidStatus(ctx context.Context, obj *models.SystemIntake) (*models.SystemIntakeLCIDStatus, error)
 
+	ContractName(ctx context.Context, obj *models.SystemIntake) (*string, error)
 	RelationType(ctx context.Context, obj *models.SystemIntake) (*model.SystemIntakeRelationType, error)
 }
 type SystemIntakeDocumentResolver interface {
@@ -5371,6 +5373,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SystemIntake.Contract(childComplexity), true
 
+	case "SystemIntake.contractName":
+		if e.complexity.SystemIntake.ContractName == nil {
+			break
+		}
+
+		return e.complexity.SystemIntake.ContractName(childComplexity), true
+
 	case "SystemIntake.costs":
 		if e.complexity.SystemIntake.Costs == nil {
 			break
@@ -8731,6 +8740,7 @@ type SystemIntake {
   """
   lcidStatus: SystemIntakeLCIDStatus
   trbFollowUpRecommendation: SystemIntakeTRBFollowUp
+  contractName: String
   relationType: SystemIntakeRelationType # TODO: NOT IMPLEMENTED
 }
 
@@ -10446,7 +10456,7 @@ type Mutation {
   setSystemIntakeRelationNewSystem(input: SetSystemIntakeRelationNewSystemInput): UpdateSystemIntakePayload
   # TODO: NOT IMPLEMENTED
   setSystemIntakeRelationExistingSystem(input: SetSystemIntakeRelationExistingSystemInput): UpdateSystemIntakePayload
-  # TODO: NOT IMPLEMENTED
+  # TODO: NOT FULLY IMPLEMENTED
   setSystemIntakeRelationExistingService(input: SetSystemIntakeRelationExistingServiceInput): UpdateSystemIntakePayload
 
   createSystemIntakeContact(input: CreateSystemIntakeContactInput!): CreateSystemIntakeContactPayload
@@ -15831,6 +15841,8 @@ func (ec *executionContext) fieldContext_BusinessCase_systemIntake(ctx context.C
 				return ec.fieldContext_SystemIntake_lcidStatus(ctx, field)
 			case "trbFollowUpRecommendation":
 				return ec.fieldContext_SystemIntake_trbFollowUpRecommendation(ctx, field)
+			case "contractName":
+				return ec.fieldContext_SystemIntake_contractName(ctx, field)
 			case "relationType":
 				return ec.fieldContext_SystemIntake_relationType(ctx, field)
 			}
@@ -24717,6 +24729,8 @@ func (ec *executionContext) fieldContext_CreateSystemIntakeActionExtendLifecycle
 				return ec.fieldContext_SystemIntake_lcidStatus(ctx, field)
 			case "trbFollowUpRecommendation":
 				return ec.fieldContext_SystemIntake_trbFollowUpRecommendation(ctx, field)
+			case "contractName":
+				return ec.fieldContext_SystemIntake_contractName(ctx, field)
 			case "relationType":
 				return ec.fieldContext_SystemIntake_relationType(ctx, field)
 			}
@@ -29548,6 +29562,8 @@ func (ec *executionContext) fieldContext_Mutation_createSystemIntake(ctx context
 				return ec.fieldContext_SystemIntake_lcidStatus(ctx, field)
 			case "trbFollowUpRecommendation":
 				return ec.fieldContext_SystemIntake_trbFollowUpRecommendation(ctx, field)
+			case "contractName":
+				return ec.fieldContext_SystemIntake_contractName(ctx, field)
 			case "relationType":
 				return ec.fieldContext_SystemIntake_relationType(ctx, field)
 			}
@@ -34991,6 +35007,8 @@ func (ec *executionContext) fieldContext_Query_systemIntake(ctx context.Context,
 				return ec.fieldContext_SystemIntake_lcidStatus(ctx, field)
 			case "trbFollowUpRecommendation":
 				return ec.fieldContext_SystemIntake_trbFollowUpRecommendation(ctx, field)
+			case "contractName":
+				return ec.fieldContext_SystemIntake_contractName(ctx, field)
 			case "relationType":
 				return ec.fieldContext_SystemIntake_relationType(ctx, field)
 			}
@@ -35206,6 +35224,8 @@ func (ec *executionContext) fieldContext_Query_systemIntakes(ctx context.Context
 				return ec.fieldContext_SystemIntake_lcidStatus(ctx, field)
 			case "trbFollowUpRecommendation":
 				return ec.fieldContext_SystemIntake_trbFollowUpRecommendation(ctx, field)
+			case "contractName":
+				return ec.fieldContext_SystemIntake_contractName(ctx, field)
 			case "relationType":
 				return ec.fieldContext_SystemIntake_relationType(ctx, field)
 			}
@@ -35453,6 +35473,8 @@ func (ec *executionContext) fieldContext_Query_systemIntakesWithLcids(ctx contex
 				return ec.fieldContext_SystemIntake_lcidStatus(ctx, field)
 			case "trbFollowUpRecommendation":
 				return ec.fieldContext_SystemIntake_trbFollowUpRecommendation(ctx, field)
+			case "contractName":
+				return ec.fieldContext_SystemIntake_contractName(ctx, field)
 			case "relationType":
 				return ec.fieldContext_SystemIntake_relationType(ctx, field)
 			}
@@ -36664,6 +36686,8 @@ func (ec *executionContext) fieldContext_Query_relatedSystemIntakes(ctx context.
 				return ec.fieldContext_SystemIntake_lcidStatus(ctx, field)
 			case "trbFollowUpRecommendation":
 				return ec.fieldContext_SystemIntake_trbFollowUpRecommendation(ctx, field)
+			case "contractName":
+				return ec.fieldContext_SystemIntake_contractName(ctx, field)
 			case "relationType":
 				return ec.fieldContext_SystemIntake_relationType(ctx, field)
 			}
@@ -41135,6 +41159,47 @@ func (ec *executionContext) fieldContext_SystemIntake_trbFollowUpRecommendation(
 	return fc, nil
 }
 
+func (ec *executionContext) _SystemIntake_contractName(ctx context.Context, field graphql.CollectedField, obj *models.SystemIntake) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SystemIntake_contractName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.SystemIntake().ContractName(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SystemIntake_contractName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SystemIntake",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SystemIntake_relationType(ctx context.Context, field graphql.CollectedField, obj *models.SystemIntake) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SystemIntake_relationType(ctx, field)
 	if err != nil {
@@ -41391,6 +41456,8 @@ func (ec *executionContext) fieldContext_SystemIntakeAction_systemIntake(ctx con
 				return ec.fieldContext_SystemIntake_lcidStatus(ctx, field)
 			case "trbFollowUpRecommendation":
 				return ec.fieldContext_SystemIntake_trbFollowUpRecommendation(ctx, field)
+			case "contractName":
+				return ec.fieldContext_SystemIntake_contractName(ctx, field)
 			case "relationType":
 				return ec.fieldContext_SystemIntake_relationType(ctx, field)
 			}
@@ -50550,6 +50617,8 @@ func (ec *executionContext) fieldContext_TRBRequestForm_systemIntakes(ctx contex
 				return ec.fieldContext_SystemIntake_lcidStatus(ctx, field)
 			case "trbFollowUpRecommendation":
 				return ec.fieldContext_SystemIntake_trbFollowUpRecommendation(ctx, field)
+			case "contractName":
+				return ec.fieldContext_SystemIntake_contractName(ctx, field)
 			case "relationType":
 				return ec.fieldContext_SystemIntake_relationType(ctx, field)
 			}
@@ -51789,6 +51858,8 @@ func (ec *executionContext) fieldContext_UpdateSystemIntakePayload_systemIntake(
 				return ec.fieldContext_SystemIntake_lcidStatus(ctx, field)
 			case "trbFollowUpRecommendation":
 				return ec.fieldContext_SystemIntake_trbFollowUpRecommendation(ctx, field)
+			case "contractName":
+				return ec.fieldContext_SystemIntake_contractName(ctx, field)
 			case "relationType":
 				return ec.fieldContext_SystemIntake_relationType(ctx, field)
 			}
@@ -67832,6 +67903,39 @@ func (ec *executionContext) _SystemIntake(ctx context.Context, sel ast.Selection
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "trbFollowUpRecommendation":
 			out.Values[i] = ec._SystemIntake_trbFollowUpRecommendation(ctx, field, obj)
+		case "contractName":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._SystemIntake_contractName(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "relationType":
 			field := field
 

--- a/pkg/graph/resolvers/system_intake_relation.go
+++ b/pkg/graph/resolvers/system_intake_relation.go
@@ -3,7 +3,7 @@ package resolvers
 import (
 	"context"
 
-	"github.com/guregu/null"
+	"github.com/guregu/null/zero"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/cmsgov/easi-app/pkg/graph/model"
@@ -28,7 +28,7 @@ func SetSystemIntakeRelationExistingService(
 		}
 
 		// Set contract name
-		intake.ContractName = null.StringFrom(input.ContractName)
+		intake.ContractName = zero.StringFrom(input.ContractName)
 		updatedIntake, err := store.UpdateSystemIntake(ctx, intake)
 		if err != nil {
 			return nil, err
@@ -57,7 +57,7 @@ func SetSystemIntakeRelationNewSystem(
 		}
 
 		// Clear contract name
-		intake.ContractName = null.NewString("", false)
+		intake.ContractName = zero.StringFromPtr(nil)
 		updatedIntake, err := store.UpdateSystemIntake(ctx, intake)
 		if err != nil {
 			return nil, err
@@ -86,7 +86,7 @@ func SetSystemIntakeRelationExistingSystem(
 		}
 
 		// Clear contract name
-		intake.ContractName = null.NewString("", false)
+		intake.ContractName = zero.StringFromPtr(nil)
 		updatedIntake, err := store.UpdateSystemIntake(ctx, intake)
 		if err != nil {
 			return nil, err

--- a/pkg/graph/resolvers/system_intake_relation.go
+++ b/pkg/graph/resolvers/system_intake_relation.go
@@ -40,3 +40,61 @@ func SetSystemIntakeRelationExistingService(
 		return updatedIntake, nil
 	})
 }
+
+// SetSystemIntakeRelationNewSystem effectively clears the relationship between a system intake
+// and any previously set list of CEDAR Systems and contract/service names. It also
+// sets any contract number relationships.
+func SetSystemIntakeRelationNewSystem(
+	ctx context.Context,
+	store *storage.Store,
+	input *model.SetSystemIntakeRelationNewSystemInput,
+) (*models.SystemIntake, error) {
+	return sqlutils.WithTransaction[models.SystemIntake](store, func(tx *sqlx.Tx) (*models.SystemIntake, error) {
+		// Fetch intake by ID
+		intake, err := store.FetchSystemIntakeByID(ctx, input.SystemIntakeID)
+		if err != nil {
+			return nil, err
+		}
+
+		// Clear contract name
+		intake.ContractName = null.NewString("", false)
+		updatedIntake, err := store.UpdateSystemIntake(ctx, intake)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO: STORE -> Delete CEDAR system relationships
+		// TODO: STORE -> Delete & recreate contract number relationships
+
+		return updatedIntake, nil
+	})
+}
+
+// SetSystemIntakeRelationExistingSystem sets the relationship between a system intake and
+// a list of CEDAR Systems by setting an array of CEDAR System IDs, clearing any data about
+// contract/service names, and setting any contract number relationships.
+func SetSystemIntakeRelationExistingSystem(
+	ctx context.Context,
+	store *storage.Store,
+	input *model.SetSystemIntakeRelationExistingSystemInput,
+) (*models.SystemIntake, error) {
+	return sqlutils.WithTransaction[models.SystemIntake](store, func(tx *sqlx.Tx) (*models.SystemIntake, error) {
+		// Fetch intake by ID
+		intake, err := store.FetchSystemIntakeByID(ctx, input.SystemIntakeID)
+		if err != nil {
+			return nil, err
+		}
+
+		// Clear contract name
+		intake.ContractName = null.NewString("", false)
+		updatedIntake, err := store.UpdateSystemIntake(ctx, intake)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO: STORE -> Add CEDAR system relationships
+		// TODO: STORE -> Delete & recreate contract number relationships
+
+		return updatedIntake, nil
+	})
+}

--- a/pkg/graph/resolvers/system_intake_relation.go
+++ b/pkg/graph/resolvers/system_intake_relation.go
@@ -1,0 +1,42 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/guregu/null"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/cmsgov/easi-app/pkg/graph/model"
+	"github.com/cmsgov/easi-app/pkg/models"
+	"github.com/cmsgov/easi-app/pkg/sqlutils"
+	"github.com/cmsgov/easi-app/pkg/storage"
+)
+
+// SetSystemIntakeRelationExistingService sets the relationship between a system intake and
+// an existing service by setting a free-text contract/service name, clearing relationships between
+// intakes and CEDAR systems, and setting any contract number relationships
+func SetSystemIntakeRelationExistingService(
+	ctx context.Context,
+	store *storage.Store,
+	input *model.SetSystemIntakeRelationExistingServiceInput,
+) (*models.SystemIntake, error) {
+	return sqlutils.WithTransaction[models.SystemIntake](store, func(tx *sqlx.Tx) (*models.SystemIntake, error) {
+		// Fetch intake by ID
+		intake, err := store.FetchSystemIntakeByID(ctx, input.SystemIntakeID)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set contract name
+		intake.ContractName = null.StringFrom(input.ContractName)
+		updatedIntake, err := store.UpdateSystemIntake(ctx, intake)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO: STORE -> Remove CEDAR system relationships
+		// TODO: STORE -> Delete & recreate contract number relationships
+
+		return updatedIntake, nil
+	})
+}

--- a/pkg/graph/resolvers/system_intake_relation_test.go
+++ b/pkg/graph/resolvers/system_intake_relation_test.go
@@ -3,7 +3,7 @@ package resolvers
 import (
 	"time"
 
-	"github.com/guregu/null"
+	"github.com/guregu/null/zero"
 
 	"github.com/cmsgov/easi-app/pkg/graph/model"
 	"github.com/cmsgov/easi-app/pkg/models"
@@ -21,7 +21,7 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationNewSystem() {
 		Status:       models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType:  models.SystemIntakeRequestTypeNEW,
 		SubmittedAt:  &submittedAt,
-		ContractName: null.StringFrom("My Test Contract Name"),
+		ContractName: zero.StringFrom("My Test Contract Name"),
 	})
 	suite.NoError(err)
 	suite.NotNil(openIntake)
@@ -55,7 +55,7 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingSystem() {
 		Status:       models.SystemIntakeStatusINTAKESUBMITTED,
 		RequestType:  models.SystemIntakeRequestTypeNEW,
 		SubmittedAt:  &submittedAt,
-		ContractName: null.StringFrom("My Test Contract Name"),
+		ContractName: zero.StringFrom("My Test Contract Name"),
 	})
 	suite.NoError(err)
 	suite.NotNil(openIntake)

--- a/pkg/graph/resolvers/system_intake_relation_test.go
+++ b/pkg/graph/resolvers/system_intake_relation_test.go
@@ -1,0 +1,44 @@
+package resolvers
+
+import (
+	"time"
+
+	"github.com/cmsgov/easi-app/pkg/graph/model"
+	"github.com/cmsgov/easi-app/pkg/models"
+)
+
+func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingService() {
+	ctx := suite.testConfigs.Context
+	store := suite.testConfigs.Store
+
+	submittedAt := time.Now()
+
+	// Create an inital intake
+	openIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
+		State:       models.SystemIntakeStateOPEN,
+		Status:      models.SystemIntakeStatusINTAKESUBMITTED,
+		RequestType: models.SystemIntakeRequestTypeNEW,
+		SubmittedAt: &submittedAt,
+	})
+	suite.NoError(err)
+	suite.NotNil(openIntake)
+
+	// Set the existing service relationship
+	contractName := "My Test Contract Name"
+	input := &model.SetSystemIntakeRelationExistingServiceInput{
+		SystemIntakeID: openIntake.ID,
+		ContractName:   contractName,
+		// TODO: ContractNumbers
+	}
+	updatedIntake, err := SetSystemIntakeRelationExistingService(ctx, store, input)
+	suite.NoError(err)
+
+	// Once implemented, we'll need to add tests that ensure the following
+	// 1. TODO - Removal of CEDAR System ID relationships that might be existing
+	// 2. TODO - That contract number relationships are deleted and recreated properly
+	//
+	// These may best be tested by other tests, or can be added to this test
+
+	// Ensure the contract name was set properly
+	suite.Equal(updatedIntake.ContractName.ValueOrZero(), contractName)
+}

--- a/pkg/graph/resolvers/system_intake_relation_test.go
+++ b/pkg/graph/resolvers/system_intake_relation_test.go
@@ -3,9 +3,80 @@ package resolvers
 import (
 	"time"
 
+	"github.com/guregu/null"
+
 	"github.com/cmsgov/easi-app/pkg/graph/model"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
+
+func (suite *ResolverSuite) TestSetSystemIntakeRelationNewSystem() {
+	ctx := suite.testConfigs.Context
+	store := suite.testConfigs.Store
+
+	submittedAt := time.Now()
+
+	// Create an inital intake that has an existing contract name
+	openIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
+		State:        models.SystemIntakeStateOPEN,
+		Status:       models.SystemIntakeStatusINTAKESUBMITTED,
+		RequestType:  models.SystemIntakeRequestTypeNEW,
+		SubmittedAt:  &submittedAt,
+		ContractName: null.StringFrom("My Test Contract Name"),
+	})
+	suite.NoError(err)
+	suite.NotNil(openIntake)
+
+	// Set the "new system" relationship
+	input := &model.SetSystemIntakeRelationNewSystemInput{
+		SystemIntakeID: openIntake.ID,
+		// TODO: ContractNumbers
+	}
+	updatedIntake, err := SetSystemIntakeRelationNewSystem(ctx, store, input)
+	suite.NoError(err)
+
+	// Once fully implemented, we'll need to add tests that ensure the following
+	// 1. TODO - Removal of CEDAR System ID relationships that might be existing
+	// 2. TODO - That contract number relationships are deleted and recreated properly
+	//
+	// These may best be tested by other tests, or can be added to this test
+
+	// Ensure the contract name was deleted properly
+	suite.True(updatedIntake.ContractName.IsZero())
+}
+func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingSystem() {
+	ctx := suite.testConfigs.Context
+	store := suite.testConfigs.Store
+
+	submittedAt := time.Now()
+
+	// Create an inital intake that has an existing contract name
+	openIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
+		State:        models.SystemIntakeStateOPEN,
+		Status:       models.SystemIntakeStatusINTAKESUBMITTED,
+		RequestType:  models.SystemIntakeRequestTypeNEW,
+		SubmittedAt:  &submittedAt,
+		ContractName: null.StringFrom("My Test Contract Name"),
+	})
+	suite.NoError(err)
+	suite.NotNil(openIntake)
+
+	// Set the "new system" relationship
+	input := &model.SetSystemIntakeRelationExistingSystemInput{
+		SystemIntakeID: openIntake.ID,
+		// TODO: ContractNumbers
+	}
+	updatedIntake, err := SetSystemIntakeRelationExistingSystem(ctx, store, input)
+	suite.NoError(err)
+
+	// Once fully implemented, we'll need to add tests that ensure the following
+	// 1. TODO - Setting of CEDAR System ID relationships that might be existing
+	// 2. TODO - That contract number relationships are deleted and recreated properly
+	//
+	// These may best be tested by other tests, or can be added to this test
+
+	// Ensure the contract name was deleted properly
+	suite.True(updatedIntake.ContractName.IsZero())
+}
 
 func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingService() {
 	ctx := suite.testConfigs.Context

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -1056,6 +1056,7 @@ type SystemIntake {
   """
   lcidStatus: SystemIntakeLCIDStatus
   trbFollowUpRecommendation: SystemIntakeTRBFollowUp
+  contractName: String
   relationType: SystemIntakeRelationType # TODO: NOT IMPLEMENTED
 }
 
@@ -2771,7 +2772,7 @@ type Mutation {
   setSystemIntakeRelationNewSystem(input: SetSystemIntakeRelationNewSystemInput): UpdateSystemIntakePayload
   # TODO: NOT IMPLEMENTED
   setSystemIntakeRelationExistingSystem(input: SetSystemIntakeRelationExistingSystemInput): UpdateSystemIntakePayload
-  # TODO: NOT IMPLEMENTED
+  # TODO: NOT FULLY IMPLEMENTED
   setSystemIntakeRelationExistingService(input: SetSystemIntakeRelationExistingServiceInput): UpdateSystemIntakePayload
 
   createSystemIntakeContact(input: CreateSystemIntakeContactInput!): CreateSystemIntakeContactPayload

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1791,7 +1791,14 @@ func (r *mutationResolver) SetSystemIntakeRelationExistingService(ctx context.Co
 	// 1. Delete (if any) existing CEDAR System ID relations that might have been set by SetSystemIntakeRelationExistingSystem()
 	// 2. Set the free-text contract/service name
 	// 3. Delete & Create Contract Number relations (Delete & Create because this mutation always receives the full state of the relations)
-	panic(fmt.Errorf("not implemented: SetSystemIntakeRelationExistingService - setSystemIntakeRelationExistingService"))
+	intake, err := resolvers.SetSystemIntakeRelationExistingService(ctx, r.store, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.UpdateSystemIntakePayload{
+		SystemIntake: intake,
+	}, nil
 }
 
 // CreateSystemIntakeContact is the resolver for the createSystemIntakeContact field.
@@ -3098,7 +3105,7 @@ func (r *systemIntakeResolver) LcidStatus(ctx context.Context, obj *models.Syste
 
 // ContractName is the resolver for the contractName field.
 func (r *systemIntakeResolver) ContractName(ctx context.Context, obj *models.SystemIntake) (*string, error) {
-	panic(fmt.Errorf("not implemented: ContractName - contractName"))
+	return obj.ContractName.Ptr(), nil
 }
 
 // RelationType is the resolver for the relationType field.

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -3096,6 +3096,11 @@ func (r *systemIntakeResolver) LcidStatus(ctx context.Context, obj *models.Syste
 	return obj.LCIDStatus(time.Now()), nil
 }
 
+// ContractName is the resolver for the contractName field.
+func (r *systemIntakeResolver) ContractName(ctx context.Context, obj *models.SystemIntake) (*string, error) {
+	panic(fmt.Errorf("not implemented: ContractName - contractName"))
+}
+
 // RelationType is the resolver for the relationType field.
 func (r *systemIntakeResolver) RelationType(ctx context.Context, obj *models.SystemIntake) (*model.SystemIntakeRelationType, error) {
 	// The purpose of this resolver is to return the kind of relation that has been set for this System Intake

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1765,7 +1765,14 @@ func (r *mutationResolver) SetSystemIntakeRelationNewSystem(ctx context.Context,
 	// 1. Delete (if any) existing CEDAR System ID relations that were set by SetSystemIntakeRelationExistingSystem()
 	// 2. Delete (if any) existing free-text contract/service name that might have been set by SetSystemIntakeRelationExistingService()
 	// 3. Delete & Create Contract Number relations (Delete & Create because this mutation always receives the full state of the relations)
-	panic(fmt.Errorf("not implemented: SetSystemIntakeRelationNewSystem - setSystemIntakeRelationNewSystem"))
+	intake, err := resolvers.SetSystemIntakeRelationNewSystem(ctx, r.store, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.UpdateSystemIntakePayload{
+		SystemIntake: intake,
+	}, nil
 }
 
 // SetSystemIntakeRelationExistingSystem is the resolver for the setSystemIntakeRelationExistingSystem field.
@@ -1778,7 +1785,14 @@ func (r *mutationResolver) SetSystemIntakeRelationExistingSystem(ctx context.Con
 	// 1. Delete (if any) existing free-text contract/service name that might have been set by SetSystemIntakeRelationExistingService()
 	// 2. Delete & Create CEDAR System ID relations (Delete & Create because this mutation always receives the full state of the relations)
 	// 3. Delete & Create Contract Number relations (Delete & Create because this mutation always receives the full state of the relations)
-	panic(fmt.Errorf("not implemented: SetSystemIntakeRelationExistingSystem - setSystemIntakeRelationExistingSystem"))
+	intake, err := resolvers.SetSystemIntakeRelationExistingSystem(ctx, r.store, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.UpdateSystemIntakePayload{
+		SystemIntake: intake,
+	}, nil
 }
 
 // SetSystemIntakeRelationExistingService is the resolver for the setSystemIntakeRelationExistingService field.

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/guregu/null"
+	"github.com/guregu/null/zero"
 )
 
 // SystemIntakeStatus represents the status of a system intake
@@ -184,7 +185,7 @@ type SystemIntake struct {
 	FinalBusinessCaseState      SystemIntakeFormState        `json:"finalBusinessCaseState" db:"final_business_case_state"`
 	DecisionState               SystemIntakeDecisionState    `json:"decisionState" db:"decision_state"`
 	TRBFollowUpRecommendation   *SystemIntakeTRBFollowUp     `json:"trbFollowUpRecommendation" db:"trb_follow_up_recommendation"`
-	ContractName                null.String                  `json:"contractName" db:"contract_name"`
+	ContractName                zero.String                  `json:"contractName" db:"contract_name"`
 }
 
 // SystemIntakes is a list of System Intakes

--- a/pkg/models/system_intake.go
+++ b/pkg/models/system_intake.go
@@ -184,6 +184,7 @@ type SystemIntake struct {
 	FinalBusinessCaseState      SystemIntakeFormState        `json:"finalBusinessCaseState" db:"final_business_case_state"`
 	DecisionState               SystemIntakeDecisionState    `json:"decisionState" db:"decision_state"`
 	TRBFollowUpRecommendation   *SystemIntakeTRBFollowUp     `json:"trbFollowUpRecommendation" db:"trb_follow_up_recommendation"`
+	ContractName                null.String                  `json:"contractName" db:"contract_name"`
 }
 
 // SystemIntakes is a list of System Intakes

--- a/pkg/storage/system_intake.go
+++ b/pkg/storage/system_intake.go
@@ -100,6 +100,7 @@ func (s *Store) CreateSystemIntake(ctx context.Context, intake *models.SystemInt
 			grb_date,
 			has_ui_changes,
 			trb_follow_up_recommendation,
+			contract_name,
 			created_at,
 			updated_at
 		)
@@ -155,6 +156,7 @@ func (s *Store) CreateSystemIntake(ctx context.Context, intake *models.SystemInt
 			:grb_date,
 			:has_ui_changes,
 			:trb_follow_up_recommendation,
+			:contract_name,
 			:created_at,
 			:updated_at
 		)`
@@ -242,7 +244,8 @@ func (s *Store) UpdateSystemIntake(ctx context.Context, intake *models.SystemInt
 			admin_lead = :admin_lead,
 			cedar_system_id = :cedar_system_id,
 			has_ui_changes = :has_ui_changes,
-			trb_follow_up_recommendation = :trb_follow_up_recommendation
+			trb_follow_up_recommendation = :trb_follow_up_recommendation,
+			contract_name = :contract_name
 		WHERE system_intakes.id = :id
 	`
 	_, err := s.db.NamedExec(

--- a/pkg/storage/system_intake_relation.go
+++ b/pkg/storage/system_intake_relation.go
@@ -1,0 +1,7 @@
+package storage
+
+import (
+	_ "embed" // embed is used to embed the SQL file content
+)
+
+// TODO Implement store methods that have to deal with setting System Intake linking/relation data


### PR DESCRIPTION
# EASI-3755 and EASI-3872

## Changes and Description

- Introduces a new `ContractName` field that intends to capture the free-text input that users will select when linking a System Intake to an existing Contract or Service

This PR does _not_ fully implement any of the stubbed resolvers introduced in https://github.com/CMSgov/easi-app/pull/2385, but just creates the necessary DB migrations, model updates, and resolver code that sets the new `ContractName` field. What still needs to be implemented in the `setSystemIntakeRelationExistingService()` resolver is the remainder of the resolver code that should set contract numbers and also clear existing relationships between CEDAR Systems and System Intakes, if set.

## TODO

- [x] Update Postman collection
- [x] Add testing instructions

## How to test this change

You can use `scripts/dev db:seed` to see the database and use the postman collection to validate that the field is `null` for most intakes, set for the intake from the dev data, and that the mutation works as expected!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
