### PR TITLE
[NOREF] Fix business case initial ID

### DIFF
--- a/src/data/businessCase.ts
+++ b/src/data/businessCase.ts
@@ -95,7 +95,7 @@ export const defaultProposedSolution = {
 
 export const businessCaseInitialData: BusinessCaseModel = {
   status: 'OPEN',
-  systemIntakeId: '34ded286-02fa-4457-b1a5-0fc6ec00ecf5', // just a random UUID. All business cases should have a systemIntakeId
+  systemIntakeId: '',
   systemIntakeStatus: '',
   requestName: '',
   requester: {

--- a/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionA.test.tsx
+++ b/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionA.test.tsx
@@ -53,7 +53,8 @@ describe('Business case alternative a solution', () => {
     businessCase: {
       form: {
         ...businessCaseInitialData,
-        id: '75746af8-9a9b-4558-a375-cf9848eb2b0d'
+        id: '75746af8-9a9b-4558-a375-cf9848eb2b0d',
+        systemIntakeId: '943916ee-7a30-4213-990e-02c4fb97382a'
       },
       isLoading: false,
       isSaving: false,
@@ -105,6 +106,7 @@ describe('Business case alternative a solution', () => {
         form: {
           ...businessCaseInitialData,
           id: '75746af8-9a9b-4558-a375-cf9848eb2b0d',
+          systemIntakeId: '943916ee-7a30-4213-990e-02c4fb97382a',
           alternativeB: {
             ...defaultProposedSolution,
             title: 'Alt B'
@@ -147,6 +149,7 @@ describe('Business case alternative a solution', () => {
         form: {
           ...businessCaseInitialData,
           id: '75746af8-9a9b-4558-a375-cf9848eb2b0d',
+          systemIntakeId: '943916ee-7a30-4213-990e-02c4fb97382a',
           systemIntakeStatus: 'BIZ_CASE_FINAL_NEEDED'
         },
         isLoading: false,

--- a/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionB.test.tsx
+++ b/src/views/BusinessCase/AlternativeSolution/AlternativeSolutionB.test.tsx
@@ -54,6 +54,7 @@ describe('Business case alternative b solution', () => {
       form: {
         ...businessCaseInitialData,
         id: '75746af8-9a9b-4558-a375-cf9848eb2b0d',
+        systemIntakeId: '34ded286-02fa-4457-b1a5-0fc6ec00ecf5',
         alternativeB: {
           ...defaultProposedSolution,
           title: 'Alt B'
@@ -110,6 +111,7 @@ describe('Business case alternative b solution', () => {
         form: {
           ...businessCaseInitialData,
           id: '75746af8-9a9b-4558-a375-cf9848eb2b0d',
+          systemIntakeId: '34ded286-02fa-4457-b1a5-0fc6ec00ecf5',
           systemIntakeStatus: 'BIZ_CASE_FINAL_NEEDED',
           alternativeB: defaultProposedSolution
         },

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/__snapshots__/index.test.tsx.snap
@@ -474,7 +474,7 @@ exports[`The GRT business case review > matches the snapshot 1`] = `
     </div>
     <a
       class="usa-button margin-top-5"
-      href="/governance-review-team/34ded286-02fa-4457-b1a5-0fc6ec00ecf5/actions"
+      href="/governance-review-team/c9dcaca2-c500-45ae-96ce-a4ae527b4c8a/actions"
     >
       Take an action
     </a>

--- a/src/views/GovernanceReviewTeam/BusinessCaseReview/index.test.tsx
+++ b/src/views/GovernanceReviewTeam/BusinessCaseReview/index.test.tsx
@@ -16,6 +16,7 @@ describe('The GRT business case review', () => {
   const mockBusinessCase: BusinessCaseModel = {
     ...businessCaseInitialData,
     id: '54e829a9-6ce3-4b4b-81b0-7781b1e22821',
+    systemIntakeId: 'c9dcaca2-c500-45ae-96ce-a4ae527b4c8a',
     requestName: 'Easy Access to System Information',
     requester: {
       name: 'Jane Doe',


### PR DESCRIPTION
# EASI-NOREF

## Changes and Description

- Move definition of default `systemIntakeId` to individual tests, rather than in `src/data`, which is actually used in the app (not just in test)

## How to test this change

Same testing instructions as https://github.com/CMSgov/easi-app/pull/2396

- Seed the DB
- Visit the requester task list for `Edits requested on draft biz case` (Signed in as `USR1`)
- Ensure that when you edit the form, the network tab only shows valid requests with ID's (pictures below of valid and not valid)

![image](https://github.com/CMSgov/easi-app/assets/15203744/5888eb23-eebb-4ed0-998d-05db949d1e52)
![image](https://github.com/CMSgov/easi-app/assets/15203744/af267cb6-9190-4152-87a4-b12177e790eb)


## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
