### PR TITLE
[NOREF] Fix location matching for TRB request type component

### DIFF
--- a/src/views/TechnicalAssistance/RequestType.tsx
+++ b/src/views/TechnicalAssistance/RequestType.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { useHistory, useParams, useRouteMatch } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
 import {
   Button,
@@ -36,7 +36,7 @@ function RequestType() {
   const { t } = useTranslation('technicalAssistance');
 
   const history = useHistory();
-  const { pathname } = useLocation();
+  const { path: pathname } = useRouteMatch();
   const isNew = pathname.startsWith('/trb/start');
 
   const { id } = useParams<{


### PR DESCRIPTION
# NOREF

## Changes and Description

- This fixes a bug with case sensitive paths messing up the TRB Request Type component

## How to test this change

- Start the app
- Navigate to http://localhost:3000/TRB/start (notice the capitalized `TRB`. Make sure Chrome/Browser didn't replace it with `trb` from your history! Use Incognito mode to help prevent that)
- Ensure that when you try and set the request type, you're directed to the flow for creating a new TRB request
- Ensure that when you click "back" at the top of the page, you're directed back to the homepage, and don't receive an error

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
