### PR TITLE
EASI-3558 TRB - Change Default Sort Order

### DIFF
--- a/src/views/TechnicalAssistance/TrbAdminTeamHome.tsx
+++ b/src/views/TechnicalAssistance/TrbAdminTeamHome.tsx
@@ -425,7 +425,7 @@ function TrbExistingRequestsTable({ requests }: TrbRequestsTableProps) {
       autoResetSortBy: false,
       autoResetPage: true,
       initialState: {
-        sortBy: useMemo(() => [{ id: 'form.submittedAt', desc: true }], []),
+        sortBy: useMemo(() => [{ id: 'consultMeetingTime', desc: true }], []),
         pageIndex: 0,
         pageSize: 10
       }


### PR DESCRIPTION
# EASI-3558

## Changes and Description

Trb request tables will initially sort by a consult meeting date.

Requests without a consult date will be at the end of a descending list.

<!-- Put a description here! -->

## How to test this change
Check that general table features such as the global filter still work