### PR TITLE
[NOREF] Clean up change retire date and expire LCID email tests

### DIFF
--- a/pkg/email/system_intake_change_lcid_retirement_date_test.go
+++ b/pkg/email/system_intake_change_lcid_retirement_date_test.go
@@ -29,24 +29,11 @@ func (s *EmailTestSuite) TestIntakeChangeLCIDRetirementDateNotification() {
 	}
 	client, err := NewClient(s.config, &sender)
 	s.NoError(err)
-	err = client.SystemIntake.SendChangeLCIDRetirementDateNotification(
-		ctx,
-		recipients,
-		lifecycleID,
-		&retiresAt,
-		&expiresAt,
-		&issuedAt,
-		lifecycleScope,
-		lifecycleCostBaseline,
-		decisionNextSteps,
-		additionalInfo,
-	)
-	s.NoError(err)
-	expectedSubject := fmt.Sprintf("The retirement date for a Life Cycle ID (%s) has been changed", lifecycleID)
-	s.Equal(expectedSubject, sender.subject)
 
 	getExpectedEmail := func(
 		issuedAt *time.Time,
+		scope *models.HTML,
+		nextSteps *models.HTML,
 		additionalInfo *models.HTML,
 	) string {
 		var additionalInfoStr string
@@ -93,23 +80,12 @@ func (s *EmailTestSuite) TestIntakeChangeLCIDRetirementDateNotification() {
 			lifecycleID,
 			issuedAtStr,
 			expiresAt.Format("01/02/2006"),
-			*lifecycleScope.StringPointer(),
+			scope.ToTemplate(),
 			lifecycleCostBaseline,
-			*decisionNextSteps.StringPointer(),
+			nextSteps.ToTemplate(),
 			additionalInfoStr,
 		)
 	}
-
-	expectedEmail := getExpectedEmail(&issuedAt, additionalInfo)
-	s.Run("Recipient is correct", func() {
-		allRecipients := []models.EmailAddress{
-			recipient,
-		}
-		s.ElementsMatch(sender.toAddresses, allRecipients)
-	})
-	s.Run("Includes all info", func() {
-		s.EqualHTML(expectedEmail, sender.body)
-	})
 
 	err = client.SystemIntake.SendChangeLCIDRetirementDateNotification(
 		ctx,
@@ -117,17 +93,79 @@ func (s *EmailTestSuite) TestIntakeChangeLCIDRetirementDateNotification() {
 		lifecycleID,
 		&retiresAt,
 		&expiresAt,
-		nil,
+		&issuedAt,
 		lifecycleScope,
 		lifecycleCostBaseline,
 		decisionNextSteps,
-		nil,
+		additionalInfo,
 	)
 	s.NoError(err)
-	expectedEmail = getExpectedEmail(nil, nil)
 
-	s.Run("Should omit additional info and issuedAt if absent", func() {
+	s.Run("Subject is correct", func() {
+		expectedSubject := fmt.Sprintf("The retirement date for a Life Cycle ID (%s) has been changed", lifecycleID)
+		s.Equal(expectedSubject, sender.subject)
+	})
+
+	s.Run("Recipient is correct", func() {
+		allRecipients := []models.EmailAddress{
+			recipient,
+		}
+		s.ElementsMatch(sender.toAddresses, allRecipients)
+	})
+
+	s.Run("Includes all info", func() {
+		expectedEmail := getExpectedEmail(
+			&issuedAt,
+			lifecycleScope,
+			decisionNextSteps,
+			additionalInfo,
+		)
 		s.EqualHTML(expectedEmail, sender.body)
 	})
 
+	s.Run("Should omit additional info and issuedAt if absent", func() {
+		err = client.SystemIntake.SendChangeLCIDRetirementDateNotification(
+			ctx,
+			recipients,
+			lifecycleID,
+			&retiresAt,
+			&expiresAt,
+			nil, //issuedAt
+			lifecycleScope,
+			lifecycleCostBaseline,
+			decisionNextSteps,
+			nil, // add'l info
+		)
+		s.NoError(err)
+		expectedEmail := getExpectedEmail(
+			nil, //issuedAt
+			lifecycleScope,
+			decisionNextSteps,
+			nil, // add'l info
+		)
+		s.EqualHTML(expectedEmail, sender.body)
+	})
+
+	s.Run("Should omit scope and next steps if absent", func() {
+		err = client.SystemIntake.SendChangeLCIDRetirementDateNotification(
+			ctx,
+			recipients,
+			lifecycleID,
+			&retiresAt,
+			&expiresAt,
+			nil, //issuedAt
+			nil, // scope
+			lifecycleCostBaseline,
+			nil, // next steps
+			nil, // add'l info
+		)
+		s.NoError(err)
+		expectedEmail := getExpectedEmail(
+			nil, //issuedAt
+			nil, // scope
+			nil, // next steps
+			nil, // add'l info
+		)
+		s.EqualHTML(expectedEmail, sender.body)
+	})
 }


### PR DESCRIPTION
# NOREF

## Changes and Description

- This PR just cleans up some of the tests related to changes in [2411](https://github.com/CMSgov/easi-app/pull/2411).

## How to test this change

```sh
go test ./pkg/email -run TestEmailTestSuite/TestIntakeChangeLCIDRetirementDateNotification
```

and 

```sh
go test ./pkg/email -run TestEmailTestSuite/TestIntakeExpireLCIDNotification
```

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
