### PR TITLE
[NOREF] Fix radio text schema with nullable() as suggested by lib warn

### DIFF
--- a/src/validations/businessCaseSchema.ts
+++ b/src/validations/businessCaseSchema.ts
@@ -215,9 +215,11 @@ export const BusinessCaseFinalValidationSchema = {
             )
         })
       }),
-      hasUserInterface: Yup.string().required(
-        'Tell us whether the Alternative A solution will have user interface'
-      ),
+      hasUserInterface: Yup.string()
+        .nullable()
+        .required(
+          'Tell us whether the Alternative A solution will have user interface'
+        ),
       pros: Yup.string()
         .trim()
         .required('Tell us about the pros of Alternative A solution'),


### PR DESCRIPTION
# NOREF
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

Patch for an uncaught error found here https://github.com/CMSgov/easi-app/pull/2436#pullrequestreview-1885332658

If you're looking in detail, it seems that only alta needs the nullable. the other forms and schemas with `hasUserInterface` don't behave quite the same and don't have that dev warn.