### PR TITLE
[EASI-3878] Add trbLinkRequestsRequester flag

### DIFF
--- a/src/types/flags.ts
+++ b/src/types/flags.ts
@@ -12,6 +12,7 @@ export type Flags = {
   hide508Workflow: boolean;
   portfolioUpdateReport: boolean;
   itgovLinkRequestsRequester: boolean;
+  trbLinkRequestsRequester: boolean;
 };
 
 export type FlagsState = {

--- a/src/views/FlagsWrapper/index.tsx
+++ b/src/views/FlagsWrapper/index.tsx
@@ -44,7 +44,8 @@ const UserTargetingWrapper = ({ children }: WrapperProps) => {
             technicalAssistance: true,
             hide508Workflow: true,
             portfolioUpdateReport: false,
-            itgovLinkRequestsRequester: false
+            itgovLinkRequestsRequester: false,
+            trbLinkRequestsRequester: false
           }
         });
 


### PR DESCRIPTION
# EASI-3702, EASI-3878

## Changes and Description

- Adds `trbLinkRequestsRequester` flag to match new flag in LaunchDarkly

This flag isn't used anywhere, and is just being made in preparation for upcoming TRB Request linking work on the frontend

## How to test this change

### Simple
- Make sure that the flag name in the code matches the key in LaunchDarkly

### Detailed
- Ensure EASi is configured locally to point to LaunchDarkly
- `scripts/dev up`
- Sign in with your EUA account
- Navigate to http://localhost:3000/user-diagnostics, ensure the flag matches what's in LD
- Modify the targeting in the `local` LD environment to target your user with a different value for the flag
- Ensure the flag value has been updated on the /user-diagnostics page

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
