### PR TITLE
[EASI-4069] - Add business owner info to cedar system

### DIFF
--- a/cmd/devdata/main.go
+++ b/cmd/devdata/main.go
@@ -525,7 +525,10 @@ func main() {
 		store,
 		intakeID,
 		[]string{"12345", "67890"},
-		[]string{"54321", "09876"},
+		[]string{
+			"{11AB1A00-1234-5678-ABC1-1A001B00CC0A}",
+			"{11AB1A00-1234-5678-ABC1-1A001B00CC1B}",
+		},
 	)
 
 	// 3. Intake related to an existing contract/service
@@ -547,7 +550,10 @@ func main() {
 		store,
 		intakeID,
 		[]string{"12345", "67890"},
-		[]string{"54321", "09876"},
+		[]string{
+			"{11AB1A00-1234-5678-ABC1-1A001B00CC0A}",
+			"{11AB1A00-1234-5678-ABC1-1A001B00CC1B}",
+		},
 	)
 	unlinkSystemIntakeRelation(logger, store, intakeID)
 

--- a/pkg/cedar/core/system_detail.go
+++ b/pkg/cedar/core/system_detail.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	apisystems "github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/system"
+	"github.com/cmsgov/easi-app/pkg/local"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -13,7 +14,11 @@ import (
 func (c *Client) GetSystemDetail(ctx context.Context, cedarSystemID string) (*models.CedarSystemDetails, error) {
 	if !c.cedarCoreEnabled(ctx) {
 		appcontext.ZLogger(ctx).Info("CEDAR Core is disabled")
-		return nil, nil
+		return &models.CedarSystemDetails{
+			CedarSystem:                 local.GetMockSystem(cedarSystemID),
+			BusinessOwnerInformation:    &models.BusinessOwnerInformation{},
+			SystemMaintainerInformation: &models.SystemMaintainerInformation{},
+		}, nil
 	}
 
 	cedarSystem, err := c.GetSystem(ctx, cedarSystemID)

--- a/pkg/cedar/core/system_summary.go
+++ b/pkg/cedar/core/system_summary.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/apperrors"
 	apisystems "github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/system"
+	"github.com/cmsgov/easi-app/pkg/local"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -30,7 +31,7 @@ func (c *Client) getCachedSystemMap(ctx context.Context) map[string]*models.Ceda
 func (c *Client) GetSystemSummary(ctx context.Context, tryCache bool) ([]*models.CedarSystem, error) {
 	if !c.cedarCoreEnabled(ctx) {
 		appcontext.ZLogger(ctx).Info("CEDAR Core is disabled")
-		return getMockSystems()
+		return local.GetMockSystems(), nil
 	}
 
 	// Check and use cache before making API call
@@ -145,7 +146,7 @@ func (c *Client) getSystemFromCache(ctx context.Context, systemID string) *model
 func (c *Client) GetSystem(ctx context.Context, systemID string) (*models.CedarSystem, error) {
 	if !c.cedarCoreEnabled(ctx) {
 		appcontext.ZLogger(ctx).Info("CEDAR Core is disabled")
-		return getMockSystem(systemID)
+		return local.GetMockSystem(systemID), nil
 	}
 
 	// Try the cache first

--- a/pkg/cedar/core/system_summary_test.go
+++ b/pkg/cedar/core/system_summary_test.go
@@ -10,6 +10,7 @@ import (
 	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
+	"github.com/cmsgov/easi-app/pkg/local"
 )
 
 type SystemSummaryTestSuite struct {
@@ -37,8 +38,8 @@ func (s *SystemSummaryTestSuite) TestGetSystemSummary() {
 		s.NoError(err)
 
 		// ensure mock data is returned
-		s.Equal(len(mockSystems), len(resp))
-		for _, v := range mockSystems {
+		s.Equal(len(local.GetMockSystems()), len(resp))
+		for _, v := range local.GetMockSystems() {
 			s.Contains(resp, v)
 		}
 	})
@@ -57,8 +58,8 @@ func (s *SystemSummaryTestSuite) TestGetSystem() {
 		s.Empty(resp)
 
 		// should return mocked system when given corresponding mockKey
-		for k, v := range mockSystems {
-			resp, err = c.GetSystem(ctx, k)
+		for _, v := range local.GetMockSystems() {
+			resp, err = c.GetSystem(ctx, v.ID)
 			s.NoError(err)
 			s.Equal(v, resp)
 		}

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -52,6 +52,7 @@ type ResolverRoot interface {
 	CedarExchange() CedarExchangeResolver
 	CedarRole() CedarRoleResolver
 	CedarRoleType() CedarRoleTypeResolver
+	CedarSystem() CedarSystemResolver
 	CedarSystemDetails() CedarSystemDetailsResolver
 	CedarThreat() CedarThreatResolver
 	GovernanceRequestFeedback() GovernanceRequestFeedbackResolver
@@ -332,6 +333,7 @@ type ComplexityRoot struct {
 		Acronym                 func(childComplexity int) int
 		BusinessOwnerOrg        func(childComplexity int) int
 		BusinessOwnerOrgComp    func(childComplexity int) int
+		BusinessOwnerRoles      func(childComplexity int) int
 		Description             func(childComplexity int) int
 		ID                      func(childComplexity int) int
 		Name                    func(childComplexity int) int
@@ -1272,6 +1274,9 @@ type CedarRoleResolver interface {
 }
 type CedarRoleTypeResolver interface {
 	Description(ctx context.Context, obj *models.CedarRoleType) (*string, error)
+}
+type CedarSystemResolver interface {
+	BusinessOwnerRoles(ctx context.Context, obj *models.CedarSystem) ([]*models.CedarRole, error)
 }
 type CedarSystemDetailsResolver interface {
 	SystemMaintainerInformation(ctx context.Context, obj *models.CedarSystemDetails) (*model.CedarSystemMaintainerInformation, error)
@@ -2942,6 +2947,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CedarSystem.BusinessOwnerOrgComp(childComplexity), true
+
+	case "CedarSystem.businessOwnerRoles":
+		if e.complexity.CedarSystem.BusinessOwnerRoles == nil {
+			break
+		}
+
+		return e.complexity.CedarSystem.BusinessOwnerRoles(childComplexity), true
 
 	case "CedarSystem.description":
 		if e.complexity.CedarSystem.Description == nil {
@@ -7768,6 +7780,7 @@ type CedarSystem {
 	status: String
 	businessOwnerOrg: String
 	businessOwnerOrgComp: String
+  businessOwnerRoles: [CedarRole!]!
 	systemMaintainerOrg: String
 	systemMaintainerOrgComp: String
   versionId: String
@@ -21344,6 +21357,84 @@ func (ec *executionContext) fieldContext_CedarSystem_businessOwnerOrgComp(ctx co
 	return fc, nil
 }
 
+func (ec *executionContext) _CedarSystem_businessOwnerRoles(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CedarSystem_businessOwnerRoles(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.CedarSystem().BusinessOwnerRoles(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*models.CedarRole)
+	fc.Result = res
+	return ec.marshalNCedarRole2ᚕᚖgithubᚗcomᚋcmsgovᚋeasiᚑappᚋpkgᚋmodelsᚐCedarRoleᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CedarSystem_businessOwnerRoles(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CedarSystem",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "application":
+				return ec.fieldContext_CedarRole_application(ctx, field)
+			case "objectID":
+				return ec.fieldContext_CedarRole_objectID(ctx, field)
+			case "roleTypeID":
+				return ec.fieldContext_CedarRole_roleTypeID(ctx, field)
+			case "assigneeType":
+				return ec.fieldContext_CedarRole_assigneeType(ctx, field)
+			case "assigneeUsername":
+				return ec.fieldContext_CedarRole_assigneeUsername(ctx, field)
+			case "assigneeEmail":
+				return ec.fieldContext_CedarRole_assigneeEmail(ctx, field)
+			case "assigneeOrgID":
+				return ec.fieldContext_CedarRole_assigneeOrgID(ctx, field)
+			case "assigneeOrgName":
+				return ec.fieldContext_CedarRole_assigneeOrgName(ctx, field)
+			case "assigneeFirstName":
+				return ec.fieldContext_CedarRole_assigneeFirstName(ctx, field)
+			case "assigneeLastName":
+				return ec.fieldContext_CedarRole_assigneeLastName(ctx, field)
+			case "assigneePhone":
+				return ec.fieldContext_CedarRole_assigneePhone(ctx, field)
+			case "assigneeDesc":
+				return ec.fieldContext_CedarRole_assigneeDesc(ctx, field)
+			case "roleTypeName":
+				return ec.fieldContext_CedarRole_roleTypeName(ctx, field)
+			case "roleTypeDesc":
+				return ec.fieldContext_CedarRole_roleTypeDesc(ctx, field)
+			case "roleID":
+				return ec.fieldContext_CedarRole_roleID(ctx, field)
+			case "objectType":
+				return ec.fieldContext_CedarRole_objectType(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CedarRole", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CedarSystem_systemMaintainerOrg(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystem) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CedarSystem_systemMaintainerOrg(ctx, field)
 	if err != nil {
@@ -21608,6 +21699,8 @@ func (ec *executionContext) fieldContext_CedarSystemDetails_cedarSystem(ctx cont
 				return ec.fieldContext_CedarSystem_businessOwnerOrg(ctx, field)
 			case "businessOwnerOrgComp":
 				return ec.fieldContext_CedarSystem_businessOwnerOrgComp(ctx, field)
+			case "businessOwnerRoles":
+				return ec.fieldContext_CedarSystem_businessOwnerRoles(ctx, field)
 			case "systemMaintainerOrg":
 				return ec.fieldContext_CedarSystem_systemMaintainerOrg(ctx, field)
 			case "systemMaintainerOrgComp":
@@ -34277,6 +34370,8 @@ func (ec *executionContext) fieldContext_Query_cedarSystem(ctx context.Context, 
 				return ec.fieldContext_CedarSystem_businessOwnerOrg(ctx, field)
 			case "businessOwnerOrgComp":
 				return ec.fieldContext_CedarSystem_businessOwnerOrgComp(ctx, field)
+			case "businessOwnerRoles":
+				return ec.fieldContext_CedarSystem_businessOwnerRoles(ctx, field)
 			case "systemMaintainerOrg":
 				return ec.fieldContext_CedarSystem_systemMaintainerOrg(ctx, field)
 			case "systemMaintainerOrgComp":
@@ -34354,6 +34449,8 @@ func (ec *executionContext) fieldContext_Query_cedarSystems(ctx context.Context,
 				return ec.fieldContext_CedarSystem_businessOwnerOrg(ctx, field)
 			case "businessOwnerOrgComp":
 				return ec.fieldContext_CedarSystem_businessOwnerOrgComp(ctx, field)
+			case "businessOwnerRoles":
+				return ec.fieldContext_CedarSystem_businessOwnerRoles(ctx, field)
 			case "systemMaintainerOrg":
 				return ec.fieldContext_CedarSystem_systemMaintainerOrg(ctx, field)
 			case "systemMaintainerOrgComp":
@@ -39798,6 +39895,8 @@ func (ec *executionContext) fieldContext_SystemIntake_systems(ctx context.Contex
 				return ec.fieldContext_CedarSystem_businessOwnerOrg(ctx, field)
 			case "businessOwnerOrgComp":
 				return ec.fieldContext_CedarSystem_businessOwnerOrgComp(ctx, field)
+			case "businessOwnerRoles":
+				return ec.fieldContext_CedarSystem_businessOwnerRoles(ctx, field)
 			case "systemMaintainerOrg":
 				return ec.fieldContext_CedarSystem_systemMaintainerOrg(ctx, field)
 			case "systemMaintainerOrgComp":
@@ -47402,6 +47501,8 @@ func (ec *executionContext) fieldContext_TRBRequest_systems(ctx context.Context,
 				return ec.fieldContext_CedarSystem_businessOwnerOrg(ctx, field)
 			case "businessOwnerOrgComp":
 				return ec.fieldContext_CedarSystem_businessOwnerOrgComp(ctx, field)
+			case "businessOwnerRoles":
+				return ec.fieldContext_CedarSystem_businessOwnerRoles(ctx, field)
 			case "systemMaintainerOrg":
 				return ec.fieldContext_CedarSystem_systemMaintainerOrg(ctx, field)
 			case "systemMaintainerOrgComp":
@@ -62147,12 +62248,12 @@ func (ec *executionContext) _CedarSystem(ctx context.Context, sel ast.SelectionS
 		case "id":
 			out.Values[i] = ec._CedarSystem_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "name":
 			out.Values[i] = ec._CedarSystem_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "description":
 			out.Values[i] = ec._CedarSystem_description(ctx, field, obj)
@@ -62164,6 +62265,42 @@ func (ec *executionContext) _CedarSystem(ctx context.Context, sel ast.SelectionS
 			out.Values[i] = ec._CedarSystem_businessOwnerOrg(ctx, field, obj)
 		case "businessOwnerOrgComp":
 			out.Values[i] = ec._CedarSystem_businessOwnerOrgComp(ctx, field, obj)
+		case "businessOwnerRoles":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._CedarSystem_businessOwnerRoles(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "systemMaintainerOrg":
 			out.Values[i] = ec._CedarSystem_systemMaintainerOrg(ctx, field, obj)
 		case "systemMaintainerOrgComp":

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -100,6 +100,7 @@ type CedarSystem {
 	status: String
 	businessOwnerOrg: String
 	businessOwnerOrgComp: String
+  businessOwnerRoles: [CedarRole!]!
 	systemMaintainerOrg: String
 	systemMaintainerOrgComp: String
   versionId: String

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -629,6 +629,15 @@ func (r *cedarRoleTypeResolver) Description(ctx context.Context, obj *models.Ced
 	return obj.Description.Ptr(), nil
 }
 
+// BusinessOwnerRoles is the resolver for the businessOwnerRoles field.
+func (r *cedarSystemResolver) BusinessOwnerRoles(ctx context.Context, obj *models.CedarSystem) ([]*models.CedarRole, error) {
+	cedarRoles, err := r.cedarCoreClient.GetBusinessOwnerRolesBySystem(ctx, obj.ID)
+	if err != nil {
+		return nil, err
+	}
+	return cedarRoles, nil
+}
+
 // SystemMaintainerInformation is the resolver for the systemMaintainerInformation field.
 func (r *cedarSystemDetailsResolver) SystemMaintainerInformation(ctx context.Context, obj *models.CedarSystemDetails) (*model.CedarSystemMaintainerInformation, error) {
 	ipEnabledCt := int(obj.SystemMaintainerInformation.IPEnabledAssetCount)
@@ -3068,6 +3077,9 @@ func (r *Resolver) CedarRole() generated.CedarRoleResolver { return &cedarRoleRe
 // CedarRoleType returns generated.CedarRoleTypeResolver implementation.
 func (r *Resolver) CedarRoleType() generated.CedarRoleTypeResolver { return &cedarRoleTypeResolver{r} }
 
+// CedarSystem returns generated.CedarSystemResolver implementation.
+func (r *Resolver) CedarSystem() generated.CedarSystemResolver { return &cedarSystemResolver{r} }
+
 // CedarSystemDetails returns generated.CedarSystemDetailsResolver implementation.
 func (r *Resolver) CedarSystemDetails() generated.CedarSystemDetailsResolver {
 	return &cedarSystemDetailsResolver{r}
@@ -3159,6 +3171,7 @@ type cedarDeploymentResolver struct{ *Resolver }
 type cedarExchangeResolver struct{ *Resolver }
 type cedarRoleResolver struct{ *Resolver }
 type cedarRoleTypeResolver struct{ *Resolver }
+type cedarSystemResolver struct{ *Resolver }
 type cedarSystemDetailsResolver struct{ *Resolver }
 type cedarThreatResolver struct{ *Resolver }
 type governanceRequestFeedbackResolver struct{ *Resolver }

--- a/pkg/local/cedar_core.go
+++ b/pkg/local/cedar_core.go
@@ -1,6 +1,12 @@
-package cedarcore
+package local
 
 import (
+	"fmt"
+
+	"github.com/guregu/null"
+	"github.com/guregu/null/zero"
+
+	"github.com/cmsgov/easi-app/pkg/helpers"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -67,18 +73,190 @@ var mockSystems = map[string]*models.CedarSystem{
 	},
 }
 
-func getMockSystems() ([]*models.CedarSystem, error) {
+// GetMockSystems returns a mocked list of Cedar Systems
+func GetMockSystems() []*models.CedarSystem {
 	var systems []*models.CedarSystem
 	for _, v := range mockSystems {
 		systems = append(systems, v)
 	}
-	return systems, nil
+	return systems
 }
 
-func getMockSystem(systemID string) (*models.CedarSystem, error) {
+// GetMockSystem returns a single mocked Cedar System by ID
+func GetMockSystem(systemID string) *models.CedarSystem {
 	system, ok := mockSystems[systemID]
 	if !ok {
-		return nil, nil
+		return nil
 	}
-	return system, nil
+	return system
+}
+
+var mockRoleTypes = []*models.CedarRoleType{
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID01}",
+		Application: "alfabet",
+		Name:        "API Contact",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID02}",
+		Application: "alfabet",
+		Name:        "Business Question Contact",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID03}",
+		Application: "alfabet",
+		Name:        "Survey Point of Contact",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID04}",
+		Application: "alfabet",
+		Name:        "Government Task Lead (GTL)",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID05}",
+		Application: "alfabet",
+		Name:        "Support Staff",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID06}",
+		Application: "alfabet",
+		Name:        "System Maintainer",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID07}",
+		Application: "alfabet",
+		Name:        "ISSO",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID08}",
+		Application: "alfabet",
+		Name:        "Contracting Officer's Representative (COR)",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID09}",
+		Application: "alfabet",
+		Name:        "Business Owner",
+		Description: zero.StringFrom("The organization or person in the business who owns the application and thus is typically responsible for managing the functional requirements."),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID10}",
+		Application: "alfabet",
+		Name:        "Subject Matter Expert (SME)",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID11}",
+		Application: "alfabet",
+		Name:        "Technical System Issues Contact",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID12}",
+		Application: "alfabet",
+		Name:        "Budget Analyst",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID13}",
+		Application: "alfabet",
+		Name:        "Data Center Contact",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID14}",
+		Application: "alfabet",
+		Name:        "Project Lead",
+		Description: zero.StringFromPtr(nil),
+	},
+	{
+		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID15}",
+		Application: "alfabet",
+		Name:        "AI Contact",
+		Description: zero.StringFromPtr(nil),
+	},
+}
+
+// GetMockRoleTypes returns a list of mocked role types
+func GetMockRoleTypes() []*models.CedarRoleType {
+	return mockRoleTypes
+}
+
+// GetMockRoleTypeByRoleTypeID returns a single role type by ID
+func GetMockRoleTypeByRoleTypeID(roleTypeID string) *models.CedarRoleType {
+	for _, rt := range mockRoleTypes {
+		if rt.ID == roleTypeID {
+			return rt
+		}
+	}
+	return &models.CedarRoleType{}
+}
+
+// GetMockSystemRoles returns mocked roles for a single CEDAR system, filtered by role type ID
+func GetMockSystemRoles(cedarSystemID string, roleTypeID null.String) []*models.CedarRole {
+	roleTypeIDStr := roleTypeID.String
+	roleTypes := GetMockRoleTypes()
+	users := getMockUserData()
+	mockSystemRoles := []*models.CedarRole{}
+
+	makeMockRoleFromUserAndRoleType := func(
+		roleID string,
+		user *models.UserInfo,
+		rt *models.CedarRoleType,
+	) *models.CedarRole {
+		return &models.CedarRole{
+			Application:       "alfabet", // should always be "alfabet"
+			ObjectID:          cedarSystemID,
+			AssigneeType:      helpers.PointerTo(models.PersonAssignee),
+			AssigneeUsername:  zero.StringFrom(user.Username),
+			AssigneeEmail:     zero.StringFrom(fmt.Sprintf(`%s.%s@fake.local`, user.FirstName, user.LastName)),
+			AssigneeFirstName: zero.StringFrom(user.FirstName),
+			AssigneeLastName:  zero.StringFrom(user.LastName),
+			AssigneePhone:     zero.StringFrom("123-456-7890"),
+			RoleTypeName:      zero.StringFrom(rt.Name),
+			RoleTypeDesc:      rt.Description,
+			RoleTypeID:        rt.ID,
+			RoleID:            zero.StringFrom(roleID),
+		}
+	}
+	for i, rt := range roleTypes {
+		// if role type ID was provided and does not match current role type ID, don't add it to results
+		if roleTypeIDStr != "" && roleTypeIDStr != rt.ID {
+			continue
+		}
+		role := makeMockRoleFromUserAndRoleType(
+			fmt.Sprintf(`{FAKE12AB-12A3-12a1-1AB2-AB12ROLEID%02d}`, i),
+			users[i],
+			rt,
+		)
+		mockSystemRoles = append(mockSystemRoles, role)
+	}
+
+	fakeBusinessOwnerRoleTypeID := "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID09}"
+	fakeBusinessOwnerRoleType := GetMockRoleTypeByRoleTypeID(fakeBusinessOwnerRoleTypeID)
+
+	// add extra business owners if roleTypeID was not provided or the provided type ID was for Biz Owner
+	if roleTypeIDStr == "" || roleTypeIDStr == fakeBusinessOwnerRoleTypeID {
+		mockSystemRoles = append(
+			mockSystemRoles,
+			makeMockRoleFromUserAndRoleType(
+				fmt.Sprintf(`{FAKE12AB-12A3-12a1-1AB2-AB12ROLEID%02d}`, len(mockSystemRoles)+1),
+				users[len(mockSystemRoles)+1],
+				fakeBusinessOwnerRoleType,
+			),
+			makeMockRoleFromUserAndRoleType(
+				fmt.Sprintf(`{FAKE12AB-12A3-12a1-1AB2-AB12ROLEID%02d}`, len(mockSystemRoles)+2),
+				users[len(mockSystemRoles)+2],
+				fakeBusinessOwnerRoleType,
+			),
+		)
+	}
+	return mockSystemRoles
 }


### PR DESCRIPTION
# EASI-4069

## Changes and Description

- Adds the ability to return `businessOwnerRoles` on a `CedarSystem`.
  - Note: Asking for business owner roles on `cedarSystems` causes CEDAR to time out.
- Adds mock data for easier local development.

## How to test this change

1. Seed/start the App
2. Query for a Cedar System and `businessOwnerRoles`

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
