### PR TITLE
[EASI-4067] All CMS systems table and button group

### DIFF
--- a/src/i18n/en-US/systemProfile.ts
+++ b/src/i18n/en-US/systemProfile.ts
@@ -298,8 +298,9 @@ const systemProfile = {
     }
   },
   systemTable: {
-    title: 'All systems',
-    subtitle: 'Bookmark systems that you want to access more quickly.',
+    title: 'All CMS systems',
+    subtitle:
+      'Click the bookmark icon (<icon />) to bookmark systems that you want to access more quickly.',
     id: 'system-list',
     search: 'Search Table',
     header: {
@@ -307,6 +308,12 @@ const systemProfile = {
       systemOwner: 'CMS Component',
       systemAcronym: 'Acronym',
       systemStatus: 'ATO Status'
+    },
+    view: 'View',
+    buttonGroup: {
+      allSystems: 'All systems',
+      mySystems: 'My systems',
+      bookmarkedSystems: 'Bookmarked systems'
     }
   },
   bookmark: {

--- a/src/views/Home/index.test.tsx
+++ b/src/views/Home/index.test.tsx
@@ -115,7 +115,7 @@ describe('The home page', () => {
 
       expect(screen.getByRole('heading', { name: 'IT Governance' }));
       expect(screen.getByRole('heading', { name: 'My open requests' }));
-      expect(screen.getByRole('heading', { name: 'All systems' }));
+      expect(screen.getByRole('heading', { name: 'All CMS systems' }));
     });
   });
 

--- a/src/views/SystemList/__snapshots__/index.test.tsx.snap
+++ b/src/views/SystemList/__snapshots__/index.test.tsx.snap
@@ -68,66 +68,71 @@ exports[`System List View > when there are requests > matches snapshot 1`] = `
       />
     </div>
     <h2
-      class="margin-bottom-0"
+      class="margin-bottom-2"
     >
-      All systems
+      All CMS systems
     </h2>
-    <p
-      class="margin-bottom-5"
+    Click the bookmark icon (
+    <svg
+      class="usa-icon text-bookmark-icon"
+      focusable="false"
+      height="1em"
+      role="img"
+      viewBox="0 0 24 24"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      Bookmark systems that you want to access more quickly.
-    </p>
-    <form
-      class="usa-form usa-search margin-bottom-4"
-      data-testid="table-client-filter"
-      role="search"
-    >
-      <label
-        class="usa-sr-only"
-        data-testid="label"
-        for="system-list-search"
-      >
-        Search Table
-      </label>
-      <input
-        class="usa-input"
-        data-testid="textInput"
-        id="system-list-search"
-        name="All systems Search"
-        role="searchbox"
-        type="search"
-        value=""
+      <path
+        d="M0 0h24v24H0z"
+        fill="none"
       />
-      <button
-        class="usa-button grid-row flex-justify-center flex-align-center no-pointer"
-        data-testid="button"
-        type="submit"
-      >
-        <svg
-          class="usa-icon usa-icon--size-3"
-          focusable="false"
-          height="1em"
-          role="img"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M0 0h24v24H0z"
-            fill="none"
-          />
-          <path
-            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-          />
-        </svg>
-      </button>
-    </form>
-    <div
-      class="margin-bottom-4 display-flex flex-align-center"
-      data-testid="page-results"
+      <path
+        d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
+      />
+    </svg>
+    ) to bookmark systems that you want to access more quickly.
+    <p
+      class="text-bold margin-0 margin-top-3"
     >
-      Showing 1-4 of 4 results 
-    </div>
+      View
+    </p>
+    <ul
+      class="usa-button-group usa-button-group--segmented margin-y-2"
+    >
+      <li
+        class="usa-button-group__item"
+      >
+        <button
+          class="usa-button"
+          data-testid="button"
+          type="button"
+        >
+          All systems
+        </button>
+      </li>
+      <li
+        class="usa-button-group__item"
+      >
+        <button
+          class="usa-button usa-button--outline"
+          data-testid="button"
+          type="button"
+        >
+          My systems
+        </button>
+      </li>
+      <li
+        class="usa-button-group__item"
+      >
+        <button
+          class="usa-button usa-button--outline"
+          data-testid="button"
+          type="button"
+        >
+          Bookmarked systems
+        </button>
+      </li>
+    </ul>
     <div
       class="usa-table-container--scrollable"
       data-testid="scrollable-table-container"
@@ -528,33 +533,6 @@ exports[`System List View > when there are requests > matches snapshot 1`] = `
     <div
       class="grid-row grid-gap grid-gap-lg"
     >
-      <nav
-        aria-label="Pagination"
-        class="usa-pagination padding-bottom-1 desktop:grid-col-fill"
-        data-testid="table-pagination"
-      >
-        <ul
-          class="usa-pagination__list"
-        >
-          <li
-            class="usa-pagination__item usa-pagination__page-no"
-          >
-            <div>
-              <div
-                class="usa-pagination__item"
-              >
-                <button
-                  aria-label="Page 1"
-                  class="usa-pagination__button usa-current"
-                  type="button"
-                >
-                  1
-                </button>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </nav>
       <div
         class="desktop:margin-top-2 desktop:grid-col-auto"
       >

--- a/src/views/SystemList/index.scss
+++ b/src/views/SystemList/index.scss
@@ -31,4 +31,7 @@
         color: $medium-gray;
       }
     }
+    .text-bookmark-icon {
+        top: 3px;
+    }
 }

--- a/src/views/SystemList/index.test.tsx
+++ b/src/views/SystemList/index.test.tsx
@@ -103,7 +103,7 @@ describe('System List View', () => {
         <MemoryRouter>
           <MockedProvider mocks={mocks} addTypename={false}>
             <Table
-              defaultPageSize={1}
+              defaultPageSize={3}
               systems={mockSystemInfo}
               savedBookmarks={[]}
               refetchBookmarks={() => null}
@@ -124,7 +124,7 @@ describe('System List View', () => {
       await waitFor(() => new Promise(res => setTimeout(res, 200)));
 
       // ZXC is a mocked table row text item that should not be included in filtered results
-      expect(await screen.queryByText('ZXC')).toBeNull();
+      expect(screen.queryByText('ASD')).toBeNull();
     });
 
     it('matches snapshot', async () => {

--- a/src/views/SystemList/index.test.tsx
+++ b/src/views/SystemList/index.test.tsx
@@ -9,6 +9,7 @@ import GetCedarSystemsQuery from 'queries/GetCedarSystemsQuery';
 import { mockBookmarkInfo, mockSystemInfo } from 'views/Sandbox/mockSystemData';
 
 import SystemList from './index';
+import Table from './Table';
 
 // TODO:  Mock Bookmark GQL query once connected to BE
 // Currently component is baked with mocked data from file
@@ -101,7 +102,12 @@ describe('System List View', () => {
       render(
         <MemoryRouter>
           <MockedProvider mocks={mocks} addTypename={false}>
-            <SystemList />
+            <Table
+              defaultPageSize={1}
+              systems={mockSystemInfo}
+              savedBookmarks={[]}
+              refetchBookmarks={() => null}
+            />
           </MockedProvider>
         </MemoryRouter>
       );

--- a/src/views/SystemList/index.tsx
+++ b/src/views/SystemList/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useQuery } from '@apollo/client';
 import {
   CardGroup,
@@ -117,13 +117,16 @@ export const SystemList = () => {
             </SectionWrapper>
           )}
 
-          <h2 className="margin-bottom-0">
+          <h2 className="margin-bottom-2">
             {t('systemProfile:systemTable.title')}
           </h2>
 
-          <p className="margin-bottom-5">
-            {t('systemProfile:systemTable.subtitle')}
-          </p>
+          <Trans
+            i18nKey="systemProfile:systemTable.subtitle"
+            components={{
+              icon: <IconBookmark className="text-bookmark-icon" />
+            }}
+          />
 
           {/* TODO: standardize/format error messages from CEDAR - either on FE or BE */}
 


### PR DESCRIPTION
# EASI-4067
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

- Added `<ButtonGroup />` component to toggle table type state
- Added switch/filter function to swap data sets based on table type
- Added url query param in preparation for fetching table type from url when menu bar is complete 
- Updated unit test

<!-- Put a description here! -->

## How to test this change

- Navigate to Systems tab
- Verify the toggle works (only for all systems and bookmarked systems.  My systems will come later)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
