### PR TITLE
[NOREF] Moved onchange handler to submit handler for contract intake

### DIFF
--- a/src/views/SystemIntake/ContractDetails/index.tsx
+++ b/src/views/SystemIntake/ContractDetails/index.tsx
@@ -154,6 +154,29 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
   };
 
   const onSubmit = (values?: ContractDetailsForm) => {
+    const intakePayload = { ...values };
+
+    if (
+      values?.contract.hasContract === 'NOT_STARTED' ||
+      values?.contract.hasContract === 'NOT_NEEDED'
+    ) {
+      intakePayload!.contract = {
+        contractor: '',
+        endDate: {
+          day: '',
+          month: '',
+          year: ''
+        },
+        hasContract: '',
+        startDate: {
+          day: '',
+          month: '',
+          year: ''
+        },
+        numbers: ''
+      };
+    }
+
     if (values) {
       mutate({
         variables: {
@@ -785,17 +808,6 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                       context: 'NOT_STARTED'
                     })}
                     value="NOT_STARTED"
-                    onChange={() => {
-                      setFieldValue('contract.hasContract', 'NOT_STARTED');
-                      setFieldValue('contract.contractor', '');
-                      setFieldValue('contract.numbers', '');
-                      setFieldValue('contract.startDate.month', '');
-                      setFieldValue('contract.startDate.day', '');
-                      setFieldValue('contract.startDate.year', '');
-                      setFieldValue('contract.endDate.month', '');
-                      setFieldValue('contract.endDate.day', '');
-                      setFieldValue('contract.endDate.year', '');
-                    }}
                   />
                   <Field
                     as={Radio}
@@ -806,17 +818,6 @@ const ContractDetails = ({ systemIntake }: ContractDetailsProps) => {
                       context: 'NOT_NEEDED'
                     })}
                     value="NOT_NEEDED"
-                    onChange={() => {
-                      setFieldValue('contract.hasContract', 'NOT_NEEDED');
-                      setFieldValue('contract.contractor', '');
-                      setFieldValue('contract.numbers', '');
-                      setFieldValue('contract.startDate.month', '');
-                      setFieldValue('contract.startDate.day', '');
-                      setFieldValue('contract.startDate.year', '');
-                      setFieldValue('contract.endDate.month', '');
-                      setFieldValue('contract.endDate.day', '');
-                      setFieldValue('contract.endDate.year', '');
-                    }}
                   />
                 </fieldset>
               </FieldGroup>


### PR DESCRIPTION
# NOREF
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

[Doc](https://docs.google.com/document/d/1rbiG21FIO51F-JUKgPZ6UYF2vwwD9ht0RZsTHeaQkAs/edit#heading=h.1xd88vdpols3)

## Changes and Description

- Moved the form onChange handler that clears contract data
- Contract information is now cleared on submit, rather than on change

<!-- Put a description here! -->

## How to test this change

- Add a contract number on the linking form
- Progress to thrid page of intake
- Verify contract number renders on form selections
- Verify that clicking `I haven't started acquisition planning yet` or `I don't anticipate needing contractor support` does not clear out the form values.  Should only clear after submission
- Verify data persistence of selection

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
