### PR TITLE
[NOREF] Remove null types from cedar core

### DIFF
--- a/pkg/cedar/core/authority_to_operate.go
+++ b/pkg/cedar/core/authority_to_operate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
@@ -33,7 +32,7 @@ func (c *Client) GetAuthorityToOperate(ctx context.Context, cedarSystemID string
 
 	// Construct the parameters
 	params := apiauthority.NewAuthorityToOperateFindListParams()
-	params.SetSystemID(&cedarSystem.VersionID)
+	params.SetSystemID(cedarSystem.VersionID.Ptr())
 	params.HTTPClient = c.hc
 
 	// Make the API call
@@ -52,21 +51,23 @@ func (c *Client) GetAuthorityToOperate(ctx context.Context, cedarSystemID string
 	// Populate the ATO fields by converting each item in resp.Payload.AuthorityToOperate
 	for _, ato := range resp.Payload.AuthorityToOperateList {
 		retVal = append(retVal, &models.CedarAuthorityToOperate{
-			ActualDispositionDate: zero.TimeFrom(time.Time(ato.ActualDispositionDate)),
-			CedarID:               *ato.CedarID, // required
-			ContainsPersonallyIdentifiableInformation: null.BoolFrom(ato.ContainsPersonallyIdentifiableInformation),
-			CountOfTotalNonPrivilegedUserPopulation:   null.IntFrom(int64(ato.CountOfTotalNonPrivilegedUserPopulation)),
-			CountOfOpenPoams:                          null.IntFrom(int64(ato.CountOfOpenPoams)),
-			CountOfTotalPrivilegedUserPopulation:      null.IntFrom(int64(ato.CountOfTotalPrivilegedUserPopulation)),
+			UUID:    zero.StringFromPtr(ato.UUID),    // required
+			CedarID: zero.StringFromPtr(ato.CedarID), // required
+
+			ActualDispositionDate:                     zero.TimeFrom(time.Time(ato.ActualDispositionDate)),
+			ContainsPersonallyIdentifiableInformation: ato.ContainsPersonallyIdentifiableInformation,
+			CountOfTotalNonPrivilegedUserPopulation:   int(ato.CountOfTotalNonPrivilegedUserPopulation),
+			CountOfOpenPoams:                          int(ato.CountOfOpenPoams),
+			CountOfTotalPrivilegedUserPopulation:      int(ato.CountOfTotalPrivilegedUserPopulation),
 			DateAuthorizationMemoExpires:              zero.TimeFrom(time.Time(ato.DateAuthorizationMemoExpires)),
 			DateAuthorizationMemoSigned:               zero.TimeFrom(time.Time(ato.DateAuthorizationMemoSigned)),
 			EAuthenticationLevel:                      zero.StringFrom(ato.EAuthenticationLevel),
-			Fips199OverallImpactRating:                null.IntFrom(int64(ato.Fips199OverallImpactRating)),
+			Fips199OverallImpactRating:                int(ato.Fips199OverallImpactRating),
 			FismaSystemAcronym:                        zero.StringFrom(ato.FismaSystemAcronym),
 			FismaSystemName:                           zero.StringFrom(ato.FismaSystemName),
-			IsAccessedByNonOrganizationalUsers:        null.BoolFrom(ato.IsAccessedByNonOrganizationalUsers),
-			IsPiiLimitedToUserNameAndPass:             null.BoolFrom(ato.IsPiiLimitedToUserNameAndPass),
-			IsProtectedHealthInformation:              null.BoolFrom(ato.IsProtectedHealthInformation),
+			IsAccessedByNonOrganizationalUsers:        ato.IsAccessedByNonOrganizationalUsers,
+			IsPiiLimitedToUserNameAndPass:             ato.IsPiiLimitedToUserNameAndPass,
+			IsProtectedHealthInformation:              ato.IsProtectedHealthInformation,
 			LastActScaDate:                            zero.TimeFrom(time.Time(ato.LastActScaDate)),
 			LastAssessmentDate:                        zero.TimeFrom(time.Time(ato.LastAssessmentDate)),
 			LastContingencyPlanCompletionDate:         zero.TimeFrom(time.Time(ato.LastContingencyPlanCompletionDate)),
@@ -74,12 +75,11 @@ func (c *Client) GetAuthorityToOperate(ctx context.Context, cedarSystemID string
 			PiaCompletionDate:                         zero.TimeFrom(time.Time(ato.PiaCompletionDate)),
 			PrimaryCyberRiskAdvisor:                   zero.StringFrom(ato.PrimaryCyberRiskAdvisor),
 			PrivacySubjectMatterExpert:                zero.StringFrom(ato.PrivacySubjectMatterExpert),
-			RecoveryPointObjective:                    null.FloatFrom(float64(ato.RecoveryPointObjective)),
-			RecoveryTimeObjective:                     null.FloatFrom(float64(ato.RecoveryTimeObjective)),
-			SystemOfRecordsNotice:                     ato.SystemOfRecordsNotice,
+			RecoveryPointObjective:                    float64(ato.RecoveryPointObjective),
+			RecoveryTimeObjective:                     float64(ato.RecoveryTimeObjective),
+			SystemOfRecordsNotice:                     models.ZeroStringsFrom(ato.SystemOfRecordsNotice),
 			TLCPhase:                                  zero.StringFrom(ato.TlcPhase),
 			XLCPhase:                                  zero.StringFrom(ato.XlcPhase),
-			UUID:                                      *ato.UUID, // required
 		})
 	}
 

--- a/pkg/cedar/core/budget.go
+++ b/pkg/cedar/core/budget.go
@@ -21,7 +21,7 @@ func (c *Client) GetBudgetBySystem(ctx context.Context, cedarSystemID string) ([
 	params := budget.NewBudgetFindParams()
 
 	// Construct the parameters
-	params.SetSystemID(&cedarSystem.VersionID)
+	params.SetSystemID(cedarSystem.VersionID.Ptr())
 	params.HTTPClient = c.hc
 
 	if err != nil {

--- a/pkg/cedar/core/contract.go
+++ b/pkg/cedar/core/contract.go
@@ -21,7 +21,7 @@ func (c *Client) GetContractBySystem(ctx context.Context, cedarSystemID string) 
 	params := contract.NewContractFindParams()
 
 	// Construct the parameters
-	params.SetSystemID(&cedarSystem.VersionID)
+	params.SetSystemID(cedarSystem.VersionID.Ptr())
 	params.HTTPClient = c.hc
 
 	if err != nil {

--- a/pkg/cedar/core/deployment.go
+++ b/pkg/cedar/core/deployment.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
 	"go.uber.org/zap"
 
@@ -16,9 +15,9 @@ import (
 
 // GetDeploymentsOptionalParams represents the optional parameters that can be used to filter deployments when searching through the CEDAR API
 type GetDeploymentsOptionalParams struct {
-	DeploymentType null.String
-	State          null.String
-	Status         null.String
+	DeploymentType *string
+	State          *string
+	Status         *string
 }
 
 // GetDeployments makes a GET call to the /deployment endpoint
@@ -35,20 +34,20 @@ func (c *Client) GetDeployments(ctx context.Context, cedarSystemID string, optio
 
 	// Construct the parameters
 	params := apideployments.NewDeploymentFindListParams()
-	params.SetSystemID(cedarSystem.VersionID)
+	params.SetSystemID(cedarSystem.VersionID.String)
 	params.HTTPClient = c.hc
 
 	if optionalParams != nil {
-		if optionalParams.DeploymentType.Ptr() != nil {
-			params.SetDeploymentType(optionalParams.DeploymentType.Ptr())
+		if optionalParams.DeploymentType != nil {
+			params.SetDeploymentType(optionalParams.DeploymentType)
 		}
 
-		if optionalParams.State.Ptr() != nil {
-			params.SetState(optionalParams.State.Ptr())
+		if optionalParams.State != nil {
+			params.SetState(optionalParams.State)
 		}
 
-		if optionalParams.Status.Ptr() != nil {
-			params.SetStatus(optionalParams.Status.Ptr())
+		if optionalParams.Status != nil {
+			params.SetStatus(optionalParams.Status)
 		}
 	}
 
@@ -84,9 +83,9 @@ func (c *Client) GetDeployments(ctx context.Context, cedarSystemID string, optio
 		}
 
 		retDeployment := &models.CedarDeployment{
-			ID:                *deployment.ID,
-			Name:              *deployment.Name,
-			SystemID:          *deployment.SystemID,
+			ID:                zero.StringFromPtr(deployment.ID),
+			Name:              zero.StringFromPtr(deployment.Name),
+			SystemID:          zero.StringFromPtr(deployment.SystemID),
 			StartDate:         zero.TimeFrom(time.Time(deployment.StartDate)),
 			EndDate:           zero.TimeFrom(time.Time(deployment.EndDate)),
 			IsHotSite:         zero.StringFrom(deployment.IsHotSite),

--- a/pkg/cedar/core/exchange.go
+++ b/pkg/cedar/core/exchange.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
@@ -26,7 +25,7 @@ func (c *Client) GetExchangesBySystem(ctx context.Context, cedarSystemID string)
 
 	// Construct the parameters
 	params := exchange.NewExchangeFindListParams()
-	params.SetSystemID(cedarSystem.VersionID)
+	params.SetSystemID(cedarSystem.VersionID.String)
 	params.SetDirection("both")
 	params.HTTPClient = c.hc
 
@@ -43,24 +42,29 @@ func (c *Client) GetExchangesBySystem(ctx context.Context, cedarSystemID string)
 		typeOfData := make([]*models.CedarExchangeTypeOfDataItem, 0, len(exch.TypeOfData))
 		for _, item := range exch.TypeOfData {
 			typeOfData = append(typeOfData, &models.CedarExchangeTypeOfDataItem{
-				ID:   item.ID,
-				Name: item.Name,
+				ID:   zero.StringFrom(item.ID),
+				Name: zero.StringFrom(item.Name),
 			})
 		}
 
 		var direction models.ExchangeDirection
-		if exch.FromOwnerID == cedarSystem.VersionID {
+		if exch.FromOwnerID == cedarSystem.VersionID.String {
 			direction = models.ExchangeDirection(models.ExchangeDirectionSender)
-		} else if exch.ToOwnerID == cedarSystem.VersionID {
+		} else if exch.ToOwnerID == cedarSystem.VersionID.String {
 			direction = models.ExchangeDirection(models.ExchangeDirectionReceiver)
 		}
 
+		connectionFrequency := []zero.String{}
+		for _, v := range exch.ConnectionFrequency {
+			connectionFrequency = append(connectionFrequency, zero.StringFrom(v))
+		}
+
 		retVal = append(retVal, &models.CedarExchange{
-			ConnectionFrequency:        exch.ConnectionFrequency,
-			ContainsBankingData:        null.BoolFrom(exch.ContainsBankingData),
-			ContainsBeneficiaryAddress: null.BoolFrom(exch.ContainsBeneficiaryAddress),
-			ContainsPhi:                null.BoolFrom(exch.ContainsPhi),
-			ContainsPii:                null.BoolFrom(exch.ContainsPii),
+			ConnectionFrequency:        connectionFrequency,
+			ContainsBankingData:        exch.ContainsBankingData,
+			ContainsBeneficiaryAddress: exch.ContainsBeneficiaryAddress,
+			ContainsPhi:                exch.ContainsPhi,
+			ContainsPii:                exch.ContainsPii,
 			DataExchangeAgreement:      zero.StringFrom(exch.DataExchangeAgreement),
 			DataFormat:                 zero.StringFrom(exch.DataFormat),
 			DataFormatOther:            zero.StringFrom(exch.DataFormatOther),
@@ -76,9 +80,9 @@ func (c *Client) GetExchangesBySystem(ctx context.Context, cedarSystemID string)
 			FromOwnerID:                zero.StringFrom(exch.FromOwnerID),
 			FromOwnerName:              zero.StringFrom(exch.FromOwnerName),
 			FromOwnerType:              zero.StringFrom(exch.FromOwnerType),
-			IsBeneficiaryMailingFile:   null.BoolFrom(exch.IsBeneficiaryMailingFile),
+			IsBeneficiaryMailingFile:   exch.IsBeneficiaryMailingFile,
 			NumOfRecords:               zero.StringFrom(exch.NumOfRecords),
-			SharedViaAPI:               null.BoolFrom(exch.SharedViaAPI),
+			SharedViaAPI:               exch.SharedViaAPI,
 			ToOwnerID:                  zero.StringFrom(exch.ToOwnerID),
 			ToOwnerName:                zero.StringFrom(exch.ToOwnerName),
 			ToOwnerType:                zero.StringFrom(exch.ToOwnerType),

--- a/pkg/cedar/core/software_products.go
+++ b/pkg/cedar/core/software_products.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
@@ -26,7 +25,7 @@ func (c *Client) GetSoftwareProductsBySystem(ctx context.Context, cedarSystemID 
 
 	// Construct the parameters
 	params := software_products.NewSoftwareProductsFindListParams()
-	params.SetID(cedarSystem.VersionID)
+	params.SetID(cedarSystem.VersionID.String)
 	params.HTTPClient = c.hc
 
 	// Make the API call
@@ -46,10 +45,10 @@ func (c *Client) GetSoftwareProductsBySystem(ctx context.Context, cedarSystemID 
 
 	for _, softwareProduct := range resp.Payload.SoftwareProducts {
 		softwareProductItems = append(softwareProductItems, &models.SoftwareProductItem{
-			APIGatewayUse:                  null.BoolFrom(softwareProduct.APIGatewayUse),
+			APIGatewayUse:                  softwareProduct.APIGatewayUse,
 			ElaPurchase:                    zero.StringFrom(softwareProduct.ElaPurchase),
 			ElaVendorID:                    zero.StringFrom(softwareProduct.ElaVendorID),
-			ProvidesAiCapability:           null.BoolFrom(softwareProduct.ProvidesAiCapability),
+			ProvidesAiCapability:           softwareProduct.ProvidesAiCapability,
 			Refstr:                         zero.StringFrom(softwareProduct.Refstr),
 			SoftwareCatagoryConnectionGUID: zero.StringFrom(softwareProduct.SoftwareCatagoryConnectionGUID),
 			SoftwareVendorConnectionGUID:   zero.StringFrom(softwareProduct.SoftwareVendorConnectionGUID),
@@ -74,11 +73,11 @@ func (c *Client) GetSoftwareProductsBySystem(ctx context.Context, cedarSystemID 
 		APIDescPublished:    zero.StringFrom(resp.Payload.APIDescPublished),
 		APIFHIRUse:          zero.StringFrom(resp.Payload.APIFHIRUse),
 		APIFHIRUseOther:     zero.StringFrom(resp.Payload.APIFHIRUseOther),
-		APIHasPortal:        null.BoolFrom(resp.Payload.APIHasPortal),
+		APIHasPortal:        resp.Payload.APIHasPortal,
 		ApisAccessibility:   zero.StringFrom(resp.Payload.ApisAccessibility),
 		ApisDeveloped:       zero.StringFrom(resp.Payload.ApisDeveloped),
 		DevelopmentStage:    zero.StringFrom(resp.Payload.DevelopmentStage),
-		SystemHasAPIGateway: null.BoolFrom(resp.Payload.SystemHasAPIGateway),
+		SystemHasAPIGateway: resp.Payload.SystemHasAPIGateway,
 		UsesAiTech:          zero.StringFrom(resp.Payload.UsesAiTech),
 	}
 

--- a/pkg/cedar/core/system_detail.go
+++ b/pkg/cedar/core/system_detail.go
@@ -3,6 +3,9 @@ package cedarcore
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/guregu/null/zero"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	apisystems "github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/system"
@@ -28,7 +31,7 @@ func (c *Client) GetSystemDetail(ctx context.Context, cedarSystemID string) (*mo
 
 	// Construct the parameters
 	params := apisystems.NewSystemDetailFindByIDParams()
-	params.SetID(cedarSystem.VersionID)
+	params.SetID(cedarSystem.VersionID.String)
 	params.HTTPClient = c.hc
 
 	// Make the API call
@@ -48,15 +51,15 @@ func (c *Client) GetSystemDetail(ctx context.Context, cedarSystemID string) (*mo
 
 	if busOwnerInfo := sys.BusinessOwnerInformation; busOwnerInfo != nil {
 		retVal.BusinessOwnerInformation = &models.BusinessOwnerInformation{
-			BeneficiaryAddressPurpose:      busOwnerInfo.BeneficiaryAddressPurpose,
-			BeneficiaryAddressPurposeOther: busOwnerInfo.BeneficiaryAddressPurposeOther,
-			BeneficiaryAddressSource:       busOwnerInfo.BeneficiaryAddressSource,
-			BeneficiaryAddressSourceOther:  busOwnerInfo.BeneficiaryAddressSourceOther,
-			CostPerYear:                    busOwnerInfo.CostPerYear,
+			BeneficiaryAddressPurpose:      models.ZeroStringsFrom(busOwnerInfo.BeneficiaryAddressPurpose),
+			BeneficiaryAddressPurposeOther: zero.StringFrom(busOwnerInfo.BeneficiaryAddressPurposeOther),
+			BeneficiaryAddressSource:       models.ZeroStringsFrom(busOwnerInfo.BeneficiaryAddressSource),
+			BeneficiaryAddressSourceOther:  zero.StringFrom(busOwnerInfo.BeneficiaryAddressSourceOther),
+			CostPerYear:                    zero.StringFrom(busOwnerInfo.CostPerYear),
 			IsCmsOwned:                     busOwnerInfo.IsCmsOwned,
-			NumberOfContractorFte:          busOwnerInfo.NumberOfContractorFte,
-			NumberOfFederalFte:             busOwnerInfo.NumberOfFederalFte,
-			NumberOfSupportedUsersPerMonth: busOwnerInfo.NumberOfSupportedUsersPerMonth,
+			NumberOfContractorFte:          zero.StringFrom(busOwnerInfo.NumberOfContractorFte),
+			NumberOfFederalFte:             zero.StringFrom(busOwnerInfo.NumberOfFederalFte),
+			NumberOfSupportedUsersPerMonth: zero.StringFrom(busOwnerInfo.NumberOfSupportedUsersPerMonth),
 			StoresBankingData:              busOwnerInfo.StoresBankingData,
 			StoresBeneficiaryAddress:       busOwnerInfo.StoresBeneficiaryAddress,
 		}
@@ -66,30 +69,30 @@ func (c *Client) GetSystemDetail(ctx context.Context, cedarSystemID string) (*mo
 		retVal.SystemMaintainerInformation = &models.SystemMaintainerInformation{
 			AgileUsed:                  sysMaintInfo.AgileUsed,
 			BusinessArtifactsOnDemand:  sysMaintInfo.BusinessArtifactsOnDemand,
-			DeploymentFrequency:        sysMaintInfo.DeploymentFrequency,
-			DevCompletionPercent:       sysMaintInfo.DevCompletionPercent,
-			DevWorkDescription:         sysMaintInfo.DevWorkDescription,
+			DeploymentFrequency:        zero.StringFrom(sysMaintInfo.DeploymentFrequency),
+			DevCompletionPercent:       zero.StringFrom(sysMaintInfo.DevCompletionPercent),
+			DevWorkDescription:         zero.StringFrom(sysMaintInfo.DevWorkDescription),
 			EcapParticipation:          sysMaintInfo.EcapParticipation,
-			FrontendAccessType:         sysMaintInfo.FrontendAccessType,
+			FrontendAccessType:         zero.StringFrom(sysMaintInfo.FrontendAccessType),
 			HardCodedIPAddress:         sysMaintInfo.HardCodedIPAddress,
-			IP6EnabledAssetPercent:     sysMaintInfo.Ip6EnabledAssetPercent,
-			IP6TransitionPlan:          sysMaintInfo.Ip6TransitionPlan,
-			IPEnabledAssetCount:        sysMaintInfo.IPEnabledAssetCount,
-			MajorRefreshDate:           sysMaintInfo.MajorRefreshDate.String(),
-			NetAccessibility:           sysMaintInfo.NetAccessibility,
+			IP6EnabledAssetPercent:     zero.StringFrom(sysMaintInfo.Ip6EnabledAssetPercent),
+			IP6TransitionPlan:          zero.StringFrom(sysMaintInfo.Ip6TransitionPlan),
+			IPEnabledAssetCount:        int(sysMaintInfo.IPEnabledAssetCount),
+			MajorRefreshDate:           zero.TimeFrom(time.Time(sysMaintInfo.MajorRefreshDate)),
+			NetAccessibility:           zero.StringFrom(sysMaintInfo.NetAccessibility),
 			OmDocumentationOnDemand:    sysMaintInfo.OmDocumentationOnDemand,
-			PlansToRetireReplace:       sysMaintInfo.PlansToRetireReplace,
-			QuarterToRetireReplace:     sysMaintInfo.QuarterToRetireReplace,
-			RecordsManagementBucket:    sysMaintInfo.RecordsManagementBucket,
+			PlansToRetireReplace:       zero.StringFrom(sysMaintInfo.PlansToRetireReplace),
+			QuarterToRetireReplace:     zero.StringFrom(sysMaintInfo.QuarterToRetireReplace),
+			RecordsManagementBucket:    models.ZeroStringsFrom(sysMaintInfo.RecordsManagementBucket),
 			SourceCodeOnDemand:         sysMaintInfo.SourceCodeOnDemand,
-			SystemCustomization:        sysMaintInfo.SystemCustomization,
+			SystemCustomization:        zero.StringFrom(sysMaintInfo.SystemCustomization),
 			SystemDesignOnDemand:       sysMaintInfo.SystemDesignOnDemand,
-			SystemProductionDate:       sysMaintInfo.SystemProductionDate.String(),
+			SystemProductionDate:       zero.TimeFrom(time.Time(sysMaintInfo.SystemProductionDate)),
 			SystemRequirementsOnDemand: sysMaintInfo.SystemRequirementsOnDemand,
 			TestPlanOnDemand:           sysMaintInfo.TestPlanOnDemand,
 			TestReportsOnDemand:        sysMaintInfo.TestReportsOnDemand,
 			TestScriptsOnDemand:        sysMaintInfo.TestScriptsOnDemand,
-			YearToRetireReplace:        sysMaintInfo.YearToRetireReplace,
+			YearToRetireReplace:        zero.StringFrom(sysMaintInfo.YearToRetireReplace),
 		}
 	}
 	return retVal, nil

--- a/pkg/cedar/core/system_summary.go
+++ b/pkg/cedar/core/system_summary.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/guregu/null"
+	"github.com/guregu/null/zero"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/apperrors"
 	apisystems "github.com/cmsgov/easi-app/pkg/cedar/core/gen/client/system"
+	"github.com/cmsgov/easi-app/pkg/helpers"
 	"github.com/cmsgov/easi-app/pkg/local"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
@@ -61,8 +62,8 @@ func (c *Client) GetSystemSummary(ctx context.Context, tryCache bool, euaUserID 
 
 	// Construct the parameters
 	params := apisystems.NewSystemSummaryFindListParams()
-	params.SetState(null.StringFrom("active").Ptr())
-	params.SetIncludeInSurvey(null.BoolFrom(true).Ptr())
+	params.SetState(helpers.PointerTo("active"))
+	params.SetIncludeInSurvey(helpers.PointerTo(true))
 
 	params.SetUserName(euaUserID)
 	// as we add more filters, we can set them here
@@ -92,16 +93,16 @@ func (c *Client) GetSystemSummary(ctx context.Context, tryCache bool, euaUserID 
 	for _, sys := range resp.Payload.SystemSummary {
 		if sys.IctObjectID != nil {
 			cedarSys := &models.CedarSystem{
-				VersionID:               *sys.ID,
-				Name:                    *sys.Name,
-				Description:             sys.Description,
-				Acronym:                 sys.Acronym,
-				Status:                  sys.Status,
-				BusinessOwnerOrg:        sys.BusinessOwnerOrg,
-				BusinessOwnerOrgComp:    sys.BusinessOwnerOrgComp,
-				SystemMaintainerOrg:     sys.SystemMaintainerOrg,
-				SystemMaintainerOrgComp: sys.SystemMaintainerOrgComp,
-				ID:                      *sys.IctObjectID,
+				VersionID:               zero.StringFromPtr(sys.ID),
+				Name:                    zero.StringFromPtr(sys.Name),
+				Description:             zero.StringFrom(sys.Description),
+				Acronym:                 zero.StringFrom(sys.Acronym),
+				Status:                  zero.StringFrom(sys.Status),
+				BusinessOwnerOrg:        zero.StringFrom(sys.BusinessOwnerOrg),
+				BusinessOwnerOrgComp:    zero.StringFrom(sys.BusinessOwnerOrgComp),
+				SystemMaintainerOrg:     zero.StringFrom(sys.SystemMaintainerOrg),
+				SystemMaintainerOrgComp: zero.StringFrom(sys.SystemMaintainerOrgComp),
+				ID:                      zero.StringFromPtr(sys.IctObjectID),
 			}
 			retVal = append(retVal, cedarSys)
 		}
@@ -131,7 +132,7 @@ func (c *Client) populateSystemSummaryCache(ctx context.Context) error {
 	systemSummaryMap := make(map[string]*models.CedarSystem)
 	for _, sys := range systemSummary {
 		if sys != nil {
-			systemSummaryMap[sys.ID] = sys
+			systemSummaryMap[sys.ID.String] = sys
 		}
 	}
 

--- a/pkg/cedar/core/system_summary_test.go
+++ b/pkg/cedar/core/system_summary_test.go
@@ -57,7 +57,7 @@ func (s *SystemSummaryTestSuite) TestGetSystem() {
 
 		// should return mocked system when given corresponding mockKey
 		for _, v := range local.GetMockSystems() {
-			resp, err = c.GetSystem(ctx, v.ID)
+			resp, err = c.GetSystem(ctx, v.ID.String)
 			s.NoError(err)
 			s.Equal(v, resp)
 		}

--- a/pkg/cedar/core/threat.go
+++ b/pkg/cedar/core/threat.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
@@ -40,7 +39,7 @@ func (c *Client) GetThreat(ctx context.Context, cedarSystemID string) ([]*models
 
 	// Run through all ATO objects and append ATO ID(s) to id list
 	for _, ato := range cedarATOs {
-		atoIDs = append(atoIDs, ato.CedarID)
+		atoIDs = append(atoIDs, ato.CedarID.String)
 	}
 
 	// Construct the parameters
@@ -65,7 +64,7 @@ func (c *Client) GetThreat(ctx context.Context, cedarSystemID string) ([]*models
 		retVal = append(retVal, &models.CedarThreat{
 			AlternativeID:     zero.StringFrom(threat.AlternativeID),
 			ControlFamily:     zero.StringFrom(threat.ControlFamily),
-			DaysOpen:          null.IntFrom(int64(threat.DaysOpen)),
+			DaysOpen:          int(threat.DaysOpen),
 			ID:                zero.StringFrom(threat.ID),
 			ParentID:          zero.StringFrom(threat.ParentID),
 			Type:              zero.StringFrom(threat.Type),

--- a/pkg/cedar/core/url.go
+++ b/pkg/cedar/core/url.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
@@ -30,7 +29,7 @@ func (c *Client) GetURLsForSystem(ctx context.Context, cedarSystemID string) ([]
 
 	// Construct the parameters
 	params := apiurl.NewURLFindListParams()
-	params.SetID(cedarSystem.VersionID)
+	params.SetID(cedarSystem.VersionID.String)
 	params.HTTPClient = c.hc
 
 	// Make the API call
@@ -49,11 +48,11 @@ func (c *Client) GetURLsForSystem(ctx context.Context, cedarSystemID string) ([]
 	// convert items in response payload to our models
 	for _, url := range resp.Payload.URLList {
 		retVal = append(retVal, &models.CedarURL{
-			ID:                             *url.URLID,
+			ID:                             zero.StringFromPtr(url.URLID),
 			Address:                        zero.StringFrom(url.Address),
-			IsBehindWebApplicationFirewall: null.BoolFrom(url.IsBehindWebApplicationFirewall),
-			IsAPIEndpoint:                  null.BoolFrom(url.IsAPIEndpoint),
-			IsVersionCodeRepository:        null.BoolFrom(url.IsVersionCodeRepository),
+			IsBehindWebApplicationFirewall: url.IsBehindWebApplicationFirewall,
+			IsAPIEndpoint:                  url.IsAPIEndpoint,
+			IsVersionCodeRepository:        url.IsVersionCodeRepository,
 			URLHostingEnv:                  zero.StringFrom(url.URLHostingEnv),
 		})
 	}

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -7966,7 +7966,7 @@ type CedarSystemMaintainerInformation {
 	ip6EnabledAssetPercent: String
 	ip6TransitionPlan: String
 	ipEnabledAssetCount: Int
-	majorRefreshDate: String
+	majorRefreshDate: Time
 	netAccessibility: String
 	omDocumentationOnDemand: Boolean
 	plansToRetireReplace: String
@@ -7975,7 +7975,7 @@ type CedarSystemMaintainerInformation {
 	sourceCodeOnDemand: Boolean
 	systemCustomization: String
 	systemDesignOnDemand: Boolean
-	systemProductionDate: String
+	systemProductionDate: Time
 	systemRequirementsOnDemand: Boolean
 	testPlanOnDemand: Boolean
 	testReportsOnDemand: Boolean
@@ -16228,9 +16228,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_cedarId(ctx context.Context
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_cedarId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -16272,9 +16272,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_uuid(ctx context.Context, f
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_uuid(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -16354,9 +16354,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_containsPersonallyIdentifia
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_containsPersonallyIdentifiableInformation(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -16398,9 +16398,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_countOfTotalNonPrivilegedUs
 		}
 		return graphql.Null
 	}
-	res := resTmp.(null.Int)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNInt2githubᚗcomᚋgureguᚋnullᚐInt(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_countOfTotalNonPrivilegedUserPopulation(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -16442,9 +16442,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_countOfOpenPoams(ctx contex
 		}
 		return graphql.Null
 	}
-	res := resTmp.(null.Int)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNInt2githubᚗcomᚋgureguᚋnullᚐInt(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_countOfOpenPoams(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -16486,9 +16486,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_countOfTotalPrivilegedUserP
 		}
 		return graphql.Null
 	}
-	res := resTmp.(null.Int)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNInt2githubᚗcomᚋgureguᚋnullᚐInt(ctx, field.Selections, res)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_countOfTotalPrivilegedUserPopulation(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -16650,9 +16650,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_fips199OverallImpactRating(
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Int)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalOInt2githubᚗcomᚋgureguᚋnullᚐInt(ctx, field.Selections, res)
+	return ec.marshalOInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_fips199OverallImpactRating(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -16773,9 +16773,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_isAccessedByNonOrganization
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_isAccessedByNonOrganizationalUsers(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -16814,9 +16814,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_isPiiLimitedToUserNameAndPa
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_isPiiLimitedToUserNameAndPass(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -16855,9 +16855,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_isProtectedHealthInformatio
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_isProtectedHealthInformation(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -17183,9 +17183,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_recoveryPointObjective(ctx 
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Float)
+	res := resTmp.(float64)
 	fc.Result = res
-	return ec.marshalOFloat2githubᚗcomᚋgureguᚋnullᚐFloat(ctx, field.Selections, res)
+	return ec.marshalOFloat2float64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_recoveryPointObjective(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -17224,9 +17224,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_recoveryTimeObjective(ctx c
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Float)
+	res := resTmp.(float64)
 	fc.Result = res
-	return ec.marshalOFloat2githubᚗcomᚋgureguᚋnullᚐFloat(ctx, field.Selections, res)
+	return ec.marshalOFloat2float64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_recoveryTimeObjective(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -17268,9 +17268,9 @@ func (ec *executionContext) _CedarAuthorityToOperate_systemOfRecordsNotice(ctx c
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]string)
+	res := resTmp.([]zero.String)
 	fc.Result = res
-	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+	return ec.marshalNString2ᚕgithubᚗcomᚋgureguᚋnullᚋzeroᚐStringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarAuthorityToOperate_systemOfRecordsNotice(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -18384,9 +18384,9 @@ func (ec *executionContext) _CedarDeployment_id(ctx context.Context, field graph
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarDeployment_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -18428,9 +18428,9 @@ func (ec *executionContext) _CedarDeployment_name(ctx context.Context, field gra
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarDeployment_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -18472,9 +18472,9 @@ func (ec *executionContext) _CedarDeployment_systemID(ctx context.Context, field
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarDeployment_systemID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -19162,9 +19162,9 @@ func (ec *executionContext) _CedarExchange_connectionFrequency(ctx context.Conte
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]string)
+	res := resTmp.([]zero.String)
 	fc.Result = res
-	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+	return ec.marshalNString2ᚕgithubᚗcomᚋgureguᚋnullᚋzeroᚐStringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarExchange_connectionFrequency(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -19203,9 +19203,9 @@ func (ec *executionContext) _CedarExchange_containsBankingData(ctx context.Conte
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarExchange_containsBankingData(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -19244,9 +19244,9 @@ func (ec *executionContext) _CedarExchange_containsBeneficiaryAddress(ctx contex
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarExchange_containsBeneficiaryAddress(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -19285,9 +19285,9 @@ func (ec *executionContext) _CedarExchange_containsPhi(ctx context.Context, fiel
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarExchange_containsPhi(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -19326,9 +19326,9 @@ func (ec *executionContext) _CedarExchange_containsPii(ctx context.Context, fiel
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarExchange_containsPii(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -19982,9 +19982,9 @@ func (ec *executionContext) _CedarExchange_isBeneficiaryMailingFile(ctx context.
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarExchange_isBeneficiaryMailingFile(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20064,9 +20064,9 @@ func (ec *executionContext) _CedarExchange_sharedViaApi(ctx context.Context, fie
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarExchange_sharedViaApi(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20278,9 +20278,9 @@ func (ec *executionContext) _CedarExchangeTypeOfDataItem_id(ctx context.Context,
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalOString2string(ctx, field.Selections, res)
+	return ec.marshalOString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarExchangeTypeOfDataItem_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20319,9 +20319,9 @@ func (ec *executionContext) _CedarExchangeTypeOfDataItem_name(ctx context.Contex
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalOString2string(ctx, field.Selections, res)
+	return ec.marshalOString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarExchangeTypeOfDataItem_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20363,9 +20363,9 @@ func (ec *executionContext) _CedarRole_application(ctx context.Context, field gr
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarRole_application(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20407,9 +20407,9 @@ func (ec *executionContext) _CedarRole_objectID(ctx context.Context, field graph
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarRole_objectID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20451,9 +20451,9 @@ func (ec *executionContext) _CedarRole_roleTypeID(ctx context.Context, field gra
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarRole_roleTypeID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -21028,9 +21028,9 @@ func (ec *executionContext) _CedarRoleType_id(ctx context.Context, field graphql
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarRoleType_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -21072,9 +21072,9 @@ func (ec *executionContext) _CedarRoleType_application(ctx context.Context, fiel
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarRoleType_application(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -21116,9 +21116,9 @@ func (ec *executionContext) _CedarRoleType_name(ctx context.Context, field graph
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarRoleType_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22065,9 +22065,9 @@ func (ec *executionContext) _CedarSoftwareProducts_apiHasPortal(ctx context.Cont
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSoftwareProducts_apiHasPortal(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22303,9 +22303,9 @@ func (ec *executionContext) _CedarSoftwareProducts_systemHasAPIGateway(ctx conte
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSoftwareProducts_systemHasAPIGateway(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22388,9 +22388,9 @@ func (ec *executionContext) _CedarSystem_id(ctx context.Context, field graphql.C
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSystem_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22432,9 +22432,9 @@ func (ec *executionContext) _CedarSystem_name(ctx context.Context, field graphql
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSystem_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22473,9 +22473,9 @@ func (ec *executionContext) _CedarSystem_description(ctx context.Context, field 
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalOString2string(ctx, field.Selections, res)
+	return ec.marshalOString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSystem_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22514,9 +22514,9 @@ func (ec *executionContext) _CedarSystem_acronym(ctx context.Context, field grap
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalOString2string(ctx, field.Selections, res)
+	return ec.marshalOString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSystem_acronym(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22555,9 +22555,9 @@ func (ec *executionContext) _CedarSystem_status(ctx context.Context, field graph
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalOString2string(ctx, field.Selections, res)
+	return ec.marshalOString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSystem_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22596,9 +22596,9 @@ func (ec *executionContext) _CedarSystem_businessOwnerOrg(ctx context.Context, f
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalOString2string(ctx, field.Selections, res)
+	return ec.marshalOString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSystem_businessOwnerOrg(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22637,9 +22637,9 @@ func (ec *executionContext) _CedarSystem_businessOwnerOrgComp(ctx context.Contex
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalOString2string(ctx, field.Selections, res)
+	return ec.marshalOString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSystem_businessOwnerOrgComp(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22756,9 +22756,9 @@ func (ec *executionContext) _CedarSystem_systemMaintainerOrg(ctx context.Context
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalOString2string(ctx, field.Selections, res)
+	return ec.marshalOString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSystem_systemMaintainerOrg(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22797,9 +22797,9 @@ func (ec *executionContext) _CedarSystem_systemMaintainerOrgComp(ctx context.Con
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalOString2string(ctx, field.Selections, res)
+	return ec.marshalOString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSystem_systemMaintainerOrgComp(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22838,9 +22838,9 @@ func (ec *executionContext) _CedarSystem_versionId(ctx context.Context, field gr
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalOString2string(ctx, field.Selections, res)
+	return ec.marshalOString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSystem_versionId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -23930,9 +23930,9 @@ func (ec *executionContext) _CedarSystemMaintainerInformation_majorRefreshDate(c
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(*time.Time)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSystemMaintainerInformation_majorRefreshDate(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -23942,7 +23942,7 @@ func (ec *executionContext) fieldContext_CedarSystemMaintainerInformation_majorR
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -24302,9 +24302,9 @@ func (ec *executionContext) _CedarSystemMaintainerInformation_systemProductionDa
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(*time.Time)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarSystemMaintainerInformation_systemProductionDate(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -24314,7 +24314,7 @@ func (ec *executionContext) fieldContext_CedarSystemMaintainerInformation_system
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -24630,9 +24630,9 @@ func (ec *executionContext) _CedarThreat_daysOpen(ctx context.Context, field gra
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Int)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalOInt2githubᚗcomᚋgureguᚋnullᚐInt(ctx, field.Selections, res)
+	return ec.marshalOInt2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarThreat_daysOpen(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -24838,9 +24838,9 @@ func (ec *executionContext) _CedarURL_id(ctx context.Context, field graphql.Coll
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(zero.String)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarURL_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -24920,9 +24920,9 @@ func (ec *executionContext) _CedarURL_isBehindWebApplicationFirewall(ctx context
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarURL_isBehindWebApplicationFirewall(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -24961,9 +24961,9 @@ func (ec *executionContext) _CedarURL_isAPIEndpoint(ctx context.Context, field g
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarURL_isAPIEndpoint(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -25002,9 +25002,9 @@ func (ec *executionContext) _CedarURL_isVersionCodeRepository(ctx context.Contex
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(null.Bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2githubᚗcomᚋgureguᚋnullᚐBool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CedarURL_isVersionCodeRepository(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -70846,21 +70846,6 @@ func (ec *executionContext) marshalNITGovTaskStatuses2ᚖgithubᚗcomᚋcmsgov�
 	return ec._ITGovTaskStatuses(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNInt2githubᚗcomᚋgureguᚋnullᚐInt(ctx context.Context, v interface{}) (null.Int, error) {
-	res, err := models.UnmarshalNullInt(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNInt2githubᚗcomᚋgureguᚋnullᚐInt(ctx context.Context, sel ast.SelectionSet, v null.Int) graphql.Marshaler {
-	res := models.MarshalNullInt(v)
-	if res == graphql.Null {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-	}
-	return res
-}
-
 func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}) (int, error) {
 	res, err := graphql.UnmarshalInt(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -71031,6 +71016,21 @@ func (ec *executionContext) unmarshalNSetTRBRequestRelationNewSystemInput2github
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx context.Context, v interface{}) (zero.String, error) {
+	res, err := models.UnmarshalZeroString(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx context.Context, sel ast.SelectionSet, v zero.String) graphql.Marshaler {
+	res := models.MarshalZeroString(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {
 	res, err := graphql.UnmarshalString(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -71044,6 +71044,38 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNString2ᚕgithubᚗcomᚋgureguᚋnullᚋzeroᚐStringᚄ(ctx context.Context, v interface{}) ([]zero.String, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]zero.String, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNString2ᚕgithubᚗcomᚋgureguᚋnullᚋzeroᚐStringᚄ(ctx context.Context, sel ast.SelectionSet, v []zero.String) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNString2githubᚗcomᚋgureguᚋnullᚋzeroᚐString(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalNString2ᚕstring(ctx context.Context, v interface{}) ([]string, error) {
@@ -73695,13 +73727,13 @@ func (ec *executionContext) marshalOExchangeDirection2githubᚗcomᚋcmsgovᚋea
 	return res
 }
 
-func (ec *executionContext) unmarshalOFloat2githubᚗcomᚋgureguᚋnullᚐFloat(ctx context.Context, v interface{}) (null.Float, error) {
-	res, err := models.UnmarshalNullFloat(v)
+func (ec *executionContext) unmarshalOFloat2float64(ctx context.Context, v interface{}) (float64, error) {
+	res, err := graphql.UnmarshalFloat(v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOFloat2githubᚗcomᚋgureguᚋnullᚐFloat(ctx context.Context, sel ast.SelectionSet, v null.Float) graphql.Marshaler {
-	res := models.MarshalNullFloat(v)
+func (ec *executionContext) marshalOFloat2float64(ctx context.Context, sel ast.SelectionSet, v float64) graphql.Marshaler {
+	res := graphql.MarshalFloat(v)
 	return res
 }
 
@@ -73728,13 +73760,13 @@ func (ec *executionContext) marshalOHTML2ᚖgithubᚗcomᚋcmsgovᚋeasiᚑapp�
 	return graphql.WrapContextMarshaler(ctx, v)
 }
 
-func (ec *executionContext) unmarshalOInt2githubᚗcomᚋgureguᚋnullᚐInt(ctx context.Context, v interface{}) (null.Int, error) {
-	res, err := models.UnmarshalNullInt(v)
+func (ec *executionContext) unmarshalOInt2int(ctx context.Context, v interface{}) (int, error) {
+	res, err := graphql.UnmarshalInt(v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOInt2githubᚗcomᚋgureguᚋnullᚐInt(ctx context.Context, sel ast.SelectionSet, v null.Int) graphql.Marshaler {
-	res := models.MarshalNullInt(v)
+func (ec *executionContext) marshalOInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
+	res := graphql.MarshalInt(v)
 	return res
 }
 

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -84,32 +84,32 @@ type CedarSoftwareProductItem struct {
 
 // SystemMaintainerInformation contains information about the system maintainer of a CEDAR system
 type CedarSystemMaintainerInformation struct {
-	AgileUsed                  *bool    `json:"agileUsed,omitempty"`
-	BusinessArtifactsOnDemand  *bool    `json:"businessArtifactsOnDemand,omitempty"`
-	DeploymentFrequency        *string  `json:"deploymentFrequency,omitempty"`
-	DevCompletionPercent       *string  `json:"devCompletionPercent,omitempty"`
-	DevWorkDescription         *string  `json:"devWorkDescription,omitempty"`
-	EcapParticipation          *bool    `json:"ecapParticipation,omitempty"`
-	FrontendAccessType         *string  `json:"frontendAccessType,omitempty"`
-	HardCodedIPAddress         *bool    `json:"hardCodedIPAddress,omitempty"`
-	IP6EnabledAssetPercent     *string  `json:"ip6EnabledAssetPercent,omitempty"`
-	IP6TransitionPlan          *string  `json:"ip6TransitionPlan,omitempty"`
-	IPEnabledAssetCount        *int     `json:"ipEnabledAssetCount,omitempty"`
-	MajorRefreshDate           *string  `json:"majorRefreshDate,omitempty"`
-	NetAccessibility           *string  `json:"netAccessibility,omitempty"`
-	OmDocumentationOnDemand    *bool    `json:"omDocumentationOnDemand,omitempty"`
-	PlansToRetireReplace       *string  `json:"plansToRetireReplace,omitempty"`
-	QuarterToRetireReplace     *string  `json:"quarterToRetireReplace,omitempty"`
-	RecordsManagementBucket    []string `json:"recordsManagementBucket"`
-	SourceCodeOnDemand         *bool    `json:"sourceCodeOnDemand,omitempty"`
-	SystemCustomization        *string  `json:"systemCustomization,omitempty"`
-	SystemDesignOnDemand       *bool    `json:"systemDesignOnDemand,omitempty"`
-	SystemProductionDate       *string  `json:"systemProductionDate,omitempty"`
-	SystemRequirementsOnDemand *bool    `json:"systemRequirementsOnDemand,omitempty"`
-	TestPlanOnDemand           *bool    `json:"testPlanOnDemand,omitempty"`
-	TestReportsOnDemand        *bool    `json:"testReportsOnDemand,omitempty"`
-	TestScriptsOnDemand        *bool    `json:"testScriptsOnDemand,omitempty"`
-	YearToRetireReplace        *string  `json:"yearToRetireReplace,omitempty"`
+	AgileUsed                  *bool      `json:"agileUsed,omitempty"`
+	BusinessArtifactsOnDemand  *bool      `json:"businessArtifactsOnDemand,omitempty"`
+	DeploymentFrequency        *string    `json:"deploymentFrequency,omitempty"`
+	DevCompletionPercent       *string    `json:"devCompletionPercent,omitempty"`
+	DevWorkDescription         *string    `json:"devWorkDescription,omitempty"`
+	EcapParticipation          *bool      `json:"ecapParticipation,omitempty"`
+	FrontendAccessType         *string    `json:"frontendAccessType,omitempty"`
+	HardCodedIPAddress         *bool      `json:"hardCodedIPAddress,omitempty"`
+	IP6EnabledAssetPercent     *string    `json:"ip6EnabledAssetPercent,omitempty"`
+	IP6TransitionPlan          *string    `json:"ip6TransitionPlan,omitempty"`
+	IPEnabledAssetCount        *int       `json:"ipEnabledAssetCount,omitempty"`
+	MajorRefreshDate           *time.Time `json:"majorRefreshDate,omitempty"`
+	NetAccessibility           *string    `json:"netAccessibility,omitempty"`
+	OmDocumentationOnDemand    *bool      `json:"omDocumentationOnDemand,omitempty"`
+	PlansToRetireReplace       *string    `json:"plansToRetireReplace,omitempty"`
+	QuarterToRetireReplace     *string    `json:"quarterToRetireReplace,omitempty"`
+	RecordsManagementBucket    []string   `json:"recordsManagementBucket"`
+	SourceCodeOnDemand         *bool      `json:"sourceCodeOnDemand,omitempty"`
+	SystemCustomization        *string    `json:"systemCustomization,omitempty"`
+	SystemDesignOnDemand       *bool      `json:"systemDesignOnDemand,omitempty"`
+	SystemProductionDate       *time.Time `json:"systemProductionDate,omitempty"`
+	SystemRequirementsOnDemand *bool      `json:"systemRequirementsOnDemand,omitempty"`
+	TestPlanOnDemand           *bool      `json:"testPlanOnDemand,omitempty"`
+	TestReportsOnDemand        *bool      `json:"testReportsOnDemand,omitempty"`
+	TestScriptsOnDemand        *bool      `json:"testScriptsOnDemand,omitempty"`
+	YearToRetireReplace        *string    `json:"yearToRetireReplace,omitempty"`
 }
 
 // The input needed to close a TRB request

--- a/pkg/graph/resolvers/resolver_test.go
+++ b/pkg/graph/resolvers/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/guregu/null/zero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -183,6 +184,6 @@ func (suite *ResolverSuite) createNewIntake() *models.SystemIntake {
 
 func mockGetCedarSystem(_ context.Context, systemID string) (*models.CedarSystem, error) {
 	return &models.CedarSystem{
-		ID: systemID,
+		ID: zero.StringFrom(systemID),
 	}, nil
 }

--- a/pkg/graph/resolvers/system_intake_relation_test.go
+++ b/pkg/graph/resolvers/system_intake_relation_test.go
@@ -250,7 +250,7 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingSystem() {
 			// Ensure the system IDs were modified properly
 			suite.Equal(len(caseValues.NewSystemIDs), len(updatedIntakeSystemIDs))
 			for _, v := range updatedIntakeSystemIDs {
-				suite.Contains(caseValues.NewSystemIDs, v.ID)
+				suite.Contains(caseValues.NewSystemIDs, v.ID.String)
 			}
 
 			// Ensure the contract numbers were modified properly

--- a/pkg/graph/resolvers/system_intake_system_test.go
+++ b/pkg/graph/resolvers/system_intake_system_test.go
@@ -73,15 +73,15 @@ func (s *ResolverSuite) TestIntakeRelatedSystems() {
 		)
 
 		for _, result := range data {
-			if result.ID == systemID1 {
+			if result.ID.String == systemID1 {
 				found1 = true
 			}
 
-			if result.ID == systemID2 {
+			if result.ID.String == systemID2 {
 				found2 = true
 			}
 
-			if result.ID == systemID3 {
+			if result.ID.String == systemID3 {
 				found3 = true
 			}
 		}

--- a/pkg/graph/resolvers/trb_request_relation_test.go
+++ b/pkg/graph/resolvers/trb_request_relation_test.go
@@ -244,7 +244,7 @@ func (suite *ResolverSuite) TestSetTRBRequestRelationExistingSystem() {
 			// Ensure the system IDs were modified properly
 			suite.Equal(len(caseValues.NewSystemIDs), len(updatedTRBRequestSystemIDs))
 			for _, v := range updatedTRBRequestSystemIDs {
-				suite.Contains(caseValues.NewSystemIDs, v.ID)
+				suite.Contains(caseValues.NewSystemIDs, v.ID.String)
 			}
 
 			// Ensure the contract numbers were modified properly

--- a/pkg/graph/resolvers/trb_request_system_test.go
+++ b/pkg/graph/resolvers/trb_request_system_test.go
@@ -65,15 +65,15 @@ func (s *ResolverSuite) TestTRBRequestRelatedSystems() {
 		)
 
 		for _, result := range data {
-			if result.ID == systemID1 {
+			if result.ID.String == systemID1 {
 				found1 = true
 			}
 
-			if result.ID == systemID2 {
+			if result.ID.String == systemID2 {
 				found2 = true
 			}
 
-			if result.ID == systemID3 {
+			if result.ID.String == systemID3 {
 				found3 = true
 			}
 		}

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -193,7 +193,7 @@ type CedarSystemMaintainerInformation {
 	ip6EnabledAssetPercent: String
 	ip6TransitionPlan: String
 	ipEnabledAssetCount: Int
-	majorRefreshDate: String
+	majorRefreshDate: Time
 	netAccessibility: String
 	omDocumentationOnDemand: Boolean
 	plansToRetireReplace: String
@@ -202,7 +202,7 @@ type CedarSystemMaintainerInformation {
 	sourceCodeOnDemand: Boolean
 	systemCustomization: String
 	systemDesignOnDemand: Boolean
-	systemProductionDate: String
+	systemProductionDate: Time
 	systemRequirementsOnDemand: Boolean
 	testPlanOnDemand: Boolean
 	testReportsOnDemand: Boolean

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -255,10 +255,10 @@ func (r *cedarSoftwareProductsResolver) SoftwareProducts(ctx context.Context, ob
 	var softwareProductItems []*model.CedarSoftwareProductItem
 	for _, softwareProduct := range softwareProducts {
 		softwareProductItem := &model.CedarSoftwareProductItem{
-			APIGatewayUse:                  softwareProduct.APIGatewayUse.Ptr(),
+			APIGatewayUse:                  &softwareProduct.APIGatewayUse,
 			ElaPurchase:                    softwareProduct.ElaPurchase.Ptr(),
 			ElaVendorID:                    softwareProduct.ElaVendorID.Ptr(),
-			ProvidesAiCapability:           softwareProduct.ProvidesAiCapability.Ptr(),
+			ProvidesAiCapability:           &softwareProduct.ProvidesAiCapability,
 			Refstr:                         softwareProduct.Refstr.Ptr(),
 			SoftwareCatagoryConnectionGUID: softwareProduct.SoftwareCatagoryConnectionGUID.Ptr(),
 			SoftwareVendorConnectionGUID:   softwareProduct.SoftwareVendorConnectionGUID.Ptr(),
@@ -278,7 +278,7 @@ func (r *cedarSoftwareProductsResolver) SoftwareProducts(ctx context.Context, ob
 
 // BusinessOwnerRoles is the resolver for the businessOwnerRoles field.
 func (r *cedarSystemResolver) BusinessOwnerRoles(ctx context.Context, obj *models.CedarSystem) ([]*models.CedarRole, error) {
-	cedarRoles, err := r.cedarCoreClient.GetBusinessOwnerRolesBySystem(ctx, obj.ID)
+	cedarRoles, err := r.cedarCoreClient.GetBusinessOwnerRolesBySystem(ctx, obj.ID.String)
 	if err != nil {
 		return nil, err
 	}
@@ -291,45 +291,45 @@ func (r *cedarSystemDetailsResolver) SystemMaintainerInformation(ctx context.Con
 	return &model.CedarSystemMaintainerInformation{
 		AgileUsed:                  &obj.SystemMaintainerInformation.AgileUsed,
 		BusinessArtifactsOnDemand:  &obj.SystemMaintainerInformation.BusinessArtifactsOnDemand,
-		DeploymentFrequency:        &obj.SystemMaintainerInformation.DeploymentFrequency,
-		DevCompletionPercent:       &obj.SystemMaintainerInformation.DevCompletionPercent,
-		DevWorkDescription:         &obj.SystemMaintainerInformation.DevWorkDescription,
+		DeploymentFrequency:        obj.SystemMaintainerInformation.DeploymentFrequency.Ptr(),
+		DevCompletionPercent:       obj.SystemMaintainerInformation.DevCompletionPercent.Ptr(),
+		DevWorkDescription:         obj.SystemMaintainerInformation.DevWorkDescription.Ptr(),
 		EcapParticipation:          &obj.SystemMaintainerInformation.EcapParticipation,
-		FrontendAccessType:         &obj.SystemMaintainerInformation.FrontendAccessType,
+		FrontendAccessType:         obj.SystemMaintainerInformation.FrontendAccessType.Ptr(),
 		HardCodedIPAddress:         &obj.SystemMaintainerInformation.HardCodedIPAddress,
-		IP6EnabledAssetPercent:     &obj.SystemMaintainerInformation.IP6EnabledAssetPercent,
-		IP6TransitionPlan:          &obj.SystemMaintainerInformation.IP6TransitionPlan,
+		IP6EnabledAssetPercent:     obj.SystemMaintainerInformation.IP6EnabledAssetPercent.Ptr(),
+		IP6TransitionPlan:          obj.SystemMaintainerInformation.IP6TransitionPlan.Ptr(),
 		IPEnabledAssetCount:        &ipEnabledCt,
-		MajorRefreshDate:           &obj.SystemMaintainerInformation.MajorRefreshDate,
-		NetAccessibility:           &obj.SystemMaintainerInformation.NetAccessibility,
+		MajorRefreshDate:           obj.SystemMaintainerInformation.MajorRefreshDate.Ptr(),
+		NetAccessibility:           obj.SystemMaintainerInformation.NetAccessibility.Ptr(),
 		OmDocumentationOnDemand:    &obj.SystemMaintainerInformation.OmDocumentationOnDemand,
-		PlansToRetireReplace:       &obj.SystemMaintainerInformation.PlansToRetireReplace,
-		QuarterToRetireReplace:     &obj.SystemMaintainerInformation.QuarterToRetireReplace,
-		RecordsManagementBucket:    obj.SystemMaintainerInformation.RecordsManagementBucket,
+		PlansToRetireReplace:       obj.SystemMaintainerInformation.PlansToRetireReplace.Ptr(),
+		QuarterToRetireReplace:     obj.SystemMaintainerInformation.QuarterToRetireReplace.Ptr(),
+		RecordsManagementBucket:    models.StringsFromZeroStrs(obj.SystemMaintainerInformation.RecordsManagementBucket),
 		SourceCodeOnDemand:         &obj.SystemMaintainerInformation.SourceCodeOnDemand,
-		SystemCustomization:        &obj.SystemMaintainerInformation.SystemCustomization,
+		SystemCustomization:        obj.SystemMaintainerInformation.SystemCustomization.Ptr(),
 		SystemDesignOnDemand:       &obj.SystemMaintainerInformation.SystemDesignOnDemand,
-		SystemProductionDate:       &obj.SystemMaintainerInformation.SystemProductionDate,
+		SystemProductionDate:       obj.SystemMaintainerInformation.SystemProductionDate.Ptr(),
 		SystemRequirementsOnDemand: &obj.SystemMaintainerInformation.SystemRequirementsOnDemand,
 		TestPlanOnDemand:           &obj.SystemMaintainerInformation.TestPlanOnDemand,
 		TestReportsOnDemand:        &obj.SystemMaintainerInformation.TestReportsOnDemand,
 		TestScriptsOnDemand:        &obj.SystemMaintainerInformation.TestScriptsOnDemand,
-		YearToRetireReplace:        &obj.SystemMaintainerInformation.YearToRetireReplace,
+		YearToRetireReplace:        obj.SystemMaintainerInformation.YearToRetireReplace.Ptr(),
 	}, nil
 }
 
 // BusinessOwnerInformation is the resolver for the businessOwnerInformation field.
 func (r *cedarSystemDetailsResolver) BusinessOwnerInformation(ctx context.Context, obj *models.CedarSystemDetails) (*model.CedarBusinessOwnerInformation, error) {
 	return &model.CedarBusinessOwnerInformation{
-		BeneficiaryAddressPurpose:      obj.BusinessOwnerInformation.BeneficiaryAddressPurpose,
-		BeneficiaryAddressPurposeOther: &obj.BusinessOwnerInformation.BeneficiaryAddressPurposeOther,
-		BeneficiaryAddressSource:       obj.BusinessOwnerInformation.BeneficiaryAddressSource,
-		BeneficiaryAddressSourceOther:  &obj.BusinessOwnerInformation.BeneficiaryAddressSourceOther,
-		CostPerYear:                    &obj.BusinessOwnerInformation.CostPerYear,
+		BeneficiaryAddressPurpose:      models.StringsFromZeroStrs(obj.BusinessOwnerInformation.BeneficiaryAddressPurpose),
+		BeneficiaryAddressPurposeOther: obj.BusinessOwnerInformation.BeneficiaryAddressPurposeOther.Ptr(),
+		BeneficiaryAddressSource:       models.StringsFromZeroStrs(obj.BusinessOwnerInformation.BeneficiaryAddressSource),
+		BeneficiaryAddressSourceOther:  obj.BusinessOwnerInformation.BeneficiaryAddressSourceOther.Ptr(),
+		CostPerYear:                    obj.BusinessOwnerInformation.CostPerYear.Ptr(),
 		IsCmsOwned:                     &obj.BusinessOwnerInformation.IsCmsOwned,
-		NumberOfContractorFte:          &obj.BusinessOwnerInformation.NumberOfContractorFte,
-		NumberOfFederalFte:             &obj.BusinessOwnerInformation.NumberOfFederalFte,
-		NumberOfSupportedUsersPerMonth: &obj.BusinessOwnerInformation.NumberOfSupportedUsersPerMonth,
+		NumberOfContractorFte:          obj.BusinessOwnerInformation.NumberOfContractorFte.Ptr(),
+		NumberOfFederalFte:             obj.BusinessOwnerInformation.NumberOfFederalFte.Ptr(),
+		NumberOfSupportedUsersPerMonth: obj.BusinessOwnerInformation.NumberOfSupportedUsersPerMonth.Ptr(),
 		StoresBankingData:              &obj.BusinessOwnerInformation.StoresBankingData,
 		StoresBeneficiaryAddress:       &obj.BusinessOwnerInformation.StoresBeneficiaryAddress,
 	}, nil
@@ -409,7 +409,7 @@ func (r *mutationResolver) CreateAccessibilityRequest(ctx context.Context, input
 			return nil, cedarSystemErr
 		}
 		newRequest.CedarSystemID = null.StringFromPtr(input.CedarSystemID)
-		systemName = cedarSystem.Name
+		systemName = cedarSystem.Name.String
 	}
 
 	newRequest.Name = systemName
@@ -1780,15 +1780,15 @@ func (r *queryResolver) Deployments(ctx context.Context, cedarSystemID string, d
 		optionalParams = &cedarcore.GetDeploymentsOptionalParams{}
 
 		if deploymentType != nil {
-			optionalParams.DeploymentType = null.StringFromPtr(deploymentType)
+			optionalParams.DeploymentType = deploymentType
 		}
 
 		if state != nil {
-			optionalParams.State = null.StringFromPtr(state)
+			optionalParams.State = state
 		}
 
 		if status != nil {
-			optionalParams.Status = null.StringFromPtr(status)
+			optionalParams.Status = status
 		}
 	}
 
@@ -1812,7 +1812,7 @@ func (r *queryResolver) RoleTypes(ctx context.Context) ([]*models.CedarRoleType,
 
 // Roles is the resolver for the roles field.
 func (r *queryResolver) Roles(ctx context.Context, cedarSystemID string, roleTypeID *string) ([]*models.CedarRole, error) {
-	cedarRoles, err := r.cedarCoreClient.GetRolesBySystem(ctx, cedarSystemID, null.StringFromPtr(roleTypeID))
+	cedarRoles, err := r.cedarCoreClient.GetRolesBySystem(ctx, cedarSystemID, roleTypeID)
 	if err != nil {
 		return nil, err
 	}
@@ -1854,7 +1854,7 @@ func (r *queryResolver) CedarSystemDetails(ctx context.Context, cedarSystemID st
 	var cedarRoles []*models.CedarRole
 	var errR error
 	g.Go(func() error {
-		cedarRoles, errR = r.cedarCoreClient.GetRolesBySystem(ctx, cedarSystemID, null.String{})
+		cedarRoles, errR = r.cedarCoreClient.GetRolesBySystem(ctx, cedarSystemID, nil)
 		return errR
 	})
 

--- a/pkg/local/cedar_core.go
+++ b/pkg/local/cedar_core.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
 
 	"github.com/cmsgov/easi-app/pkg/helpers"
@@ -13,64 +12,64 @@ import (
 
 var mockSystems = map[string]*models.CedarSystem{
 	"{11AB1A00-1234-5678-ABC1-1A001B00CC0A}": {
-		ID:                      "{11AB1A00-1234-5678-ABC1-1A001B00CC0A}",
-		Name:                    "Centers for Management Services",
-		Acronym:                 "CMS",
-		Description:             "Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis.",
-		VersionID:               "{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}",
-		Status:                  "",
-		BusinessOwnerOrg:        "Information Systems Team",
-		BusinessOwnerOrgComp:    "IST",
-		SystemMaintainerOrg:     "Division of Quality Assurance",
-		SystemMaintainerOrgComp: "DQA",
+		ID:                      zero.StringFrom("{11AB1A00-1234-5678-ABC1-1A001B00CC0A}"),
+		Name:                    zero.StringFrom("Centers for Management Services"),
+		Acronym:                 zero.StringFrom("CMS"),
+		Description:             zero.StringFrom("Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis."),
+		VersionID:               zero.StringFrom("{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}"),
+		Status:                  zero.StringFrom(""),
+		BusinessOwnerOrg:        zero.StringFrom("Information Systems Team"),
+		BusinessOwnerOrgComp:    zero.StringFrom("IST"),
+		SystemMaintainerOrg:     zero.StringFrom("Division of Quality Assurance"),
+		SystemMaintainerOrgComp: zero.StringFrom("DQA"),
 	},
 	"{11AB1A00-1234-5678-ABC1-1A001B00CC1B}": {
-		ID:                      "{11AB1A00-1234-5678-ABC1-1A001B00CC1B}",
-		Name:                    "Office of Funny Walks",
-		Acronym:                 "OFW",
-		Description:             "Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis.",
-		VersionID:               "{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}",
-		Status:                  "",
-		BusinessOwnerOrg:        "Information Systems Team",
-		BusinessOwnerOrgComp:    "IST",
-		SystemMaintainerOrg:     "Division of Quality Assurance",
-		SystemMaintainerOrgComp: "DQA",
+		ID:                      zero.StringFrom("{11AB1A00-1234-5678-ABC1-1A001B00CC1B}"),
+		Name:                    zero.StringFrom("Office of Funny Walks"),
+		Acronym:                 zero.StringFrom("OFW"),
+		Description:             zero.StringFrom("Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis."),
+		VersionID:               zero.StringFrom("{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}"),
+		Status:                  zero.StringFrom(""),
+		BusinessOwnerOrg:        zero.StringFrom("Information Systems Team"),
+		BusinessOwnerOrgComp:    zero.StringFrom("IST"),
+		SystemMaintainerOrg:     zero.StringFrom("Division of Quality Assurance"),
+		SystemMaintainerOrgComp: zero.StringFrom("DQA"),
 	},
 	"{11AB1A00-1234-5678-ABC1-1A001B00CC2C}": {
-		ID:                      "{11AB1A00-1234-5678-ABC1-1A001B00CC2C}",
-		Name:                    "Quality Assurance Team",
-		Acronym:                 "QAT",
-		Description:             "Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis.",
-		VersionID:               "{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}",
-		Status:                  "",
-		BusinessOwnerOrg:        "Information Systems Team",
-		BusinessOwnerOrgComp:    "IST",
-		SystemMaintainerOrg:     "Division of Quality Assurance",
-		SystemMaintainerOrgComp: "DQA",
+		ID:                      zero.StringFrom("{11AB1A00-1234-5678-ABC1-1A001B00CC2C}"),
+		Name:                    zero.StringFrom("Quality Assurance Team"),
+		Acronym:                 zero.StringFrom("QAT"),
+		Description:             zero.StringFrom("Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis."),
+		VersionID:               zero.StringFrom("{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}"),
+		Status:                  zero.StringFrom(""),
+		BusinessOwnerOrg:        zero.StringFrom("Information Systems Team"),
+		BusinessOwnerOrgComp:    zero.StringFrom("IST"),
+		SystemMaintainerOrg:     zero.StringFrom("Division of Quality Assurance"),
+		SystemMaintainerOrgComp: zero.StringFrom("DQA"),
 	},
 	"{11AB1A00-1234-5678-ABC1-1A001B00CC3D}": {
-		ID:                      "{11AB1A00-1234-5678-ABC1-1A001B00CC3D}",
-		Name:                    "Strategic Work Information Management System",
-		Acronym:                 "SWIMS",
-		Description:             "Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis.",
-		VersionID:               "{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}",
-		Status:                  "",
-		BusinessOwnerOrg:        "Managerial Mission Management",
-		BusinessOwnerOrgComp:    "MMM",
-		SystemMaintainerOrg:     "Division of Divisive Divergence",
-		SystemMaintainerOrgComp: "DODD",
+		ID:                      zero.StringFrom("{11AB1A00-1234-5678-ABC1-1A001B00CC3D}"),
+		Name:                    zero.StringFrom("Strategic Work Information Management System"),
+		Acronym:                 zero.StringFrom("SWIMS"),
+		Description:             zero.StringFrom("Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis."),
+		VersionID:               zero.StringFrom("{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}"),
+		Status:                  zero.StringFrom(""),
+		BusinessOwnerOrg:        zero.StringFrom("Managerial Mission Management"),
+		BusinessOwnerOrgComp:    zero.StringFrom("MMM"),
+		SystemMaintainerOrg:     zero.StringFrom("Division of Divisive Divergence"),
+		SystemMaintainerOrgComp: zero.StringFrom("DODD"),
 	},
 	"{11AB1A00-1234-5678-ABC1-1A001B00CC4E}": {
-		ID:                      "{11AB1A00-1234-5678-ABC1-1A001B00CC4E}",
-		Name:                    "Center for Central Centrifugal Certainty",
-		Acronym:                 "CCCC",
-		Description:             "Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis.",
-		VersionID:               "{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}",
-		Status:                  "",
-		BusinessOwnerOrg:        "Managerial Mission Management",
-		BusinessOwnerOrgComp:    "MMM",
-		SystemMaintainerOrg:     "Division of Divisive Divergence",
-		SystemMaintainerOrgComp: "DODD",
+		ID:                      zero.StringFrom("{11AB1A00-1234-5678-ABC1-1A001B00CC4E}"),
+		Name:                    zero.StringFrom("Center for Central Centrifugal Certainty"),
+		Acronym:                 zero.StringFrom("CCCC"),
+		Description:             zero.StringFrom("Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis."),
+		VersionID:               zero.StringFrom("{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}"),
+		Status:                  zero.StringFrom(""),
+		BusinessOwnerOrg:        zero.StringFrom("Managerial Mission Management"),
+		BusinessOwnerOrgComp:    zero.StringFrom("MMM"),
+		SystemMaintainerOrg:     zero.StringFrom("Division of Divisive Divergence"),
+		SystemMaintainerOrgComp: zero.StringFrom("DODD"),
 	},
 }
 
@@ -87,7 +86,7 @@ func GetMockSystems() []*models.CedarSystem {
 func GetFilteredMockSystems() []*models.CedarSystem {
 	systems := GetMockSystems()
 	sort.Slice(systems, func(i, j int) bool {
-		return systems[i].ID < systems[j].ID
+		return systems[i].ID.String < systems[j].ID.String
 	})
 
 	if len(systems) >= 2 {
@@ -108,93 +107,93 @@ func GetMockSystem(systemID string) *models.CedarSystem {
 
 var mockRoleTypes = []*models.CedarRoleType{
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID01}",
-		Application: "alfabet",
-		Name:        "API Contact",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID01}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("API Contact"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID02}",
-		Application: "alfabet",
-		Name:        "Business Question Contact",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID02}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("Business Question Contact"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID03}",
-		Application: "alfabet",
-		Name:        "Survey Point of Contact",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID03}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("Survey Point of Contact"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID04}",
-		Application: "alfabet",
-		Name:        "Government Task Lead (GTL)",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID04}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("Government Task Lead (GTL)"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID05}",
-		Application: "alfabet",
-		Name:        "Support Staff",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID05}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("Support Staff"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID06}",
-		Application: "alfabet",
-		Name:        "System Maintainer",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID06}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("System Maintainer"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID07}",
-		Application: "alfabet",
-		Name:        "ISSO",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID07}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("ISSO"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID08}",
-		Application: "alfabet",
-		Name:        "Contracting Officer's Representative (COR)",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID08}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("Contracting Officer's Representative (COR)"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID09}",
-		Application: "alfabet",
-		Name:        "Business Owner",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID09}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("Business Owner"),
 		Description: zero.StringFrom("The organization or person in the business who owns the application and thus is typically responsible for managing the functional requirements."),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID10}",
-		Application: "alfabet",
-		Name:        "Subject Matter Expert (SME)",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID10}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("Subject Matter Expert (SME)"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID11}",
-		Application: "alfabet",
-		Name:        "Technical System Issues Contact",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID11}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("Technical System Issues Contact"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID12}",
-		Application: "alfabet",
-		Name:        "Budget Analyst",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID12}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("Budget Analyst"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID13}",
-		Application: "alfabet",
-		Name:        "Data Center Contact",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID13}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("Data Center Contact"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID14}",
-		Application: "alfabet",
-		Name:        "Project Lead",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID14}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("Project Lead"),
 		Description: zero.StringFromPtr(nil),
 	},
 	{
-		ID:          "{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID15}",
-		Application: "alfabet",
-		Name:        "AI Contact",
+		ID:          zero.StringFrom("{FAKE12AB-12A3-12a1-1AB2-ROLETYPEID15}"),
+		Application: zero.StringFrom("alfabet"),
+		Name:        zero.StringFrom("AI Contact"),
 		Description: zero.StringFromPtr(nil),
 	},
 }
@@ -207,7 +206,7 @@ func GetMockRoleTypes() []*models.CedarRoleType {
 // GetMockRoleTypeByRoleTypeID returns a single role type by ID
 func GetMockRoleTypeByRoleTypeID(roleTypeID string) *models.CedarRoleType {
 	for _, rt := range mockRoleTypes {
-		if rt.ID == roleTypeID {
+		if rt.ID.String == roleTypeID {
 			return rt
 		}
 	}
@@ -215,8 +214,11 @@ func GetMockRoleTypeByRoleTypeID(roleTypeID string) *models.CedarRoleType {
 }
 
 // GetMockSystemRoles returns mocked roles for a single CEDAR system, filtered by role type ID
-func GetMockSystemRoles(cedarSystemID string, roleTypeID null.String) []*models.CedarRole {
-	roleTypeIDStr := roleTypeID.String
+func GetMockSystemRoles(cedarSystemID string, roleTypeID *string) []*models.CedarRole {
+	var roleTypeIDStr string
+	if roleTypeID != nil {
+		roleTypeIDStr = *roleTypeID
+	}
 	roleTypes := GetMockRoleTypes()
 	users := getMockUserData()
 	mockSystemRoles := []*models.CedarRole{}
@@ -227,15 +229,15 @@ func GetMockSystemRoles(cedarSystemID string, roleTypeID null.String) []*models.
 		rt *models.CedarRoleType,
 	) *models.CedarRole {
 		return &models.CedarRole{
-			Application:       "alfabet", // should always be "alfabet"
-			ObjectID:          cedarSystemID,
+			Application:       zero.StringFrom("alfabet"), // should always be "alfabet"
+			ObjectID:          zero.StringFrom(cedarSystemID),
 			AssigneeType:      helpers.PointerTo(models.PersonAssignee),
 			AssigneeUsername:  zero.StringFrom(user.Username),
 			AssigneeEmail:     zero.StringFrom(fmt.Sprintf(`%s.%s@fake.local`, user.FirstName, user.LastName)),
 			AssigneeFirstName: zero.StringFrom(user.FirstName),
 			AssigneeLastName:  zero.StringFrom(user.LastName),
 			AssigneePhone:     zero.StringFrom("123-456-7890"),
-			RoleTypeName:      zero.StringFrom(rt.Name),
+			RoleTypeName:      rt.Name,
 			RoleTypeDesc:      rt.Description,
 			RoleTypeID:        rt.ID,
 			RoleID:            zero.StringFrom(roleID),
@@ -243,7 +245,7 @@ func GetMockSystemRoles(cedarSystemID string, roleTypeID null.String) []*models.
 	}
 	for i, rt := range roleTypes {
 		// if role type ID was provided and does not match current role type ID, don't add it to results
-		if roleTypeIDStr != "" && roleTypeIDStr != rt.ID {
+		if roleTypeIDStr != "" && roleTypeIDStr != rt.ID.String {
 			continue
 		}
 		role := makeMockRoleFromUserAndRoleType(

--- a/pkg/models/cedar_authority_to_operate.go
+++ b/pkg/models/cedar_authority_to_operate.go
@@ -1,32 +1,31 @@
 package models
 
 import (
-	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
 )
 
 // CedarAuthorityToOperate is the model for ATO information that comes back from the CEDAR Core API
 type CedarAuthorityToOperate struct {
 	// always-present fields
-	CedarID               string   `json:"cedarId"`
-	UUID                  string   `json:"uuid"`
-	SystemOfRecordsNotice []string `json:"systemOfRecordsNotice"`
+	CedarID               zero.String   `json:"cedarId"`
+	UUID                  zero.String   `json:"uuid"`
+	SystemOfRecordsNotice []zero.String `json:"systemOfRecordsNotice"`
 
 	// possibly-null fields
 	ActualDispositionDate                     zero.Time   `json:"actualDispositionDate"`
-	ContainsPersonallyIdentifiableInformation null.Bool   `json:"containsPersonallyIdentifiableInformation"`
-	CountOfTotalNonPrivilegedUserPopulation   null.Int    `json:"countOfTotalNonPrivilegedUserPopulation"`
-	CountOfOpenPoams                          null.Int    `json:"countOfOpenPoams"`
-	CountOfTotalPrivilegedUserPopulation      null.Int    `json:"countOfTotalPrivilegedUserPopulation"`
+	ContainsPersonallyIdentifiableInformation bool        `json:"containsPersonallyIdentifiableInformation"`
+	CountOfTotalNonPrivilegedUserPopulation   int         `json:"countOfTotalNonPrivilegedUserPopulation"`
+	CountOfOpenPoams                          int         `json:"countOfOpenPoams"`
+	CountOfTotalPrivilegedUserPopulation      int         `json:"countOfTotalPrivilegedUserPopulation"`
 	DateAuthorizationMemoExpires              zero.Time   `json:"dateAuthorizationMemoExpires"`
 	DateAuthorizationMemoSigned               zero.Time   `json:"dateAuthorizationMemoSigned"`
 	EAuthenticationLevel                      zero.String `json:"eAuthenticationLevel"`
-	Fips199OverallImpactRating                null.Int    `json:"fips199OverallImpactRating"`
+	Fips199OverallImpactRating                int         `json:"fips199OverallImpactRating"`
 	FismaSystemAcronym                        zero.String `json:"fismaSystemAcronym"`
 	FismaSystemName                           zero.String `json:"fismaSystemName"`
-	IsAccessedByNonOrganizationalUsers        null.Bool   `json:"isAccessedByNonOrganizationalUsers"`
-	IsPiiLimitedToUserNameAndPass             null.Bool   `json:"isPiiLimitedToUserNameAndPass"`
-	IsProtectedHealthInformation              null.Bool   `json:"isProtectedHealthInformation"`
+	IsAccessedByNonOrganizationalUsers        bool        `json:"isAccessedByNonOrganizationalUsers"`
+	IsPiiLimitedToUserNameAndPass             bool        `json:"isPiiLimitedToUserNameAndPass"`
+	IsProtectedHealthInformation              bool        `json:"isProtectedHealthInformation"`
 	LastActScaDate                            zero.Time   `json:"lastActScaDate"`
 	LastAssessmentDate                        zero.Time   `json:"lastAssessmentDate"`
 	LastContingencyPlanCompletionDate         zero.Time   `json:"lastContingencyPlanCompletionDate"`
@@ -34,8 +33,8 @@ type CedarAuthorityToOperate struct {
 	PiaCompletionDate                         zero.Time   `json:"piaCompletionDate"`
 	PrimaryCyberRiskAdvisor                   zero.String `json:"primaryCyberRiskAdvisor"`
 	PrivacySubjectMatterExpert                zero.String `json:"privacySubjectMatterExpert"`
-	RecoveryPointObjective                    null.Float  `json:"recoveryPointObjective"`
-	RecoveryTimeObjective                     null.Float  `json:"recoveryTimeObjective"`
+	RecoveryPointObjective                    float64     `json:"recoveryPointObjective"`
+	RecoveryTimeObjective                     float64     `json:"recoveryTimeObjective"`
 	TLCPhase                                  zero.String `json:"tlcPhase"`
 	XLCPhase                                  zero.String `json:"xlcPhase"`
 }

--- a/pkg/models/cedar_deployment.go
+++ b/pkg/models/cedar_deployment.go
@@ -26,9 +26,9 @@ type CedarDataCenter struct {
 // CedarDeployment represents a single Deployment object returned from the CEDAR API
 type CedarDeployment struct {
 	// always-present fields
-	ID       string
-	Name     string
-	SystemID string
+	ID       zero.String
+	Name     zero.String
+	SystemID zero.String
 
 	// possibly-null fields
 	StartDate                zero.Time

--- a/pkg/models/cedar_exchange.go
+++ b/pkg/models/cedar_exchange.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
 )
 
@@ -17,17 +16,17 @@ const (
 
 // CedarExchangeTypeOfDataItem is one item of the TypeofData slice in a CedarExchange
 type CedarExchangeTypeOfDataItem struct {
-	ID   string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+	ID   zero.String `json:"id,omitempty"`
+	Name zero.String `json:"name,omitempty"`
 }
 
 // CedarExchange contains information about how data is exchanged between a CEDAR system and another system
 type CedarExchange struct {
-	ConnectionFrequency        []string                       `json:"connectionFrequency"`
-	ContainsBankingData        null.Bool                      `json:"containsBankingData,omitempty"`
-	ContainsBeneficiaryAddress null.Bool                      `json:"containsBeneficiaryAddress,omitempty"`
-	ContainsPhi                null.Bool                      `json:"containsPhi,omitempty"`
-	ContainsPii                null.Bool                      `json:"containsPii,omitempty"`
+	ConnectionFrequency        []zero.String                  `json:"connectionFrequency"`
+	ContainsBankingData        bool                           `json:"containsBankingData,omitempty"`
+	ContainsBeneficiaryAddress bool                           `json:"containsBeneficiaryAddress,omitempty"`
+	ContainsPhi                bool                           `json:"containsPhi,omitempty"`
+	ContainsPii                bool                           `json:"containsPii,omitempty"`
 	DataExchangeAgreement      zero.String                    `json:"dataExchangeAgreement,omitempty"`
 	DataFormat                 zero.String                    `json:"dataFormat,omitempty"`
 	DataFormatOther            zero.String                    `json:"dataFormatOther,omitempty"`
@@ -43,9 +42,9 @@ type CedarExchange struct {
 	FromOwnerID                zero.String                    `json:"fromOwnerId,omitempty"`
 	FromOwnerName              zero.String                    `json:"fromOwnerName,omitempty"`
 	FromOwnerType              zero.String                    `json:"fromOwnerType,omitempty"`
-	IsBeneficiaryMailingFile   null.Bool                      `json:"isBeneficiaryMailingFile,omitempty"`
+	IsBeneficiaryMailingFile   bool                           `json:"isBeneficiaryMailingFile,omitempty"`
 	NumOfRecords               zero.String                    `json:"numOfRecords,omitempty"`
-	SharedViaAPI               null.Bool                      `json:"sharedViaApi,omitempty"`
+	SharedViaAPI               bool                           `json:"sharedViaApi,omitempty"`
 	ToOwnerID                  zero.String                    `json:"toOwnerId,omitempty"`
 	ToOwnerName                zero.String                    `json:"toOwnerName,omitempty"`
 	ToOwnerType                zero.String                    `json:"toOwnerType,omitempty"`

--- a/pkg/models/cedar_role.go
+++ b/pkg/models/cedar_role.go
@@ -16,9 +16,9 @@ const (
 // CedarRole is the model for the role that a user holds for some system
 type CedarRole struct {
 	// always-present fields
-	Application string // should always be "alfabet"
-	ObjectID    string // ID of the system that the role is assigned to
-	RoleTypeID  string
+	Application zero.String // should always be "alfabet"
+	ObjectID    zero.String // ID of the system that the role is assigned to
+	RoleTypeID  zero.String
 
 	// possibly-null fields
 	AssigneeType      *CedarAssigneeType
@@ -40,9 +40,9 @@ type CedarRole struct {
 // CedarRoleType is the model for a type of role that a user or organization can hold for some system, i.e. "Business Owner" or "Project Lead"
 type CedarRoleType struct {
 	// always-present fields
-	ID          string
-	Application string // should always be "alfabet"
-	Name        string
+	ID          zero.String
+	Application zero.String // should always be "alfabet"
+	Name        zero.String
 
 	// possibly-null fields
 	Description zero.String

--- a/pkg/models/cedar_software_products.go
+++ b/pkg/models/cedar_software_products.go
@@ -1,16 +1,15 @@
 package models
 
 import (
-	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
 )
 
 // SoftwareProductItem represents a single SoftwareProductSearchItem object which is an internal struct used in SoftwareProduct
 type SoftwareProductItem struct {
-	APIGatewayUse                  null.Bool   `json:"api_gateway_use,omitempty"`
+	APIGatewayUse                  bool        `json:"api_gateway_use,omitempty"`
 	ElaPurchase                    zero.String `json:"ela_purchase,omitempty"`
 	ElaVendorID                    zero.String `json:"ela_vendor_id,omitempty"`
-	ProvidesAiCapability           null.Bool   `json:"provides_ai_capability,omitempty"`
+	ProvidesAiCapability           bool        `json:"provides_ai_capability,omitempty"`
 	Refstr                         zero.String `json:"refstr,omitempty"`
 	SoftwareCatagoryConnectionGUID zero.String `json:"softwareCatagoryConnectionGuid,omitempty"`
 	SoftwareVendorConnectionGUID   zero.String `json:"softwareVendorConnectionGuid,omitempty"`
@@ -36,10 +35,10 @@ type CedarSoftwareProducts struct {
 	APIDescPublished    zero.String `json:"apiDescPublished,omitempty"`
 	APIFHIRUse          zero.String `json:"apiFHIRUse,omitempty"`
 	APIFHIRUseOther     zero.String `json:"apiFHIRUseOther,omitempty"`
-	APIHasPortal        null.Bool   `json:"apiHasPortal,omitempty"`
+	APIHasPortal        bool        `json:"apiHasPortal,omitempty"`
 	ApisAccessibility   zero.String `json:"apisAccessibility,omitempty"`
 	ApisDeveloped       zero.String `json:"apisDeveloped,omitempty"`
 	DevelopmentStage    zero.String `json:"developmentStage,omitempty"`
-	SystemHasAPIGateway null.Bool   `json:"systemHasApiGateway,omitempty"`
+	SystemHasAPIGateway bool        `json:"systemHasApiGateway,omitempty"`
 	UsesAiTech          zero.String `json:"usesAiTech,omitempty"`
 }

--- a/pkg/models/cedar_system.go
+++ b/pkg/models/cedar_system.go
@@ -1,62 +1,66 @@
 package models
 
+import (
+	"github.com/guregu/null/zero"
+)
+
 // CedarSystem is the model for a single system that comes back from the CEDAR Core API
 type CedarSystem struct {
-	ID                      string `json:"id"`
-	Name                    string `json:"name"`
-	Description             string `json:"description"`
-	Acronym                 string `json:"acronym"`
-	Status                  string `json:"status"`
-	BusinessOwnerOrg        string `json:"businessOwnerOrg"`
-	BusinessOwnerOrgComp    string `json:"businessOwnerOrgComp"`
-	SystemMaintainerOrg     string `json:"systemMaintainerOrg"`
-	SystemMaintainerOrgComp string `json:"systemMaintainerOrgComp"`
-	VersionID               string `json:"versionId"`
+	ID                      zero.String `json:"id"`
+	Name                    zero.String `json:"name"`
+	Description             zero.String `json:"description"`
+	Acronym                 zero.String `json:"acronym"`
+	Status                  zero.String `json:"status"`
+	BusinessOwnerOrg        zero.String `json:"businessOwnerOrg"`
+	BusinessOwnerOrgComp    zero.String `json:"businessOwnerOrgComp"`
+	SystemMaintainerOrg     zero.String `json:"systemMaintainerOrg"`
+	SystemMaintainerOrgComp zero.String `json:"systemMaintainerOrgComp"`
+	VersionID               zero.String `json:"versionId"`
 }
 
 // BusinessOwnerInformation contains information about the business owner for a CEDAR system
 type BusinessOwnerInformation struct {
-	BeneficiaryAddressPurpose      []string `json:"beneficiaryAddressPurpose"`
-	BeneficiaryAddressPurposeOther string   `json:"beneficiaryAddressPurposeOther"`
-	BeneficiaryAddressSource       []string `json:"beneficiaryAddressSource"`
-	BeneficiaryAddressSourceOther  string   `json:"beneficiaryAddressSourceOther"`
-	CostPerYear                    string   `json:"costPerYear"`
-	IsCmsOwned                     bool     `json:"isCmsOwned"`
-	NumberOfContractorFte          string   `json:"numberOfContractorFte"`
-	NumberOfFederalFte             string   `json:"numberOfFederalFte"`
-	NumberOfSupportedUsersPerMonth string   `json:"numberOfSupportedUsersPerMonth"`
-	StoresBankingData              bool     `json:"storesBankingData"`
-	StoresBeneficiaryAddress       bool     `json:"storesBeneficiaryAddress"`
+	BeneficiaryAddressPurpose      []zero.String `json:"beneficiaryAddressPurpose"`
+	BeneficiaryAddressPurposeOther zero.String   `json:"beneficiaryAddressPurposeOther"`
+	BeneficiaryAddressSource       []zero.String `json:"beneficiaryAddressSource"`
+	BeneficiaryAddressSourceOther  zero.String   `json:"beneficiaryAddressSourceOther"`
+	CostPerYear                    zero.String   `json:"costPerYear"`
+	IsCmsOwned                     bool          `json:"isCmsOwned"`
+	NumberOfContractorFte          zero.String   `json:"numberOfContractorFte"`
+	NumberOfFederalFte             zero.String   `json:"numberOfFederalFte"`
+	NumberOfSupportedUsersPerMonth zero.String   `json:"numberOfSupportedUsersPerMonth"`
+	StoresBankingData              bool          `json:"storesBankingData"`
+	StoresBeneficiaryAddress       bool          `json:"storesBeneficiaryAddress"`
 }
 
 // SystemMaintainerInformation contains information about the system maintainer of a CEDAR system
 type SystemMaintainerInformation struct {
-	AgileUsed                  bool     `json:"agileUsed"`
-	BusinessArtifactsOnDemand  bool     `json:"businessArtifactsOnDemand"`
-	DeploymentFrequency        string   `json:"deploymentFrequency"`
-	DevCompletionPercent       string   `json:"devCompletionPercent"`
-	DevWorkDescription         string   `json:"devWorkDescription"`
-	EcapParticipation          bool     `json:"ecapParticipation"`
-	FrontendAccessType         string   `json:"frontendAccessType"`
-	HardCodedIPAddress         bool     `json:"hardCodedIpAddress"`
-	IP6EnabledAssetPercent     string   `json:"ip6EnabledAssetPercent"`
-	IP6TransitionPlan          string   `json:"ip6TransitionPlan"`
-	IPEnabledAssetCount        int32    `json:"ipEnabledAssetCount"`
-	MajorRefreshDate           string   `json:"majorRefreshDate"`
-	NetAccessibility           string   `json:"netAccessibility"`
-	OmDocumentationOnDemand    bool     `json:"omDocumentationOnDemand"`
-	PlansToRetireReplace       string   `json:"plansToRetireReplace"`
-	QuarterToRetireReplace     string   `json:"quarterToRetireReplace"`
-	RecordsManagementBucket    []string `json:"recordsManagementBucket"`
-	SourceCodeOnDemand         bool     `json:"sourceCodeOnDemand"`
-	SystemCustomization        string   `json:"systemCustomization"`
-	SystemDesignOnDemand       bool     `json:"systemDesignOnDemand"`
-	SystemProductionDate       string   `json:"systemProductionDate"`
-	SystemRequirementsOnDemand bool     `json:"systemRequirementsOnDemand"`
-	TestPlanOnDemand           bool     `json:"testPlanOnDemand"`
-	TestReportsOnDemand        bool     `json:"testReportsOnDemand"`
-	TestScriptsOnDemand        bool     `json:"testScriptsOnDemand"`
-	YearToRetireReplace        string   `json:"yearToRetireReplace"`
+	AgileUsed                  bool          `json:"agileUsed"`
+	BusinessArtifactsOnDemand  bool          `json:"businessArtifactsOnDemand"`
+	DeploymentFrequency        zero.String   `json:"deploymentFrequency"`
+	DevCompletionPercent       zero.String   `json:"devCompletionPercent"`
+	DevWorkDescription         zero.String   `json:"devWorkDescription"`
+	EcapParticipation          bool          `json:"ecapParticipation"`
+	FrontendAccessType         zero.String   `json:"frontendAccessType"`
+	HardCodedIPAddress         bool          `json:"hardCodedIpAddress"`
+	IP6EnabledAssetPercent     zero.String   `json:"ip6EnabledAssetPercent"`
+	IP6TransitionPlan          zero.String   `json:"ip6TransitionPlan"`
+	IPEnabledAssetCount        int           `json:"ipEnabledAssetCount"`
+	MajorRefreshDate           zero.Time     `json:"majorRefreshDate"`
+	NetAccessibility           zero.String   `json:"netAccessibility"`
+	OmDocumentationOnDemand    bool          `json:"omDocumentationOnDemand"`
+	PlansToRetireReplace       zero.String   `json:"plansToRetireReplace"`
+	QuarterToRetireReplace     zero.String   `json:"quarterToRetireReplace"`
+	RecordsManagementBucket    []zero.String `json:"recordsManagementBucket"`
+	SourceCodeOnDemand         bool          `json:"sourceCodeOnDemand"`
+	SystemCustomization        zero.String   `json:"systemCustomization"`
+	SystemDesignOnDemand       bool          `json:"systemDesignOnDemand"`
+	SystemProductionDate       zero.Time     `json:"systemProductionDate"`
+	SystemRequirementsOnDemand bool          `json:"systemRequirementsOnDemand"`
+	TestPlanOnDemand           bool          `json:"testPlanOnDemand"`
+	TestReportsOnDemand        bool          `json:"testReportsOnDemand"`
+	TestScriptsOnDemand        bool          `json:"testScriptsOnDemand"`
+	YearToRetireReplace        zero.String   `json:"yearToRetireReplace"`
 }
 
 // CedarSystemDetails contains more detailed information related to a CEDAR system

--- a/pkg/models/cedar_threat.go
+++ b/pkg/models/cedar_threat.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
 )
 
@@ -10,7 +9,7 @@ type CedarThreat struct {
 	// possibly-null fields
 	AlternativeID     zero.String `json:"alternativeId"`
 	ControlFamily     zero.String `json:"controlFamily"`
-	DaysOpen          null.Int    `json:"daysOpen"`
+	DaysOpen          int         `json:"daysOpen"`
 	ID                zero.String `json:"id"`
 	ParentID          zero.String `json:"parentId"`
 	Type              zero.String `json:"type"`

--- a/pkg/models/cedar_url.go
+++ b/pkg/models/cedar_url.go
@@ -1,20 +1,19 @@
 package models
 
 import (
-	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
 )
 
 // CedarURL represents a single URL object returned from the CEDAR API
 type CedarURL struct {
 	// always-present field
-	ID string
+	ID zero.String
 
 	// possibly-null fields
 
 	Address                        zero.String // The actual URL.
-	IsBehindWebApplicationFirewall null.Bool
-	IsAPIEndpoint                  null.Bool
-	IsVersionCodeRepository        null.Bool   // Represents whether this URL provides access to a versioned code repository.
+	IsBehindWebApplicationFirewall bool
+	IsAPIEndpoint                  bool
+	IsVersionCodeRepository        bool        // Represents whether this URL provides access to a versioned code repository.
 	URLHostingEnv                  zero.String // This should correspond with .DeploymentType on a CedarDeployment object.
 }

--- a/pkg/models/model_helpers.go
+++ b/pkg/models/model_helpers.go
@@ -1,6 +1,9 @@
 package models
 
-import "github.com/lib/pq"
+import (
+	"github.com/guregu/null/zero"
+	"github.com/lib/pq"
+)
 
 // ConvertEnums converts a pq.StringArray to specific, castable type
 func ConvertEnums[EnumType ~string](pqGroups pq.StringArray) []EnumType {
@@ -15,4 +18,20 @@ func ConvertEnums[EnumType ~string](pqGroups pq.StringArray) []EnumType {
 func HTMLPointer(input string) *HTML {
 	html := HTML(input)
 	return &html
+}
+
+func ZeroStringsFrom(strs []string) []zero.String {
+	retStrs := []zero.String{}
+	for _, s := range strs {
+		retStrs = append(retStrs, zero.StringFrom(s))
+	}
+	return retStrs
+}
+
+func StringsFromZeroStrs(zs []zero.String) []string {
+	retStrs := []string{}
+	for _, s := range zs {
+		retStrs = append(retStrs, s.String)
+	}
+	return retStrs
 }


### PR DESCRIPTION
# NOREF

## Changes and Description

The code generator for the client defaults to zero values, so there's not much use wrapping them in the `null` package types.

- Removes `null` package types from CEDAR core client. 
- Replaces nil pointer dereferences with `zero.String` types for safety in the client.

## How to test this change

- Run the test suites
- Use Postman to test CEDAR resolvers
- Use client to check Systems tab content

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
