### PR TITLE
[NOREF] Replace Context calls

### DIFF
--- a/pkg/dataloaders/user_info_loader.go
+++ b/pkg/dataloaders/user_info_loader.go
@@ -24,13 +24,15 @@ func (loaders *DataLoaders) BatchUserInfos(
 
 	userInfos, err := loaders.FetchUserInfos(ctx, euas)
 	if err != nil {
-		appcontext.ZLogger(ctx).Error("Error fetching user infos", zap.Error(err))
+		appcontext.ZLogger(ctx).Error("Error fetching user infos from Okta", zap.Error(err))
 		return results
 	}
 
-	// In the case of a Context cancellation, we'll get back an entirely empty slice
-	// In this case, we don't want to return any errors at all
-	// Just return empty results
+	// If we didn't get an error back, yet there's still an empty slice, we can assume
+	// that the Context was cancelled
+	//
+	// In this case, we don't want to return any errors at all, but
+	// instead just return empty results
 	if len(userInfos) == 0 {
 		appcontext.ZLogger(ctx).Warn("Empty EUA results from FetchUserInfos")
 		return results

--- a/pkg/dataloaders/user_info_loader.go
+++ b/pkg/dataloaders/user_info_loader.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/graph-gophers/dataloader"
 
+	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
@@ -29,6 +30,14 @@ func (loaders *DataLoaders) BatchUserInfos(
 
 	for _, userInfo := range userInfos {
 		euaUserInfoMap[userInfo.Username] = userInfo
+	}
+
+	// In the case of a Context cancellation, we'll get back an entirely empty slice
+	// In this case, we don't want to return any errors at all
+	// Just return empty resultsd
+	if len(userInfos) == 0 {
+		appcontext.ZLogger(ctx).Warn("Empty EUA results from FetchUserInfos")
+		return results
 	}
 
 	for i, key := range keys {

--- a/pkg/graph/resolvers/system_intake_system.go
+++ b/pkg/graph/resolvers/system_intake_system.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/dataloaders"
@@ -19,14 +20,14 @@ func SystemIntakeSystems(
 
 	siSystems, err := dataloaders.GetSystemIntakeSystemsBySystemIntakeID(ctx, systemIntakeID)
 	if err != nil {
-		appcontext.ZLogger(ctx).Error("unable to retrieve cedar system ids from db")
+		appcontext.ZLogger(ctx).Error("unable to retrieve cedar system ids from db", zap.Error(err))
 		return nil, err
 	}
 	systems := []*models.CedarSystem{}
 	for _, v := range siSystems {
 		cedarSystemSummary, err := getCedarSystem(ctx, v.SystemID)
 		if err != nil {
-			appcontext.ZLogger(ctx).Error("unable to retrieve system from cedar")
+			appcontext.ZLogger(ctx).Error("unable to retrieve system from cedar", zap.Error(err))
 			continue
 		}
 		systems = append(systems, cedarSystemSummary)

--- a/pkg/graph/resolvers/trb_request_system.go
+++ b/pkg/graph/resolvers/trb_request_system.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/pkg/appcontext"
 	"github.com/cmsgov/easi-app/pkg/dataloaders"
@@ -19,14 +20,14 @@ func TRBRequestSystems(
 
 	trbRequests, err := dataloaders.GetTRBRequestSystemsByTRBRequestID(ctx, trbRequestID)
 	if err != nil {
-		appcontext.ZLogger(ctx).Error("unable to retrieve cedar system ids from db")
+		appcontext.ZLogger(ctx).Error("unable to retrieve cedar system ids from db", zap.Error(err))
 		return nil, err
 	}
 	systems := []*models.CedarSystem{}
 	for _, v := range trbRequests {
 		cedarSystemSummary, err := getCedarSystem(ctx, v.SystemID)
 		if err != nil {
-			appcontext.ZLogger(ctx).Error("unable to retrieve system from cedar")
+			appcontext.ZLogger(ctx).Error("unable to retrieve system from cedar", zap.Error(err))
 			continue
 		}
 		systems = append(systems, cedarSystemSummary)

--- a/pkg/oktaapi/client_wrapper.go
+++ b/pkg/oktaapi/client_wrapper.go
@@ -108,11 +108,14 @@ func (cw *ClientWrapper) FetchUserInfos(ctx context.Context, usernames []string)
 			logger.Error("Error searching Okta users", zap.Error(err), zap.String("usernames", strings.Join(usernames, ", ")))
 			return nil, err
 		}
-		// If it's a context cancellation, log as such and continue on
+		// err is a context cancellation error, log as such and continue on
 		logger.Warn("Context cancelled while searching Okta users", zap.Error(err))
 		return nil, nil
 	}
 
+	// API call was a success, but no users were found.
+	// We consider this an error, since we're expecting to find users
+	// since this isn't a "search", but a lookup by EUA ID
 	if len(searchedUsers) == 0 {
 		appcontext.ZLogger(ctx).Error("no users found when calling FetchUserInfos", zap.String("usernames", strings.Join(usernames, ",")))
 		return users, fmt.Errorf("no users found")

--- a/pkg/oktaapi/client_wrapper.go
+++ b/pkg/oktaapi/client_wrapper.go
@@ -110,6 +110,12 @@ func (cw *ClientWrapper) FetchUserInfos(ctx context.Context, usernames []string)
 		}
 		// If it's a context cancellation, log as such and continue on
 		logger.Warn("Context cancelled while searching Okta users", zap.Error(err))
+		return nil, nil
+	}
+
+	if len(searchedUsers) == 0 {
+		appcontext.ZLogger(ctx).Error("no users found when calling FetchUserInfos", zap.String("usernames", strings.Join(usernames, ",")))
+		return users, fmt.Errorf("no users found")
 	}
 
 	for _, user := range searchedUsers {

--- a/pkg/oktaapi/client_wrapper.go
+++ b/pkg/oktaapi/client_wrapper.go
@@ -108,7 +108,7 @@ func (cw *ClientWrapper) FetchUserInfos(ctx context.Context, usernames []string)
 			logger.Error("Error searching Okta users", zap.Error(err), zap.String("usernames", strings.Join(usernames, ", ")))
 			return nil, err
 		}
-		// err is a context cancellation error, log as such and continue on
+		// err is a context cancellation error, log and return early
 		logger.Warn("Context cancelled while searching Okta users", zap.Error(err))
 		return nil, nil
 	}

--- a/pkg/storage/system_intake_contract_number.go
+++ b/pkg/storage/system_intake_contract_number.go
@@ -21,7 +21,7 @@ func (s *Store) SetSystemIntakeContractNumbers(ctx context.Context, tx *sqlx.Tx,
 		return errors.New("unexpected nil system intake ID when linking system intake to contract numbers")
 	}
 
-	if _, err := tx.NamedExecContext(ctx, sqlqueries.SystemIntakeContractNumberForm.Delete, map[string]interface{}{
+	if _, err := tx.NamedExec(sqlqueries.SystemIntakeContractNumberForm.Delete, map[string]interface{}{
 		"contract_numbers": pq.StringArray(contractNumbers),
 		"system_intake_id": systemIntakeID,
 	}); err != nil {
@@ -48,7 +48,7 @@ func (s *Store) SetSystemIntakeContractNumbers(ctx context.Context, tx *sqlx.Tx,
 		setSystemIntakeContractNumbersLinks[i] = contractNumberLink
 	}
 
-	if _, err := tx.NamedExecContext(ctx, sqlqueries.SystemIntakeContractNumberForm.Set, setSystemIntakeContractNumbersLinks); err != nil {
+	if _, err := tx.NamedExec(sqlqueries.SystemIntakeContractNumberForm.Set, setSystemIntakeContractNumbersLinks); err != nil {
 		appcontext.ZLogger(ctx).Error("Failed to insert linked system intake to contract numbers", zap.Error(err))
 		return err
 	}
@@ -58,14 +58,14 @@ func (s *Store) SetSystemIntakeContractNumbers(ctx context.Context, tx *sqlx.Tx,
 
 // SystemIntakeContractNumbersBySystemIntakeIDLOADER gets multiple groups of Contract Numbers by System Intake ID
 func (s *Store) SystemIntakeContractNumbersBySystemIntakeIDLOADER(ctx context.Context, paramTableJSON string) (map[string][]*models.SystemIntakeContractNumber, error) {
-	stmt, err := s.db.PrepareNamedContext(ctx, sqlqueries.SystemIntakeContractNumberForm.SelectBySystemIntakeIDLOADER)
+	stmt, err := s.db.PrepareNamed(sqlqueries.SystemIntakeContractNumberForm.SelectBySystemIntakeIDLOADER)
 	if err != nil {
 		return nil, err
 	}
 	defer stmt.Close()
 
 	var contracts []*models.SystemIntakeContractNumber
-	err = stmt.SelectContext(ctx, &contracts, map[string]interface{}{
+	err = stmt.Select(&contracts, map[string]interface{}{
 		"param_table_json": paramTableJSON,
 	})
 	if err != nil {

--- a/pkg/storage/system_intake_contract_number_test.go
+++ b/pkg/storage/system_intake_contract_number_test.go
@@ -122,7 +122,7 @@ func (s *StoreTestSuite) TestLinkSystemIntakeContractNumbers() {
 
 		s.True(fourthContractTime.After(firstThreeContractsTime))
 
-		_, err = s.db.ExecContext(ctx, "DELETE FROM system_intakes WHERE id = ANY($1)", pq.Array(createdIDs))
+		_, err = s.db.Exec("DELETE FROM system_intakes WHERE id = ANY($1)", pq.Array(createdIDs))
 		s.NoError(err)
 	})
 }

--- a/pkg/storage/system_intake_system.go
+++ b/pkg/storage/system_intake_system.go
@@ -21,7 +21,7 @@ func (s *Store) SetSystemIntakeSystems(ctx context.Context, tx *sqlx.Tx, systemI
 		return errors.New("unexpected nil system intake ID when linking system intake to system id")
 	}
 
-	if _, err := tx.NamedExecContext(ctx, sqlqueries.SystemIntakeSystemForm.Delete, map[string]interface{}{
+	if _, err := tx.NamedExec(sqlqueries.SystemIntakeSystemForm.Delete, map[string]interface{}{
 		"system_ids":       pq.StringArray(systemIDs),
 		"system_intake_id": systemIntakeID,
 	}); err != nil {
@@ -48,7 +48,7 @@ func (s *Store) SetSystemIntakeSystems(ctx context.Context, tx *sqlx.Tx, systemI
 		setSystemIntakeSystemsLinks[i] = systemIDLink
 	}
 
-	if _, err := tx.NamedExecContext(ctx, sqlqueries.SystemIntakeSystemForm.Set, setSystemIntakeSystemsLinks); err != nil {
+	if _, err := tx.NamedExec(sqlqueries.SystemIntakeSystemForm.Set, setSystemIntakeSystemsLinks); err != nil {
 		appcontext.ZLogger(ctx).Error("Failed to insert linked system intake to system ids", zap.Error(err))
 		return err
 	}
@@ -58,14 +58,14 @@ func (s *Store) SetSystemIntakeSystems(ctx context.Context, tx *sqlx.Tx, systemI
 
 // SystemIntakeSystemsBySystemIntakeIDLOADER gets multiple groups of system ids by System Intake ID
 func (s *Store) SystemIntakeSystemsBySystemIntakeIDLOADER(ctx context.Context, paramTableJSON string) (map[string][]*models.SystemIntakeSystem, error) {
-	stmt, err := s.db.PrepareNamedContext(ctx, sqlqueries.SystemIntakeSystemForm.SelectBySystemIntakeIDLOADER)
+	stmt, err := s.db.PrepareNamed(sqlqueries.SystemIntakeSystemForm.SelectBySystemIntakeIDLOADER)
 	if err != nil {
 		return nil, err
 	}
 	defer stmt.Close()
 
 	var systems []*models.SystemIntakeSystem
-	err = stmt.SelectContext(ctx, &systems, map[string]interface{}{
+	err = stmt.Select(&systems, map[string]interface{}{
 		"param_table_json": paramTableJSON,
 	})
 	if err != nil {

--- a/pkg/storage/system_intake_system_test.go
+++ b/pkg/storage/system_intake_system_test.go
@@ -122,7 +122,7 @@ func (s *StoreTestSuite) TestLinkSystemIntakeSystems() {
 
 		s.True(fourthsystemTime.After(firstThreesystemsTime))
 
-		_, err = s.db.ExecContext(ctx, "DELETE FROM system_intakes WHERE id = ANY($1)", pq.Array(createdIDs))
+		_, err = s.db.Exec("DELETE FROM system_intakes WHERE id = ANY($1)", pq.Array(createdIDs))
 		s.NoError(err)
 	})
 }

--- a/pkg/storage/trb_request_contract_number.go
+++ b/pkg/storage/trb_request_contract_number.go
@@ -21,7 +21,7 @@ func (s *Store) SetTRBRequestContractNumbers(ctx context.Context, tx *sqlx.Tx, t
 		return errors.New("unexpected nil TRB Request ID when linking TRB Request to contract numbers")
 	}
 
-	if _, err := tx.NamedExecContext(ctx, sqlqueries.TRBRequestContractNumbersForm.Delete, map[string]interface{}{
+	if _, err := tx.NamedExec(sqlqueries.TRBRequestContractNumbersForm.Delete, map[string]interface{}{
 		"contract_numbers": pq.Array(contractNumbers),
 		"trb_request_id":   trbRequestID,
 	}); err != nil {
@@ -48,7 +48,7 @@ func (s *Store) SetTRBRequestContractNumbers(ctx context.Context, tx *sqlx.Tx, t
 		setTRBRequestContractNumbersLinks[i] = contractNumberLink
 	}
 
-	if _, err := tx.NamedExecContext(ctx, sqlqueries.TRBRequestContractNumbersForm.Set, setTRBRequestContractNumbersLinks); err != nil {
+	if _, err := tx.NamedExec(sqlqueries.TRBRequestContractNumbersForm.Set, setTRBRequestContractNumbersLinks); err != nil {
 		appcontext.ZLogger(ctx).Error("Failed to insert linked TRB Request to contract numbers", zap.Error(err))
 		return err
 	}
@@ -58,14 +58,14 @@ func (s *Store) SetTRBRequestContractNumbers(ctx context.Context, tx *sqlx.Tx, t
 
 // TRBRequestContractNumbersByTRBRequestIDLOADER gets multiple groups of Contract Numbers by TRB Request ID
 func (s *Store) TRBRequestContractNumbersByTRBRequestIDLOADER(ctx context.Context, paramTableJSON string) (map[string][]*models.TRBRequestContractNumber, error) {
-	stmt, err := s.db.PrepareNamedContext(ctx, sqlqueries.TRBRequestContractNumbersForm.SelectByTRBRequestIDLOADER)
+	stmt, err := s.db.PrepareNamed(sqlqueries.TRBRequestContractNumbersForm.SelectByTRBRequestIDLOADER)
 	if err != nil {
 		return nil, err
 	}
 	defer stmt.Close()
 
 	var contracts []*models.TRBRequestContractNumber
-	err = stmt.SelectContext(ctx, &contracts, map[string]interface{}{
+	err = stmt.Select(&contracts, map[string]interface{}{
 		"param_table_json": paramTableJSON,
 	})
 	if err != nil {

--- a/pkg/storage/trb_request_contract_number_test.go
+++ b/pkg/storage/trb_request_contract_number_test.go
@@ -112,7 +112,7 @@ func (s *StoreTestSuite) TestLinkTRBRequestContractNumbers() {
 
 		s.True(fourthContractTime.After(firstThreeContractsTime))
 
-		_, err = s.db.ExecContext(ctx, "DELETE FROM trb_request WHERE id = ANY($1)", pq.Array(createdIDs))
+		_, err = s.db.Exec("DELETE FROM trb_request WHERE id = ANY($1)", pq.Array(createdIDs))
 		s.NoError(err)
 	})
 }

--- a/pkg/storage/trb_request_system.go
+++ b/pkg/storage/trb_request_system.go
@@ -21,7 +21,7 @@ func (s *Store) SetTRBRequestSystems(ctx context.Context, tx *sqlx.Tx, trbReques
 		return errors.New("unexpected nil trb request ID when linking trb request to system id")
 	}
 
-	if _, err := tx.NamedExecContext(ctx, sqlqueries.TRBRequestSystemForm.Delete, map[string]interface{}{
+	if _, err := tx.NamedExec(sqlqueries.TRBRequestSystemForm.Delete, map[string]interface{}{
 		"system_ids":     pq.StringArray(systemIDs),
 		"trb_request_id": trbRequestID,
 	}); err != nil {
@@ -48,7 +48,7 @@ func (s *Store) SetTRBRequestSystems(ctx context.Context, tx *sqlx.Tx, trbReques
 		setTRBRequestSystemsLinks[i] = systemIDLink
 	}
 
-	if _, err := tx.NamedExecContext(ctx, sqlqueries.TRBRequestSystemForm.Set, setTRBRequestSystemsLinks); err != nil {
+	if _, err := tx.NamedExec(sqlqueries.TRBRequestSystemForm.Set, setTRBRequestSystemsLinks); err != nil {
 		appcontext.ZLogger(ctx).Error("Failed to insert linked trb request to system ids", zap.Error(err))
 		return err
 	}
@@ -58,14 +58,14 @@ func (s *Store) SetTRBRequestSystems(ctx context.Context, tx *sqlx.Tx, trbReques
 
 // TRBRequestSystemsByTRBRequestIDLOADER gets multiple groups of system ids by TRB Request ID
 func (s *Store) TRBRequestSystemsByTRBRequestIDLOADER(ctx context.Context, paramTableJSON string) (map[string][]*models.TRBRequestSystem, error) {
-	stmt, err := s.db.PrepareNamedContext(ctx, sqlqueries.TRBRequestSystemForm.SelectByTRBRequestIDLOADER)
+	stmt, err := s.db.PrepareNamed(sqlqueries.TRBRequestSystemForm.SelectByTRBRequestIDLOADER)
 	if err != nil {
 		return nil, err
 	}
 	defer stmt.Close()
 
 	var systems []*models.TRBRequestSystem
-	err = stmt.SelectContext(ctx, &systems, map[string]interface{}{
+	err = stmt.Select(&systems, map[string]interface{}{
 		"param_table_json": paramTableJSON,
 	})
 	if err != nil {

--- a/pkg/storage/trb_request_system_test.go
+++ b/pkg/storage/trb_request_system_test.go
@@ -122,7 +122,7 @@ func (s *StoreTestSuite) TestLinkTRBRequestSystems() {
 
 		s.True(fourthsystemTime.After(firstThreesystemsTime))
 
-		_, err = s.db.ExecContext(ctx, "DELETE FROM trb_request WHERE id = ANY($1)", pq.Array(createdIDs))
+		_, err = s.db.Exec("DELETE FROM trb_request WHERE id = ANY($1)", pq.Array(createdIDs))
 		s.NoError(err)
 	})
 }


### PR DESCRIPTION
## Changes and Description

- Replaced some calls that used `Context` with ones that don't. This can have some (IMO) minor performance downsides, but I think for our application is probably a cleaner approach
- Added some extra logging of `err` objects to ensure we have clear error content

The point of this PR is to hopefully reduce the number of errors that we seem to get alerted on that have to deal with `Context Canceled` which, generally speaking, aren't worthy of an alert (and aren't even really considered an error for us)

## How to test this change

TBD

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
