### PR TITLE
[NOREF] Higher level "RequestType" attempt

### DIFF
--- a/src/components/LinkCard/index.stories.tsx
+++ b/src/components/LinkCard/index.stories.tsx
@@ -8,5 +8,5 @@ export default {
 };
 
 export const Default = () => {
-  return <LinkCard type="TRB" />;
+  return <LinkCard type="trb" />;
 };

--- a/src/components/LinkCard/index.test.tsx
+++ b/src/components/LinkCard/index.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import LinkCard from './index';
 
 describe('LinkCard', () => {
-  const wrapper = shallow(<LinkCard type="TRB" />);
+  const wrapper = shallow(<LinkCard type="trb" />);
   it('renders without crashing', () => {
     expect(wrapper.length).toEqual(1);
   });

--- a/src/components/LinkCard/index.tsx
+++ b/src/components/LinkCard/index.tsx
@@ -5,12 +5,11 @@ import { Button, IconArrowForward } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 
 import UswdsReactLink from 'components/LinkWrapper';
-
-export type LinkRequestType = 'ITGov' | 'TRB' | '508';
+import { RequestType } from 'types/requestType';
 
 type LinkCardProps = {
   className?: string;
-  type: LinkRequestType;
+  type: RequestType;
 } & JSX.IntrinsicElements['div'];
 
 const LinkCard = ({ className, type }: LinkCardProps) => {

--- a/src/i18n/en-US/home.ts
+++ b/src/i18n/en-US/home.ts
@@ -56,7 +56,7 @@ const home = {
   },
   actionTitle: 'Available services',
   actions: {
-    ITGov: {
+    itgov: {
       heading: 'IT Governance',
       body:
         'Get approval for a new IT project, apply for a new Life Cycle ID (LCID), and amend an existing LCID.',
@@ -74,7 +74,7 @@ const home = {
       button: 'Start a 508 testing request',
       buttonLink: '/508/testing-overview?continue=true'
     },
-    TRB: {
+    trb: {
       heading: 'Technical assistance',
       body:
         'Get help, feedback, and guidance for your IT project, courtesy of the Technical Review Board (TRB).',

--- a/src/views/AdditionalInformation/index.tsx
+++ b/src/views/AdditionalInformation/index.tsx
@@ -7,6 +7,7 @@ import PageHeading from 'components/PageHeading';
 import SystemCardTable from 'components/SystemCard/table';
 import { GetTrbRequestSummary_trbRequest as TrbRequest } from 'queries/types/GetTrbRequestSummary';
 import { SystemIntake } from 'queries/types/SystemIntake';
+import { RequestType } from 'types/requestType';
 import formatContractNumbers from 'utils/formatContractNumbers';
 
 const AdditionalInformation = ({
@@ -14,7 +15,7 @@ const AdditionalInformation = ({
   type
 }: {
   request: TrbRequest | SystemIntake;
-  type: 'itgov' | 'trb';
+  type: RequestType;
 }) => {
   const { t } = useTranslation('admin');
 

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -5,11 +5,12 @@ import { withRouter } from 'react-router-dom';
 import { Grid } from '@trussworks/react-uswds';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 
-import LinkCard, { LinkRequestType } from 'components/LinkCard';
+import LinkCard from 'components/LinkCard';
 import MainContent from 'components/MainContent';
 import PageHeading from 'components/PageHeading';
 import useMessage from 'hooks/useMessage';
 import { AppState } from 'reducers/rootReducer';
+import { RequestType } from 'types/requestType';
 import user from 'utils/user';
 import List from 'views/Accessibility/AccessibilityRequest/List';
 import Table from 'views/MyRequests/Table';
@@ -29,6 +30,8 @@ const Home = () => {
   const flags = useFlags();
 
   const { Message } = useMessage();
+
+  const requestTypes: RequestType[] = ['itgov', 'trb'];
 
   const renderView = () => {
     if (isUserSet) {
@@ -89,12 +92,9 @@ const Home = () => {
               </h2>
 
               <Grid row gap={2}>
-                {['ITGov', 'TRB'].map(requestType => (
+                {requestTypes.map(requestType => (
                   <Grid tablet={{ col: 6 }} key={requestType}>
-                    <LinkCard
-                      className="margin-top-1"
-                      type={requestType as LinkRequestType}
-                    />
+                    <LinkCard className="margin-top-1" type={requestType} />
                   </Grid>
                 ))}
               </Grid>


### PR DESCRIPTION
An attempt to consolidate "Request Types" for the frontend to switch between "TRB" and "System Intake" contexts for abstract component modes.

`types/requestType#RequestType` is the recent thought for this, but is there a better name for this? This pr can simply be a rename for this new reference.

There are some name collisions that we may want to sort out between FE and BE types
- [graphql-global-types.ts#RequestType](https://github.com/CMSgov/easi-app/blob/main/src/types/graphql-global-types.ts#L181-L184) exists but the options are only: `ACCESSIBILITY_REQUEST`, `GOVERNANCE_REQUEST`
- `types/systemIntake#RequestType` already exists on the FE, do we leave this? Or maybe rename to `SystemIntakeRequestType`? And then do the same for the other `TRBRequestType`?