### PR TITLE
[NOREF] Update cy.wait when using Okta search dropdown from 1000 to 3000

### DIFF
--- a/cypress/e2e/governanceReviewTeam.cy.js
+++ b/cypress/e2e/governanceReviewTeam.cy.js
@@ -561,7 +561,7 @@ describe('Governance Review Team', () => {
 
     cy.get('#react-select-IntakeForm-ContactCommonName-input')
       .type('Aaron A')
-      .wait(1000)
+      .wait(3000)
       .type('{downArrow}{enter}')
       .should('have.value', 'Aaron Adams, ADMN (aaron.adams@local.fake)');
 

--- a/cypress/support/systemIntake.js
+++ b/cypress/support/systemIntake.js
@@ -7,7 +7,7 @@ cy.systemIntake = {
 
       cy.get('#react-select-IntakeForm-BusinessOwnerName-input')
         .type('Audrey')
-        .wait(1000)
+        .wait(3000)
         .type('{downarrow}{enter}')
         .should('have.value', 'Audrey Abrams, ADMI (audrey.abrams@local.fake)');
 
@@ -22,7 +22,7 @@ cy.systemIntake = {
 
       cy.get('#react-select-IntakeForm-ProductManagerName-input')
         .type('Delphia')
-        .wait(1000)
+        .wait(3000)
         .type('{downArrow}{enter}')
         .should('have.value', 'Delphia Green, GBRG (delphia.green@local.fake)');
 


### PR DESCRIPTION
## Changes and Description

- Updates `.wait()` commands used when searching Okta users from `1000` to `3000` to help avoid test flakes

### Example failures:
- [On main](https://github.com/CMSgov/easi-app/actions/runs/8392887076/job/22986683666)
- [On a PR](https://github.com/CMSgov/easi-app/actions/runs/8391681993/job/22982709102)

## How to test this change

- Ensure E2E tests still pass in CI!

I'll re-run the job on here a few times to ensure it doesn't flake

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
