### PR TITLE
Fixed navbar hover style

### DIFF
--- a/src/components/NavigationBar/index.scss
+++ b/src/components/NavigationBar/index.scss
@@ -84,8 +84,8 @@
     }
 }
 
-.easi-nav .usa-current:not(.system-dropdown)::after {
-    bottom: -.25rem !important;
+.usa-header--basic .usa-nav__link:not(.system-dropdown):hover::after {
+    bottom: 0rem !important;
 }
 
 .usa-nav__submenu {


### PR DESCRIPTION
# NOREF
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

Not sure where this was recently introduced, but a navbar style was overridden, causing the hover/current underline to not be in the correct position for all tabs, except for System.

- Fixed style on `NavigationBar` to align underline positions

<!-- Put a description here! -->

## How to test this change

Verify on hover, that all navigation bar underlines are in correct position

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
