### PR TITLE
EASI-4160 Remove Contract number from ITGO linking flows

### DIFF
--- a/pkg/graph/resolvers/system_intake_relation.go
+++ b/pkg/graph/resolvers/system_intake_relation.go
@@ -41,10 +41,12 @@ func SetSystemIntakeRelationExistingService(
 		if err := store.SetSystemIntakeSystems(ctx, tx, input.SystemIntakeID, []string{}); err != nil {
 			return nil, err
 		}
+
 		// Delete & recreate contract number relationships
-		if err := store.SetSystemIntakeContractNumbers(ctx, tx, input.SystemIntakeID, input.ContractNumbers); err != nil {
-			return nil, err
-		}
+		// DISABLED: See Note [EASI-4160 Disable Contract Number Linking]
+		// if err := store.SetSystemIntakeContractNumbers(ctx, tx, input.SystemIntakeID, input.ContractNumbers); err != nil {
+		// 	return nil, err
+		// }
 
 		return updatedIntake, nil
 	})
@@ -78,10 +80,12 @@ func SetSystemIntakeRelationNewSystem(
 		if err := store.SetSystemIntakeSystems(ctx, tx, input.SystemIntakeID, []string{}); err != nil {
 			return nil, err
 		}
+
 		// Delete & recreate contract number relationships
-		if err := store.SetSystemIntakeContractNumbers(ctx, tx, input.SystemIntakeID, input.ContractNumbers); err != nil {
-			return nil, err
-		}
+		// DISABLED: See Note [EASI-4160 Disable Contract Number Linking]
+		// if err := store.SetSystemIntakeContractNumbers(ctx, tx, input.SystemIntakeID, input.ContractNumbers); err != nil {
+		// 	return nil, err
+		// }
 
 		return updatedIntake, nil
 	})
@@ -123,10 +127,12 @@ func SetSystemIntakeRelationExistingSystem(
 		if err := store.SetSystemIntakeSystems(ctx, tx, input.SystemIntakeID, input.CedarSystemIDs); err != nil {
 			return nil, err
 		}
+
 		// Delete & recreate contract number relationships
-		if err := store.SetSystemIntakeContractNumbers(ctx, tx, input.SystemIntakeID, input.ContractNumbers); err != nil {
-			return nil, err
-		}
+		// DISABLED: See Note [EASI-4160 Disable Contract Number Linking]
+		// if err := store.SetSystemIntakeContractNumbers(ctx, tx, input.SystemIntakeID, input.ContractNumbers); err != nil {
+		// 	return nil, err
+		// }
 
 		return updatedIntake, nil
 	})
@@ -155,12 +161,13 @@ func UnlinkSystemIntakeRelation(
 		// Clear contract number relationships by setting an empty array of contract #'s
 		// declare this as an explicit empty slice instead of `nil`
 		// TODO: (Sam) update `SetSystemIntakeContractNumbers` to allow for `nil`
-		if err = store.SetSystemIntakeContractNumbers(ctx, tx, intakeID, []string{}); err != nil {
-			return nil, err
-		}
+		// DISABLED: See Note [EASI-4160 Disable Contract Number Linking]
+		// if err := store.SetSystemIntakeContractNumbers(ctx, tx, intakeID, []string{}); err != nil {
+		// 	return nil, err
+		// }
 
 		// Clear CEDAR system relationships
-		if err = store.SetSystemIntakeSystems(ctx, tx, intakeID, []string{}); err != nil {
+		if err := store.SetSystemIntakeSystems(ctx, tx, intakeID, []string{}); err != nil {
 			return nil, err
 		}
 
@@ -173,3 +180,9 @@ func UnlinkSystemIntakeRelation(
 		return updatedIntake, nil
 	})
 }
+
+/*
+	Note [EASI-4160 Disable Contract Number Linking]
+	We have temporarily disabled contract number linking from the UI Linking page as it allows for submitted System Intakes to be edited. These
+	submitted System Intakes should be immutable, and the new linking functionality does not adhere to that.
+*/

--- a/pkg/graph/resolvers/system_intake_relation_test.go
+++ b/pkg/graph/resolvers/system_intake_relation_test.go
@@ -128,10 +128,13 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationNewSystem() {
 			}
 
 			// Ensure the contract numbers were modified properly
-			suite.Equal(len(caseValues.NewContractNumbers), len(updatedIntakeContractNumbers))
-			for _, v := range updatedIntakeContractNumbers {
-				suite.Contains(caseValues.NewContractNumbers, v.ContractNumber)
-			}
+			// skip the following test, see Note [EASI-4160 Disable Contract Number Linking]
+			// suite.Equal(len(caseValues.NewContractNumbers), len(updatedIntakeContractNumbers))
+			// for _, v := range updatedIntakeContractNumbers {
+			// 	suite.Contains(caseValues.NewContractNumbers, v.ContractNumber)
+			// }
+			// temp, remove after the above is uncommented
+			_ = updatedIntakeContractNumbers
 
 			// Check relation type
 			suite.NotNil(updatedIntake.SystemRelationType)
@@ -251,10 +254,13 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingSystem() {
 			}
 
 			// Ensure the contract numbers were modified properly
-			suite.Equal(len(caseValues.NewContractNumbers), len(updatedIntakeContractNumbers))
-			for _, v := range updatedIntakeContractNumbers {
-				suite.Contains(caseValues.NewContractNumbers, v.ContractNumber)
-			}
+			// skip the following test, see Note [EASI-4160 Disable Contract Number Linking]
+			// suite.Equal(len(caseValues.NewContractNumbers), len(updatedIntakeContractNumbers))
+			// for _, v := range updatedIntakeContractNumbers {
+			// 	suite.Contains(caseValues.NewContractNumbers, v.ContractNumber)
+			// }
+			// temp, remove when above is uncommented
+			_ = updatedIntakeContractNumbers
 
 			// Check relation type
 			suite.NotNil(updatedIntake.SystemRelationType)
@@ -372,10 +378,13 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingService() {
 
 			// Ensure the contract numbers were modified properly
 			// Existing Service relation should always remove existing system IDs
-			suite.Equal(len(caseValues.NewContractNumbers), len(updatedIntakeContractNumbers))
-			for _, v := range updatedIntakeContractNumbers {
-				suite.Contains(caseValues.NewContractNumbers, v.ContractNumber)
-			}
+			// skip the following test, see Note [EASI-4160 Disable Contract Number Linking]
+			// suite.Equal(len(caseValues.NewContractNumbers), len(updatedIntakeContractNumbers))
+			// for _, v := range updatedIntakeContractNumbers {
+			// 	suite.Contains(caseValues.NewContractNumbers, v.ContractNumber)
+			// }
+			// temp, remove after the above is uncommented
+			_ = updatedIntakeContractNumbers
 
 			// Check relation type
 			suite.NotNil(updatedIntake.SystemRelationType)
@@ -425,9 +434,10 @@ func (suite *ResolverSuite) TestUnlinkSystemIntakeRelation() {
 		suite.Nil(unlinkedIntake.SystemRelationType)
 
 		// Check contract numbers are cleared
-		nums, err := SystemIntakeContractNumbers(ctx, unlinkedIntake.ID)
-		suite.NoError(err)
-		suite.Empty(nums)
+		// skip the following test, see Note [EASI-4160 Disable Contract Number Linking]
+		// nums, err := SystemIntakeContractNumbers(ctx, unlinkedIntake.ID)
+		// suite.NoError(err)
+		// suite.Empty(nums)
 
 		// Check system IDs are cleared
 		systemIDs, err := SystemIntakeSystems(ctx, mockGetCedarSystem, unlinkedIntake.ID)
@@ -471,9 +481,10 @@ func (suite *ResolverSuite) TestUnlinkSystemIntakeRelation() {
 		suite.Nil(unlinkedIntake.SystemRelationType)
 
 		// Check contract numbers are cleared
-		nums, err := SystemIntakeContractNumbers(ctx, unlinkedIntake.ID)
-		suite.NoError(err)
-		suite.Empty(nums)
+		// skip the following test, see Note [EASI-4160 Disable Contract Number Linking]
+		// nums, err := SystemIntakeContractNumbers(ctx, unlinkedIntake.ID)
+		// suite.NoError(err)
+		// suite.Empty(nums)
 
 		// Check system IDs are cleared
 		systemIDs, err := SystemIntakeSystems(ctx, mockGetCedarSystem, unlinkedIntake.ID)

--- a/src/views/AdditionalInformation/index.tsx
+++ b/src/views/AdditionalInformation/index.tsx
@@ -69,18 +69,19 @@ const AdditionalInformation = ({
         </div>
       )}
 
-      {request.contractNumbers?.length > 0 && (
-        <div className="margin-top-3">
-          <strong>
-            {t('contractNumber', {
-              count: request.contractNumbers.length
-            })}
-          </strong>
-          <p className="margin-top-1">
-            {formatContractNumbers(request.contractNumbers)}
-          </p>
-        </div>
-      )}
+      {type !== 'itgov' && // Hide the contract number field from itgov, see Note [EASI-4160 Disable Contract Number Linking]
+        request.contractNumbers?.length > 0 && (
+          <div className="margin-top-3">
+            <strong>
+              {t('contractNumber', {
+                count: request.contractNumbers.length
+              })}
+            </strong>
+            <p className="margin-top-1">
+              {formatContractNumbers(request.contractNumbers)}
+            </p>
+          </div>
+        )}
     </div>
   );
 };

--- a/src/views/GovernanceTaskList/AdditionalRequestInfo.tsx
+++ b/src/views/GovernanceTaskList/AdditionalRequestInfo.tsx
@@ -143,21 +143,22 @@ function AdditionalRequestInfo({
         </p>
       )}
 
-      {system.relationType !== null && (
-        <p>
-          <span className="text-base">
-            {t('additionalRequestInfo.contractNumber')}
-          </span>
-          <br />
-          {system.contractNumbers.length ? (
-            formatContractNumbers(system.contractNumbers)
-          ) : (
-            <em className="text-base">
-              {t('additionalRequestInfo.noContractNumber')}
-            </em>
-          )}
-        </p>
-      )}
+      {system.requestType !== 'itgov' && // Hide the contract number field from itgov, see Note [EASI-4160 Disable Contract Number Linking]
+        system.relationType !== null && (
+          <p>
+            <span className="text-base">
+              {t('additionalRequestInfo.contractNumber')}
+            </span>
+            <br />
+            {system.contractNumbers.length ? (
+              formatContractNumbers(system.contractNumbers)
+            ) : (
+              <em className="text-base">
+                {t('additionalRequestInfo.noContractNumber')}
+              </em>
+            )}
+          </p>
+        )}
     </div>
   );
 }

--- a/src/views/RequestLinkForm/index.tsx
+++ b/src/views/RequestLinkForm/index.tsx
@@ -479,28 +479,29 @@ const RequestLinkForm = ({
                     checked={relation === RequestRelationType.NEW_SYSTEM}
                   />
 
-                  {relation === RequestRelationType.NEW_SYSTEM && (
-                    <Controller
-                      name="contractNumbers"
-                      control={control}
-                      render={({ field }) => (
-                        <FormGroup className="margin-left-4">
-                          <Label
-                            htmlFor="contractNumber"
-                            hint={t('link.form.field.contractNumberNew.help')}
-                          >
-                            {t('link.form.field.contractNumberNew.label')}
-                          </Label>
-                          <TextInput
-                            {...field}
-                            ref={null}
-                            id="contractNumbers"
-                            type="text"
-                          />
-                        </FormGroup>
-                      )}
-                    />
-                  )}
+                  {relation === RequestRelationType.NEW_SYSTEM &&
+                    requestType === 'trb' && ( // Hide the contract number field from itgov
+                      <Controller
+                        name="contractNumbers"
+                        control={control}
+                        render={({ field }) => (
+                          <FormGroup className="margin-left-4">
+                            <Label
+                              htmlFor="contractNumber"
+                              hint={t('link.form.field.contractNumberNew.help')}
+                            >
+                              {t('link.form.field.contractNumberNew.label')}
+                            </Label>
+                            <TextInput
+                              {...field}
+                              ref={null}
+                              id="contractNumbers"
+                              type="text"
+                            />
+                          </FormGroup>
+                        )}
+                      />
+                    )}
 
                   {/* Existing system */}
                   <Radio
@@ -544,30 +545,32 @@ const RequestLinkForm = ({
                         )}
                       />
 
-                      <Controller
-                        name="contractNumbers"
-                        control={control}
-                        render={({ field }) => (
-                          <FormGroup>
-                            <Label
-                              htmlFor="contractNumber"
-                              hint={t(
-                                'link.form.field.contractNumberExisting.help'
-                              )}
-                            >
-                              {t(
-                                'link.form.field.contractNumberExisting.label'
-                              )}
-                            </Label>
-                            <TextInput
-                              {...field}
-                              ref={null}
-                              id="contractNumbers"
-                              type="text"
-                            />
-                          </FormGroup>
-                        )}
-                      />
+                      {requestType === 'trb' && ( // Hide the contract number field from itgov
+                        <Controller
+                          name="contractNumbers"
+                          control={control}
+                          render={({ field }) => (
+                            <FormGroup>
+                              <Label
+                                htmlFor="contractNumber"
+                                hint={t(
+                                  'link.form.field.contractNumberExisting.help'
+                                )}
+                              >
+                                {t(
+                                  'link.form.field.contractNumberExisting.label'
+                                )}
+                              </Label>
+                              <TextInput
+                                {...field}
+                                ref={null}
+                                id="contractNumbers"
+                                type="text"
+                              />
+                            </FormGroup>
+                          )}
+                        />
+                      )}
                     </div>
                   )}
 
@@ -607,30 +610,32 @@ const RequestLinkForm = ({
                         )}
                       />
 
-                      <Controller
-                        name="contractNumbers"
-                        control={control}
-                        render={({ field }) => (
-                          <FormGroup>
-                            <Label
-                              htmlFor="contractNumber"
-                              hint={t(
-                                'link.form.field.contractNumberExisting.help'
-                              )}
-                            >
-                              {t(
-                                'link.form.field.contractNumberExisting.label'
-                              )}
-                            </Label>
-                            <TextInput
-                              {...field}
-                              ref={null}
-                              id="contractNumbers"
-                              type="text"
-                            />
-                          </FormGroup>
-                        )}
-                      />
+                      {requestType === 'trb' && ( // Hide the contract number field from itgov
+                        <Controller
+                          name="contractNumbers"
+                          control={control}
+                          render={({ field }) => (
+                            <FormGroup>
+                              <Label
+                                htmlFor="contractNumber"
+                                hint={t(
+                                  'link.form.field.contractNumberExisting.help'
+                                )}
+                              >
+                                {t(
+                                  'link.form.field.contractNumberExisting.label'
+                                )}
+                              </Label>
+                              <TextInput
+                                {...field}
+                                ref={null}
+                                id="contractNumbers"
+                                type="text"
+                              />
+                            </FormGroup>
+                          )}
+                        />
+                      )}
                     </div>
                   )}
                 </Fieldset>

--- a/src/views/RequestLinkForm/index.tsx
+++ b/src/views/RequestLinkForm/index.tsx
@@ -480,7 +480,7 @@ const RequestLinkForm = ({
                   />
 
                   {relation === RequestRelationType.NEW_SYSTEM &&
-                    requestType === 'trb' && ( // Hide the contract number field from itgov, see Note [EASI-4160 Disable Contract Number Linking]
+                    requestType !== 'itgov' && ( // Hide the contract number field from itgov, see Note [EASI-4160 Disable Contract Number Linking]
                       <Controller
                         name="contractNumbers"
                         control={control}
@@ -545,7 +545,7 @@ const RequestLinkForm = ({
                         )}
                       />
 
-                      {requestType === 'trb' && ( // Hide the contract number field from itgov, see Note [EASI-4160 Disable Contract Number Linking]
+                      {requestType !== 'itgov' && ( // Hide the contract number field from itgov, see Note [EASI-4160 Disable Contract Number Linking]
                         <Controller
                           name="contractNumbers"
                           control={control}
@@ -610,7 +610,7 @@ const RequestLinkForm = ({
                         )}
                       />
 
-                      {requestType === 'trb' && ( // Hide the contract number field from itgov, see Note [EASI-4160 Disable Contract Number Linking]
+                      {requestType !== 'itgov' && ( // Hide the contract number field from itgov, see Note [EASI-4160 Disable Contract Number Linking]
                         <Controller
                           name="contractNumbers"
                           control={control}

--- a/src/views/RequestLinkForm/index.tsx
+++ b/src/views/RequestLinkForm/index.tsx
@@ -480,7 +480,7 @@ const RequestLinkForm = ({
                   />
 
                   {relation === RequestRelationType.NEW_SYSTEM &&
-                    requestType === 'trb' && ( // Hide the contract number field from itgov
+                    requestType === 'trb' && ( // Hide the contract number field from itgov, see Note [EASI-4160 Disable Contract Number Linking]
                       <Controller
                         name="contractNumbers"
                         control={control}
@@ -545,7 +545,7 @@ const RequestLinkForm = ({
                         )}
                       />
 
-                      {requestType === 'trb' && ( // Hide the contract number field from itgov
+                      {requestType === 'trb' && ( // Hide the contract number field from itgov, see Note [EASI-4160 Disable Contract Number Linking]
                         <Controller
                           name="contractNumbers"
                           control={control}
@@ -610,7 +610,7 @@ const RequestLinkForm = ({
                         )}
                       />
 
-                      {requestType === 'trb' && ( // Hide the contract number field from itgov
+                      {requestType === 'trb' && ( // Hide the contract number field from itgov, see Note [EASI-4160 Disable Contract Number Linking]
                         <Controller
                           name="contractNumbers"
                           control={control}


### PR DESCRIPTION
# EASI-4160

This hides the **Contract number** fields on the `itgov` link form. Since the field was already optional, hiding the ui was good enough.