### PR TITLE
[EASI-4160] manually update/unlink contract numbers with note reference

### DIFF
--- a/cmd/devdata/system_intake.go
+++ b/cmd/devdata/system_intake.go
@@ -347,7 +347,7 @@ func setSystemIntakeRelationExistingService(
 func unlinkSystemIntakeRelation(logger *zap.Logger, store *storage.Store, intakeID uuid.UUID) {
 	ctx := mock.CtxWithLoggerAndPrincipal(logger, store, intakeID.String())
 
-	// temp, manually unlink contractn umbers
+	// temp, manually unlink contract numbers
 	// see Note [EASI-4160 Disable Contract Number Linking]
 	if err := sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 		return store.SetSystemIntakeContractNumbers(ctx, tx, intakeID, []string{})

--- a/cmd/devdata/system_intake.go
+++ b/cmd/devdata/system_intake.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/guregu/null"
+	"github.com/jmoiron/sqlx"
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/easi-app/cmd/devdata/mock"
 	"github.com/cmsgov/easi-app/pkg/graph/model"
 	"github.com/cmsgov/easi-app/pkg/graph/resolvers"
 	"github.com/cmsgov/easi-app/pkg/models"
+	"github.com/cmsgov/easi-app/pkg/sqlutils"
 	"github.com/cmsgov/easi-app/pkg/storage"
 )
 
@@ -265,6 +267,15 @@ func setSystemIntakeRelationNewSystem(
 		SystemIntakeID:  intakeID,
 		ContractNumbers: contractNumbers,
 	}
+
+	// temp, manually set these contract numbers
+	// see Note [EASI-4160 Disable Contract Number Linking]
+	if err := sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
+		return store.SetSystemIntakeContractNumbers(ctx, tx, intakeID, contractNumbers)
+	}); err != nil {
+		panic(err)
+	}
+
 	if _, err := resolvers.SetSystemIntakeRelationNewSystem(ctx, store, input); err != nil {
 		panic(err)
 	}
@@ -283,6 +294,15 @@ func setSystemIntakeRelationExistingSystem(
 		ContractNumbers: contractNumbers,
 		CedarSystemIDs:  cedarSystemIDs,
 	}
+
+	// temp, manually set these contract numbers
+	// see Note [EASI-4160 Disable Contract Number Linking]
+	if err := sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
+		return store.SetSystemIntakeContractNumbers(ctx, tx, intakeID, contractNumbers)
+	}); err != nil {
+		panic(err)
+	}
+
 	_, err := resolvers.SetSystemIntakeRelationExistingSystem(
 		ctx,
 		store,
@@ -309,6 +329,15 @@ func setSystemIntakeRelationExistingService(
 		ContractName:    contractName,
 		ContractNumbers: contractNumbers,
 	}
+
+	// temp, manually set these contract numbers
+	// see Note [EASI-4160 Disable Contract Number Linking]
+	if err := sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
+		return store.SetSystemIntakeContractNumbers(ctx, tx, intakeID, contractNumbers)
+	}); err != nil {
+		panic(err)
+	}
+
 	_, err := resolvers.SetSystemIntakeRelationExistingService(ctx, store, input)
 	if err != nil {
 		panic(err)
@@ -317,6 +346,15 @@ func setSystemIntakeRelationExistingService(
 
 func unlinkSystemIntakeRelation(logger *zap.Logger, store *storage.Store, intakeID uuid.UUID) {
 	ctx := mock.CtxWithLoggerAndPrincipal(logger, store, intakeID.String())
+
+	// temp, manually unlink contractn umbers
+	// see Note [EASI-4160 Disable Contract Number Linking]
+	if err := sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
+		return store.SetSystemIntakeContractNumbers(ctx, tx, intakeID, []string{})
+	}); err != nil {
+		panic(err)
+	}
+
 	if _, err := resolvers.UnlinkSystemIntakeRelation(ctx, store, intakeID); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# EASI-4160
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

- manually link/unlink contract numbers while disabled in UI
- `Note [EASI-4160 Disable Contract Number Linking]`

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
