### PR TITLE
CI client_typecheck continue-on-error true (default)

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -251,4 +251,3 @@ jobs:
           cat test.log >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
           exit $result_code
-        continue-on-error: true

--- a/src/views/SystemProfile/mockSystemData.ts
+++ b/src/views/SystemProfile/mockSystemData.ts
@@ -53,7 +53,6 @@ export type tempSystemDataProp = {
 
 export const systemData: tempSystemDataProp[] = [
   {
-    id: '1',
     title: 'Beneficiary Information in the Cloud',
     status: 'Active',
     qualityStatus: 'Passed',

--- a/src/views/SystemProfile/mockSystemData.ts
+++ b/src/views/SystemProfile/mockSystemData.ts
@@ -53,6 +53,7 @@ export type tempSystemDataProp = {
 
 export const systemData: tempSystemDataProp[] = [
   {
+    id: '1',
     title: 'Beneficiary Information in the Cloud',
     status: 'Active',
     qualityStatus: 'Passed',


### PR DESCRIPTION
# NOREF
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

Make the CI typescript check error failures consistent with the local dev pre-commit typescript check requirement.