### PR TITLE
[NOREF] Modify Dockerfile to use from scratch instead of distroless (CVE-2024-2511)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,12 @@ COPY cmd/ ./cmd/
 COPY pkg/ ./pkg/
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin/easi ./cmd/easi
 
-FROM gcr.io/distroless/base:latest
+FROM scratch
 
 WORKDIR /easi/
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=base /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=build /easi/pkg/email/templates ./templates
 COPY --from=build /easi/bin/easi ./
 


### PR DESCRIPTION
## Changes and Description

- Modify Dockerfile to use `FROM scratch` to remove any extra container/OS-level dependencies that might cause vulnerability findings.

## How to test this change

- Ensure pipeline passes when building and pushing to ECR (`build_application_images` job)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
