### PR TITLE
[NOREF] Disable ECR findings blocking the GHA pipeline

### DIFF
--- a/.github/workflows/build_application_images.yml
+++ b/.github/workflows/build_application_images.yml
@@ -137,6 +137,9 @@ jobs:
       - name: Check for vulnerability scan findings
         run: |
           ./scripts/check_ecr_findings "easi-backend" "$GIT_HASH" "7"
+        # We've had too many issues with undefined or low-level vulnerabilities blocking our pipeline
+        # We're going to ignore them for now, but continue to scan and log them.
+        continue-on-error: true
       - name: Announce failure
         if: ${{ failure() }}
         run: |


### PR DESCRIPTION
## Changes and Description

- Disable functionality that blocked the GHA pipeline if an ECR finding was caught during an image scan. See comment for more details

## How to test this change

Ensure pipeline still passes. See examples below:
- [Failing job from another branch](https://github.com/CMSgov/easi-app/actions/runs/8619337558/job/23623792549?pr=2539)
- [Passing job from _this_ branch](https://github.com/CMSgov/easi-app/actions/runs/8620647886/job/23627880298?pr=2541#step:9:21)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
