### PR TITLE
[EASI-4129] Add logging to CEDAR core calls

### DIFF
--- a/pkg/cedar/core/client.go
+++ b/pkg/cedar/core/client.go
@@ -28,12 +28,18 @@ func (t *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	resp, err := http.DefaultTransport.RoundTrip(r)
 	end := time.Now().UnixMilli()
 
+	// Start a status code of 0, in case the request fails (and we get a nil resp)
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+	}
+
 	t.logger.Info(
 		"Call to CEDAR core",
 		zap.String("service", "cedarcore"),
 		zap.Bool("cacheEnabled", false),
 		zap.String("method", r.Method),
-		zap.Int("status", resp.StatusCode),
+		zap.Int("status", status),
 		zap.String("path", r.URL.Path),
 		zap.String("queryParams", r.URL.RawQuery),
 		zap.Int64("timeMS", end-start),

--- a/pkg/cedar/core/client.go
+++ b/pkg/cedar/core/client.go
@@ -19,11 +19,38 @@ const (
 	cedarCoreCacheDurationDefault = time.Hour * 6
 )
 
+type loggingTransport struct {
+	logger *zap.Logger
+}
+
+func (t *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	start := time.Now().UnixMilli()
+	resp, err := http.DefaultTransport.RoundTrip(r)
+	end := time.Now().UnixMilli()
+
+	t.logger.Info(
+		"Call to CEDAR core",
+		zap.String("service", "cedarcore"),
+		zap.Bool("cacheEnabled", false),
+		zap.String("method", r.Method),
+		zap.Int("status", resp.StatusCode),
+		zap.String("path", r.URL.Path),
+		zap.String("queryParams", r.URL.RawQuery),
+		zap.Int64("timeMS", end-start),
+	)
+
+	return resp, err
+}
+
 // NewClient builds the type that holds a connection to the CEDAR Core API
 func NewClient(ctx context.Context, cedarHost string, cedarAPIKey string, cedarAPIVersion string, cacheRefreshTime time.Duration, mockEnabled bool) *Client {
 	c := cache.New(cache.NoExpiration, cache.NoExpiration) // Don't expire data _or_ clean it up
 
-	hc := http.DefaultClient
+	hc := http.Client{
+		Transport: &loggingTransport{
+			logger: appcontext.ZLogger(ctx),
+		},
+	}
 
 	basePath := "/gateway/CEDAR Core API/" + cedarAPIVersion
 	client := &Client{
@@ -41,7 +68,7 @@ func NewClient(ctx context.Context, cedarHost string, cedarAPIKey string, cedarA
 			),
 			strfmt.Default,
 		),
-		hc:    hc,
+		hc:    &hc,
 		cache: c,
 	}
 


### PR DESCRIPTION
# EASI-4129

## Changes and Description

- Adds logging to the CEDAR core client

I added generic logging to the CEDAR core client using a custom Transport/RoundTrip and included a response time alongside a few other fields.

## How to test this change

Make some requests to CEDAR core with mocking disabled and look at the container logs.

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
