### PR TITLE
[EASI-4131, EASI-4132] Systems tab UX fixes

### DIFF
--- a/src/components/NavigationBar/index.scss
+++ b/src/components/NavigationBar/index.scss
@@ -78,9 +78,10 @@
                 color: $easi-blue;
             }
         }
+    }
 
-        
-
+    .usa-accordion__button.usa-current[aria-expanded="false"] {
+        color: $easi-blue;
     }
 }
 
@@ -100,7 +101,10 @@
 }
 
 .system-dropdown:hover {
-    color: color('base-dark') !important;
+    @media (min-width: $desktop) {
+        color: color('base-dark') !important;
+    }
+
     &::after {
         bottom: 0 !important;
     }

--- a/src/components/NavigationBar/index.scss
+++ b/src/components/NavigationBar/index.scss
@@ -28,8 +28,6 @@
 
 .usa-nav__primary-item {
     .easi-nav {
-        display: flex;
-
         &__item {
             display: flex;
         }
@@ -77,6 +75,12 @@
             .usa-logo__text {
                 color: $easi-blue;
             }
+        }
+    }
+
+    @media (min-width: $desktop) {
+        .easi-nav {
+            display: flex;
         }
     }
 

--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Link, NavLink, useLocation } from 'react-router-dom';
+import { NavHashLink } from 'react-router-hash-link';
 import {
   Header,
   IconMenu,
@@ -67,17 +68,17 @@ const systemLinks = (
   isUserSet: boolean
 ) => [
   {
-    link: '/systems?table-type=all-systems',
+    link: '/systems?table-type=all-systems#systemsTable',
     label: 'allCMSSystems',
     isEnabled: true
   },
   {
-    link: '/systems?table-type=my-systems',
+    link: '/systems?table-type=my-systems#systemsTable',
     label: 'mySystems',
     isEnabled: true
   },
   {
-    link: '/systems?table-type=bookmarked-systems',
+    link: '/systems?table-type=bookmarked-systems#systemsTable',
     label: 'bookmarkedSystems',
     isEnabled: true
   },
@@ -132,7 +133,7 @@ const NavigationBar = ({ signout, userName }: NavigationProps) => {
 
   const systemNavLinks = systemLinks(flags, groups, isUserSet).map(route => (
     <div className="easi-nav" key={route.label}>
-      <NavLink
+      <NavHashLink
         to={route.link}
         className="usa-nav__link easi-nav__sublink"
         onClick={() => {
@@ -147,7 +148,7 @@ const NavigationBar = ({ signout, userName }: NavigationProps) => {
         >
           {t(`header:${route.label}`)}
         </em>
-      </NavLink>
+      </NavHashLink>
     </div>
   ));
 

--- a/src/components/shared/SectionWrapper/index.tsx
+++ b/src/components/shared/SectionWrapper/index.tsx
@@ -5,6 +5,7 @@ import './index.scss';
 
 type SectionWrapperProps = {
   className?: string;
+  id?: string;
   children?: ReactNode;
   border?: boolean;
   borderBottom?: boolean;
@@ -13,6 +14,7 @@ type SectionWrapperProps = {
 
 const SectionWrapper = ({
   className,
+  id,
   children,
   border,
   borderBottom,
@@ -28,7 +30,7 @@ const SectionWrapper = ({
     className
   );
   return (
-    <div data-testid="section-wrapper" className={classNames}>
+    <div data-testid="section-wrapper" className={classNames} id={id}>
       {children}
     </div>
   );

--- a/src/views/SystemList/__snapshots__/index.test.tsx.snap
+++ b/src/views/SystemList/__snapshots__/index.test.tsx.snap
@@ -74,476 +74,482 @@ exports[`System List View > when there are requests > matches snapshot 1`] = `
         data-testid="CardGroup"
       />
     </div>
-    <h2
-      class="margin-bottom-2"
+    <div
+      class="easi-section"
+      data-testid="section-wrapper"
+      id="systemsTable"
     >
-      All CMS systems
-    </h2>
-    Click the bookmark icon (
-    <svg
-      class="usa-icon text-bookmark-icon"
-      focusable="false"
-      height="1em"
-      role="img"
-      viewBox="0 0 24 24"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
-      />
-    </svg>
-    ) to bookmark systems that you want to access more quickly.
-    <div>
-      <div
-        class="margin-bottom-6"
+      <h2
+        class="margin-bottom-2"
       >
-        <p
-          class="text-bold margin-0 margin-top-3"
-        >
-          View
-        </p>
-        <ul
-          class="usa-button-group usa-button-group--segmented margin-bottom-2 margin-top-1"
-        >
-          <li
-            class="usa-button-group__item"
-          >
-            <button
-              class="usa-button"
-              data-testid="button"
-              type="button"
-            >
-              All systems
-            </button>
-          </li>
-          <li
-            class="usa-button-group__item"
-          >
-            <button
-              class="usa-button usa-button--outline"
-              data-testid="button"
-              type="button"
-            >
-              My systems
-            </button>
-          </li>
-          <li
-            class="usa-button-group__item"
-          >
-            <button
-              class="usa-button usa-button--outline"
-              data-testid="button"
-              type="button"
-            >
-              Bookmarked systems
-            </button>
-          </li>
-        </ul>
-        <div
-          class="usa-table-container--scrollable"
-          data-testid="scrollable-table-container"
-        >
-          <table
-            class="usa-table usa-table--borderless src-components-Table-Table-module__fullwidth--fOyj6"
-            data-testid="table"
-          >
-            <caption
-              class="usa-sr-only"
-            >
-              systemTable.caption
-            </caption>
-            <thead>
-              <tr
-                role="row"
-              >
-                <th
-                  aria-sort="none"
-                  colspan="1"
-                  role="columnheader"
-                  scope="col"
-                  style="min-width: 50px; padding: 0px 0px 0px .5em; position: relative;"
-                  title="Toggle SortBy"
-                >
-                  <button
-                    class="usa-button usa-button--unstyled"
-                    style="cursor: pointer;"
-                    title="Toggle SortBy"
-                    type="button"
-                  >
-                    <svg
-                      class="usa-icon"
-                      focusable="false"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 0h24v24H0z"
-                        fill="none"
-                      />
-                      <path
-                        d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
-                      />
-                    </svg>
-                    <svg
-                      class="usa-icon margin-left-05 position-absolute"
-                      data-testid="caret--sort"
-                      focusable="false"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 0h24v24H0z"
-                        fill="none"
-                      />
-                      <path
-                        d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
-                      />
-                    </svg>
-                  </button>
-                </th>
-                <th
-                  aria-sort="none"
-                  colspan="1"
-                  role="columnheader"
-                  scope="col"
-                  style="min-width: 150px; position: relative;"
-                  title="Toggle SortBy"
-                >
-                  <button
-                    class="usa-button usa-button--unstyled"
-                    style="cursor: pointer;"
-                    title="Toggle SortBy"
-                    type="button"
-                  >
-                    Acronym
-                    <svg
-                      class="usa-icon margin-left-05 position-absolute"
-                      data-testid="caret--sort"
-                      focusable="false"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 0h24v24H0z"
-                        fill="none"
-                      />
-                      <path
-                        d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
-                      />
-                    </svg>
-                  </button>
-                </th>
-                <th
-                  aria-sort="ascending"
-                  colspan="1"
-                  role="columnheader"
-                  scope="col"
-                  style="min-width: 150px; position: relative;"
-                  title="Toggle SortBy"
-                >
-                  <button
-                    class="usa-button usa-button--unstyled"
-                    style="cursor: pointer;"
-                    title="Toggle SortBy"
-                    type="button"
-                  >
-                    System name
-                    <svg
-                      class="usa-icon margin-left-05 position-absolute"
-                      data-testid="caret--up"
-                      focusable="false"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 0h24v24H0z"
-                        fill="none"
-                      />
-                      <path
-                        d="m12 8-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"
-                      />
-                    </svg>
-                  </button>
-                </th>
-                <th
-                  aria-sort="none"
-                  colspan="1"
-                  role="columnheader"
-                  scope="col"
-                  style="min-width: 150px; position: relative;"
-                  title="Toggle SortBy"
-                >
-                  <button
-                    class="usa-button usa-button--unstyled"
-                    style="cursor: pointer;"
-                    title="Toggle SortBy"
-                    type="button"
-                  >
-                    CMS component
-                    <svg
-                      class="usa-icon margin-left-05 position-absolute"
-                      data-testid="caret--sort"
-                      focusable="false"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 0h24v24H0z"
-                        fill="none"
-                      />
-                      <path
-                        d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
-                      />
-                    </svg>
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody
-              role="rowgroup"
-            >
-              <tr
-                role="row"
-              >
-                <th
-                  role="cell"
-                  style="padding-left: .5em;"
-                >
-                  <button
-                    class="usa-button usa-button--unstyled"
-                    data-testid="button"
-                    type="button"
-                  >
-                    <svg
-                      class="usa-icon text-base-lighter"
-                      focusable="false"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 0h24v24H0z"
-                        fill="none"
-                      />
-                      <path
-                        d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
-                      />
-                    </svg>
-                  </button>
-                </th>
-                <th
-                  role="cell"
-                >
-                  ZXC
-                </th>
-                <th
-                  role="cell"
-                >
-                  <a
-                    class="usa-link"
-                    href="/systems/3/home/top"
-                  >
-                    Government
-                  </a>
-                </th>
-                <th
-                  role="cell"
-                >
-                  <p>
-                    CMMI
-                  </p>
-                </th>
-              </tr>
-              <tr
-                role="row"
-              >
-                <th
-                  role="cell"
-                  style="padding-left: .5em;"
-                >
-                  <button
-                    class="usa-button usa-button--unstyled"
-                    data-testid="button"
-                    type="button"
-                  >
-                    <svg
-                      class="usa-icon text-base-lighter"
-                      focusable="false"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 0h24v24H0z"
-                        fill="none"
-                      />
-                      <path
-                        d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
-                      />
-                    </svg>
-                  </button>
-                </th>
-                <th
-                  role="cell"
-                >
-                  HAM
-                </th>
-                <th
-                  role="cell"
-                >
-                  <a
-                    class="usa-link"
-                    href="/systems/1/home/top"
-                  >
-                    Happiness Achievement Module
-                  </a>
-                </th>
-                <th
-                  role="cell"
-                >
-                  <p>
-                    CMMI
-                  </p>
-                </th>
-              </tr>
-              <tr
-                role="row"
-              >
-                <th
-                  role="cell"
-                  style="padding-left: .5em;"
-                >
-                  <button
-                    class="usa-button usa-button--unstyled"
-                    data-testid="button"
-                    type="button"
-                  >
-                    <svg
-                      class="usa-icon text-base-lighter"
-                      focusable="false"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 0h24v24H0z"
-                        fill="none"
-                      />
-                      <path
-                        d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
-                      />
-                    </svg>
-                  </button>
-                </th>
-                <th
-                  role="cell"
-                >
-                  BBC
-                </th>
-                <th
-                  role="cell"
-                >
-                  <a
-                    class="usa-link"
-                    href="/systems/326-9-0/home/top"
-                  >
-                    Medicare Beneficiary Contact Center
-                  </a>
-                </th>
-                <th
-                  role="cell"
-                >
-                  <p>
-                    Division of Call Center Systems
-                  </p>
-                </th>
-              </tr>
-              <tr
-                role="row"
-              >
-                <th
-                  role="cell"
-                  style="padding-left: .5em;"
-                >
-                  <button
-                    class="usa-button usa-button--unstyled"
-                    data-testid="button"
-                    type="button"
-                  >
-                    <svg
-                      class="usa-icon text-base-lighter"
-                      focusable="false"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M0 0h24v24H0z"
-                        fill="none"
-                      />
-                      <path
-                        d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
-                      />
-                    </svg>
-                  </button>
-                </th>
-                <th
-                  role="cell"
-                >
-                  ASD
-                </th>
-                <th
-                  role="cell"
-                >
-                  <a
-                    class="usa-link"
-                    href="/systems/326-1-0/home/top"
-                  >
-                    Systems
-                  </a>
-                </th>
-                <th
-                  role="cell"
-                >
-                  <p>
-                    CMMI
-                  </p>
-                </th>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <div
-          class="grid-row grid-gap grid-gap-lg"
+        All CMS systems
+      </h2>
+      Click the bookmark icon (
+      <svg
+        class="usa-icon text-bookmark-icon"
+        focusable="false"
+        height="1em"
+        role="img"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
         />
+        <path
+          d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
+        />
+      </svg>
+      ) to bookmark systems that you want to access more quickly.
+      <div>
+        <div
+          class="margin-bottom-6"
+        >
+          <p
+            class="text-bold margin-0 margin-top-3"
+          >
+            View
+          </p>
+          <ul
+            class="usa-button-group usa-button-group--segmented margin-bottom-2 margin-top-1"
+          >
+            <li
+              class="usa-button-group__item"
+            >
+              <button
+                class="usa-button"
+                data-testid="button"
+                type="button"
+              >
+                All systems
+              </button>
+            </li>
+            <li
+              class="usa-button-group__item"
+            >
+              <button
+                class="usa-button usa-button--outline"
+                data-testid="button"
+                type="button"
+              >
+                My systems
+              </button>
+            </li>
+            <li
+              class="usa-button-group__item"
+            >
+              <button
+                class="usa-button usa-button--outline"
+                data-testid="button"
+                type="button"
+              >
+                Bookmarked systems
+              </button>
+            </li>
+          </ul>
+          <div
+            class="usa-table-container--scrollable"
+            data-testid="scrollable-table-container"
+          >
+            <table
+              class="usa-table usa-table--borderless src-components-Table-Table-module__fullwidth--fOyj6"
+              data-testid="table"
+            >
+              <caption
+                class="usa-sr-only"
+              >
+                systemTable.caption
+              </caption>
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    aria-sort="none"
+                    colspan="1"
+                    role="columnheader"
+                    scope="col"
+                    style="min-width: 50px; padding: 0px 0px 0px .5em; position: relative;"
+                    title="Toggle SortBy"
+                  >
+                    <button
+                      class="usa-button usa-button--unstyled"
+                      style="cursor: pointer;"
+                      title="Toggle SortBy"
+                      type="button"
+                    >
+                      <svg
+                        class="usa-icon"
+                        focusable="false"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                      <svg
+                        class="usa-icon margin-left-05 position-absolute"
+                        data-testid="caret--sort"
+                        focusable="false"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    colspan="1"
+                    role="columnheader"
+                    scope="col"
+                    style="min-width: 150px; position: relative;"
+                    title="Toggle SortBy"
+                  >
+                    <button
+                      class="usa-button usa-button--unstyled"
+                      style="cursor: pointer;"
+                      title="Toggle SortBy"
+                      type="button"
+                    >
+                      Acronym
+                      <svg
+                        class="usa-icon margin-left-05 position-absolute"
+                        data-testid="caret--sort"
+                        focusable="false"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="ascending"
+                    colspan="1"
+                    role="columnheader"
+                    scope="col"
+                    style="min-width: 150px; position: relative;"
+                    title="Toggle SortBy"
+                  >
+                    <button
+                      class="usa-button usa-button--unstyled"
+                      style="cursor: pointer;"
+                      title="Toggle SortBy"
+                      type="button"
+                    >
+                      System name
+                      <svg
+                        class="usa-icon margin-left-05 position-absolute"
+                        data-testid="caret--up"
+                        focusable="false"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="m12 8-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    colspan="1"
+                    role="columnheader"
+                    scope="col"
+                    style="min-width: 150px; position: relative;"
+                    title="Toggle SortBy"
+                  >
+                    <button
+                      class="usa-button usa-button--unstyled"
+                      style="cursor: pointer;"
+                      title="Toggle SortBy"
+                      type="button"
+                    >
+                      CMS component
+                      <svg
+                        class="usa-icon margin-left-05 position-absolute"
+                        data-testid="caret--sort"
+                        focusable="false"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  role="row"
+                >
+                  <th
+                    role="cell"
+                    style="padding-left: .5em;"
+                  >
+                    <button
+                      class="usa-button usa-button--unstyled"
+                      data-testid="button"
+                      type="button"
+                    >
+                      <svg
+                        class="usa-icon text-base-lighter"
+                        focusable="false"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    role="cell"
+                  >
+                    ZXC
+                  </th>
+                  <th
+                    role="cell"
+                  >
+                    <a
+                      class="usa-link"
+                      href="/systems/3/home/top"
+                    >
+                      Government
+                    </a>
+                  </th>
+                  <th
+                    role="cell"
+                  >
+                    <p>
+                      CMMI
+                    </p>
+                  </th>
+                </tr>
+                <tr
+                  role="row"
+                >
+                  <th
+                    role="cell"
+                    style="padding-left: .5em;"
+                  >
+                    <button
+                      class="usa-button usa-button--unstyled"
+                      data-testid="button"
+                      type="button"
+                    >
+                      <svg
+                        class="usa-icon text-base-lighter"
+                        focusable="false"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    role="cell"
+                  >
+                    HAM
+                  </th>
+                  <th
+                    role="cell"
+                  >
+                    <a
+                      class="usa-link"
+                      href="/systems/1/home/top"
+                    >
+                      Happiness Achievement Module
+                    </a>
+                  </th>
+                  <th
+                    role="cell"
+                  >
+                    <p>
+                      CMMI
+                    </p>
+                  </th>
+                </tr>
+                <tr
+                  role="row"
+                >
+                  <th
+                    role="cell"
+                    style="padding-left: .5em;"
+                  >
+                    <button
+                      class="usa-button usa-button--unstyled"
+                      data-testid="button"
+                      type="button"
+                    >
+                      <svg
+                        class="usa-icon text-base-lighter"
+                        focusable="false"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    role="cell"
+                  >
+                    BBC
+                  </th>
+                  <th
+                    role="cell"
+                  >
+                    <a
+                      class="usa-link"
+                      href="/systems/326-9-0/home/top"
+                    >
+                      Medicare Beneficiary Contact Center
+                    </a>
+                  </th>
+                  <th
+                    role="cell"
+                  >
+                    <p>
+                      Division of Call Center Systems
+                    </p>
+                  </th>
+                </tr>
+                <tr
+                  role="row"
+                >
+                  <th
+                    role="cell"
+                    style="padding-left: .5em;"
+                  >
+                    <button
+                      class="usa-button usa-button--unstyled"
+                      data-testid="button"
+                      type="button"
+                    >
+                      <svg
+                        class="usa-icon text-base-lighter"
+                        focusable="false"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    role="cell"
+                  >
+                    ASD
+                  </th>
+                  <th
+                    role="cell"
+                  >
+                    <a
+                      class="usa-link"
+                      href="/systems/326-1-0/home/top"
+                    >
+                      Systems
+                    </a>
+                  </th>
+                  <th
+                    role="cell"
+                  >
+                    <p>
+                      CMMI
+                    </p>
+                  </th>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div
+            class="grid-row grid-gap grid-gap-lg"
+          />
+        </div>
       </div>
     </div>
   </main>

--- a/src/views/SystemList/index.tsx
+++ b/src/views/SystemList/index.tsx
@@ -161,32 +161,34 @@ export const SystemList = () => {
             </SectionWrapper>
           )}
 
-          <h2 className="margin-bottom-2">
-            {t('systemProfile:systemTable.title')}
-          </h2>
+          <SectionWrapper id="systemsTable">
+            <h2 className="margin-bottom-2">
+              {t('systemProfile:systemTable.title')}
+            </h2>
 
-          <Trans
-            i18nKey="systemProfile:systemTable.subtitle"
-            components={{
-              icon: <IconBookmark className="text-bookmark-icon" />
-            }}
-          />
+            <Trans
+              i18nKey="systemProfile:systemTable.subtitle"
+              components={{
+                icon: <IconBookmark className="text-bookmark-icon" />
+              }}
+            />
 
-          {error1 || error2 ? (
-            <ErrorAlert heading="System error">
-              <AlertText>
-                <span>{t('systemProfile:gql.fail')}</span>
-              </AlertText>
-            </ErrorAlert>
-          ) : (
-            <div ref={systemsRef}>
-              <Table
-                systems={systemsTableData}
-                savedBookmarks={bookmarks}
-                refetchBookmarks={refetchBookmarks}
-              />
-            </div>
-          )}
+            {error1 || error2 ? (
+              <ErrorAlert heading="System error">
+                <AlertText>
+                  <span>{t('systemProfile:gql.fail')}</span>
+                </AlertText>
+              </ErrorAlert>
+            ) : (
+              <div ref={systemsRef}>
+                <Table
+                  systems={systemsTableData}
+                  savedBookmarks={bookmarks}
+                  refetchBookmarks={refetchBookmarks}
+                />
+              </div>
+            )}
+          </SectionWrapper>
         </>
       )}
     </MainContent>


### PR DESCRIPTION
# EASI-4131, EASI-4132
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

- Updated systems tab dropdown links
- Fixed Systems tab active and hover states

<!-- Put a description here! -->

## How to test this change

1. Verify systems tab dropdown links go to table
2. When on systems page, navigation tab text should be blue

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
