### PR TITLE
[NOREF] Add env vars for cache time and to bypass cache

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -115,6 +115,8 @@ export CEDAR_API_URL="webmethods-apigw.cedarimpl.cms.gov"
 export CEDAR_API_KEY=""
 export CEDAR_CORE_API_VERSION="2.0.0"
 export CEDAR_EMAIL_ADDRESS="EnterpriseArchitecture@notCMS.gov"
+export CEDAR_CACHE_EXPIRE_TIME="7d"
+export CEDAR_CORE_SKIP_PROXY=false
 
 # Frontend Dev
 export ESLINT_NO_DEV_ERRORS=true

--- a/cedarproxy/nginx.conf
+++ b/cedarproxy/nginx.conf
@@ -33,7 +33,7 @@ http {
     # include /etc/nginx/conf.d/*.conf;
 
     proxy_cache_path /nginxcache keys_zone=cedarcorecache:10m;
-    proxy_cache_valid 200 302 24h;
+    proxy_cache_valid 200 302 ${CEDAR_CACHE_EXPIRE_TIME};
 
     server {
         listen 8001;

--- a/cedarproxy/nginx.conf
+++ b/cedarproxy/nginx.conf
@@ -34,6 +34,7 @@ http {
 
     proxy_cache_path /nginxcache keys_zone=cedarcorecache:10m;
     proxy_cache_valid 200 302 ${CEDAR_CACHE_EXPIRE_TIME};
+    proxy_cache_use_stale error timeout updating http_500 http_504
 
     server {
         listen 8001;

--- a/deploy/base/cedarproxy.yaml
+++ b/deploy/base/cedarproxy.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: easi
 data:
   CEDAR_API_URL: webmethods-apigw.cedarimpl.cms.gov
+  CEDAR_CACHE_EXPIRE_TIME: "7d"
 
 ---
 

--- a/deploy/base/easi.yaml
+++ b/deploy/base/easi.yaml
@@ -6,11 +6,11 @@ metadata:
 data:
   CEDAR_CORE_MOCK: 'true'
   CEDAR_INTAKE_ENABLED: 'false'
-  CEDAR_API_KEY: ''
+  CEDAR_API_KEY: ""
   CEDAR_PROXY_URL: ""
+  CEDAR_CORE_SKIP_PROXY: "false"
   CEDAR_API_URL: "webmethods-apigw.cedarimpl.cms.gov"
   CEDAR_CORE_API_VERSION: "2.0.0"
-  CEDAR_CACHE_INTERVAL: "30m"
   CEDAR_EMAIL_ADDRESS: "EnterpriseArchitecture@notCMS.gov"
   APP_ENV: local
   CLIENT_PROTOCOL: http

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       - CEDAR_API_KEY
       - CEDAR_API_URL
       - CEDAR_PROXY_URL=cedarproxy:8001
+      - CEDAR_CORE_SKIP_PROXY
       - CEDAR_CORE_API_VERSION
-      - CEDAR_CACHE_INTERVAL
       - CEDAR_EMAIL_ADDRESS
       - HTTP_PROXY
       - HTTPS_PROXY
@@ -79,6 +79,7 @@ services:
     image: cedarproxy:latest
     environment:
       - CEDAR_API_URL
+      - CEDAR_CACHE_EXPIRE_TIME
     build:
       dockerfile: Dockerfile.cedarproxy
       context: ./cedarproxy/

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -170,6 +170,9 @@ const CEDARAPIURL = "CEDAR_API_URL"
 // CEDARAPIKey is the key for accessing CEDAR
 const CEDARAPIKey = "CEDAR_API_KEY" // #nosec
 
+// CEDARCoreSkipProxy is the key for whether to make calls directly to CEDAR Core
+const CEDARCoreSkipProxy = "CEDAR_CORE_SKIP_PROXY"
+
 // CEDAREmailAddress is the key for the env var that holds the email address that we use when notifying CEDAR of changes
 const CEDAREmailAddress = "CEDAR_EMAIL_ADDRESS"
 

--- a/pkg/cedar/core/client_test.go
+++ b/pkg/cedar/core/client_test.go
@@ -27,7 +27,7 @@ func (s *ClientTestSuite) TestClient() {
 	ctx := appcontext.WithLogger(context.Background(), s.logger)
 
 	s.Run("Instantiation successful", func() {
-		c := NewClient(ctx, "fake", "fake", "1.0.0", true)
+		c := NewClient(ctx, "fake", "fake", "1.0.0", false, true)
 		s.NotNil(c)
 	})
 }

--- a/pkg/cedar/core/system_summary_test.go
+++ b/pkg/cedar/core/system_summary_test.go
@@ -28,7 +28,7 @@ func (s *SystemSummaryTestSuite) TestGetSystemSummary() {
 	ctx := appcontext.WithLogger(context.Background(), s.logger)
 
 	s.Run("LD defaults protects invocation of GetSystemSummary", func() {
-		c := NewClient(ctx, "fake", "fake", "1.0.0", true)
+		c := NewClient(ctx, "fake", "fake", "1.0.0", false, true)
 		resp, err := c.GetSystemSummary(ctx)
 		s.NoError(err)
 
@@ -40,7 +40,7 @@ func (s *SystemSummaryTestSuite) TestGetSystemSummary() {
 	})
 
 	s.Run("Retrieves filtered list when EUA filter is present", func() {
-		c := NewClient(ctx, "fake", "fake", "1.0.0", true)
+		c := NewClient(ctx, "fake", "fake", "1.0.0", false, true)
 		resp, err := c.GetSystemSummary(ctx, WithEuaIDFilter("USR1"))
 		s.NoError(err)
 
@@ -52,7 +52,7 @@ func (s *SystemSummaryTestSuite) TestGetSystemSummary() {
 	})
 
 	s.Run("Retrieves filtered list when Sub-System filter is present", func() {
-		c := NewClient(ctx, "fake", "fake", "1.0.0", true)
+		c := NewClient(ctx, "fake", "fake", "1.0.0", false, true)
 		resp, err := c.GetSystemSummary(ctx, WithSubSystems("1"))
 		s.NoError(err)
 
@@ -68,7 +68,7 @@ func (s *SystemSummaryTestSuite) TestGetSystem() {
 	ctx := appcontext.WithLogger(context.Background(), s.logger)
 
 	s.Run("LD defaults protects invocation of GetSystem", func() {
-		c := NewClient(ctx, "fake", "fake", "1.0.0", true)
+		c := NewClient(ctx, "fake", "fake", "1.0.0", false, true)
 		_, err := c.GetSystem(ctx, "fake")
 		s.NoError(err)
 

--- a/pkg/graph/schema.resolvers_test.go
+++ b/pkg/graph/schema.resolvers_test.go
@@ -147,7 +147,7 @@ func TestGraphQLTestSuite(t *testing.T) {
 	}
 
 	oktaAPIClient := local.NewOktaAPIClient()
-	cedarCoreClient := cedarcore.NewClient(appcontext.WithLogger(context.Background(), logger), "fake", "fake", "1.0.0", true)
+	cedarCoreClient := cedarcore.NewClient(appcontext.WithLogger(context.Background(), logger), "fake", "fake", "1.0.0", false, true)
 
 	directives := generated.DirectiveRoot{HasRole: func(ctx context.Context, obj interface{}, next graphql.Resolver, role model.Role) (res interface{}, err error) {
 		return next(ctx)

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -121,10 +121,17 @@ func (s *Server) routes(
 		}
 	}
 
+	var cedarCoreURL string
+	if s.Config.GetBool(appconfig.CEDARCoreSkipProxy) {
+		cedarCoreURL = s.Config.GetString(appconfig.CEDARAPIURL)
+	} else {
+		cedarCoreURL = s.Config.GetString(appconfig.CEDARPROXYURL)
+	}
+
 	// set up CEDAR core API client
 	coreClient := cedarcore.NewClient(
 		appcontext.WithLogger(context.Background(), s.logger),
-		s.Config.GetString(appconfig.CEDARPROXYURL),
+		cedarCoreURL,
 		s.Config.GetString(appconfig.CEDARAPIKey),
 		s.Config.GetString(appconfig.CEDARCoreAPIVersion),
 		s.Config.GetBool(appconfig.CEDARCoreMock),

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -134,6 +134,7 @@ func (s *Server) routes(
 		cedarCoreURL,
 		s.Config.GetString(appconfig.CEDARAPIKey),
 		s.Config.GetString(appconfig.CEDARCoreAPIVersion),
+		s.Config.GetBool(appconfig.CEDARCoreSkipProxy),
 		s.Config.GetBool(appconfig.CEDARCoreMock),
 	)
 


### PR DESCRIPTION
# NOREF

## Changes and Description

- Adds the `CEDAR_CACHE_EXPIRE_TIME` environmental variable to allow for setting the length of time the nginx proxy caches requests without directly modifying the nginx config. Setting a new cache time will require a manual redeploy of the nginx proxy though due to [GitHub action](https://github.com/CMSgov/easi-app/blob/main/.github/workflows/deploy_to_environment.yml#L44-L53) only monitoring for changes to the `/cedarproxy` folder or the swagger client.
- Adds the `CEDAR_CORE_SKIP_PROXY` env var that allows for bypassing the nginx proxy if desired.
    - Note: This would require a manual redeploy though since the variable is read in on server start. It might make sense to revisit how we implement env vars or use launchdarkly instead.
- Adds a [`proxy_cache_use_stale` rule to nginx](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_use_stale) that allows for returning older responses in the event of timeouts, errors, etc.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
