### PR TITLE
[NOREF] add semicolon to allow cedarproxy to start

### DIFF
--- a/cedarproxy/nginx.conf
+++ b/cedarproxy/nginx.conf
@@ -34,7 +34,7 @@ http {
 
     proxy_cache_path /nginxcache keys_zone=cedarcorecache:10m;
     proxy_cache_valid 200 302 ${CEDAR_CACHE_EXPIRE_TIME};
-    proxy_cache_use_stale error timeout updating http_500 http_504
+    proxy_cache_use_stale error timeout updating http_500 http_504;
 
     server {
         listen 8001;


### PR DESCRIPTION
# NOREF

## Changes and Description

- I forgot a semicolon. Whoops! This will allow the nginx service to start locally.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
