### PR TITLE
EASI-4374: improve cedarproxy deployment stability

### DIFF
--- a/.github/workflows/build_cedarproxy_image.yml
+++ b/.github/workflows/build_cedarproxy_image.yml
@@ -6,7 +6,7 @@ on:
       force_cedarproxy:
         required: true
         type: boolean
-        default: false
+        default: true # Per EASI-4374, we want to force cedarproxy deployments in the event pipeline deployment is skipped/cancelled
 
 env:
   EASI_APP_NODE_VERSION: "16.14.0"

--- a/.github/workflows/deploy_cedarproxy.yml
+++ b/.github/workflows/deploy_cedarproxy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Environment
+name: Deploy Cedarproxy to Environment
 
 on:
   workflow_call:
@@ -9,7 +9,7 @@ on:
       force_cedarproxy:
         required: true
         type: boolean
-        default: false
+        default: true # Per EASI-4374, we want to force cedarproxy deployments in the event pipeline deployment is skipped/cancelled
 
 env:
   GIT_HASH: ${{ github.sha }}

--- a/.github/workflows/deploy_pipeline.yml
+++ b/.github/workflows/deploy_pipeline.yml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/build_cedarproxy_image.yml
     secrets: inherit
     with:
-      force_cedarproxy: false
+      force_cedarproxy: true
 
   Run_Tests:
     uses: ./.github/workflows/run_tests.yml
@@ -47,7 +47,7 @@ jobs:
     with:
       env: dev
       lambda_version: 10
-      force_cedarproxy: false
+      force_cedarproxy: true # Per EASI-4374, we want to force cedarproxy deployments in the event pipeline deployment is skipped/cancelled
     secrets: inherit
 
   deploy_impl:
@@ -55,7 +55,7 @@ jobs:
     uses: ./.github/workflows/deploy_to_environment.yml
     with:
       env: impl
-      force_cedarproxy: false
+      force_cedarproxy: true # Per EASI-4374, we want to force cedarproxy deployments in the event pipeline deployment is skipped/cancelled
       lambda_version: 9
     secrets: inherit
   
@@ -64,6 +64,6 @@ jobs:
     uses: ./.github/workflows/deploy_to_environment.yml
     with:
       env: prod
-      force_cedarproxy: false
+      force_cedarproxy: true # Per EASI-4374, we want to force cedarproxy deployments in the event pipeline deployment is skipped/cancelled
       lambda_version: 8
     secrets: inherit

--- a/scripts/deploy_ecs_service.sh
+++ b/scripts/deploy_ecs_service.sh
@@ -14,3 +14,5 @@ aws ecs update-service --cluster "${ECS_CLUSTER}" \
                        --service "${SERVICE_NAME}" \
                        --task-definition "${TASK_FAMILY}:${TASK_REVISION}" \
                        --no-cli-pager
+
+aws ecs wait services-stable --cluster "${ECS_CLUSTER}" --service "${SERVICE_NAME}"


### PR DESCRIPTION
# EASI-4374
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

- **Always** build and deploy cedarproxy
- call `aws ecs wait` after updating deployment to ensure service is healthy

<!-- Put a description here! -->

## How to test this change

Pipeline changes, no local testing required. 

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
