### PR TITLE
[EASI-4390] Stop filtering for active CEDAR systems when searching by ID

### DIFF
--- a/EASI.postman_collection.json
+++ b/EASI.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "e419bb52-6eb6-4e55-b8e1-13739f505412",
+		"_postman_id": "c3118885-03b2-4dc9-8127-33243d8593cd",
 		"name": "EASI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "32724285"
+		"_exporter_id": "11253221"
 	},
 	"item": [
 		{
@@ -1996,8 +1996,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2024,14 +2023,50 @@
 									"response": []
 								},
 								{
+									"name": "Get Systems (include inactive)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"// const systems = JSON.parse(pm.response.text())\r",
+													"// console.log(systems.count)\r",
+													"// console.log(systems.SystemSummary.filter(sys => sys.state !== 'Active').map(({name, id, state}) => ({name, id, state})))"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{CedarApiUrl}}/system/summary",
+											"host": [
+												"{{CedarApiUrl}}"
+											],
+											"path": [
+												"system",
+												"summary"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "Get My Systems",
 									"request": {
 										"method": "GET",
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2068,8 +2103,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2097,8 +2131,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2126,8 +2159,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2155,8 +2187,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2184,8 +2215,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2213,8 +2243,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2246,8 +2275,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2279,8 +2307,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2308,8 +2335,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2337,8 +2363,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2361,8 +2386,7 @@
 										"header": [
 											{
 												"key": "Content-Type",
-												"value": "application/json",
-												"type": "text"
+												"value": "application/json"
 											}
 										],
 										"url": {
@@ -2384,7 +2408,7 @@
 								"apikey": [
 									{
 										"key": "value",
-										"value": "{{CedarApiKeyG}}",
+										"value": "{{CedarApiKey}}",
 										"type": "string"
 									},
 									{

--- a/EASI.postman_collection.json
+++ b/EASI.postman_collection.json
@@ -2029,9 +2029,9 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"// const systems = JSON.parse(pm.response.text())\r",
-													"// console.log(systems.count)\r",
-													"// console.log(systems.SystemSummary.filter(sys => sys.state !== 'Active').map(({name, id, state}) => ({name, id, state})))"
+													"const systems = JSON.parse(pm.response.text())\r",
+													"console.log(systems.count)\r",
+													"console.log(systems.SystemSummary.filter(sys => sys.state !== 'Active').map(({name, id, state}) => ({name, id, state})))"
 												],
 												"type": "text/javascript",
 												"packages": {}

--- a/cmd/devdata/main.go
+++ b/cmd/devdata/main.go
@@ -557,6 +557,20 @@ func main() {
 	)
 	unlinkSystemIntakeRelation(logger, store, intakeID)
 
+	// 5. Link deactivated Systems
+	intakeID = uuid.MustParse("04cb8a97-3515-4071-9b80-2710834cd94c")
+	makeSystemIntakeAndSubmit("System Intake Relation (Deactivated System)", &intakeID, requesterEUA, logger, store)
+	setSystemIntakeRelationExistingSystem(
+		logger,
+		store,
+		intakeID,
+		[]string{"12345", "67890"},
+		[]string{
+			"{11AB1A00-1234-5678-ABC1-1A001B00CC5F}",
+			"{11AB1A00-1234-5678-ABC1-1A001B00CC6G}",
+		},
+	)
+
 	// initial intake form
 	intakeID = uuid.MustParse("14ecf18c-8367-402d-a48e-92e7d2853f50")
 	makeSystemIntakeAndSubmit("initial form filled and submitted", &intakeID, requesterEUA, logger, store)

--- a/cmd/devdata/trb_request.go
+++ b/cmd/devdata/trb_request.go
@@ -38,6 +38,7 @@ func (s *seederConfig) seedTRBRequests(ctx context.Context) error {
 		s.seedTRBCase13,
 		s.seedTRBCase14,
 		s.seedTRBCase15,
+		s.seedTRBCase16,
 	}
 
 	for _, seedFunc := range cases {
@@ -432,6 +433,26 @@ func (s *seederConfig) seedTRBCase15(ctx context.Context) error {
 		return err
 	}
 	err = s.seedTRBWithAttendees(ctx, trbRequest.ID)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *seederConfig) seedTRBCase16(ctx context.Context) error {
+	trbRequest, err := s.seedTRBWithForm(ctx, null.StringFrom("Case 16 - Completed request form with Existing Inactive System Relation").Ptr(), true)
+	if err != nil {
+		return err
+	}
+	_, err = s.addTRBExistingSystemRelation(
+		ctx,
+		trbRequest.ID,
+		[]string{"123", "456"}, // contract numbers
+		[]string{ // cedar system IDs, these mock IDs are from the client helper
+			"{11AB1A00-1234-5678-ABC1-1A001B00CC6G}",
+			"{11AB1A00-1234-5678-ABC1-1A001B00CC5F}",
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/cedar/core/role.go
+++ b/pkg/cedar/core/role.go
@@ -368,7 +368,7 @@ func (c *Client) SetRolesForUser(ctx context.Context, cedarSystemID string, euaU
 		return nil, err
 	}
 	// re-populate the cache for "My Systems"
-	_, err = c.GetSystemSummary(ctx, WithEuaIDFilter(euaUserID))
+	_, err = c.GetSystemSummary(ctx, SystemSummaryParams.WithEuaIDFilter(euaUserID))
 	if err != nil {
 		appcontext.ZLogger(ctx).Warn("error refreshing my systems for user")
 	}

--- a/pkg/cedar/core/role.go
+++ b/pkg/cedar/core/role.go
@@ -368,7 +368,7 @@ func (c *Client) SetRolesForUser(ctx context.Context, cedarSystemID string, euaU
 		return nil, err
 	}
 	// re-populate the cache for "My Systems"
-	_, err = c.GetSystemSummary(ctx, SystemSummaryParams.WithEuaIDFilter(euaUserID))
+	_, err = c.GetSystemSummary(ctx, SystemSummaryOpts.WithEuaIDFilter(euaUserID))
 	if err != nil {
 		appcontext.ZLogger(ctx).Warn("error refreshing my systems for user")
 	}

--- a/pkg/cedar/core/system_summary.go
+++ b/pkg/cedar/core/system_summary.go
@@ -143,7 +143,7 @@ type systemSummaryParamOpts struct{}
 var SystemSummaryParams = systemSummaryParamOpts{}
 
 // WithDeactivatedSystems returns all systems
-func (_ systemSummaryParamOpts) WithDeactivatedSystems() systemSummaryParamFilterOpt {
+func (systemSummaryParamOpts) WithDeactivatedSystems() systemSummaryParamFilterOpt {
 	return func(params *apisystems.SystemSummaryFindListParams) {
 		params.SetState(nil)
 		params.SetIncludeInSurvey(nil)
@@ -151,14 +151,14 @@ func (_ systemSummaryParamOpts) WithDeactivatedSystems() systemSummaryParamFilte
 }
 
 // WithEuaIDFilter sets given EUA onto the params
-func (_ systemSummaryParamOpts) WithEuaIDFilter(euaUserId string) systemSummaryParamFilterOpt {
+func (systemSummaryParamOpts) WithEuaIDFilter(euaUserId string) systemSummaryParamFilterOpt {
 	return func(params *apisystems.SystemSummaryFindListParams) {
 		params.SetUserName(&euaUserId)
 	}
 }
 
 // WithSubSystems sets given cedar system ID as the parent system for which we are looking for sub-systems
-func (_ systemSummaryParamOpts) WithSubSystems(cedarSystemId string) systemSummaryParamFilterOpt {
+func (systemSummaryParamOpts) WithSubSystems(cedarSystemId string) systemSummaryParamFilterOpt {
 	return func(params *apisystems.SystemSummaryFindListParams) {
 		params.SetBelongsTo(&cedarSystemId)
 

--- a/pkg/cedar/core/system_summary.go
+++ b/pkg/cedar/core/system_summary.go
@@ -117,7 +117,7 @@ func (c *Client) GetSystem(ctx context.Context, systemID string) (*models.CedarS
 		return cedarcoremock.GetSystem(systemID), nil
 	}
 
-	systemSummary, err := c.GetSystemSummary(ctx, SystemSummaryParams.WithDeactivatedSystems())
+	systemSummary, err := c.GetSystemSummary(ctx, SystemSummaryOpts.WithDeactivatedSystems())
 	if err != nil {
 		return nil, err
 	}
@@ -137,13 +137,13 @@ func (c *Client) GetSystem(ctx context.Context, systemID string) (*models.CedarS
 
 type systemSummaryParamFilterOpt func(*apisystems.SystemSummaryFindListParams)
 
-type systemSummaryParamOpts struct{}
+type systemSummaryOpts struct{}
 
-// SystemSummaryParams contains methods for options to pass to system summary calls
-var SystemSummaryParams = systemSummaryParamOpts{}
+// SystemSummaryOpts contains methods for options to pass to system summary calls
+var SystemSummaryOpts = systemSummaryOpts{}
 
 // WithDeactivatedSystems returns all systems
-func (systemSummaryParamOpts) WithDeactivatedSystems() systemSummaryParamFilterOpt {
+func (systemSummaryOpts) WithDeactivatedSystems() systemSummaryParamFilterOpt {
 	return func(params *apisystems.SystemSummaryFindListParams) {
 		params.SetState(nil)
 		params.SetIncludeInSurvey(nil)
@@ -151,14 +151,14 @@ func (systemSummaryParamOpts) WithDeactivatedSystems() systemSummaryParamFilterO
 }
 
 // WithEuaIDFilter sets given EUA onto the params
-func (systemSummaryParamOpts) WithEuaIDFilter(euaUserId string) systemSummaryParamFilterOpt {
+func (systemSummaryOpts) WithEuaIDFilter(euaUserId string) systemSummaryParamFilterOpt {
 	return func(params *apisystems.SystemSummaryFindListParams) {
 		params.SetUserName(&euaUserId)
 	}
 }
 
 // WithSubSystems sets given cedar system ID as the parent system for which we are looking for sub-systems
-func (systemSummaryParamOpts) WithSubSystems(cedarSystemId string) systemSummaryParamFilterOpt {
+func (systemSummaryOpts) WithSubSystems(cedarSystemId string) systemSummaryParamFilterOpt {
 	return func(params *apisystems.SystemSummaryFindListParams) {
 		params.SetBelongsTo(&cedarSystemId)
 

--- a/pkg/cedar/core/system_summary.go
+++ b/pkg/cedar/core/system_summary.go
@@ -19,18 +19,6 @@ import (
 // GetSystemSummary makes a GET call to the /system/summary endpoint
 // If `tryCache` is true and `euaUserID` is nil, we will try to hit the cache. Otherwise, we will make an API call as we cannot filter on EUA on our end
 func (c *Client) GetSystemSummary(ctx context.Context, opts ...systemSummaryParamFilterOpt) ([]*models.CedarSystem, error) {
-	if c.mockEnabled {
-		appcontext.ZLogger(ctx).Info("CEDAR Core is disabled")
-
-		// Simulate a filter by only returning a subset of the mock systems
-		if len(opts) > 0 {
-			return cedarcoremock.GetFilteredSystems(), nil
-		}
-
-		// Else return entire set
-		return cedarcoremock.GetSystems(), nil
-	}
-
 	// Construct the parameters
 	params := apisystems.NewSystemSummaryFindListParams()
 
@@ -43,6 +31,22 @@ func (c *Client) GetSystemSummary(ctx context.Context, opts ...systemSummaryPara
 		if opt != nil {
 			opt(params)
 		}
+	}
+
+	if c.mockEnabled {
+		appcontext.ZLogger(ctx).Info("CEDAR Core is disabled")
+
+		// Simulate a filter by only returning a subset of the mock systems
+		if params.UserName != nil || params.BelongsTo != nil {
+			return cedarcoremock.GetFilteredSystems(), nil
+		}
+		// nil State should return all systems including inactive/deactivated
+		if params.State == nil {
+			return cedarcoremock.GetAllSystems(), nil
+		}
+
+		// Else return entire set of active systems
+		return cedarcoremock.GetActiveSystems(), nil
 	}
 
 	params.HTTPClient = c.hc
@@ -82,6 +86,7 @@ func (c *Client) GetSystemSummary(ctx context.Context, opts ...systemSummaryPara
 				Name:                    zero.StringFromPtr(sys.Name),
 				Description:             zero.StringFrom(sys.Description),
 				Acronym:                 zero.StringFrom(sys.Acronym),
+				State:                   zero.StringFrom(sys.State),
 				Status:                  zero.StringFrom(sys.Status),
 				BusinessOwnerOrg:        zero.StringFrom(sys.BusinessOwnerOrg),
 				BusinessOwnerOrgComp:    zero.StringFrom(sys.BusinessOwnerOrgComp),
@@ -112,7 +117,7 @@ func (c *Client) GetSystem(ctx context.Context, systemID string) (*models.CedarS
 		return cedarcoremock.GetSystem(systemID), nil
 	}
 
-	systemSummary, err := c.GetSystemSummary(ctx, nil)
+	systemSummary, err := c.GetSystemSummary(ctx, SystemSummaryParams.WithDeactivatedSystems())
 	if err != nil {
 		return nil, err
 	}
@@ -132,15 +137,28 @@ func (c *Client) GetSystem(ctx context.Context, systemID string) (*models.CedarS
 
 type systemSummaryParamFilterOpt func(*apisystems.SystemSummaryFindListParams)
 
+type systemSummaryParamOpts struct{}
+
+// SystemSummaryParams contains methods for options to pass to system summary calls
+var SystemSummaryParams = systemSummaryParamOpts{}
+
+// WithDeactivatedSystems returns all systems
+func (_ systemSummaryParamOpts) WithDeactivatedSystems() systemSummaryParamFilterOpt {
+	return func(params *apisystems.SystemSummaryFindListParams) {
+		params.SetState(nil)
+		params.SetIncludeInSurvey(nil)
+	}
+}
+
 // WithEuaIDFilter sets given EUA onto the params
-func WithEuaIDFilter(euaUserId string) systemSummaryParamFilterOpt {
+func (_ systemSummaryParamOpts) WithEuaIDFilter(euaUserId string) systemSummaryParamFilterOpt {
 	return func(params *apisystems.SystemSummaryFindListParams) {
 		params.SetUserName(&euaUserId)
 	}
 }
 
 // WithSubSystems sets given cedar system ID as the parent system for which we are looking for sub-systems
-func WithSubSystems(cedarSystemId string) systemSummaryParamFilterOpt {
+func (_ systemSummaryParamOpts) WithSubSystems(cedarSystemId string) systemSummaryParamFilterOpt {
 	return func(params *apisystems.SystemSummaryFindListParams) {
 		params.SetBelongsTo(&cedarSystemId)
 

--- a/pkg/cedar/core/system_summary_test.go
+++ b/pkg/cedar/core/system_summary_test.go
@@ -41,7 +41,7 @@ func (s *SystemSummaryTestSuite) TestGetSystemSummary() {
 
 	s.Run("Retrieves filtered list when EUA filter is present", func() {
 		c := NewClient(ctx, "fake", "fake", "1.0.0", false, true)
-		resp, err := c.GetSystemSummary(ctx, SystemSummaryParams.WithEuaIDFilter("USR1"))
+		resp, err := c.GetSystemSummary(ctx, SystemSummaryOpts.WithEuaIDFilter("USR1"))
 		s.NoError(err)
 
 		// ensure filtered mock data is returned
@@ -53,7 +53,7 @@ func (s *SystemSummaryTestSuite) TestGetSystemSummary() {
 
 	s.Run("Retrieves filtered list when Sub-System filter is present", func() {
 		c := NewClient(ctx, "fake", "fake", "1.0.0", false, true)
-		resp, err := c.GetSystemSummary(ctx, SystemSummaryParams.WithSubSystems("1"))
+		resp, err := c.GetSystemSummary(ctx, SystemSummaryOpts.WithSubSystems("1"))
 		s.NoError(err)
 
 		// ensure filtered mock data is returned

--- a/pkg/cedar/core/system_summary_test.go
+++ b/pkg/cedar/core/system_summary_test.go
@@ -33,15 +33,15 @@ func (s *SystemSummaryTestSuite) TestGetSystemSummary() {
 		s.NoError(err)
 
 		// ensure mock data is returned
-		s.Equal(len(cedarcoremock.GetSystems()), len(resp))
-		for _, v := range cedarcoremock.GetSystems() {
+		s.Equal(len(cedarcoremock.GetActiveSystems()), len(resp))
+		for _, v := range cedarcoremock.GetActiveSystems() {
 			s.Contains(resp, v)
 		}
 	})
 
 	s.Run("Retrieves filtered list when EUA filter is present", func() {
 		c := NewClient(ctx, "fake", "fake", "1.0.0", false, true)
-		resp, err := c.GetSystemSummary(ctx, WithEuaIDFilter("USR1"))
+		resp, err := c.GetSystemSummary(ctx, SystemSummaryParams.WithEuaIDFilter("USR1"))
 		s.NoError(err)
 
 		// ensure filtered mock data is returned
@@ -53,7 +53,7 @@ func (s *SystemSummaryTestSuite) TestGetSystemSummary() {
 
 	s.Run("Retrieves filtered list when Sub-System filter is present", func() {
 		c := NewClient(ctx, "fake", "fake", "1.0.0", false, true)
-		resp, err := c.GetSystemSummary(ctx, WithSubSystems("1"))
+		resp, err := c.GetSystemSummary(ctx, SystemSummaryParams.WithSubSystems("1"))
 		s.NoError(err)
 
 		// ensure filtered mock data is returned
@@ -72,8 +72,8 @@ func (s *SystemSummaryTestSuite) TestGetSystem() {
 		_, err := c.GetSystem(ctx, "fake")
 		s.NoError(err)
 
-		// should return mocked system when given corresponding mockKey
-		for _, v := range cedarcoremock.GetSystems() {
+		// should return mocked system when given corresponding mockKey, including inactive/deactivated systems
+		for _, v := range cedarcoremock.GetAllSystems() {
 			resp, err := c.GetSystem(ctx, v.ID.String)
 			s.NoError(err)
 			s.Equal(v, resp)

--- a/pkg/graph/resolvers/cedar_system_bookmarks_test.go
+++ b/pkg/graph/resolvers/cedar_system_bookmarks_test.go
@@ -8,7 +8,7 @@ import (
 func (s *ResolverSuite) TestCedarSystemBookmarks() {
 	ctx := s.testConfigs.Context
 
-	mockSystems := cedarcoremock.GetSystems()
+	mockSystems := cedarcoremock.GetActiveSystems()
 	s.Len(mockSystems, 5)
 
 	cedarSystemID := mockSystems[0].ID.String

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1274,7 +1274,7 @@ func (r *queryResolver) CedarSystems(ctx context.Context) ([]*models.CedarSystem
 
 // CedarSubSystems is the resolver for the cedarSubSystems field.
 func (r *queryResolver) CedarSubSystems(ctx context.Context, cedarSystemID string) ([]*models.CedarSubSystem, error) {
-	systems, err := r.cedarCoreClient.GetSystemSummary(ctx, cedarcore.SystemSummaryParams.WithSubSystems(cedarSystemID))
+	systems, err := r.cedarCoreClient.GetSystemSummary(ctx, cedarcore.SystemSummaryOpts.WithSubSystems(cedarSystemID))
 	if err != nil {
 		return nil, err
 	}
@@ -1300,7 +1300,7 @@ func (r *queryResolver) CedarContractsBySystem(ctx context.Context, cedarSystemI
 // MyCedarSystems is the resolver for the myCedarSystems field.
 func (r *queryResolver) MyCedarSystems(ctx context.Context) ([]*models.CedarSystem, error) {
 	requesterEUAID := appcontext.Principal(ctx).ID()
-	return r.cedarCoreClient.GetSystemSummary(ctx, cedarcore.SystemSummaryParams.WithEuaIDFilter(requesterEUAID))
+	return r.cedarCoreClient.GetSystemSummary(ctx, cedarcore.SystemSummaryOpts.WithEuaIDFilter(requesterEUAID))
 }
 
 // CedarSystemBookmarks is the resolver for the cedarSystemBookmarks field.

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1274,7 +1274,7 @@ func (r *queryResolver) CedarSystems(ctx context.Context) ([]*models.CedarSystem
 
 // CedarSubSystems is the resolver for the cedarSubSystems field.
 func (r *queryResolver) CedarSubSystems(ctx context.Context, cedarSystemID string) ([]*models.CedarSubSystem, error) {
-	systems, err := r.cedarCoreClient.GetSystemSummary(ctx, cedarcore.WithSubSystems(cedarSystemID))
+	systems, err := r.cedarCoreClient.GetSystemSummary(ctx, cedarcore.SystemSummaryParams.WithSubSystems(cedarSystemID))
 	if err != nil {
 		return nil, err
 	}
@@ -1300,7 +1300,7 @@ func (r *queryResolver) CedarContractsBySystem(ctx context.Context, cedarSystemI
 // MyCedarSystems is the resolver for the myCedarSystems field.
 func (r *queryResolver) MyCedarSystems(ctx context.Context) ([]*models.CedarSystem, error) {
 	requesterEUAID := appcontext.Principal(ctx).ID()
-	return r.cedarCoreClient.GetSystemSummary(ctx, cedarcore.WithEuaIDFilter(requesterEUAID))
+	return r.cedarCoreClient.GetSystemSummary(ctx, cedarcore.SystemSummaryParams.WithEuaIDFilter(requesterEUAID))
 }
 
 // CedarSystemBookmarks is the resolver for the cedarSystemBookmarks field.

--- a/pkg/local/cedarcoremock/system_summary.go
+++ b/pkg/local/cedarcoremock/system_summary.go
@@ -17,6 +17,7 @@ var mockSystems = map[string]*models.CedarSystem{
 		Acronym:                 zero.StringFrom("CMS"),
 		Description:             zero.StringFrom("Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis."),
 		VersionID:               zero.StringFrom("{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}"),
+		State:                   zero.StringFrom("active"),
 		Status:                  zero.StringFrom(""),
 		BusinessOwnerOrg:        zero.StringFrom("Information Systems Team"),
 		BusinessOwnerOrgComp:    zero.StringFrom("IST"),
@@ -30,6 +31,7 @@ var mockSystems = map[string]*models.CedarSystem{
 		Acronym:                 zero.StringFrom("OFW"),
 		Description:             zero.StringFrom("Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis."),
 		VersionID:               zero.StringFrom("{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}"),
+		State:                   zero.StringFrom("active"),
 		Status:                  zero.StringFrom(""),
 		BusinessOwnerOrg:        zero.StringFrom("Information Systems Team"),
 		BusinessOwnerOrgComp:    zero.StringFrom("IST"),
@@ -43,6 +45,7 @@ var mockSystems = map[string]*models.CedarSystem{
 		Acronym:                 zero.StringFrom("QAT"),
 		Description:             zero.StringFrom("Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis."),
 		VersionID:               zero.StringFrom("{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}"),
+		State:                   zero.StringFrom("active"),
 		Status:                  zero.StringFrom(""),
 		BusinessOwnerOrg:        zero.StringFrom("Information Systems Team"),
 		BusinessOwnerOrgComp:    zero.StringFrom("IST"),
@@ -56,6 +59,7 @@ var mockSystems = map[string]*models.CedarSystem{
 		Acronym:                 zero.StringFrom("SWIMS"),
 		Description:             zero.StringFrom("Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis."),
 		VersionID:               zero.StringFrom("{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}"),
+		State:                   zero.StringFrom("active"),
 		Status:                  zero.StringFrom(""),
 		BusinessOwnerOrg:        zero.StringFrom("Managerial Mission Management"),
 		BusinessOwnerOrgComp:    zero.StringFrom("MMM"),
@@ -69,6 +73,7 @@ var mockSystems = map[string]*models.CedarSystem{
 		Acronym:                 zero.StringFrom("CCCC"),
 		Description:             zero.StringFrom("Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis."),
 		VersionID:               zero.StringFrom("{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}"),
+		State:                   zero.StringFrom("active"),
 		Status:                  zero.StringFrom(""),
 		BusinessOwnerOrg:        zero.StringFrom("Managerial Mission Management"),
 		BusinessOwnerOrgComp:    zero.StringFrom("MMM"),
@@ -76,10 +81,38 @@ var mockSystems = map[string]*models.CedarSystem{
 		SystemMaintainerOrgComp: zero.StringFrom("DODD"),
 		UUID:                    zero.StringFrom("46434d7c-5193-4a9d-82b1-0c4d3ceb4237"),
 	},
+	"{11AB1A00-1234-5678-ABC1-1A001B00CC5F}": {
+		ID:                      zero.StringFrom("{11AB1A00-1234-5678-ABC1-1A001B00CC5F}"),
+		Name:                    zero.StringFrom("Office of Official Obfuscation"),
+		Acronym:                 zero.StringFrom("OOO"),
+		Description:             zero.StringFrom("Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis."),
+		VersionID:               zero.StringFrom("{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}"),
+		State:                   zero.StringFrom("deactivated"),
+		Status:                  zero.StringFrom(""),
+		BusinessOwnerOrg:        zero.StringFrom("Managerial Mission Management"),
+		BusinessOwnerOrgComp:    zero.StringFrom("MMM"),
+		SystemMaintainerOrg:     zero.StringFrom("Division of Divisive Divergence"),
+		SystemMaintainerOrgComp: zero.StringFrom("DODD"),
+		UUID:                    zero.StringFrom("1cd0e318-7a30-4fc9-8e28-388019f56851"),
+	},
+	"{11AB1A00-1234-5678-ABC1-1A001B00CC6G}": {
+		ID:                      zero.StringFrom("{11AB1A00-1234-5678-ABC1-1A001B00CC6G}"),
+		Name:                    zero.StringFrom("Artificial Intelligence Task Force"),
+		Acronym:                 zero.StringFrom("AITF"),
+		Description:             zero.StringFrom("Lorem ipsum dolor sit amet, officia excepteur ex fugiat reprehenderit enim labore culpa sint ad nisi Lorem pariatur mollit ex esse exercitation amet. Nisi anim cupidatat excepteur officia. Reprehenderit nostrud nostrud ipsum Lorem est aliquip amet voluptate voluptate dolor minim nulla est proident. Nostrud officia pariatur ut officia. Sit irure elit esse ea nulla sunt ex occaecat reprehenderit commodo officia dolor Lorem duis laboris cupidatat officia voluptate. Culpa proident adipisicing id nulla nisi laboris ex in Lorem sunt duis officia eiusmod. Aliqua reprehenderit commodo ex non excepteur duis sunt velit enim. Voluptate laboris sint cupidatat ullamco ut ea consectetur et est culpa et culpa duis."),
+		VersionID:               zero.StringFrom("{12A123B1-1A2B-1A23-1AB2-12A3456BC7D8}"),
+		State:                   zero.StringFrom("deactivated"),
+		Status:                  zero.StringFrom(""),
+		BusinessOwnerOrg:        zero.StringFrom("Managerial Mission Management"),
+		BusinessOwnerOrgComp:    zero.StringFrom("MMM"),
+		SystemMaintainerOrg:     zero.StringFrom("Division of Divisive Divergence"),
+		SystemMaintainerOrgComp: zero.StringFrom("DODD"),
+		UUID:                    zero.StringFrom("a967ad28-4a69-4031-b53f-687396b87fa5"),
+	},
 }
 
 // GetSystems returns a mocked list of Cedar Systems
-func GetSystems() []*models.CedarSystem {
+func GetAllSystems() []*models.CedarSystem {
 	var systems []*models.CedarSystem
 	for _, v := range mockSystems {
 		systems = append(systems, v)
@@ -87,9 +120,20 @@ func GetSystems() []*models.CedarSystem {
 	return systems
 }
 
+// GetActiveSystems returns only active systems
+func GetActiveSystems() []*models.CedarSystem {
+	var systems []*models.CedarSystem
+	for _, v := range mockSystems {
+		if v.State.String == "active" {
+			systems = append(systems, v)
+		}
+	}
+	return systems
+}
+
 // GetFilteredSystems returns the first two mocked Cedar Systems, ordered by ID
 func GetFilteredSystems() []*models.CedarSystem {
-	systems := GetSystems()
+	systems := GetActiveSystems()
 	sort.Slice(systems, func(i, j int) bool {
 		return systems[i].ID.String < systems[j].ID.String
 	})

--- a/pkg/models/cedar_system.go
+++ b/pkg/models/cedar_system.go
@@ -10,6 +10,7 @@ type CedarSystem struct {
 	Name                    zero.String `json:"name"`
 	Description             zero.String `json:"description"`
 	Acronym                 zero.String `json:"acronym"`
+	State                   zero.String `json:"state"`
 	Status                  zero.String `json:"status"`
 	BusinessOwnerOrg        zero.String `json:"businessOwnerOrg"`
 	BusinessOwnerOrgComp    zero.String `json:"businessOwnerOrgComp"`

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -233,7 +233,7 @@ func (s *Server) routes(
 	graphqlServer.AroundResponses(NewGQLResponseMiddleware())
 
 	getCedarSystems := func(ctx context.Context) ([]*models.CedarSystem, error) {
-		return coreClient.GetSystemSummary(ctx, cedarcore.SystemSummaryParams.WithDeactivatedSystems())
+		return coreClient.GetSystemSummary(ctx, cedarcore.SystemSummaryOpts.WithDeactivatedSystems())
 	}
 
 	dataLoaders := dataloaders.NewDataLoaders(store, userSearchClient.FetchUserInfos, getCedarSystems)

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -233,7 +233,7 @@ func (s *Server) routes(
 	graphqlServer.AroundResponses(NewGQLResponseMiddleware())
 
 	getCedarSystems := func(ctx context.Context) ([]*models.CedarSystem, error) {
-		return coreClient.GetSystemSummary(ctx)
+		return coreClient.GetSystemSummary(ctx, cedarcore.SystemSummaryParams.WithDeactivatedSystems())
 	}
 
 	dataLoaders := dataloaders.NewDataLoaders(store, userSearchClient.FetchUserInfos, getCedarSystems)


### PR DESCRIPTION
# EASI-4390

## Changes and Description

Current `GetSystem` by ID CEDAR client calls rely on the system summary endpoint and filter the returned data set down by the requested system ID. However, if the system is inactive, this will break since the default behavior of the client was to only ask for active systems.

- Creates an option for CEDAR client system summary calls to not filter by active systems.
- Uses aforementioned option for GetSystem calls, including in the dataloader on startup.
- Adjusts local mocks to allow for the new filter and adds two inactive systems.
  - Tests dependent on those mock calls were also updated.
  - Intake request with an inactive system relation also added to seed data.
- Updates Postman collection to include direct call to CEDAR for all systems (including inactive).
    - Also fixes `{{CedarApiUrlG}}` to `{{CedarApiUrl}}`.
- Adds other options to a struct to group options by SystemSummary, ex: `cedarcore.SystemSummaryParams.WithDeactivatedSystems()` instead of `cedarcore.WithDeactivatedSystems()`.

## How to test this change

Mock seed data was updated to include an intake request and a TRB request with an inactive system relation. One could also make a request, attach a system, then use the Postman collection to find an inactive system and edit the relation table to point to the inactive system instead and test that way.

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
