### PR TITLE
EASI-4337 Alignment update for "Systems" heading

### DIFF
--- a/src/components/NavigationBar/index.scss
+++ b/src/components/NavigationBar/index.scss
@@ -38,18 +38,18 @@
 
         &__link {
             color: color('base-dark');
-            padding: 1em;            
+            padding: 1em;
         }
 
         &__sublink {
-            
+
             padding-left: 1rem !important;
             &:hover {
                 text-decoration: none !important;
             }
             @media (min-width: $desktop) {
                 color: white !important;
-            }           
+            }
         }
 
         &__current {
@@ -63,10 +63,10 @@
             margin-top: 2em
         };
 
-        a {   
+        a {
             &:visited {
                 color: color('base-dark')
-            }             
+            }
         }
 
         .usa-current {
@@ -112,9 +112,4 @@
     &::after {
         bottom: 0 !important;
     }
-}
-
-.system-dropdown {
-    padding-top: 0.9rem !important;
-    padding-bottom: 1.1rem !important;
 }


### PR DESCRIPTION
# EASI-4337

For some reason the previous fix isn't needed anymore. Not sure what it was meant to be applied for at the time, but it seems to be okay on my end without any more style settings.

After changes:
<img width="2320" alt="Screen Shot 2024-05-30 at 10 20 02 AM" src="https://github.com/CMSgov/easi-app/assets/97050498/e6d46d7f-3e61-4c2c-8dd3-e96c1fb60be7">
