### PR TITLE
[EASI-4104] Add isMySystem to system details resolver

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -368,6 +368,7 @@ type ComplexityRoot struct {
 		BusinessOwnerInformation    func(childComplexity int) int
 		CedarSystem                 func(childComplexity int) int
 		Deployments                 func(childComplexity int) int
+		IsMySystem                  func(childComplexity int) int
 		Roles                       func(childComplexity int) int
 		SystemMaintainerInformation func(childComplexity int) int
 		Threats                     func(childComplexity int) int
@@ -3049,6 +3050,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CedarSystemDetails.Deployments(childComplexity), true
+
+	case "CedarSystemDetails.isMySystem":
+		if e.complexity.CedarSystemDetails.IsMySystem == nil {
+			break
+		}
+
+		return e.complexity.CedarSystemDetails.IsMySystem(childComplexity), true
 
 	case "CedarSystemDetails.roles":
 		if e.complexity.CedarSystemDetails.Roles == nil {
@@ -7778,6 +7786,7 @@ type CedarSystemDetails {
  deployments: [CedarDeployment!]!
  threats: [CedarThreat!]!
  urls: [CedarURL!]!
+ isMySystem: Boolean
 }
 
 """
@@ -22743,6 +22752,47 @@ func (ec *executionContext) fieldContext_CedarSystemDetails_urls(_ context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _CedarSystemDetails_isMySystem(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystemDetails) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CedarSystemDetails_isMySystem(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsMySystem, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CedarSystemDetails_isMySystem(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CedarSystemDetails",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CedarSystemMaintainerInformation_agileUsed(ctx context.Context, field graphql.CollectedField, obj *models.CedarSystemMaintainerInformation) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CedarSystemMaintainerInformation_agileUsed(ctx, field)
 	if err != nil {
@@ -35006,6 +35056,8 @@ func (ec *executionContext) fieldContext_Query_cedarSystemDetails(ctx context.Co
 				return ec.fieldContext_CedarSystemDetails_threats(ctx, field)
 			case "urls":
 				return ec.fieldContext_CedarSystemDetails_urls(ctx, field)
+			case "isMySystem":
+				return ec.fieldContext_CedarSystemDetails_isMySystem(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type CedarSystemDetails", field.Name)
 		},
@@ -58740,6 +58792,8 @@ func (ec *executionContext) _CedarSystemDetails(ctx context.Context, sel ast.Sel
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "isMySystem":
+			out.Values[i] = ec._CedarSystemDetails_isMySystem(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -287,6 +287,7 @@ type CedarSystemDetails {
  deployments: [CedarDeployment!]!
  threats: [CedarThreat!]!
  urls: [CedarURL!]!
+ isMySystem: Boolean
 }
 
 """

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -7,6 +7,7 @@ package graph
 import (
 	"context"
 	"errors"
+	"slices"
 	"strconv"
 	"time"
 
@@ -1429,6 +1430,11 @@ func (r *queryResolver) CedarSystemDetails(ctx context.Context, cedarSystemID st
 		return nil, err
 	}
 
+	userEua := appcontext.Principal(ctx).ID()
+	isMySystem := slices.ContainsFunc(cedarRoles, func(role *models.CedarRole) bool {
+		return role.AssigneeUsername.String == userEua
+	})
+
 	dCedarSys := models.CedarSystemDetails{
 		CedarSystem:                 sysDetail.CedarSystem,
 		BusinessOwnerInformation:    sysDetail.BusinessOwnerInformation,
@@ -1437,6 +1443,7 @@ func (r *queryResolver) CedarSystemDetails(ctx context.Context, cedarSystemID st
 		Deployments:                 cedarDeployments,
 		Threats:                     cedarThreats,
 		URLs:                        cedarURLs,
+		IsMySystem:                  isMySystem,
 	}
 
 	return &dCedarSys, nil

--- a/pkg/models/cedar_system.go
+++ b/pkg/models/cedar_system.go
@@ -101,4 +101,5 @@ type CedarSystemDetails struct {
 	Deployments                 []*CedarDeployment `json:"deployments"`
 	Threats                     []*CedarThreat     `json:"threats"`
 	URLs                        []*CedarURL        `json:"urls"`
+	IsMySystem                  bool               `json:"isMySystem"`
 }


### PR DESCRIPTION
# EASI-4104

## Changes and Description

- Adds a boolean property to the systemDetails resolver so the FE can easily tell if the current user belongs to a given system.

## How to test this change

Run the following query against a given system to see if you're a member or not (remember to turn off CEDAR mocking):

```graphql
query cedarSystemDetails($cedarSystemId: String!) {
    cedarSystemDetails(cedarSystemId: $cedarSystemId){
        isMySystem
    }
}
```

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
