### PR TITLE
EASI-4415 TRB Advice Letter - Numbered list displaying incorrectly

### DIFF
--- a/src/components/RichTextEditor/index.scss
+++ b/src/components/RichTextEditor/index.scss
@@ -44,6 +44,8 @@
   }
   .toastui-editor-contents ol  {
     list-style-type: decimal;
+    // Need to assign `list-item` since the lib's original uses `li`, which breaks ff
+    counter-reset: list-item;
   }
 }
 


### PR DESCRIPTION
# EASI-4415
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

Firefox didn't like toast's original css of `counter-reset: li`. Instead `list-item` seems like a more standard value for browsers.

<!-- Put a description here! -->

## How to test this change

1. Seed data
2. The trb request **Case 6 - Draft advice letter** is a decent starting point to create the **What we recommend** `ol` `li`s
3. Check that the list item counter is correct through multiple ols and nested lis

Example before
<img width="728" alt="Screen Shot 2024-06-10 at 5 38 26 PM" src="https://github.com/CMSgov/easi-app/assets/97050498/5427c08c-4aad-4833-b4e3-d6c9812d1f78">

After
<img width="801" alt="Screen Shot 2024-06-10 at 5 38 13 PM" src="https://github.com/CMSgov/easi-app/assets/97050498/977719e8-f837-4546-98ed-d609bbc391e6">