### PR TITLE
[NOREF] Enable "stylecheck" linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ linters:
      - ineffassign
      - revive
      - staticcheck
+     - stylecheck
      - gosimple #will be deprecated in golangci-lint v2.0 in favor of staticcheck https://github.com/golangci/golangci-lint/issues/357
      - unused #will be deprecated in golangci-lint v2.0 in favor of staticcheck https://github.com/golangci/golangci-lint/issues/357
      - exhaustive
@@ -47,7 +48,7 @@ linters:
 issues:
   exclude-use-default: false
   exclude:
-    - "package-comments"
+    - "ST1000" # Exclude package comments from `stylecheck`
   exclude-rules:
     - text: 'shadow: declaration of "err" shadows declaration at'
       linters: [ govet ]

--- a/cmd/populate_user_table/iam_db.go
+++ b/cmd/populate_user_table/iam_db.go
@@ -16,9 +16,9 @@ import (
 	"github.com/cmsgov/easi-app/pkg/storage"
 )
 
-// iamDb is a custom struct that satisfies the driver.Connector so that it can be used with sql.OpenDB.
+// iamDB is a custom struct that satisfies the driver.Connector so that it can be used with sql.OpenDB.
 // It implements a custom Connect() function that will get a new IAM auth token for each connection.
-type iamDb struct {
+type iamDB struct {
 	config     storage.DBConfig
 	awsSession *session.Session
 }
@@ -27,7 +27,7 @@ type iamDb struct {
 // For this reason, each new connection actually generates a new auth token, as each auth token only lasts 15 minutes
 // Connections made with an auth token will _NOT_ drop when the token expires, so the 15 minute expiry should never matter
 // This function helps satisfy the driver.Connector interface
-func (idb *iamDb) Connect(_ context.Context) (driver.Conn, error) {
+func (idb *iamDB) Connect(_ context.Context) (driver.Conn, error) {
 	awsRegion := *idb.awsSession.Config.Region
 	awsCreds := idb.awsSession.Config.Credentials
 	dbEndpoint := fmt.Sprintf("%s:%s", idb.config.Host, idb.config.Port)
@@ -60,20 +60,20 @@ func (idb *iamDb) Connect(_ context.Context) (driver.Conn, error) {
 
 // Driver returns IAM DB instance, as it satisfies the driver.Driver interface
 // This function helps satisfy the driver.Connector interface
-func (idb *iamDb) Driver() driver.Driver {
+func (idb *iamDB) Driver() driver.Driver {
 	return idb
 }
 
 // Open would normally return a new connection to the DB, but this custom IAM DB
 // doesn't support it in favor of using `sql.OpenDB` in `newConnectionPoolWithIam`
 // This function helps satisfy the driver.Driver interface
-func (idb *iamDb) Open(_ string) (driver.Conn, error) {
+func (idb *iamDB) Open(_ string) (driver.Conn, error) {
 	return nil, errors.New("driver open method not supported")
 }
 
 // newConnectionPoolWithIam opens a sql.DB using the custom iamDb as a connector.
 // It will wrap that sql.DB and return it as a *sqlx.DB
 func newConnectionPoolWithIam(awsSession *session.Session, config storage.DBConfig) *sqlx.DB {
-	db := sql.OpenDB(&iamDb{config, awsSession})
+	db := sql.OpenDB(&iamDB{config, awsSession})
 	return sqlx.NewDb(db, "postgres")
 }

--- a/pkg/cedar/core/client.go
+++ b/pkg/cedar/core/client.go
@@ -51,7 +51,7 @@ var (
 	skipPurge  bool
 )
 
-// Purges Proxy Cache by URL using a given path
+// PurgeCacheByPath purges the Proxy Cache by URL using a given path
 func PurgeCacheByPath(ctx context.Context, path string) error {
 	if skipPurge {
 		return nil

--- a/pkg/cedar/core/software_products.go
+++ b/pkg/cedar/core/software_products.go
@@ -68,7 +68,7 @@ func (c *Client) GetSoftwareProductsBySystem(ctx context.Context, cedarSystemID 
 	// Convert the rest of the parent SoftwareProducts object
 	retVal := &models.CedarSoftwareProducts{
 		AiSolnCatg:       models.ZeroStringsFrom(resp.Payload.AiSolnCatg),
-		ApiDataArea:      models.ZeroStringsFrom(resp.Payload.APIDataArea),
+		APIDataArea:      models.ZeroStringsFrom(resp.Payload.APIDataArea),
 		SoftwareProducts: softwareProductItems,
 
 		AISolnCatgOther:     zero.StringFrom(resp.Payload.AiSolnCatgOther),

--- a/pkg/cedar/core/system_summary.go
+++ b/pkg/cedar/core/system_summary.go
@@ -141,16 +141,16 @@ func (systemSummaryOpts) WithDeactivatedSystems() systemSummaryParamFilterOpt {
 }
 
 // WithEuaIDFilter sets given EUA onto the params
-func (systemSummaryOpts) WithEuaIDFilter(euaUserId string) systemSummaryParamFilterOpt {
+func (systemSummaryOpts) WithEuaIDFilter(euaUserID string) systemSummaryParamFilterOpt {
 	return func(params *apisystems.SystemSummaryFindListParams) {
-		params.SetUserName(&euaUserId)
+		params.SetUserName(&euaUserID)
 	}
 }
 
 // WithSubSystems sets given cedar system ID as the parent system for which we are looking for sub-systems
-func (systemSummaryOpts) WithSubSystems(cedarSystemId string) systemSummaryParamFilterOpt {
+func (systemSummaryOpts) WithSubSystems(cedarSystemID string) systemSummaryParamFilterOpt {
 	return func(params *apisystems.SystemSummaryFindListParams) {
-		params.SetBelongsTo(&cedarSystemId)
+		params.SetBelongsTo(&cedarSystemID)
 
 		// we want all sub systems, not just ones included in the survey
 		// TODO: some systems come back only when `nil` is set and do not come back when `true` or `false` is set - why?

--- a/pkg/dataloaders/cedar_system_bookmark_loader.go
+++ b/pkg/dataloaders/cedar_system_bookmark_loader.go
@@ -54,12 +54,12 @@ func (loaders *DataLoaders) getBookmarkedCEDARSystems(ctx context.Context, keys 
 	return output
 }
 
-func GetCedarSystemIsBookmarked(ctx context.Context, cedarSystemId string) (bool, error) {
+func GetCedarSystemIsBookmarked(ctx context.Context, cedarSystemID string) (bool, error) {
 	allLoaders := Loaders(ctx)
 	loader := allLoaders.cedarSystemIsBookmarked
 
 	key := NewKeyArgs()
-	key.Args["cedar_system_id"] = cedarSystemId
+	key.Args["cedar_system_id"] = cedarSystemID
 	key.Args["eua_user_id"] = appcontext.Principal(ctx).ID()
 
 	thunk := loader.Loader.Load(ctx, key)

--- a/pkg/dataloaders/cedar_system_loader.go
+++ b/pkg/dataloaders/cedar_system_loader.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
-const cedar_system_loader_key = "id"
+const cedarSystemLoaderKey = "id"
 
 func (loaders *DataLoaders) getCedarSystemBatchFunction(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 	logger := appcontext.ZLogger(ctx)
@@ -36,7 +36,7 @@ func (loaders *DataLoaders) getCedarSystemBatchFunction(ctx context.Context, key
 	for index, key := range keys {
 		ck, ok := key.Raw().(KeyArgs)
 		if ok {
-			resKey := fmt.Sprint(ck.Args[cedar_system_loader_key])
+			resKey := fmt.Sprint(ck.Args[cedarSystemLoaderKey])
 			cedarSystem, ok := systemSummaryMap[resKey]
 			if ok {
 				output[index] = &dataloader.Result{Data: cedarSystem, Error: nil}
@@ -58,7 +58,7 @@ func GetCedarSystemByID(ctx context.Context, id string) (*models.CedarSystem, er
 	cedarSystemLoader := allLoaders.cedarSystemByIDLoader
 
 	key := NewKeyArgs()
-	key.Args[cedar_system_loader_key] = id
+	key.Args[cedarSystemLoaderKey] = id
 
 	thunk := cedarSystemLoader.Loader.Load(ctx, key)
 	result, err := thunk()

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -20535,7 +20535,7 @@ func (ec *executionContext) _CedarSoftwareProducts_apiDataArea(ctx context.Conte
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ApiDataArea, nil
+		return obj.APIDataArea, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/pkg/graph/resolvers/resolver_test.go
+++ b/pkg/graph/resolvers/resolver_test.go
@@ -34,18 +34,18 @@ type ResolverSuite struct {
 }
 
 // SetupTest clears the database between each test
-func (suite *ResolverSuite) SetupTest() {
+func (s *ResolverSuite) SetupTest() {
 	// We need to set the *require.Assertions here, as we need to have already called suite.Run() to ensure the
 	// test suite has been constructed before we call suite.Require()
-	suite.Assertions = suite.Require()
+	s.Assertions = s.Require()
 
 	// Clean all tables before each test
-	err := suite.testConfigs.Store.TruncateAllTablesDANGEROUS(suite.testConfigs.Logger)
-	assert.NoError(suite.T(), err)
+	err := s.testConfigs.Store.TruncateAllTablesDANGEROUS(s.testConfigs.Logger)
+	assert.NoError(s.T(), err)
 
 	// Get the user account from the DB fresh for each test
-	princ := getTestPrincipal(suite.testConfigs.Store, suite.testConfigs.UserInfo.Username)
-	suite.testConfigs.Principal = princ
+	princ := getTestPrincipal(s.testConfigs.Store, s.testConfigs.UserInfo.Username)
+	s.testConfigs.Principal = princ
 }
 
 // TestResolverSuite runs the resolver test suite
@@ -177,12 +177,12 @@ func newS3Config() upload.Config {
 }
 
 // utility method for creating a valid new system intake, checking for any errors
-func (suite *ResolverSuite) createNewIntake() *models.SystemIntake {
-	newIntake, err := suite.testConfigs.Store.CreateSystemIntake(suite.testConfigs.Context, &models.SystemIntake{
+func (s *ResolverSuite) createNewIntake() *models.SystemIntake {
+	newIntake, err := s.testConfigs.Store.CreateSystemIntake(s.testConfigs.Context, &models.SystemIntake{
 		// these fields are required by the SQL schema for the system_intakes table, and CreateSystemIntake() doesn't set them to defaults
 		RequestType: models.SystemIntakeRequestTypeNEW,
 	})
-	suite.NoError(err)
+	s.NoError(err)
 
 	return newIntake
 }

--- a/pkg/graph/resolvers/system_intake_relation_test.go
+++ b/pkg/graph/resolvers/system_intake_relation_test.go
@@ -18,9 +18,9 @@ type systemIntakeRelationTestCase struct {
 	NewSystemIDs           []string
 }
 
-func (suite *ResolverSuite) TestSetSystemIntakeRelationNewSystem() {
-	ctx := suite.testConfigs.Context
-	store := suite.testConfigs.Store
+func (s *ResolverSuite) TestSetSystemIntakeRelationNewSystem() {
+	ctx := s.testConfigs.Context
+	store := s.testConfigs.Store
 
 	submittedAt := time.Now()
 
@@ -60,36 +60,36 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationNewSystem() {
 	}
 
 	for caseName, caseValues := range contractNumberCases {
-		suite.Run(caseName, func() {
+		s.Run(caseName, func() {
 			openIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
 				State:        models.SystemIntakeStateOpen,
 				RequestType:  models.SystemIntakeRequestTypeNEW,
 				SubmittedAt:  &submittedAt,
 				ContractName: zero.StringFrom("My Test Contract Name"),
 			})
-			suite.NoError(err)
-			suite.NotNil(openIntake)
+			s.NoError(err)
+			s.NotNil(openIntake)
 
 			// Set existing contract numbers
 			err = sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 				return store.SetSystemIntakeContractNumbers(ctx, tx, openIntake.ID, caseValues.InitialContractNumbers)
 			})
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedIntakeContractNumbers, err := SystemIntakeContractNumbers(ctx, openIntake.ID)
-			suite.NoError(err)
-			suite.Equal(len(caseValues.InitialContractNumbers), len(updatedIntakeContractNumbers))
+			s.NoError(err)
+			s.Equal(len(caseValues.InitialContractNumbers), len(updatedIntakeContractNumbers))
 
 			// Set existing system IDs
 			err = sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 				return store.SetSystemIntakeSystems(ctx, tx, openIntake.ID, caseValues.InitialSystemIDs)
 
 			})
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedIntakeSystemIDs, err := SystemIntakeSystems(ctx, openIntake.ID)
-			suite.NoError(err)
-			suite.Equal(len(caseValues.InitialSystemIDs), len(updatedIntakeSystemIDs))
+			s.NoError(err)
+			s.Equal(len(caseValues.InitialSystemIDs), len(updatedIntakeSystemIDs))
 
 			// Set the "new system" relationship
 			input := &models.SetSystemIntakeRelationNewSystemInput{
@@ -99,23 +99,23 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationNewSystem() {
 
 			// Run Resolver
 			updatedIntake, err := SetSystemIntakeRelationNewSystem(ctx, store, input)
-			suite.NoError(err)
+			s.NoError(err)
 
 			// Ensure the contract name was deleted properly
-			suite.True(updatedIntake.ContractName.IsZero())
+			s.True(updatedIntake.ContractName.IsZero())
 
 			// refetch contract numbers and system IDs
 			updatedIntakeContractNumbers, err = SystemIntakeContractNumbers(ctx, updatedIntake.ID)
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedIntakeSystemIDs, err = SystemIntakeSystems(ctx, openIntake.ID)
-			suite.NoError(err)
+			s.NoError(err)
 
 			// Ensure the system IDs were modified properly
 			// New System relation should always remove existing system IDs
-			suite.Equal(len(caseValues.NewSystemIDs), len(updatedIntakeSystemIDs))
+			s.Equal(len(caseValues.NewSystemIDs), len(updatedIntakeSystemIDs))
 			for _, v := range updatedIntakeSystemIDs {
-				suite.Contains(caseValues.NewSystemIDs, v.ID)
+				s.Contains(caseValues.NewSystemIDs, v.ID)
 			}
 
 			// Ensure the contract numbers were modified properly
@@ -128,15 +128,15 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationNewSystem() {
 			_ = updatedIntakeContractNumbers
 
 			// Check relation type
-			suite.NotNil(updatedIntake.SystemRelationType)
-			suite.Equal(models.RelationTypeNewSystem, *updatedIntake.SystemRelationType)
+			s.NotNil(updatedIntake.SystemRelationType)
+			s.Equal(models.RelationTypeNewSystem, *updatedIntake.SystemRelationType)
 		})
 	}
 }
 
-func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingSystem() {
-	ctx := suite.testConfigs.Context
-	store := suite.testConfigs.Store
+func (s *ResolverSuite) TestSetSystemIntakeRelationExistingSystem() {
+	ctx := s.testConfigs.Context
+	store := s.testConfigs.Store
 
 	submittedAt := time.Now()
 
@@ -174,35 +174,35 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingSystem() {
 	}
 
 	for caseName, caseValues := range cases {
-		suite.Run(caseName, func() {
+		s.Run(caseName, func() {
 			openIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
 				State:        models.SystemIntakeStateOpen,
 				RequestType:  models.SystemIntakeRequestTypeNEW,
 				SubmittedAt:  &submittedAt,
 				ContractName: zero.StringFrom("My Test Contract Name"),
 			})
-			suite.NoError(err)
-			suite.NotNil(openIntake)
+			s.NoError(err)
+			s.NotNil(openIntake)
 
 			// Set existing contract numbers
 			err = sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 				return store.SetSystemIntakeContractNumbers(ctx, tx, openIntake.ID, caseValues.InitialContractNumbers)
 			})
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedIntakeContractNumbers, err := SystemIntakeContractNumbers(ctx, openIntake.ID)
-			suite.NoError(err)
-			suite.Equal(len(caseValues.InitialContractNumbers), len(updatedIntakeContractNumbers))
+			s.NoError(err)
+			s.Equal(len(caseValues.InitialContractNumbers), len(updatedIntakeContractNumbers))
 
 			// Set existing system IDs
 			err = sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 				return store.SetSystemIntakeSystems(ctx, tx, openIntake.ID, caseValues.InitialSystemIDs)
 			})
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedIntakeSystemIDs, err := SystemIntakeSystems(ctx, openIntake.ID)
-			suite.NoError(err)
-			suite.Equal(len(caseValues.InitialSystemIDs), len(updatedIntakeSystemIDs))
+			s.NoError(err)
+			s.Equal(len(caseValues.InitialSystemIDs), len(updatedIntakeSystemIDs))
 
 			// Set the "existing system" relationship
 			input := &models.SetSystemIntakeRelationExistingSystemInput{
@@ -219,22 +219,22 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingSystem() {
 				input,
 			)
 
-			suite.NoError(err)
+			s.NoError(err)
 
 			// Ensure the contract name was deleted properly
-			suite.True(updatedIntake.ContractName.IsZero())
+			s.True(updatedIntake.ContractName.IsZero())
 
 			// refetch contract numbers and system IDs
 			updatedIntakeContractNumbers, err = SystemIntakeContractNumbers(ctx, updatedIntake.ID)
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedIntakeSystemIDs, err = SystemIntakeSystems(ctx, openIntake.ID)
-			suite.NoError(err)
+			s.NoError(err)
 
 			// Ensure the system IDs were modified properly
-			suite.Equal(len(caseValues.NewSystemIDs), len(updatedIntakeSystemIDs))
+			s.Equal(len(caseValues.NewSystemIDs), len(updatedIntakeSystemIDs))
 			for _, v := range updatedIntakeSystemIDs {
-				suite.Contains(caseValues.NewSystemIDs, v.ID.String)
+				s.Contains(caseValues.NewSystemIDs, v.ID.String)
 			}
 
 			// Ensure the contract numbers were modified properly
@@ -247,15 +247,15 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingSystem() {
 			_ = updatedIntakeContractNumbers
 
 			// Check relation type
-			suite.NotNil(updatedIntake.SystemRelationType)
-			suite.Equal(models.RelationTypeExistingSystem, *updatedIntake.SystemRelationType)
+			s.NotNil(updatedIntake.SystemRelationType)
+			s.Equal(models.RelationTypeExistingSystem, *updatedIntake.SystemRelationType)
 		})
 	}
 }
 
-func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingService() {
-	ctx := suite.testConfigs.Context
-	store := suite.testConfigs.Store
+func (s *ResolverSuite) TestSetSystemIntakeRelationExistingService() {
+	ctx := s.testConfigs.Context
+	store := s.testConfigs.Store
 
 	submittedAt := time.Now()
 
@@ -295,37 +295,37 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingService() {
 	}
 
 	for caseName, caseValues := range cases {
-		suite.Run(caseName, func() {
+		s.Run(caseName, func() {
 			openIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
 				State:        models.SystemIntakeStateOpen,
 				RequestType:  models.SystemIntakeRequestTypeNEW,
 				SubmittedAt:  &submittedAt,
 				ContractName: zero.StringFrom("My Test Contract Name"),
 			})
-			suite.NoError(err)
-			suite.NotNil(openIntake)
+			s.NoError(err)
+			s.NotNil(openIntake)
 
 			// Set existing contract numbers
 			err = sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 				return store.SetSystemIntakeContractNumbers(ctx, tx, openIntake.ID, caseValues.InitialContractNumbers)
 
 			})
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedIntakeContractNumbers, err := SystemIntakeContractNumbers(ctx, openIntake.ID)
-			suite.NoError(err)
-			suite.Equal(len(caseValues.InitialContractNumbers), len(updatedIntakeContractNumbers))
+			s.NoError(err)
+			s.Equal(len(caseValues.InitialContractNumbers), len(updatedIntakeContractNumbers))
 
 			// Set existing system IDs
 			err = sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 				return store.SetSystemIntakeSystems(ctx, tx, openIntake.ID, caseValues.InitialSystemIDs)
 
 			})
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedIntakeSystemIDs, err := SystemIntakeSystems(ctx, openIntake.ID)
-			suite.NoError(err)
-			suite.Equal(len(caseValues.InitialSystemIDs), len(updatedIntakeSystemIDs))
+			s.NoError(err)
+			s.Equal(len(caseValues.InitialSystemIDs), len(updatedIntakeSystemIDs))
 
 			// Set the existing service relationship
 			newContractName := "My New Contract Name"
@@ -335,22 +335,22 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingService() {
 				ContractNumbers: caseValues.NewContractNumbers,
 			}
 			updatedIntake, err := SetSystemIntakeRelationExistingService(ctx, store, input)
-			suite.NoError(err)
+			s.NoError(err)
 
 			// Ensure the contract name was updated properly
-			suite.Equal(newContractName, updatedIntake.ContractName.String)
+			s.Equal(newContractName, updatedIntake.ContractName.String)
 
 			// refetch contract numbers and system IDs
 			updatedIntakeContractNumbers, err = SystemIntakeContractNumbers(ctx, updatedIntake.ID)
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedIntakeSystemIDs, err = SystemIntakeSystems(ctx, openIntake.ID)
-			suite.NoError(err)
+			s.NoError(err)
 
 			// Ensure the system IDs were modified properly
-			suite.Equal(len(caseValues.NewSystemIDs), len(updatedIntakeSystemIDs))
+			s.Equal(len(caseValues.NewSystemIDs), len(updatedIntakeSystemIDs))
 			for _, v := range updatedIntakeSystemIDs {
-				suite.Contains(caseValues.NewSystemIDs, v.ID)
+				s.Contains(caseValues.NewSystemIDs, v.ID)
 			}
 
 			// Ensure the contract numbers were modified properly
@@ -364,19 +364,19 @@ func (suite *ResolverSuite) TestSetSystemIntakeRelationExistingService() {
 			_ = updatedIntakeContractNumbers
 
 			// Check relation type
-			suite.NotNil(updatedIntake.SystemRelationType)
-			suite.Equal(models.RelationTypeExistingService, *updatedIntake.SystemRelationType)
+			s.NotNil(updatedIntake.SystemRelationType)
+			s.Equal(models.RelationTypeExistingService, *updatedIntake.SystemRelationType)
 		})
 	}
 }
 
-func (suite *ResolverSuite) TestUnlinkSystemIntakeRelation() {
-	ctx := suite.testConfigs.Context
-	store := suite.testConfigs.Store
+func (s *ResolverSuite) TestUnlinkSystemIntakeRelation() {
+	ctx := s.testConfigs.Context
+	store := s.testConfigs.Store
 
 	submittedAt := time.Now()
 
-	suite.Run("unlink new system intake", func() {
+	s.Run("unlink new system intake", func() {
 		// Create an inital intake
 		openIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
 			State:        models.SystemIntakeStateOpen,
@@ -384,8 +384,8 @@ func (suite *ResolverSuite) TestUnlinkSystemIntakeRelation() {
 			SubmittedAt:  &submittedAt,
 			ContractName: zero.StringFrom("My Test Contract Name"),
 		})
-		suite.NoError(err)
-		suite.NotNil(openIntake)
+		s.NoError(err)
+		s.NotNil(openIntake)
 
 		// Set the new system relationship
 		input := &models.SetSystemIntakeRelationNewSystemInput{
@@ -393,15 +393,15 @@ func (suite *ResolverSuite) TestUnlinkSystemIntakeRelation() {
 			ContractNumbers: []string{"12345", "67890"},
 		}
 		_, err = SetSystemIntakeRelationNewSystem(ctx, store, input)
-		suite.NoError(err) // we don't need to test the SetSystemIntakeRelationNewSystem function here
+		s.NoError(err) // we don't need to test the SetSystemIntakeRelationNewSystem function here
 
 		// Now unlink the relationship
 		unlinkedIntake, err := UnlinkSystemIntakeRelation(ctx, store, openIntake.ID)
-		suite.NoError(err)
+		s.NoError(err)
 
 		// Assert that all values are cleared appropriately
-		suite.Equal("", unlinkedIntake.ContractName.ValueOrZero())
-		suite.Nil(unlinkedIntake.SystemRelationType)
+		s.Equal("", unlinkedIntake.ContractName.ValueOrZero())
+		s.Nil(unlinkedIntake.SystemRelationType)
 
 		// Check contract numbers are cleared
 		// skip the following test, see Note [EASI-4160 Disable Contract Number Linking]
@@ -411,11 +411,11 @@ func (suite *ResolverSuite) TestUnlinkSystemIntakeRelation() {
 
 		// Check system IDs are cleared
 		systemIDs, err := SystemIntakeSystems(ctx, unlinkedIntake.ID)
-		suite.NoError(err)
-		suite.Empty(systemIDs)
+		s.NoError(err)
+		s.Empty(systemIDs)
 	})
 
-	suite.Run("unlink existing system intake", func() {
+	s.Run("unlink existing system intake", func() {
 		// Create an inital intake
 		openIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
 			State:        models.SystemIntakeStateOpen,
@@ -423,8 +423,8 @@ func (suite *ResolverSuite) TestUnlinkSystemIntakeRelation() {
 			SubmittedAt:  &submittedAt,
 			ContractName: zero.StringFrom("My Test Contract Name"),
 		})
-		suite.NoError(err)
-		suite.NotNil(openIntake)
+		s.NoError(err)
+		s.NotNil(openIntake)
 
 		// Set the existing system relationship
 		input := &models.SetSystemIntakeRelationExistingSystemInput{
@@ -440,15 +440,15 @@ func (suite *ResolverSuite) TestUnlinkSystemIntakeRelation() {
 			},
 			input,
 		)
-		suite.NoError(err) // we don't need to test the SetSystemIntakeRelationExistingSystem function here
+		s.NoError(err) // we don't need to test the SetSystemIntakeRelationExistingSystem function here
 
 		// Now unlink the relationship
 		unlinkedIntake, err := UnlinkSystemIntakeRelation(ctx, store, openIntake.ID)
-		suite.NoError(err)
+		s.NoError(err)
 
 		// Assert that all values are cleared appropriately
-		suite.Equal("", unlinkedIntake.ContractName.ValueOrZero())
-		suite.Nil(unlinkedIntake.SystemRelationType)
+		s.Equal("", unlinkedIntake.ContractName.ValueOrZero())
+		s.Nil(unlinkedIntake.SystemRelationType)
 
 		// Check contract numbers are cleared
 		// skip the following test, see Note [EASI-4160 Disable Contract Number Linking]
@@ -458,19 +458,19 @@ func (suite *ResolverSuite) TestUnlinkSystemIntakeRelation() {
 
 		// Check system IDs are cleared
 		systemIDs, err := SystemIntakeSystems(ctx, unlinkedIntake.ID)
-		suite.NoError(err)
-		suite.Empty(systemIDs)
+		s.NoError(err)
+		s.Empty(systemIDs)
 	})
 
-	suite.Run("unlink existing service intake", func() {
+	s.Run("unlink existing service intake", func() {
 		// Create an inital intake
 		openIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
 			State:       models.SystemIntakeStateOpen,
 			RequestType: models.SystemIntakeRequestTypeNEW,
 			SubmittedAt: &submittedAt,
 		})
-		suite.NoError(err)
-		suite.NotNil(openIntake)
+		s.NoError(err)
+		s.NotNil(openIntake)
 
 		// Set the existing service relationship
 		contractName := "My Test Contract Name"
@@ -480,24 +480,24 @@ func (suite *ResolverSuite) TestUnlinkSystemIntakeRelation() {
 			ContractNumbers: []string{"12345", "67890"},
 		}
 		_, err = SetSystemIntakeRelationExistingService(ctx, store, input)
-		suite.NoError(err) // we don't need to test the SetSystemIntakeRelationExistingService function here
+		s.NoError(err) // we don't need to test the SetSystemIntakeRelationExistingService function here
 
 		// Now unlink the relationship
 		unlinkedIntake, err := UnlinkSystemIntakeRelation(ctx, store, openIntake.ID)
-		suite.NoError(err)
+		s.NoError(err)
 
 		// Assert that all values are cleared appropriately
-		suite.Equal("", unlinkedIntake.ContractName.ValueOrZero())
-		suite.Nil(unlinkedIntake.SystemRelationType)
+		s.Equal("", unlinkedIntake.ContractName.ValueOrZero())
+		s.Nil(unlinkedIntake.SystemRelationType)
 
 		// Check contract numbers are cleared
 		nums, err := SystemIntakeContractNumbers(ctx, unlinkedIntake.ID)
-		suite.NoError(err)
-		suite.Empty(nums)
+		s.NoError(err)
+		s.Empty(nums)
 
 		// Check system IDs are cleared
 		systemIDs, err := SystemIntakeSystems(ctx, unlinkedIntake.ID)
-		suite.NoError(err)
-		suite.Empty(systemIDs)
+		s.NoError(err)
+		s.Empty(systemIDs)
 	})
 }

--- a/pkg/graph/resolvers/system_intake_test.go
+++ b/pkg/graph/resolvers/system_intake_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
-func (suite *ResolverSuite) TestSystemIntakesQuery() {
-	ctx := suite.testConfigs.Context
-	store := suite.testConfigs.Store
+func (s *ResolverSuite) TestSystemIntakesQuery() {
+	ctx := s.testConfigs.Context
+	store := s.testConfigs.Store
 
 	submittedAt := time.Now()
 
@@ -18,13 +18,13 @@ func (suite *ResolverSuite) TestSystemIntakesQuery() {
 		RequestType: models.SystemIntakeRequestTypeNEW,
 		SubmittedAt: &submittedAt,
 	})
-	suite.NoError(err)
-	suite.NotNil(openIntake)
+	s.NoError(err)
+	s.NotNil(openIntake)
 	// set submitted_at
 	openIntake.SubmittedAt = &submittedAt
 	openIntake, err = store.UpdateSystemIntake(ctx, openIntake)
-	suite.NoError(err)
-	suite.NotNil(openIntake)
+	s.NoError(err)
+	s.NotNil(openIntake)
 
 	// Create a closed intake
 	closedIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
@@ -32,61 +32,61 @@ func (suite *ResolverSuite) TestSystemIntakesQuery() {
 		RequestType: models.SystemIntakeRequestTypeNEW,
 		SubmittedAt: &submittedAt,
 	})
-	suite.NoError(err)
-	suite.NotNil(closedIntake)
+	s.NoError(err)
+	s.NotNil(closedIntake)
 	// set submitted_at
 	closedIntake.SubmittedAt = &submittedAt
 	closedIntake, err = store.UpdateSystemIntake(ctx, closedIntake)
-	suite.NoError(err)
-	suite.NotNil(closedIntake)
+	s.NoError(err)
+	s.NotNil(closedIntake)
 
 	// Check open intakes
 	openIntakes, err := SystemIntakes(ctx, store, true)
-	suite.NoError(err)
-	suite.Len(openIntakes, 1)
-	suite.Equal(openIntakes[0].ID, openIntake.ID)
+	s.NoError(err)
+	s.Len(openIntakes, 1)
+	s.Equal(openIntakes[0].ID, openIntake.ID)
 
 	// Check closed intakes
 	closedIntakes, err := SystemIntakes(ctx, store, false)
-	suite.NoError(err)
-	suite.Len(closedIntakes, 1)
-	suite.Equal(closedIntakes[0].ID, closedIntake.ID)
+	s.NoError(err)
+	s.Len(closedIntakes, 1)
+	s.Equal(closedIntakes[0].ID, closedIntake.ID)
 }
 
-func (suite *ResolverSuite) TestSystemIntakesQueryUnsubmitted() {
-	ctx := suite.testConfigs.Context
-	store := suite.testConfigs.Store
+func (s *ResolverSuite) TestSystemIntakesQueryUnsubmitted() {
+	ctx := s.testConfigs.Context
+	store := s.testConfigs.Store
 
 	// Create an open intake
 	openIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
 		State:       models.SystemIntakeStateOpen,
 		RequestType: models.SystemIntakeRequestTypeNEW,
 	})
-	suite.NoError(err)
-	suite.NotNil(openIntake)
+	s.NoError(err)
+	s.NotNil(openIntake)
 
 	// Create a closed intake
 	closedIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
 		State:       models.SystemIntakeStateClosed,
 		RequestType: models.SystemIntakeRequestTypeNEW,
 	})
-	suite.NoError(err)
-	suite.NotNil(closedIntake)
+	s.NoError(err)
+	s.NotNil(closedIntake)
 
 	// Check open intakes
 	openIntakes, err := SystemIntakes(ctx, store, true)
-	suite.NoError(err)
-	suite.Len(openIntakes, 0)
+	s.NoError(err)
+	s.Len(openIntakes, 0)
 
 	// Check closed intakes
 	closedIntakes, err := SystemIntakes(ctx, store, false)
-	suite.NoError(err)
-	suite.Len(closedIntakes, 0)
+	s.NoError(err)
+	s.Len(closedIntakes, 0)
 }
 
-func (suite *ResolverSuite) TestSystemIntakesQueryArchived() {
-	ctx := suite.testConfigs.Context
-	store := suite.testConfigs.Store
+func (s *ResolverSuite) TestSystemIntakesQueryArchived() {
+	ctx := s.testConfigs.Context
+	store := s.testConfigs.Store
 
 	archivedAt := time.Now()
 
@@ -95,34 +95,34 @@ func (suite *ResolverSuite) TestSystemIntakesQueryArchived() {
 		State:       models.SystemIntakeStateOpen,
 		RequestType: models.SystemIntakeRequestTypeNEW,
 	})
-	suite.NoError(err)
-	suite.NotNil(openIntake)
+	s.NoError(err)
+	s.NotNil(openIntake)
 	// set archived_at
 	openIntake.ArchivedAt = &archivedAt
 	openIntake, err = store.UpdateSystemIntake(ctx, openIntake)
-	suite.NoError(err)
-	suite.NotNil(openIntake)
+	s.NoError(err)
+	s.NotNil(openIntake)
 
 	// Create a closed intake with an `archived_at`
 	closedIntake, err := store.CreateSystemIntake(ctx, &models.SystemIntake{
 		State:       models.SystemIntakeStateClosed,
 		RequestType: models.SystemIntakeRequestTypeNEW,
 	})
-	suite.NoError(err)
-	suite.NotNil(closedIntake)
+	s.NoError(err)
+	s.NotNil(closedIntake)
 	// set archived_at
 	closedIntake.ArchivedAt = &archivedAt
 	closedIntake, err = store.UpdateSystemIntake(ctx, closedIntake)
-	suite.NoError(err)
-	suite.NotNil(closedIntake)
+	s.NoError(err)
+	s.NotNil(closedIntake)
 
 	// Check open intakes
 	openIntakes, err := SystemIntakes(ctx, store, true)
-	suite.NoError(err)
-	suite.Len(openIntakes, 0)
+	s.NoError(err)
+	s.Len(openIntakes, 0)
 
 	// Check closed intakes
 	closedIntakes, err := SystemIntakes(ctx, store, false)
-	suite.NoError(err)
-	suite.Len(closedIntakes, 0)
+	s.NoError(err)
+	s.Len(closedIntakes, 0)
 }

--- a/pkg/graph/resolvers/trb_request_document_test.go
+++ b/pkg/graph/resolvers/trb_request_document_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
-func (suite *ResolverSuite) TestTRBRequestDocumentResolvers() {
+func (s *ResolverSuite) TestTRBRequestDocumentResolvers() {
 	// general setup
-	trbRequest, err := CreateTRBRequest(suite.testConfigs.Context, models.TRBTFormalReview, suite.testConfigs.Store)
-	suite.NoError(err)
-	suite.NotNil(trbRequest)
+	trbRequest, err := CreateTRBRequest(s.testConfigs.Context, models.TRBTFormalReview, s.testConfigs.Store)
+	s.NoError(err)
+	s.NotNil(trbRequest)
 	trbRequestID := trbRequest.ID
 
 	documentToCreate := &models.TRBRequestDocument{
@@ -26,9 +26,9 @@ func (suite *ResolverSuite) TestTRBRequestDocumentResolvers() {
 	}
 	// docToBeCreated.CreatedBy will be set based on principal in test config
 
-	createdDocument := createTRBRequestDocumentSubtest(suite, trbRequestID, documentToCreate)
-	getTRBRequestDocumentsByRequestIDSubtest(suite, trbRequestID, createdDocument)
-	deleteTRBRequestDocumentSubtest(suite, createdDocument)
+	createdDocument := createTRBRequestDocumentSubtest(s, trbRequestID, documentToCreate)
+	getTRBRequestDocumentsByRequestIDSubtest(s, trbRequestID, createdDocument)
+	deleteTRBRequestDocumentSubtest(s, createdDocument)
 }
 
 // subtests are regular functions, not suite methods, so we can guarantee they run sequentially

--- a/pkg/graph/resolvers/trb_request_relation_test.go
+++ b/pkg/graph/resolvers/trb_request_relation_test.go
@@ -18,9 +18,9 @@ type trbRequestRelationTestCase struct {
 	NewSystemIDs           []string
 }
 
-func (suite *ResolverSuite) TestSetTRBRequestRelationNewSystem() {
-	store := suite.testConfigs.Store
-	ctx := suite.testConfigs.Context
+func (s *ResolverSuite) TestSetTRBRequestRelationNewSystem() {
+	store := s.testConfigs.Store
+	ctx := s.testConfigs.Context
 
 	var contractNumberCases = map[string]trbRequestRelationTestCase{
 		"adds contract numbers when no initial contract numbers exist": {
@@ -58,35 +58,35 @@ func (suite *ResolverSuite) TestSetTRBRequestRelationNewSystem() {
 	}
 
 	for caseName, caseValues := range contractNumberCases {
-		suite.Run(caseName, func() {
+		s.Run(caseName, func() {
 			trbRequest, err := CreateTRBRequest(ctx, models.TRBTNeedHelp, store)
-			suite.NoError(err)
+			s.NoError(err)
 			changes := map[string]interface{}{"contractName": zero.StringFrom("Test Name")}
 			trbRequest, err = UpdateTRBRequest(ctx, trbRequest.ID, changes, store)
-			suite.NoError(err)
-			suite.NotEqual(trbRequest.ID, uuid.Nil)
-			suite.NotNil(trbRequest)
-			suite.Equal(trbRequest.ContractName, zero.StringFrom("Test Name"))
+			s.NoError(err)
+			s.NotEqual(trbRequest.ID, uuid.Nil)
+			s.NotNil(trbRequest)
+			s.Equal(trbRequest.ContractName, zero.StringFrom("Test Name"))
 
 			// Set existing contract numbers
 			err = sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 				return store.SetTRBRequestContractNumbers(ctx, tx, trbRequest.ID, caseValues.InitialContractNumbers)
 			})
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedTRBRequestContractNumbers, err := TRBRequestContractNumbers(ctx, trbRequest.ID)
-			suite.NoError(err)
-			suite.Equal(len(caseValues.InitialContractNumbers), len(updatedTRBRequestContractNumbers))
+			s.NoError(err)
+			s.Equal(len(caseValues.InitialContractNumbers), len(updatedTRBRequestContractNumbers))
 
 			// Set existing system IDs
 			err = sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 				return store.SetTRBRequestSystems(ctx, tx, trbRequest.ID, caseValues.InitialSystemIDs)
 			})
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedTRBRequestSystemIDs, err := TRBRequestSystems(ctx, trbRequest.ID)
-			suite.NoError(err)
-			suite.Equal(len(caseValues.InitialSystemIDs), len(updatedTRBRequestSystemIDs))
+			s.NoError(err)
+			s.Equal(len(caseValues.InitialSystemIDs), len(updatedTRBRequestSystemIDs))
 
 			// Set the "new system" relationship
 			input := models.SetTRBRequestRelationNewSystemInput{
@@ -96,41 +96,41 @@ func (suite *ResolverSuite) TestSetTRBRequestRelationNewSystem() {
 
 			// Run Resolver
 			updatedTRBRequest, err := SetTRBRequestRelationNewSystem(ctx, store, input)
-			suite.NoError(err)
+			s.NoError(err)
 
 			// Ensure the contract name was deleted properly
-			suite.True(updatedTRBRequest.ContractName.IsZero())
+			s.True(updatedTRBRequest.ContractName.IsZero())
 
 			// refetch contract numbers and system IDs
 			updatedTRBRequestContractNumbers, err = TRBRequestContractNumbers(ctx, updatedTRBRequest.ID)
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedTRBRequestSystemIDs, err = TRBRequestSystems(ctx, trbRequest.ID)
-			suite.NoError(err)
+			s.NoError(err)
 
 			// Ensure the system IDs were modified properly
 			// New System relation should always remove existing system IDs
-			suite.Equal(len(caseValues.NewSystemIDs), len(updatedTRBRequestSystemIDs))
+			s.Equal(len(caseValues.NewSystemIDs), len(updatedTRBRequestSystemIDs))
 			for _, v := range updatedTRBRequestSystemIDs {
-				suite.Contains(caseValues.NewSystemIDs, v.ID)
+				s.Contains(caseValues.NewSystemIDs, v.ID)
 			}
 
 			// Ensure the contract numbers were modified properly
-			suite.Equal(len(caseValues.NewContractNumbers), len(updatedTRBRequestContractNumbers))
+			s.Equal(len(caseValues.NewContractNumbers), len(updatedTRBRequestContractNumbers))
 			for _, v := range updatedTRBRequestContractNumbers {
-				suite.Contains(caseValues.NewContractNumbers, v.ContractNumber)
+				s.Contains(caseValues.NewContractNumbers, v.ContractNumber)
 			}
 
 			// Check relation type
-			suite.NotNil(updatedTRBRequest.SystemRelationType)
-			suite.Equal(models.RelationTypeNewSystem, *updatedTRBRequest.SystemRelationType)
+			s.NotNil(updatedTRBRequest.SystemRelationType)
+			s.Equal(models.RelationTypeNewSystem, *updatedTRBRequest.SystemRelationType)
 		})
 	}
 }
 
-func (suite *ResolverSuite) TestSetTRBRequestRelationExistingSystem() {
-	store := suite.testConfigs.Store
-	ctx := suite.testConfigs.Context
+func (s *ResolverSuite) TestSetTRBRequestRelationExistingSystem() {
+	store := s.testConfigs.Store
+	ctx := s.testConfigs.Context
 
 	var cases = map[string]trbRequestRelationTestCase{
 		"adds contract numbers and system IDs when no initial ones exist": {
@@ -166,35 +166,35 @@ func (suite *ResolverSuite) TestSetTRBRequestRelationExistingSystem() {
 	}
 
 	for caseName, caseValues := range cases {
-		suite.Run(caseName, func() {
+		s.Run(caseName, func() {
 			trbRequest, err := CreateTRBRequest(ctx, models.TRBTNeedHelp, store)
-			suite.NoError(err)
+			s.NoError(err)
 			changes := map[string]interface{}{"contractName": zero.StringFrom("Test Name")}
 			trbRequest, err = UpdateTRBRequest(ctx, trbRequest.ID, changes, store)
-			suite.NoError(err)
-			suite.NotEqual(trbRequest.ID, uuid.Nil)
-			suite.NotNil(trbRequest)
-			suite.Equal(trbRequest.ContractName, zero.StringFrom("Test Name"))
+			s.NoError(err)
+			s.NotEqual(trbRequest.ID, uuid.Nil)
+			s.NotNil(trbRequest)
+			s.Equal(trbRequest.ContractName, zero.StringFrom("Test Name"))
 
 			// Set existing contract numbers
 			err = sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 				return store.SetTRBRequestContractNumbers(ctx, tx, trbRequest.ID, caseValues.InitialContractNumbers)
 			})
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedTRBRequestContractNumbers, err := TRBRequestContractNumbers(ctx, trbRequest.ID)
-			suite.NoError(err)
-			suite.Equal(len(caseValues.InitialContractNumbers), len(updatedTRBRequestContractNumbers))
+			s.NoError(err)
+			s.Equal(len(caseValues.InitialContractNumbers), len(updatedTRBRequestContractNumbers))
 
 			// Set existing system IDs
 			err = sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 				return store.SetTRBRequestSystems(ctx, tx, trbRequest.ID, caseValues.InitialSystemIDs)
 			})
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedTRBRequestSystemIDs, err := TRBRequestSystems(ctx, trbRequest.ID)
-			suite.NoError(err)
-			suite.Equal(len(caseValues.InitialSystemIDs), len(updatedTRBRequestSystemIDs))
+			s.NoError(err)
+			s.Equal(len(caseValues.InitialSystemIDs), len(updatedTRBRequestSystemIDs))
 
 			// Set the "existing system" relationship
 			input := models.SetTRBRequestRelationExistingSystemInput{
@@ -211,40 +211,40 @@ func (suite *ResolverSuite) TestSetTRBRequestRelationExistingSystem() {
 				input,
 			)
 
-			suite.NoError(err)
+			s.NoError(err)
 
 			// Ensure the contract name was deleted properly
-			suite.True(updatedTRBRequest.ContractName.IsZero())
+			s.True(updatedTRBRequest.ContractName.IsZero())
 
 			// refetch contract numbers and system IDs
 			updatedTRBRequestContractNumbers, err = TRBRequestContractNumbers(ctx, updatedTRBRequest.ID)
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedTRBRequestSystemIDs, err = TRBRequestSystems(ctx, trbRequest.ID)
-			suite.NoError(err)
+			s.NoError(err)
 
 			// Ensure the system IDs were modified properly
-			suite.Equal(len(caseValues.NewSystemIDs), len(updatedTRBRequestSystemIDs))
+			s.Equal(len(caseValues.NewSystemIDs), len(updatedTRBRequestSystemIDs))
 			for _, v := range updatedTRBRequestSystemIDs {
-				suite.Contains(caseValues.NewSystemIDs, v.ID.String)
+				s.Contains(caseValues.NewSystemIDs, v.ID.String)
 			}
 
 			// Ensure the contract numbers were modified properly
-			suite.Equal(len(caseValues.NewContractNumbers), len(updatedTRBRequestContractNumbers))
+			s.Equal(len(caseValues.NewContractNumbers), len(updatedTRBRequestContractNumbers))
 			for _, v := range updatedTRBRequestContractNumbers {
-				suite.Contains(caseValues.NewContractNumbers, v.ContractNumber)
+				s.Contains(caseValues.NewContractNumbers, v.ContractNumber)
 			}
 
 			// Check relation type
-			suite.NotNil(updatedTRBRequest.SystemRelationType)
-			suite.Equal(models.RelationTypeExistingSystem, *updatedTRBRequest.SystemRelationType)
+			s.NotNil(updatedTRBRequest.SystemRelationType)
+			s.Equal(models.RelationTypeExistingSystem, *updatedTRBRequest.SystemRelationType)
 		})
 	}
 }
 
-func (suite *ResolverSuite) TestSetTRBRequestRelationExistingService() {
-	store := suite.testConfigs.Store
-	ctx := suite.testConfigs.Context
+func (s *ResolverSuite) TestSetTRBRequestRelationExistingService() {
+	store := s.testConfigs.Store
+	ctx := s.testConfigs.Context
 
 	var cases = map[string]trbRequestRelationTestCase{
 		"adds contract numbers when no initial ones exist": {
@@ -282,31 +282,31 @@ func (suite *ResolverSuite) TestSetTRBRequestRelationExistingService() {
 	}
 
 	for caseName, caseValues := range cases {
-		suite.Run(caseName, func() {
+		s.Run(caseName, func() {
 			trbRequest, err := CreateTRBRequest(ctx, models.TRBTNeedHelp, store)
-			suite.NoError(err)
-			suite.NotEqual(trbRequest.ID, uuid.Nil)
-			suite.NotNil(trbRequest)
+			s.NoError(err)
+			s.NotEqual(trbRequest.ID, uuid.Nil)
+			s.NotNil(trbRequest)
 
 			// Set existing contract numbers
 			err = sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 				return store.SetTRBRequestContractNumbers(ctx, tx, trbRequest.ID, caseValues.InitialContractNumbers)
 			})
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedTRBRequestContractNumbers, err := TRBRequestContractNumbers(ctx, trbRequest.ID)
-			suite.NoError(err)
-			suite.Equal(len(caseValues.InitialContractNumbers), len(updatedTRBRequestContractNumbers))
+			s.NoError(err)
+			s.Equal(len(caseValues.InitialContractNumbers), len(updatedTRBRequestContractNumbers))
 
 			// Set existing system IDs
 			err = sqlutils.WithTransaction(ctx, store, func(tx *sqlx.Tx) error {
 				return store.SetTRBRequestSystems(ctx, tx, trbRequest.ID, caseValues.InitialSystemIDs)
 			})
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedTRBRequestSystemIDs, err := TRBRequestSystems(ctx, trbRequest.ID)
-			suite.NoError(err)
-			suite.Equal(len(caseValues.InitialSystemIDs), len(updatedTRBRequestSystemIDs))
+			s.NoError(err)
+			s.Equal(len(caseValues.InitialSystemIDs), len(updatedTRBRequestSystemIDs))
 
 			// Set the existing service relationship
 			newContractName := "My New Contract Name"
@@ -316,48 +316,48 @@ func (suite *ResolverSuite) TestSetTRBRequestRelationExistingService() {
 				ContractNumbers: caseValues.NewContractNumbers,
 			}
 			updatedTRBRequest, err := SetTRBRequestRelationExistingService(ctx, store, input)
-			suite.NoError(err)
+			s.NoError(err)
 
 			// Ensure the contract name was updated properly
-			suite.Equal(newContractName, updatedTRBRequest.ContractName.String)
+			s.Equal(newContractName, updatedTRBRequest.ContractName.String)
 
 			// refetch contract numbers and system IDs
 			updatedTRBRequestContractNumbers, err = TRBRequestContractNumbers(ctx, updatedTRBRequest.ID)
-			suite.NoError(err)
+			s.NoError(err)
 
 			updatedTRBRequestSystemIDs, err = TRBRequestSystems(ctx, trbRequest.ID)
-			suite.NoError(err)
+			s.NoError(err)
 
 			// Ensure the system IDs were modified properly
-			suite.Equal(len(caseValues.NewSystemIDs), len(updatedTRBRequestSystemIDs))
+			s.Equal(len(caseValues.NewSystemIDs), len(updatedTRBRequestSystemIDs))
 			for _, v := range updatedTRBRequestSystemIDs {
-				suite.Contains(caseValues.NewSystemIDs, v.ID)
+				s.Contains(caseValues.NewSystemIDs, v.ID)
 			}
 
 			// Ensure the contract numbers were modified properly
 			// Existing Service relation should always remove existing system IDs
-			suite.Equal(len(caseValues.NewContractNumbers), len(updatedTRBRequestContractNumbers))
+			s.Equal(len(caseValues.NewContractNumbers), len(updatedTRBRequestContractNumbers))
 			for _, v := range updatedTRBRequestContractNumbers {
-				suite.Contains(caseValues.NewContractNumbers, v.ContractNumber)
+				s.Contains(caseValues.NewContractNumbers, v.ContractNumber)
 			}
 
 			// Check relation type
-			suite.NotNil(updatedTRBRequest.SystemRelationType)
-			suite.Equal(models.RelationTypeExistingService, *updatedTRBRequest.SystemRelationType)
+			s.NotNil(updatedTRBRequest.SystemRelationType)
+			s.Equal(models.RelationTypeExistingService, *updatedTRBRequest.SystemRelationType)
 		})
 	}
 }
 
-func (suite *ResolverSuite) TestUnlinkTRBRequestRelation() {
-	ctx := suite.testConfigs.Context
-	store := suite.testConfigs.Store
+func (s *ResolverSuite) TestUnlinkTRBRequestRelation() {
+	ctx := s.testConfigs.Context
+	store := s.testConfigs.Store
 
-	suite.Run("unlink new trb request", func() {
+	s.Run("unlink new trb request", func() {
 		// Create an inital TRBRequest
 		trbRequest, err := CreateTRBRequest(ctx, models.TRBTNeedHelp, store)
-		suite.NoError(err)
-		suite.NotEqual(trbRequest.ID, uuid.Nil)
-		suite.NotNil(trbRequest)
+		s.NoError(err)
+		s.NotEqual(trbRequest.ID, uuid.Nil)
+		s.NotNil(trbRequest)
 
 		// Set the new system relationship
 		input := models.SetTRBRequestRelationNewSystemInput{
@@ -365,33 +365,33 @@ func (suite *ResolverSuite) TestUnlinkTRBRequestRelation() {
 			ContractNumbers: []string{"12345", "67890"},
 		}
 		_, err = SetTRBRequestRelationNewSystem(ctx, store, input)
-		suite.NoError(err) // we don't need to test the SetTRBRequestRelationNewSystem function here
+		s.NoError(err) // we don't need to test the SetTRBRequestRelationNewSystem function here
 
 		// Now unlink the relationship
 		unlinkedTRBRequest, err := UnlinkTRBRequestRelation(ctx, store, trbRequest.ID)
-		suite.NoError(err)
+		s.NoError(err)
 
 		// Assert that all values are cleared appropriately
-		suite.Equal("", unlinkedTRBRequest.ContractName.ValueOrZero())
-		suite.Nil(unlinkedTRBRequest.SystemRelationType)
+		s.Equal("", unlinkedTRBRequest.ContractName.ValueOrZero())
+		s.Nil(unlinkedTRBRequest.SystemRelationType)
 
 		// Check contract numbers are cleared
 		nums, err := TRBRequestContractNumbers(ctx, unlinkedTRBRequest.ID)
-		suite.NoError(err)
-		suite.Empty(nums)
+		s.NoError(err)
+		s.Empty(nums)
 
 		// Check system IDs are cleared
 		systemIDs, err := TRBRequestSystems(ctx, unlinkedTRBRequest.ID)
-		suite.NoError(err)
-		suite.Empty(systemIDs)
+		s.NoError(err)
+		s.Empty(systemIDs)
 	})
 
-	suite.Run("unlink existing trb request", func() {
+	s.Run("unlink existing trb request", func() {
 		// Create an inital TRBRequest
 		trbRequest, err := CreateTRBRequest(ctx, models.TRBTNeedHelp, store)
-		suite.NoError(err)
-		suite.NotEqual(trbRequest.ID, uuid.Nil)
-		suite.NotNil(trbRequest)
+		s.NoError(err)
+		s.NotEqual(trbRequest.ID, uuid.Nil)
+		s.NotNil(trbRequest)
 
 		// Set the existing system relationship
 		input := models.SetTRBRequestRelationExistingSystemInput{
@@ -407,33 +407,33 @@ func (suite *ResolverSuite) TestUnlinkTRBRequestRelation() {
 			},
 			input,
 		)
-		suite.NoError(err) // we don't need to test the SetTRBRequestRelationExistingSystem function here
+		s.NoError(err) // we don't need to test the SetTRBRequestRelationExistingSystem function here
 
 		// Now unlink the relationship
 		unlinkedTRBRequest, err := UnlinkTRBRequestRelation(ctx, store, trbRequest.ID)
-		suite.NoError(err)
+		s.NoError(err)
 
 		// Assert that all values are cleared appropriately
-		suite.Equal("", unlinkedTRBRequest.ContractName.ValueOrZero())
-		suite.Nil(unlinkedTRBRequest.SystemRelationType)
+		s.Equal("", unlinkedTRBRequest.ContractName.ValueOrZero())
+		s.Nil(unlinkedTRBRequest.SystemRelationType)
 
 		// Check contract numbers are cleared
 		nums, err := TRBRequestContractNumbers(ctx, unlinkedTRBRequest.ID)
-		suite.NoError(err)
-		suite.Empty(nums)
+		s.NoError(err)
+		s.Empty(nums)
 
 		// Check system IDs are cleared
 		systemIDs, err := TRBRequestSystems(ctx, unlinkedTRBRequest.ID)
-		suite.NoError(err)
-		suite.Empty(systemIDs)
+		s.NoError(err)
+		s.Empty(systemIDs)
 	})
 
-	suite.Run("unlink existing service TRBRequest", func() {
+	s.Run("unlink existing service TRBRequest", func() {
 		// Create an inital TRBRequest
 		trbRequest, err := CreateTRBRequest(ctx, models.TRBTNeedHelp, store)
-		suite.NoError(err)
-		suite.NotEqual(trbRequest.ID, uuid.Nil)
-		suite.NotNil(trbRequest)
+		s.NoError(err)
+		s.NotEqual(trbRequest.ID, uuid.Nil)
+		s.NotNil(trbRequest)
 
 		// Set the existing service relationship
 		contractName := "My Test Contract Name"
@@ -443,24 +443,24 @@ func (suite *ResolverSuite) TestUnlinkTRBRequestRelation() {
 			ContractNumbers: []string{"12345", "67890"},
 		}
 		_, err = SetTRBRequestRelationExistingService(ctx, store, input)
-		suite.NoError(err) // we don't need to test the SetTRBRequestRelationExistingService function here
+		s.NoError(err) // we don't need to test the SetTRBRequestRelationExistingService function here
 
 		// Now unlink the relationship
 		unlinkedTRBRequest, err := UnlinkTRBRequestRelation(ctx, store, trbRequest.ID)
-		suite.NoError(err)
+		s.NoError(err)
 
 		// Assert that all values are cleared appropriately
-		suite.Equal("", unlinkedTRBRequest.ContractName.ValueOrZero())
-		suite.Nil(unlinkedTRBRequest.SystemRelationType)
+		s.Equal("", unlinkedTRBRequest.ContractName.ValueOrZero())
+		s.Nil(unlinkedTRBRequest.SystemRelationType)
 
 		// Check contract numbers are cleared
 		nums, err := TRBRequestContractNumbers(ctx, unlinkedTRBRequest.ID)
-		suite.NoError(err)
-		suite.Empty(nums)
+		s.NoError(err)
+		s.Empty(nums)
 
 		// Check system IDs are cleared
 		systemIDs, err := TRBRequestSystems(ctx, unlinkedTRBRequest.ID)
-		suite.NoError(err)
-		suite.Empty(systemIDs)
+		s.NoError(err)
+		s.Empty(systemIDs)
 	})
 }

--- a/pkg/graph/schema.resolvers_system_intake_test.go
+++ b/pkg/graph/schema.resolvers_system_intake_test.go
@@ -1284,7 +1284,7 @@ func (s *GraphQLTestSuite) TestUpdateContractDetailsImmediatelyAfterIntakeCreati
 					}
 				}
 				ContractNumbers []struct {
-					Id             string
+					ID             string
 					SystemIntakeID string
 					ContractNumber string
 				}
@@ -1453,7 +1453,7 @@ func (s *GraphQLTestSuite) TestUpdateContractDetailsReplacesContractVehicleWithC
 					Vehicle *string
 				}
 				ContractNumbers []struct {
-					Id             string
+					ID             string
 					SystemIntakeID string
 					ContractNumber string
 				}
@@ -1645,7 +1645,7 @@ func (s *GraphQLTestSuite) TestUpdateContractDetailsRemoveContract() {
 					Vehicle *string
 				}
 				ContractNumbers []struct {
-					Id             string
+					ID             string
 					SystemIntakeID string
 					ContractNumber string
 				}

--- a/pkg/local/cedarcoremock/business_owner_information.go
+++ b/pkg/local/cedarcoremock/business_owner_information.go
@@ -89,8 +89,9 @@ var mockBusinessOwnerInformation = map[string]*models.BusinessOwnerInformation{
 	},
 }
 
-func GetBusinessOwnerInformation(cedarSystemId string) *models.BusinessOwnerInformation {
-	if val, ok := mockBusinessOwnerInformation[cedarSystemId]; ok {
+// GetBusinessOwnerInformation returns a mocked BusinessOwnerInformation struct
+func GetBusinessOwnerInformation(cedarSystemID string) *models.BusinessOwnerInformation {
+	if val, ok := mockBusinessOwnerInformation[cedarSystemID]; ok {
 		return val
 	}
 

--- a/pkg/local/cedarcoremock/exchange.go
+++ b/pkg/local/cedarcoremock/exchange.go
@@ -351,8 +351,9 @@ var mockExchanges = map[string][]*models.CedarExchange{
 	},
 }
 
-func GetExchange(cedarSystemId string) []*models.CedarExchange {
-	if val, ok := mockExchanges[cedarSystemId]; ok {
+// GetExchange returns a mock slice of CedarExchange structs
+func GetExchange(cedarSystemID string) []*models.CedarExchange {
+	if val, ok := mockExchanges[cedarSystemID]; ok {
 		return val
 	}
 

--- a/pkg/local/cedarcoremock/roles.go
+++ b/pkg/local/cedarcoremock/roles.go
@@ -118,7 +118,7 @@ func GetRoleTypeByRoleTypeID(roleTypeID string) *models.CedarRoleType {
 	return &models.CedarRoleType{}
 }
 
-// GetMockSystemRoles returns mocked roles for a single CEDAR system, filtered by role type ID
+// GetSystemRoles returns mocked roles for a single CEDAR system, filtered by role type ID
 func GetSystemRoles(cedarSystemID string, roleTypeID *string) []*models.CedarRole {
 	var roleTypeIDStr string
 	if roleTypeID != nil {

--- a/pkg/local/cedarcoremock/software_products.go
+++ b/pkg/local/cedarcoremock/software_products.go
@@ -9,7 +9,7 @@ import (
 func GetSoftwareProducts() *models.CedarSoftwareProducts {
 	return &models.CedarSoftwareProducts{
 		AiSolnCatg: []zero.String{},
-		ApiDataArea: []zero.String{
+		APIDataArea: []zero.String{
 			zero.StringFrom("Supporting Resource"),
 			zero.StringFrom("Healthcare Quality"),
 		},

--- a/pkg/local/cedarcoremock/system_maintainer_information.go
+++ b/pkg/local/cedarcoremock/system_maintainer_information.go
@@ -231,8 +231,9 @@ var mockSystemMaintainerInformation = map[string]*models.SystemMaintainerInforma
 	},
 }
 
-func GetSystemMaintainerInformation(cedarSystemId string) *models.SystemMaintainerInformation {
-	if val, ok := mockSystemMaintainerInformation[cedarSystemId]; ok {
+// GetSystemMaintainerInformation returns mocked system maintainer information for a single CEDAR system
+func GetSystemMaintainerInformation(cedarSystemID string) *models.SystemMaintainerInformation {
+	if val, ok := mockSystemMaintainerInformation[cedarSystemID]; ok {
 		return val
 	}
 

--- a/pkg/local/cedarcoremock/system_summary.go
+++ b/pkg/local/cedarcoremock/system_summary.go
@@ -111,7 +111,7 @@ var mockSystems = map[string]*models.CedarSystem{
 	},
 }
 
-// GetSystems returns a mocked list of Cedar Systems
+// GetAllSystems returns a mocked list of Cedar Systems
 func GetAllSystems() []*models.CedarSystem {
 	var systems []*models.CedarSystem
 	for _, v := range mockSystems {

--- a/pkg/models/cedar_software_products.go
+++ b/pkg/models/cedar_software_products.go
@@ -22,11 +22,11 @@ type SoftwareProductItem struct {
 	VendorName                     zero.String `json:"vendor_name,omitempty"`
 }
 
-// CedarSoftwareProduct represents a single SoftwareProduct object returned from the CEDAR API
+// CedarSoftwareProducts represents a single SoftwareProduct object returned from the CEDAR API
 type CedarSoftwareProducts struct {
 	// Always present fields
 	AiSolnCatg       []zero.String          `json:"aiSolnCatg"`
-	ApiDataArea      []zero.String          `json:"apiDataArea"`
+	APIDataArea      []zero.String          `json:"apiDataArea"`
 	SoftwareProducts []*SoftwareProductItem `json:"softwareProducts"`
 
 	// Possibly null fields

--- a/pkg/storage/system_intake_funding_source.go
+++ b/pkg/storage/system_intake_funding_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cmsgov/easi-app/pkg/sqlutils"
 )
 
+// UpdateSystemIntakeFundingSources clears and updates the funding sources of a system intake using an automatically created transaction
 func (s *Store) UpdateSystemIntakeFundingSources(ctx context.Context, systemIntakeID uuid.UUID, fundingSources []*models.SystemIntakeFundingSource) ([]*models.SystemIntakeFundingSource, error) {
 	return sqlutils.WithTransactionRet[[]*models.SystemIntakeFundingSource](ctx, s, func(tx *sqlx.Tx) ([]*models.SystemIntakeFundingSource, error) {
 		return s.UpdateSystemIntakeFundingSourcesNP(ctx, tx, systemIntakeID, fundingSources)
@@ -19,7 +20,7 @@ func (s *Store) UpdateSystemIntakeFundingSources(ctx context.Context, systemInta
 	})
 }
 
-// UpdateSystemIntakeFundingSources clears and updates the funding sources of a system intake
+// UpdateSystemIntakeFundingSourcesNP clears and updates the funding sources of a system intake
 func (s *Store) UpdateSystemIntakeFundingSourcesNP(ctx context.Context, tx *sqlx.Tx, systemIntakeID uuid.UUID, fundingSources []*models.SystemIntakeFundingSource) ([]*models.SystemIntakeFundingSource, error) {
 	now := s.clock.Now()
 

--- a/pkg/storage/transactions_test.go
+++ b/pkg/storage/transactions_test.go
@@ -13,126 +13,126 @@ import (
 
 var errArtifical = errors.New("this is an artificial error to ensure that the transaction rolls back")
 
-func (suite *StoreTestSuite) TestWithTransaction() {
+func (s *StoreTestSuite) TestWithTransaction() {
 
 	ctx := context.Background()
 	anonEua := "ANON"
-	suite.Run("No errors will commit a transaction", func() {
-		newTRB, err := sqlutils.WithTransactionRet[*models.TRBRequest](ctx, suite.store, func(tx *sqlx.Tx) (*models.TRBRequest, error) {
+	s.Run("No errors will commit a transaction", func() {
+		newTRB, err := sqlutils.WithTransactionRet[*models.TRBRequest](ctx, s.store, func(tx *sqlx.Tx) (*models.TRBRequest, error) {
 
 			trb := models.NewTRBRequest(anonEua)
 			trb.Type = models.TRBTNeedHelp
 			trb.State = models.TRBRequestStateOpen
 
-			createdTRB, err := suite.store.CreateTRBRequest(ctx, tx, trb)
+			createdTRB, err := s.store.CreateTRBRequest(ctx, tx, trb)
 			if err != nil {
 				return nil, err
 			}
 			return createdTRB, nil
 
 		})
-		suite.NoError(err)
-		suite.NotNil(newTRB)
+		s.NoError(err)
+		s.NotNil(newTRB)
 
-		trbRet, err := suite.store.GetTRBRequestByID(ctx, newTRB.ID) // If the transaction was commited, we should get the plan
-		suite.NoError(err)
-		suite.NotNil(trbRet)
+		trbRet, err := s.store.GetTRBRequestByID(ctx, newTRB.ID) // If the transaction was commited, we should get the plan
+		s.NoError(err)
+		s.NotNil(trbRet)
 	})
 
-	suite.Run("Errors will rollback a transaction", func() {
-		var createId uuid.UUID
-		retVal, err := sqlutils.WithTransactionRet[*models.TRBRequest](ctx, suite.store, func(tx *sqlx.Tx) (*models.TRBRequest, error) {
+	s.Run("Errors will rollback a transaction", func() {
+		var createID uuid.UUID
+		retVal, err := sqlutils.WithTransactionRet[*models.TRBRequest](ctx, s.store, func(tx *sqlx.Tx) (*models.TRBRequest, error) {
 
 			trb := models.NewTRBRequest(anonEua)
 			trb.Type = models.TRBTNeedHelp
 			trb.State = models.TRBRequestStateOpen
 
-			created, err := suite.store.CreateTRBRequest(ctx, tx, trb)
+			created, err := s.store.CreateTRBRequest(ctx, tx, trb)
 			if err != nil {
 				return nil, err
 			}
 
 			// prove the TRB request was created in the tx
-			suite.NotNil(created)
+			s.NotNil(created)
 
 			// assign id to external var for later
-			createId = created.ID
+			createID = created.ID
 
 			return created, errArtifical
 
 		})
-		suite.ErrorIs(err, errArtifical)
+		s.ErrorIs(err, errArtifical)
 
 		// a transaction should never return useful data on error
-		suite.Nil(retVal)
+		s.Nil(retVal)
 
 		// attempt to get new TRB by the created ID - we should not get anything
-		trb, err := suite.store.GetTRBRequestByID(ctx, createId)
-		suite.Error(err)
+		trb, err := s.store.GetTRBRequestByID(ctx, createID)
+		s.Error(err)
 
 		// that same TRB request that was not nil in the tx will now be nil after rollback
-		suite.Nil(trb)
+		s.Nil(trb)
 	})
 
-	suite.Run("With Transaction can also perform discrete db actions not directly part of the transaction", func() {
+	s.Run("With Transaction can also perform discrete db actions not directly part of the transaction", func() {
 		//NOTE: this is not behavior we should expect in production code.
 		var trbGlobal *models.TRBRequest
-		retVal, err := sqlutils.WithTransactionRet[*models.TRBRequest](ctx, suite.store, func(tx *sqlx.Tx) (*models.TRBRequest, error) {
+		retVal, err := sqlutils.WithTransactionRet[*models.TRBRequest](ctx, s.store, func(tx *sqlx.Tx) (*models.TRBRequest, error) {
 
 			trb := models.NewTRBRequest(anonEua)
 			trb.Type = models.TRBTNeedHelp
 			trb.State = models.TRBRequestStateOpen
 
-			createdTRB, err := suite.store.CreateTRBRequest(ctx, suite.store, trb) //Call the method on the store itself, so it is automatically created
+			createdTRB, err := s.store.CreateTRBRequest(ctx, s.store, trb) //Call the method on the store itself, so it is automatically created
 			if err != nil {
 				return nil, err
 			}
 			trbGlobal = createdTRB
 			return createdTRB, errArtifical
 		})
-		suite.ErrorIs(err, errArtifical)
+		s.ErrorIs(err, errArtifical)
 
 		// the return value from the transaction will be `nil`, but, to reiterate the above comment, this is a bad pattern and should not be seen in prod
-		suite.Nil(retVal)
+		s.Nil(retVal)
 
-		trbRet, err := suite.store.GetTRBRequestByID(ctx, trbGlobal.ID) // we should get the plan no matter what as it was executed outside of `tx` context
-		suite.NoError(err)
-		suite.NotNil(trbRet)
+		trbRet, err := s.store.GetTRBRequestByID(ctx, trbGlobal.ID) // we should get the plan no matter what as it was executed outside of `tx` context
+		s.NoError(err)
+		s.NotNil(trbRet)
 	})
 
-	suite.Run("With Transaction will rollback on panic", func() {
-		var createId uuid.UUID
+	s.Run("With Transaction will rollback on panic", func() {
+		var createID uuid.UUID
 
 		panicFunc := func() {
-			_ = sqlutils.WithTransaction(ctx, suite.store, func(tx *sqlx.Tx) error {
+			_ = sqlutils.WithTransaction(ctx, s.store, func(tx *sqlx.Tx) error {
 				trb := models.NewTRBRequest(anonEua)
 				trb.Type = models.TRBTNeedHelp
 				trb.State = models.TRBRequestStateOpen
 
-				createdTRB, err := suite.store.CreateTRBRequest(ctx, tx, trb)
+				createdTRB, err := s.store.CreateTRBRequest(ctx, tx, trb)
 				if err != nil {
 					return err
 				}
 
 				// prove creation
-				suite.NotNil(createdTRB)
+				s.NotNil(createdTRB)
 
 				// assign id for later
-				createId = createdTRB.ID
+				createID = createdTRB.ID
 
 				panic("panic!")
 			})
 		}
 
 		// we expect a panic, so we don't want the test to fail due to our panic
-		suite.Panics(panicFunc)
+		s.Panics(panicFunc)
 
 		// attempt to get new TRB by the created ID - we should not get anything
-		trb, err := suite.store.GetTRBRequestByID(ctx, createId)
-		suite.Error(err)
+		trb, err := s.store.GetTRBRequestByID(ctx, createID)
+		s.Error(err)
 
 		// should no longer exist due to panic-induced rollback
-		suite.Nil(trb)
+		s.Nil(trb)
 
 	})
 }

--- a/pkg/storage/trb_admin_note_trb_recommendation_link.go
+++ b/pkg/storage/trb_admin_note_trb_recommendation_link.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
-// Creates multiple link records relating a single TRB admin note to all TRB advice letter recommendations it references
+// CreateTRBAdminNoteTRBRecommendationLinks creates multiple link records relating a single TRB admin note to all TRB advice letter recommendations it references
 func (s *Store) CreateTRBAdminNoteTRBRecommendationLinks(
 	ctx context.Context,
 	trbRequestID uuid.UUID,

--- a/pkg/storage/trb_admin_note_trb_request_document_link.go
+++ b/pkg/storage/trb_admin_note_trb_request_document_link.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cmsgov/easi-app/pkg/models"
 )
 
-// Creates multiple link records relating a single TRB admin note to all TRB documents it references
+// CreateTRBAdminNoteTRBDocumentLinks creates multiple link records relating a single TRB admin note to all TRB documents it references
 func (s *Store) CreateTRBAdminNoteTRBDocumentLinks(
 	ctx context.Context,
 	trbRequestID uuid.UUID,


### PR DESCRIPTION

## Changes and Description

- Enable `stylecheck` linter, as some rules were phased out of `staticcheck` and put into `stylecheck`
- Fixed all findings
- Modified exclusion for package comments to use new `stylecheck ST1000` rule instead of `package-comments` (to maintain previous functionaltiy)

## VSCode Recommendations
If using VSCode, you can edit your settings to enable `golangci-lint` as the linter of choice for go files -- this will enable findings to appear within the editor / problems view so you can address issues before having to run the lint script! This configuration will automatically use the `.golangci-lint` file in the root of the project!
![image](https://github.com/CMSgov/easi-app/assets/15203744/b097fcb4-7a74-4e9f-8891-7ad89359e153)

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
