### PR TITLE
[NOREF] Fix the ContractCard key with more unique values

### DIFF
--- a/src/views/SystemProfile/components/Contracts/index.tsx
+++ b/src/views/SystemProfile/components/Contracts/index.tsx
@@ -155,7 +155,10 @@ const Contracts = ({ system }: SystemProfileSubviewProps) => {
         <CardGroup className="margin-0">
           {system.cedarContractsBySystem?.map(
             (contract): React.ReactNode => (
-              <ContractCard contract={contract} key={contract.id} />
+              <ContractCard
+                contract={contract}
+                key={`${contract.id}${contract.contractNumber}${contract.orderNumber}`}
+              />
             )
           )}
         </CardGroup>


### PR DESCRIPTION
## Changes and Description

- System Profile has a bug where items in the Contracts subpage are repeated ([original slack thread](https://cmsgov.slack.com/archives/C03BWN7SJD9/p1718643885958489))
- This is because the react key is the same for every item
- The original key was just the id
- Now it also has contractNumber + orderNumber for more uniqueness