### PR TITLE
[NOREF] Automatically log HTTP response times

### DIFF
--- a/pkg/cedar/core/client.go
+++ b/pkg/cedar/core/client.go
@@ -20,9 +20,8 @@ type loggingTransport struct {
 }
 
 func (t *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
-	start := time.Now().UnixMilli()
+	start := time.Now()
 	resp, err := http.DefaultTransport.RoundTrip(r)
-	end := time.Now().UnixMilli()
 
 	// Start a status code of 0, in case the request fails (and we get a nil resp)
 	status := 0
@@ -33,12 +32,11 @@ func (t *loggingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	t.logger.Info(
 		"Call to CEDAR core",
 		zap.String("service", "cedarcore"),
-		zap.Bool("cacheEnabled", false),
 		zap.String("method", r.Method),
 		zap.Int("status", status),
 		zap.String("path", r.URL.Path),
-		zap.String("queryParams", r.URL.RawQuery),
-		zap.Int64("timeMS", end-start),
+		zap.String("query-params", r.URL.RawQuery),
+		zap.Int64("cedar-response-time-ms", time.Since(start).Milliseconds()),
 	)
 
 	return resp, err

--- a/pkg/server/logger.go
+++ b/pkg/server/logger.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -28,6 +29,11 @@ func loggerMiddleware(logger *zap.Logger, environment appconfig.Environment, nex
 		)
 		ctx = appcontext.WithLogger(ctx, logger)
 
+		start := time.Now()
+		next.ServeHTTP(w, r.WithContext(ctx))
+		durationMS := time.Since(start).Milliseconds()
+
+		// Log these fields after each HTTP request
 		fields := []zap.Field{
 			zap.String("accepted-language", r.Header.Get("accepted-language")),
 			zap.Int64("content-length", r.ContentLength),
@@ -35,13 +41,12 @@ func loggerMiddleware(logger *zap.Logger, environment appconfig.Environment, nex
 			zap.String("method", r.Method),
 			zap.String("protocol-version", r.Proto),
 			zap.String("referer", r.Header.Get("referer")),
+			zap.Int64("response-time-ms", durationMS),
 			zap.String("request-source", r.RemoteAddr),
 			zap.String("url", r.URL.String()),
 			zap.String("user-agent", r.UserAgent()),
 		}
 		logger.Info("Request", fields...)
-
-		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 


### PR DESCRIPTION
## Changes and Description

Same change as made in MINT, here https://github.com/CMSgov/mint-app/pull/1184

In support of diagnosing potential areas that we might want to address for performance (largely with regards to where we might want to introduce more dataloaders), this PR adds functionality that automatically logs the response time of each request in milliseconds, allowing us to aggregate and analyze that data in Splunk.

**OF NOTE:** This PR _does_ move the `logger.Info` call _after_ the next.ServeHTTP call. This is (probably) how it should be anyways, since we don't necessarily want to hold up making the HTTP response with a logger call (and now it's needed, since we need to make the HTTP response happen before we can truly log how long it took)

## How to test this change

- `scripts/dev up`
- Load the UI in your browser
- `docker compose logs -f easi` to view the logs
- Search for `response-time-ms` and ensure requests are logged with response times.
- If you want, you can add a `time.Sleep(1 * time.Second)` to a resolver like [this](https://github.com/CMSgov/easi-app/blob/e28dca4379b04a50e88f1fc8e6bb90ac26a34a10/pkg/graph/schema.resolvers.go#L1128-L1129), load the "IT Governance" tab, and ensure that the `response-time-ms` accurately reflects the simulated delay in the resolver (this ensures that delays are captured by things like middleware, dataloaders, store methods, etc.)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
