### PR TITLE
[NOREF] package storage helpers

### DIFF
--- a/pkg/graph/resolvers/system_intake_grb_reviewer.go
+++ b/pkg/graph/resolvers/system_intake_grb_reviewer.go
@@ -40,7 +40,7 @@ func CreateSystemIntakeGRBReviewer(
 		reviewer.VotingRole = models.SIGRBReviewerVotingRole(input.VotingRole)
 		reviewer.GRBRole = models.SIGRBReviewerRole(input.GrbRole)
 		reviewer.SystemIntakeID = input.SystemIntakeID
-		err = store.CreateSystemIntakeGRBReviewer(ctx, tx, intake.ID, reviewer)
+		err = store.CreateSystemIntakeGRBReviewer(ctx, tx, reviewer)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/graph/resolvers/system_intake_grb_reviewer_test.go
+++ b/pkg/graph/resolvers/system_intake_grb_reviewer_test.go
@@ -166,7 +166,6 @@ func (s *ResolverSuite) createIntakeAndAddReviewers(reviewers ...reviewerToAdd) 
 			err = store.CreateSystemIntakeGRBReviewer(
 				ctx,
 				tx,
-				intake.ID,
 				createdReviewer,
 			)
 			if err != nil {

--- a/pkg/storage/cedar_system_bookmark.go
+++ b/pkg/storage/cedar_system_bookmark.go
@@ -97,7 +97,7 @@ func (s *Store) FetchCedarSystemIsBookmarkedByCedarSystemIDs(ctx context.Context
 	}
 
 	var results []models.BookmarkRequest
-	if err := selectNamed(ctx, s, &results, sqlqueries.CedarBookmarkSystemsForm.SelectByCedarSystemIDs, args{
+	if err := namedSelect(ctx, s, &results, sqlqueries.CedarBookmarkSystemsForm.SelectByCedarSystemIDs, args{
 		"eua_user_ids":     pq.Array(euaUserIDs),
 		"cedar_system_ids": pq.Array(systemIDs),
 	}); err != nil {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -120,7 +120,7 @@ args{
 type args map[string]any
 
 // namedSelect is a shortcut for using `sqlx` Select (SelectContext) with named arguments to prevent writing out the prepare step each time
-func namedSelect(ctx context.Context, np sqlutils.NamedPreparer, dest interface{}, sqlStatement string, arguments any) error {
+func namedSelect(ctx context.Context, np sqlutils.NamedPreparer, dest any, sqlStatement string, arguments any) error {
 	if ctx == nil {
 		ctx = context.TODO()
 		appcontext.ZLogger(ctx).Debug("nil ctx passed to namedSelect")
@@ -136,7 +136,7 @@ func namedSelect(ctx context.Context, np sqlutils.NamedPreparer, dest interface{
 }
 
 // namedGet is a shortcut for using `sqlx` Get (GetContext) with named arguments to prevent writing out the prepare step each time
-func namedGet(ctx context.Context, np sqlutils.NamedPreparer, dest interface{}, sqlStatement string, arguments any) error {
+func namedGet(ctx context.Context, np sqlutils.NamedPreparer, dest any, sqlStatement string, arguments any) error {
 	if ctx == nil {
 		ctx = context.TODO()
 		appcontext.ZLogger(ctx).Debug("nil ctx passed to namedGet")

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -118,11 +119,11 @@ args{
 */
 type args map[string]any
 
-// selectNamed is a shortcut for using `sqlx` Select (SelectContext) with named arguments to prevent writing out the prepare step each time
-func selectNamed(ctx context.Context, np sqlutils.NamedPreparer, dest interface{}, sqlStatement string, arg args) error {
+// namedSelect is a shortcut for using `sqlx` Select (SelectContext) with named arguments to prevent writing out the prepare step each time
+func namedSelect(ctx context.Context, np sqlutils.NamedPreparer, dest interface{}, sqlStatement string, arguments any) error {
 	if ctx == nil {
 		ctx = context.TODO()
-		appcontext.ZLogger(ctx).Debug("nil ctx passed to selectNamed")
+		appcontext.ZLogger(ctx).Debug("nil ctx passed to namedSelect")
 	}
 
 	stmt, err := np.PrepareNamed(sqlStatement)
@@ -131,5 +132,37 @@ func selectNamed(ctx context.Context, np sqlutils.NamedPreparer, dest interface{
 	}
 	defer stmt.Close()
 
-	return stmt.SelectContext(ctx, dest, arg)
+	return stmt.SelectContext(ctx, dest, arguments)
+}
+
+// namedGet is a shortcut for using `sqlx` Get (GetContext) with named arguments to prevent writing out the prepare step each time
+func namedGet(ctx context.Context, np sqlutils.NamedPreparer, dest interface{}, sqlStatement string, arguments any) error {
+	if ctx == nil {
+		ctx = context.TODO()
+		appcontext.ZLogger(ctx).Debug("nil ctx passed to namedGet")
+	}
+
+	stmt, err := np.PrepareNamed(sqlStatement)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	return stmt.GetContext(ctx, dest, arguments)
+}
+
+// namedExec is a shortcut for using `sqlx` Exec (ExecContext) with named arguments to prevent writing out the prepare step each time
+func namedExec(ctx context.Context, np sqlutils.NamedPreparer, sqlStatement string, arguments any) (sql.Result, error) {
+	if ctx == nil {
+		ctx = context.TODO()
+		appcontext.ZLogger(ctx).Debug("nil ctx passed to namedExec")
+	}
+
+	stmt, err := np.PrepareNamed(sqlStatement)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	return stmt.ExecContext(ctx, arguments)
 }

--- a/pkg/storage/system_intake_contract_number.go
+++ b/pkg/storage/system_intake_contract_number.go
@@ -58,7 +58,7 @@ func (s *Store) SetSystemIntakeContractNumbers(ctx context.Context, tx *sqlx.Tx,
 
 func (s *Store) SystemIntakeContractNumbersBySystemIntakeIDs(ctx context.Context, systemIntakeIDs []uuid.UUID) ([]*models.SystemIntakeContractNumber, error) {
 	var systemIntakeContractNumbers []*models.SystemIntakeContractNumber
-	return systemIntakeContractNumbers, selectNamed(ctx, s, &systemIntakeContractNumbers, sqlqueries.SystemIntakeContractNumberForm.SelectBySystemIntakeIDs, args{
+	return systemIntakeContractNumbers, namedSelect(ctx, s, &systemIntakeContractNumbers, sqlqueries.SystemIntakeContractNumberForm.SelectBySystemIntakeIDs, args{
 		"system_intake_ids": pq.Array(systemIntakeIDs),
 	})
 }

--- a/pkg/storage/system_intake_grb_reviewer.go
+++ b/pkg/storage/system_intake_grb_reviewer.go
@@ -27,7 +27,7 @@ func (s *Store) CreateSystemIntakeGRBReviewer(ctx context.Context, tx *sqlx.Tx, 
 }
 
 func (s *Store) UpdateSystemIntakeGRBReviewer(ctx context.Context, tx *sqlx.Tx, reviewerID uuid.UUID, votingRole models.SystemIntakeGRBReviewerVotingRole, grbRole models.SystemIntakeGRBReviewerRole) (*models.SystemIntakeGRBReviewer, error) {
-	var updatedReviewer *models.SystemIntakeGRBReviewer
+	updatedReviewer := &models.SystemIntakeGRBReviewer{}
 	if err := namedGet(ctx, tx, updatedReviewer, sqlqueries.SystemIntakeGRBReviewer.Update, args{
 		"reviewer_id": reviewerID,
 		"grb_role":    grbRole,

--- a/pkg/storage/system_intake_grb_reviewer.go
+++ b/pkg/storage/system_intake_grb_reviewer.go
@@ -59,7 +59,7 @@ func (s *Store) DeleteSystemIntakeGRBReviewer(ctx context.Context, tx *sqlx.Tx, 
 
 func (s *Store) SystemIntakeGRBReviewersBySystemIntakeIDs(ctx context.Context, systemIntakeIDs []uuid.UUID) ([]*models.SystemIntakeGRBReviewer, error) {
 	var systemIntakeGRBReviewers []*models.SystemIntakeGRBReviewer
-	return systemIntakeGRBReviewers, selectNamed(ctx, s, &systemIntakeGRBReviewers, sqlqueries.SystemIntakeGRBReviewer.GetBySystemIntakeID, args{
+	return systemIntakeGRBReviewers, namedSelect(ctx, s, &systemIntakeGRBReviewers, sqlqueries.SystemIntakeGRBReviewer.GetBySystemIntakeID, args{
 		"system_intake_ids": pq.Array(systemIntakeIDs),
 	})
 }

--- a/pkg/storage/system_intake_grb_reviewer.go
+++ b/pkg/storage/system_intake_grb_reviewer.go
@@ -14,11 +14,11 @@ import (
 )
 
 // CreateSystemIntakeGRBReviewer creates a GRB Reviewer
-func (s *Store) CreateSystemIntakeGRBReviewer(ctx context.Context, tx *sqlx.Tx, systemIntakeID uuid.UUID, reviewer *models.SystemIntakeGRBReviewer) error {
+func (s *Store) CreateSystemIntakeGRBReviewer(ctx context.Context, tx *sqlx.Tx, reviewer *models.SystemIntakeGRBReviewer) error {
 	if reviewer.ID == uuid.Nil {
 		reviewer.ID = uuid.New()
 	}
-	if _, err := tx.NamedExec(sqlqueries.SystemIntakeGRBReviewer.Create, reviewer); err != nil {
+	if _, err := namedExec(ctx, tx, sqlqueries.SystemIntakeGRBReviewer.Create, reviewer); err != nil {
 		appcontext.ZLogger(ctx).Error("failed to create GRB reviewer", zap.Error(err))
 		return err
 	}
@@ -27,28 +27,24 @@ func (s *Store) CreateSystemIntakeGRBReviewer(ctx context.Context, tx *sqlx.Tx, 
 }
 
 func (s *Store) UpdateSystemIntakeGRBReviewer(ctx context.Context, tx *sqlx.Tx, reviewerID uuid.UUID, votingRole models.SystemIntakeGRBReviewerVotingRole, grbRole models.SystemIntakeGRBReviewerRole) (*models.SystemIntakeGRBReviewer, error) {
-	var reviewer models.SystemIntakeGRBReviewer
-	stmt, err := tx.PrepareNamed(sqlqueries.SystemIntakeGRBReviewer.Update)
-	if err != nil {
-		appcontext.ZLogger(ctx).Error("failed to prepare update GRB reviewer query", zap.Error(err))
-		return nil, err
-	}
-	defer stmt.Close()
-	err = stmt.Get(&reviewer, args{
+	var updatedReviewer *models.SystemIntakeGRBReviewer
+	if err := namedGet(ctx, tx, updatedReviewer, sqlqueries.SystemIntakeGRBReviewer.Update, args{
 		"reviewer_id": reviewerID,
 		"grb_role":    grbRole,
 		"voting_role": votingRole,
 		"modified_by": appcontext.Principal(ctx).Account().ID,
-	})
-	if err != nil {
-		appcontext.ZLogger(ctx).Error("failed to update GRB reviewer", zap.Error(err))
-		return nil, err
+	}); err != nil {
+		appcontext.ZLogger(ctx).Error(
+			"error updating system intake GRB reviewer",
+			zap.String("reviewer_id", reviewerID.String()),
+		)
 	}
-	return &reviewer, nil
+
+	return updatedReviewer, nil
 }
 
 func (s *Store) DeleteSystemIntakeGRBReviewer(ctx context.Context, tx *sqlx.Tx, reviewerID uuid.UUID) error {
-	if _, err := tx.NamedExec(sqlqueries.SystemIntakeGRBReviewer.Delete, args{
+	if _, err := namedExec(ctx, tx, sqlqueries.SystemIntakeGRBReviewer.Delete, args{
 		"reviewer_id": reviewerID,
 	}); err != nil {
 		appcontext.ZLogger(ctx).Error("failed to delete GRB reviewer", zap.Error(err))

--- a/pkg/storage/system_intake_system.go
+++ b/pkg/storage/system_intake_system.go
@@ -58,14 +58,14 @@ func (s *Store) SetSystemIntakeSystems(ctx context.Context, tx *sqlx.Tx, systemI
 
 func (s *Store) SystemIntakeSystemsBySystemIntakeIDs(ctx context.Context, systemIntakeIDs []uuid.UUID) ([]*models.SystemIntakeSystem, error) {
 	var systemIntakeSystems []*models.SystemIntakeSystem
-	return systemIntakeSystems, selectNamed(ctx, s, &systemIntakeSystems, sqlqueries.SystemIntakeSystemForm.SelectBySystemIntakeIDs, args{
+	return systemIntakeSystems, namedSelect(ctx, s, &systemIntakeSystems, sqlqueries.SystemIntakeSystemForm.SelectBySystemIntakeIDs, args{
 		"system_intake_ids": pq.Array(systemIntakeIDs),
 	})
 }
 
 func (s *Store) SystemIntakesByCedarSystemID(ctx context.Context, cedarSystemID string, state models.SystemIntakeState) ([]*models.SystemIntake, error) {
 	var systemIntakes []*models.SystemIntake
-	return systemIntakes, selectNamed(ctx, s, &systemIntakes, sqlqueries.SystemIntakeSystemForm.SelectByCedarSystemID, args{
+	return systemIntakes, namedSelect(ctx, s, &systemIntakes, sqlqueries.SystemIntakeSystemForm.SelectByCedarSystemID, args{
 		"system_id": cedarSystemID,
 		"state":     state,
 	})

--- a/pkg/storage/trb_request_contract_number.go
+++ b/pkg/storage/trb_request_contract_number.go
@@ -58,7 +58,7 @@ func (s *Store) SetTRBRequestContractNumbers(ctx context.Context, tx *sqlx.Tx, t
 
 func (s *Store) TRBRequestContractNumbersByTRBRequestIDs(ctx context.Context, trbRequestIDs []uuid.UUID) ([]*models.TRBRequestContractNumber, error) {
 	var trbRequestContractNumbers []*models.TRBRequestContractNumber
-	return trbRequestContractNumbers, selectNamed(ctx, s, &trbRequestContractNumbers, sqlqueries.TRBRequestContractNumbersForm.SelectByTRBRequestIDs, args{
+	return trbRequestContractNumbers, namedSelect(ctx, s, &trbRequestContractNumbers, sqlqueries.TRBRequestContractNumbersForm.SelectByTRBRequestIDs, args{
 		"trb_request_ids": pq.Array(trbRequestIDs),
 	})
 }

--- a/pkg/storage/trb_request_system.go
+++ b/pkg/storage/trb_request_system.go
@@ -58,7 +58,7 @@ func (s *Store) SetTRBRequestSystems(ctx context.Context, tx *sqlx.Tx, trbReques
 
 func (s *Store) TRBRequestSystemsByTRBRequestIDs(ctx context.Context, trbRequestIDs []uuid.UUID) ([]*models.TRBRequestSystem, error) {
 	var trbRequestSystems []*models.TRBRequestSystem
-	return trbRequestSystems, selectNamed(ctx, s, &trbRequestSystems, sqlqueries.TRBRequestSystemForm.SelectByTRBRequestIDs, args{
+	return trbRequestSystems, namedSelect(ctx, s, &trbRequestSystems, sqlqueries.TRBRequestSystemForm.SelectByTRBRequestIDs, args{
 		"trb_request_ids": pq.Array(trbRequestIDs),
 	})
 }
@@ -66,7 +66,7 @@ func (s *Store) TRBRequestSystemsByTRBRequestIDs(ctx context.Context, trbRequest
 // TRBRequestsByCedarSystemID gets TRB Requests related to given Cedar System ID
 func (s *Store) TRBRequestsByCedarSystemID(ctx context.Context, cedarSystemID string, state models.TRBRequestState) ([]*models.TRBRequest, error) {
 	var trbRequests []*models.TRBRequest
-	return trbRequests, selectNamed(ctx, s, &trbRequests, sqlqueries.TRBRequestSystemForm.SelectByCedarSystemID, args{
+	return trbRequests, namedSelect(ctx, s, &trbRequests, sqlqueries.TRBRequestSystemForm.SelectByCedarSystemID, args{
 		"system_id": cedarSystemID,
 		"state":     state,
 	})

--- a/pkg/storage/user_account_store.go
+++ b/pkg/storage/user_account_store.go
@@ -87,7 +87,7 @@ func (s *Store) UserAccountGetByID(np sqlutils.NamedPreparer, id uuid.UUID) (*au
 // UserAccountsByIDs gets user accounts by user ID
 func (s *Store) UserAccountsByIDs(ctx context.Context, userIDs []uuid.UUID) ([]*authentication.UserAccount, error) {
 	var accounts []*authentication.UserAccount
-	return accounts, selectNamed(ctx, s, &accounts, sqlqueries.UserAccount.GetByIDs, args{
+	return accounts, namedSelect(ctx, s, &accounts, sqlqueries.UserAccount.GetByIDs, args{
 		"user_ids": pq.Array(userIDs),
 	})
 }


### PR DESCRIPTION
## Changes and Description

- Adds some helper methods similar to the existing `namedSelect` method (previously named `selectNamed`)
- Updates the arguments used by these methods from `type args map[string]any` to `any`
  - This still allows the _caller_ of these methods to use `type args` to construct argument maps, but also opens up code like [this](https://github.com/CMSgov/easi-app/blob/0b7dc65e56f366451d9ec2ee3e4053b25523de6d/pkg/storage/system_intake_grb_reviewer.go#L21-L24), where we're passing in a `package models` struct as an argument, rather than a `map[string]any`
- `store.CreateSystemIntakeGRBReviewer` had what appeared to be an unused parameter in its function definition, so I removed it!

These methods serve to act as helpers for executing named statements without needing to prepare a statement and automatically handle closing the statement.

The goal of these methods is to simplify our storage methods to not need to handle 2 errors (one to prepare the statement, another to execute the call)

## How to test this change

- Ensure that all unit tests and functionality pertaining to the GRB reviewer code works as expected (as this is the only place that this was modified)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
