### PR TITLE
[NOREF] Update minio server port

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -82,7 +82,7 @@ export MINIO_ACCESS_KEY='minioadmin'
 export MINIO_SECRET_KEY='minioadmin'
 
 # If not on Windows+WSL, run `scripts/dev hosts:check` to ensure this will resolve!
-export MINIO_ADDRESS="http://host.docker.internal:9000"
+export MINIO_ADDRESS="http://host.docker.internal:9004"
 
 # For connecting to a local postgres instance
 export PGHOST=localhost
@@ -99,7 +99,7 @@ export TAILSCALE_HOSTNAME=$(hostname | awk '{gsub(/\.local$/,""); print tolower(
 export TAILSCALE_CLIENT_ADDRESS="http://${TAILSCALE_HOSTNAME}:3000"
 export TAILSCALE_VITE_API_ADDRESS="http://${TAILSCALE_HOSTNAME}:8080/api/v1"
 export TAILSCALE_REACT_GRAPHQL_ADDRESS="http://${TAILSCALE_HOSTNAME}:8080/api/graph/query"
-export TAILSCALE_MINIO_ADDRESS="http://${TAILSCALE_HOSTNAME}:9000"
+export TAILSCALE_MINIO_ADDRESS="http://${TAILSCALE_HOSTNAME}:9004"
 
 export USE_TLS=false
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -83,7 +83,7 @@ jobs:
           FLAG_SOURCE: LOCAL
           MINIO_ACCESS_KEY: minioadmin
           MINIO_SECRET_KEY: minioadmin
-          MINIO_ADDRESS: http://localhost:9000 # Server tests run outside of container, so use exposed port on localhost for MinIO
+          MINIO_ADDRESS: http://localhost:9004
         run: |
           docker-compose --project-name easi-server-test -f docker-compose.ci_server_test.yml up -d db
           docker-compose --project-name easi-server-test -f docker-compose.ci_server_test.yml up --exit-code-from db_migrate db_migrate

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
         "DB_MAX_CONNECTIONS": "20",
         "AWS_REGION": "us-west-2",
         "AWS_S3_FILE_UPLOAD_BUCKET": "easi-app-file-uploads",
-        "MINIO_ADDRESS": "http://localhost:9000",
+        "MINIO_ADDRESS": "http://localhost:9004",
         "MINIO_ACCESS_KEY": "minioadmin",
         "MINIO_SECRET_KEY": "minioadmin",
         "EMAIL_TEMPLATE_DIR":"${workspaceFolder}/pkg/email/templates"
@@ -30,7 +30,7 @@
         "DB_MAX_CONNECTIONS": "20",
         "AWS_REGION": "us-west-2",
         "AWS_S3_FILE_UPLOAD_BUCKET": "easi-app-file-uploads",
-        "MINIO_ADDRESS": "http://localhost:9000",
+        "MINIO_ADDRESS": "http://localhost:9004",
         "MINIO_ACCESS_KEY": "minioadmin",
         "MINIO_SECRET_KEY": "minioadmin",
         "EMAIL_TEMPLATE_DIR":"${workspaceFolder}/pkg/email/templates"

--- a/deploy/base/easi.yaml
+++ b/deploy/base/easi.yaml
@@ -46,7 +46,7 @@ data:
   LD_ENV_USER: ''
   MINIO_ACCESS_KEY: minioadmin
   MINIO_SECRET_KEY: minioadmin
-  MINIO_ADDRESS: http://minio:9000
+  MINIO_ADDRESS: http://minio:9004
   SERVER_CERT: ''
   SERVER_KEY: ''
   USE_TLS: 'false'

--- a/deploy/base/minio.yaml
+++ b/deploy/base/minio.yaml
@@ -26,12 +26,12 @@ spec:
     spec:
       containers:
         - command: ["minio", "server", "/data", "--console-address"]
-          args: [':9001']
+          args: [':9001', '--address', ':9004']
           image: minio/minio:latest
           name: minio
           ports:
-            - containerPort: 9000
-              hostPort: 9000
+            - containerPort: 9004
+              hostPort: 9004
               protocol: TCP
             - containerPort: 9001
               hostPort: 9001
@@ -47,9 +47,9 @@ metadata:
   name: minio
 spec:
   ports:
-    - name: "9000"
-      port: 9000
-      targetPort: 9000
+    - name: "9004"
+      port: 9004
+      targetPort: 9004
     - name: "console"
       port: 9001
       targetPort: 9001
@@ -92,7 +92,7 @@ data:
       "version": "10",
       "aliases": {
         "local": {
-          "url": "http://minio:9000",
+          "url": "http://minio:9004",
           "accessKey": "minioadmin",
           "secretKey": "minioadmin",
           "api": "S3v4",

--- a/docker-compose.ci_server_test.yml
+++ b/docker-compose.ci_server_test.yml
@@ -21,7 +21,7 @@ services:
     image: minio/minio:latest
     ports:
       - '9004:9004'
-    entrypoint: minio server /data
+    entrypoint: minio server --address :9004 /data
   minio_mc:
     image: minio/mc:latest
     depends_on:

--- a/docker-compose.ci_server_test.yml
+++ b/docker-compose.ci_server_test.yml
@@ -20,7 +20,7 @@ services:
     restart: always
     image: minio/minio:latest
     ports:
-      - '9000:9000'
+      - '9004:9004'
     entrypoint: minio server /data
   minio_mc:
     image: minio/mc:latest

--- a/docker-compose.cypress_ci.yml
+++ b/docker-compose.cypress_ci.yml
@@ -18,7 +18,7 @@ services:
       - DB_MAX_CONNECTIONS=20
       - AWS_REGION=us-west-2
       - AWS_S3_FILE_UPLOAD_BUCKET=easi-app-file-uploads
-      - MINIO_ADDRESS=http://minio:9000
+      - MINIO_ADDRESS=http://minio:9004
       - MINIO_ACCESS_KEY=minioadmin
       - MINIO_SECRET_KEY=minioadmin
   easi:
@@ -32,7 +32,7 @@ services:
       - CEDAR_EMAIL_ADDRESS=fake@cedar.gov
       - FLAG_SOURCE=FILE
       - FLAGDATA_FILE=/cypress/fixtures/flagdata.json
-      - MINIO_ADDRESS=http://minio:9000
+      - MINIO_ADDRESS=http://minio:9004
     volumes:
       - ./cypress:/cypress # Mounted so that the backend container can access the file with LaunchDarkly flag values
   easi_client:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,9 +88,9 @@ services:
   minio:
     restart: always
     image: minio/minio:latest
-    entrypoint: minio server /data
+    entrypoint: minio server --address :9004 /data
     ports:
-    - '9000:9000'
+    - '9004:9004'
   minio_mc:
     image: minio/mc:latest
     depends_on:

--- a/minio_config.json
+++ b/minio_config.json
@@ -2,7 +2,7 @@
   "version": "10",
   "aliases": {
     "local": {
-      "url": "http://minio:9000",
+      "url": "http://minio:9004",
       "accessKey": "minioadmin",
       "secretKey": "minioadmin",
       "api": "S3v4",

--- a/src/data/mock/systemIntake.ts
+++ b/src/data/mock/systemIntake.ts
@@ -116,7 +116,7 @@ export const documents: SystemIntakeDocument[] = [
     status: SystemIntakeDocumentStatus.AVAILABLE,
     uploadedAt: '2023-06-14T18:24:46.310929Z',
     url:
-      'http://host.docker.internal:9000/easi-app-file-uploads/ead3f487-8aaa-47d2-aa26-335e9b560a92.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minioadmin%2F20230614%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20230614T184943Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=f71d5d63d68958a2bd8526c2b2cdd5abe78b21eb69d10739fe8f8e6fd5d010ec',
+      'http://host.docker.internal:9004/easi-app-file-uploads/ead3f487-8aaa-47d2-aa26-335e9b560a92.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minioadmin%2F20230614%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20230614T184943Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=f71d5d63d68958a2bd8526c2b2cdd5abe78b21eb69d10739fe8f8e6fd5d010ec',
     __typename: 'SystemIntakeDocument'
   },
   {
@@ -130,7 +130,7 @@ export const documents: SystemIntakeDocument[] = [
     status: SystemIntakeDocumentStatus.PENDING,
     uploadedAt: '2023-06-14T18:24:46.32661Z',
     url:
-      'http://host.docker.internal:9000/easi-app-file-uploads/7e047111-6228-4943-9c4b-0961f27858f4.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minioadmin%2F20230614%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20230614T184943Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=0e3f337697c616b01533accd95a316cbeabeb6990961b9881911c757837cbf95',
+      'http://host.docker.internal:9004/easi-app-file-uploads/7e047111-6228-4943-9c4b-0961f27858f4.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minioadmin%2F20230614%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20230614T184943Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=0e3f337697c616b01533accd95a316cbeabeb6990961b9881911c757837cbf95',
     __typename: 'SystemIntakeDocument'
   },
   {
@@ -144,7 +144,7 @@ export const documents: SystemIntakeDocument[] = [
     status: SystemIntakeDocumentStatus.UNAVAILABLE,
     uploadedAt: '2023-06-14T18:24:46.342866Z',
     url:
-      'http://host.docker.internal:9000/easi-app-file-uploads/f779e8e4-9c78-4b14-bbab-37618447f3f9.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minioadmin%2F20230614%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20230614T184943Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=7e6755645a1f163d41d2fa7c19776d0ceb4cfd3ff8e1c2918c428a551fe44764',
+      'http://host.docker.internal:9004/easi-app-file-uploads/f779e8e4-9c78-4b14-bbab-37618447f3f9.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minioadmin%2F20230614%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20230614T184943Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=7e6755645a1f163d41d2fa7c19776d0ceb4cfd3ff8e1c2918c428a551fe44764',
     __typename: 'SystemIntakeDocument'
   }
 ];


### PR DESCRIPTION
## Changes and Description

- Update internal (within container) and external (outside of container) port used by the MinIO server from `9000` to `9004`

This change was needed as starting up our backend with the ZScaler VPN client running already would cause a port conflict on `9000` (ZScaler uses this for a web UI it hosts for debugging connections)

Ideally, this wouldn't happen, but it's far easier to just change the MinIO port to something that doesn't conflict than try and address this any other way.

![image](https://github.com/CMSgov/easi-app/assets/15203744/25a47cc9-25d7-4f55-b4b9-5f4c6ed23032)

## How to test this change

- Start ZScaler
- Run `scripts/dev up`
- Ensure all services start
- Ensure file upload works within the application
- Ensure `scripts/dev minio:*` commands work as expected.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
